### PR TITLE
Filter out VMware ESX servers when gathering SCVMM inventory.

### DIFF
--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -26,6 +26,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       assert_ems
       # assert_specific_cluster
       assert_specific_host
+      assert_esx_host
       assert_specific_vm
       assert_specific_storage
       assert_relationship_tree
@@ -38,23 +39,23 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     expect(EmsCluster.count).to eq(0)
     expect(Host.count).to eq(2)
     expect(ResourcePool.count).to eq(0)
-    expect(Vm.count).to eq(2)
-    expect(VmOrTemplate.count).to eq(3)
+    expect(Vm.count).to eq(3)
+    expect(VmOrTemplate.count).to eq(4)
     expect(CustomAttribute.count).to eq(0)
     expect(CustomizationSpec.count).to eq(0)
-    expect(Disk.count).to eq(3)
+    expect(Disk.count).to eq(4)
     expect(GuestDevice.count).to eq(14)
-    expect(Hardware.count).to eq(5)
+    expect(Hardware.count).to eq(6)
     expect(Lan.count).to eq(2)
     expect(MiqScsiLun.count).to eq(0)
     expect(MiqScsiTarget.count).to eq(0)
-    expect(Network.count).to eq(2)
-    expect(OperatingSystem.count).to eq(5)
+    expect(Network.count).to eq(3)
+    expect(OperatingSystem.count).to eq(6)
     expect(Snapshot.count).to eq(1)
     expect(Switch.count).to eq(2)
     expect(SystemService.count).to eq(0)
-    expect(Relationship.count).to eq(10)
-    expect(MiqQueue.count).to eq(3)
+    expect(Relationship.count).to eq(11)
+    expect(MiqQueue.count).to eq(4)
     expect(Storage.count).to eq(2)
   end
 
@@ -70,8 +71,8 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
 
     expect(@ems.storages.size).to eq(2)
     expect(@ems.hosts.size).to eq(2)
-    expect(@ems.vms_and_templates.size).to eq(3)
-    expect(@ems.vms.size).to eq(2)
+    expect(@ems.vms_and_templates.size).to eq(4)
+    expect(@ems.vms.size).to eq(3)
     expect(@ems.miq_templates.size).to eq(1)
     expect(@ems.customization_specs.size).to eq(0)
   end
@@ -84,7 +85,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :name                        => storage_name,
       :store_type                  => nil,
       :total_space                 => 499_738_734_592,
-      :free_space                  => 467_535_630_336,
+      :free_space                  => 463_193_792_512,
       :multiplehostaccess          => 1,
       :location                    => "1c00651a-ca2a-4676-976b-55875305a89f",
       :thin_provisioning_supported => true
@@ -150,6 +151,11 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
 
     # @host2 = Host.find_by_name("SFBronagh.manageiq.com")
     # expect(@host2.ems_cluster).to eq(@cluster)
+  end
+
+  def assert_esx_host
+    esx = Host.find_by_vmm_product("VMWareESX")
+    expect(esx).to eq(nil)
   end
 
   def assert_specific_vm
@@ -222,15 +228,6 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :start_connected => true,
     )
 
-    # v = Vm.find_by_name("linux2")
-    # expect(v.hardware.networks.size).to eq(1)
-    # network = v.hardware.networks.first
-    # puts "Network #{network.inspect}"
-    # expect(network).to have_attributes(
-    #   :hostname  => "SCVMM1111.manageiq.com",
-    #   :ipaddress => "192.168.252.90"
-    # )
-
     v = Vm.find_by_name("vm_linux1")
     dvd = v.hardware.guest_devices.first
     expect(dvd).to have_attributes(
@@ -251,6 +248,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
             [ManageIQ::Providers::Microsoft::InfraManager::Template, "linux_template"] => {},
             [ManageIQ::Providers::Microsoft::InfraManager::Vm, "linux2"]               => {},
             [ManageIQ::Providers::Microsoft::InfraManager::Vm, "vm_linux1"]            => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "testing_provisioning"] => {},
           }
         }
       }

--- a/spec/tools/scvmm_data/get_inventory_output.yml
+++ b/spec/tools/scvmm_data/get_inventory_output.yml
@@ -51,7 +51,7 @@
       :DatabaseServerName: DEV-win2k12sql
       :DatabaseInstanceName: DEV-win2k12sql
       :DatabaseName: VirtualManagerDB
-      :ConnectedUserName: CLOUDFORMSWIN\Administrator
+      :ConnectedUserName: CLOUDFORMSWIN\scvmm
       :ConnectedUserGroups: &6
         :ToString: Microsoft.VirtualManager.Remoting.AccountCollection
       :UserName: Windows User
@@ -117,7 +117,7 @@
         :MountPoints:
         - C:\
         :Capacity: 299630587904
-        :FreeSpace: 264840351744
+        :FreeSpace: 267202084864
         :VolumeLabel: 
         :FileSystem: NTFS
         :IsSANMigrationPossible: false
@@ -128,9 +128,9 @@
           :ToString: dell-r410-03.cloudformswin.lab.redhat.com
           :Props:
             :RunAsAccount: 
-            :MostRecentTaskID: bab77f7b-0552-44c4-a6a6-9f3161213689
-            :MostRecentTaskUIState: Completed
-            :MostRecentTask: Change properties of virtual machine host
+            :MostRecentTaskID: a45a922f-7815-46bd-9116-b47ad83ffc1f
+            :MostRecentTaskUIState: Failed
+            :MostRecentTask: Refresh Performance Data
             :OverallStateString: OK
             :OverallState: OK
             :CommunicationStateString: Responding
@@ -147,9 +147,9 @@
             :DiskSpaceReserveMB: 10240
             :MaxDiskIOReservation: 10000
             :MemoryReserveMB: 2048
-            :VMPaths: &33
+            :VMPaths: &71
             - C:\ProgramData\Microsoft\Windows\Hyper-V
-            :BaseDiskPaths: &34 []
+            :BaseDiskPaths: &72 []
             :PROEnabled: false
             :MaintenanceHost: false
             :AvailableForPlacement: true
@@ -169,7 +169,7 @@
             :ProcessorFamily: '179'
             :CpuUtilization: 0
             :TotalMemory: 137425408000
-            :AvailableMemory: 127210
+            :AvailableMemory: 127010
             :OperatingSystem: 'Microsoft Windows Server 2012 R2 Datacenter '
             :OperatingSystemVersion: 6.3.9600
             :DVDDrives: F:;G:;
@@ -194,8 +194,8 @@
             :LiveMigrationMaximum: 2
             :LiveStorageMigrationMaximum: 2
             :UseAnyMigrationSubnet: false
-            :MigrationSubnet: &36 []
-            :MigrationSubnetUserManaged: &37 []
+            :MigrationSubnet: &73 []
+            :MigrationSubnetUserManaged: &74 []
             :MigrationAuthProtocol: CredSSP
             :MigrationPerformanceOption: UseCompression
             :SslTcpPort: 5985
@@ -219,7 +219,7 @@
             :MaximumMemoryPerVM: 1048576
             :MinimumMemoryPerVM: 32
             :SuggestedMaximumMemoryPerVM: 512
-            :ModifiedTime: 2016-02-23 12:32:07.928791500 -05:00
+            :ModifiedTime: 2016-02-29 19:53:09.520876000 -05:00
             :Agent: dell-r410-03.cloudformswin.lab.redhat.com
             :ManagedComputer: dell-r410-03.cloudformswin.lab.redhat.com
             :VMs:
@@ -268,10 +268,10 @@
             :RemoteStorageTotalCapacity: 0
             :RemoteStorageAvailableCapacity: 0
             :LocalStorageTotalCapacity: 300000000000
-            :LocalStorageAvailableCapacity: 264916131840
+            :LocalStorageAvailableCapacity: 267277864960
             :TotalStorageCapacity: 300000000000
-            :AvailableStorageCapacity: 264916131840
-            :UsedStorageCapacity: 35083868160
+            :AvailableStorageCapacity: 267277864960
+            :UsedStorageCapacity: 32722135040
             :IsDedicatedToNetworkVirtualizationGateway: false
             :FibreChannelWorldWidePortNameMinimum: C003FF3CB93B0000
             :FibreChannelWorldWidePortNameMaximum: C003FF3CB93BFFFF
@@ -301,7 +301,7 @@
             :ObjectType: VMHost
             :MarkedForDeletion: false
             :IsFullyCached: true
-            :MostRecentTaskIfLocal: Change properties of virtual machine host
+            :MostRecentTaskIfLocal: Refresh Performance Data
           :MS:
             :FQDN: dell-r410-03.cloudformswin.lab.redhat.com
             :LogicalCPUCount: 16
@@ -329,8 +329,8 @@
             :Signature: 2866457588
             :UniqueID: '2866457588'
             :Capacity: 300000000000
-            :AvailableCapacity: 264916131840
-            :PhysicallyAvailableCapacity: 264918546432
+            :AvailableCapacity: 267277864960
+            :PhysicallyAvailableCapacity: 267280279552
             :DeviceID: "\\\\.\\PHYSICALDRIVE0"
             :Index: 0
             :IsClustered: false
@@ -414,7 +414,7 @@
             :DatabaseServerName: DEV-win2k12sql
             :DatabaseInstanceName: DEV-win2k12sql
             :DatabaseName: VirtualManagerDB
-            :ConnectedUserName: CLOUDFORMSWIN\Administrator
+            :ConnectedUserName: CLOUDFORMSWIN\scvmm
             :ConnectedUserGroups: *6
             :UserName: Windows User
             :CompanyName: Red Hat - Cloudforms
@@ -453,7 +453,7 @@
         :MountPoints:
         - C:\
         :Capacity: 499738734592
-        :FreeSpace: 467535630336
+        :FreeSpace: 463193792512
         :VolumeLabel: 
         :FileSystem: 
         :IsSANMigrationPossible: false
@@ -464,9 +464,9 @@
           :ToString: dell-r410-01.cloudformswin.lab.redhat.com
           :Props:
             :RunAsAccount: 
-            :MostRecentTaskID: ce27e33b-e181-4c0c-b961-99d3dec067be
-            :MostRecentTaskUIState: Completed
-            :MostRecentTask: Refresh host
+            :MostRecentTaskID: 06be14e2-b6f3-4f53-a7e6-1124908f1d2c
+            :MostRecentTaskUIState: Failed
+            :MostRecentTask: Refresh Performance Data
             :OverallStateString: OK
             :OverallState: OK
             :CommunicationStateString: Responding
@@ -483,9 +483,9 @@
             :DiskSpaceReserveMB: 10240
             :MaxDiskIOReservation: 10000
             :MemoryReserveMB: 2048
-            :VMPaths: &26
+            :VMPaths: &54
             - C:\ProgramData\Microsoft\Windows\Hyper-V
-            :BaseDiskPaths: &27 []
+            :BaseDiskPaths: &55 []
             :PROEnabled: false
             :MaintenanceHost: false
             :AvailableForPlacement: true
@@ -505,7 +505,7 @@
             :ProcessorFamily: '179'
             :CpuUtilization: 0
             :TotalMemory: 137425408000
-            :AvailableMemory: 127763
+            :AvailableMemory: 127532
             :OperatingSystem: 'Microsoft Windows Server 2012 R2 Datacenter '
             :OperatingSystemVersion: 6.3.9600
             :DVDDrives: F:;G:;
@@ -530,8 +530,8 @@
             :LiveMigrationMaximum: 2
             :LiveStorageMigrationMaximum: 2
             :UseAnyMigrationSubnet: true
-            :MigrationSubnet: &28 []
-            :MigrationSubnetUserManaged: &29 []
+            :MigrationSubnet: &56 []
+            :MigrationSubnetUserManaged: &57 []
             :MigrationAuthProtocol: CredSSP
             :MigrationPerformanceOption: UseCompression
             :SslTcpPort: 5985
@@ -555,10 +555,11 @@
             :MaximumMemoryPerVM: 1048576
             :MinimumMemoryPerVM: 32
             :SuggestedMaximumMemoryPerVM: 512
-            :ModifiedTime: 2016-02-23 12:35:47.701376000 -05:00
+            :ModifiedTime: 2016-02-29 19:51:46.917145200 -05:00
             :Agent: dell-r410-01.cloudformswin.lab.redhat.com
             :ManagedComputer: dell-r410-01.cloudformswin.lab.redhat.com
-            :VMs: []
+            :VMs:
+            - testing_provisioning
             :Disks:
             - "\\\\.\\PHYSICALDRIVE1"
             - "\\\\.\\PHYSICALDRIVE0"
@@ -602,10 +603,10 @@
             :RemoteStorageTotalCapacity: 0
             :RemoteStorageAvailableCapacity: 0
             :LocalStorageTotalCapacity: 500107862016
-            :LocalStorageAvailableCapacity: 467611275264
+            :LocalStorageAvailableCapacity: 463269437440
             :TotalStorageCapacity: 500107862016
-            :AvailableStorageCapacity: 467611275264
-            :UsedStorageCapacity: 32496586752
+            :AvailableStorageCapacity: 463269437440
+            :UsedStorageCapacity: 36838424576
             :IsDedicatedToNetworkVirtualizationGateway: false
             :FibreChannelWorldWidePortNameMinimum: C003FF831E9E0000
             :FibreChannelWorldWidePortNameMaximum: C003FF831E9EFFFF
@@ -634,7 +635,7 @@
             :ObjectType: VMHost
             :MarkedForDeletion: false
             :IsFullyCached: true
-            :MostRecentTaskIfLocal: Refresh host
+            :MostRecentTaskIfLocal: Refresh Performance Data
           :MS:
             :FQDN: dell-r410-01.cloudformswin.lab.redhat.com
             :LogicalCPUCount: 16
@@ -661,8 +662,8 @@
             :Signature: 29360191
             :UniqueID: '29360191'
             :Capacity: 500107862016
-            :AvailableCapacity: 467611275264
-            :PhysicallyAvailableCapacity: 467613405184
+            :AvailableCapacity: 463269437440
+            :PhysicallyAvailableCapacity: 463271567360
             :DeviceID: "\\\\.\\PHYSICALDRIVE0"
             :Index: 0
             :IsClustered: false
@@ -704,7 +705,768 @@
           :I32: 10
         :MarkedForDeletion: false
         :IsFullyCached: true
-  :clusters: {}
+  :clusters:
+    :d9a2261c-7c46-4e0f-83c1-44d779d71594:
+      :Properties:
+        :ToString: CFME-ESX55-Cluster
+        :Props:
+          :Name: CFME-ESX55-Cluster
+          :ClusterName: CFME-ESX55-Cluster
+          :DomainName: 
+          :Description: 
+          :HostGroup: &13
+            :ToString: All Hosts
+            :Props:
+              :IsRoot: true
+              :CreationDate: 2016-01-20 15:45:54.683000000 -05:00
+              :Creator: 
+              :Description: 
+              :ModificationDate: 2016-01-20 15:45:54.683000000 -05:00
+              :ModifiedBy: 
+              :Name: All Hosts
+              :ParentVMHostGroup: 
+              :ParentHostGroup: 
+              :Path: All Hosts
+              :Hosts:
+              - *1
+              - *10
+              - cfme-esx-55-03
+              - cfme-esx-55-02
+              - cfme-esx-55-01
+              - cfme-esx-55-04
+              :AllChildHosts:
+              - *1
+              - *10
+              - cfme-esx-55-03
+              - cfme-esx-55-02
+              - cfme-esx-55-01
+              - cfme-esx-55-04
+              :AllChildGroups: []
+              :ChildGroups: []
+              :CustomProperty: {}
+              :AllChildClusters:
+              - CFME-ESX55-Cluster
+              :ChildClusters:
+              - CFME-ESX55-Cluster
+              :IsUnencryptedFileTransferEnabled: false
+              :InheritNetworkSettings: false
+              :AllocatedLogicalUnitTotalCapacity: 0
+              :AllocatedLogicalUnitAvailableCapacity: 0
+              :HostRemoteStorageTotalCapacity: 0
+              :HostRemoteStorageAvailableCapacity: 0
+              :HostLocalStorageTotalCapacity: 800107862016
+              :HostLocalStorageAvailableCapacity: 730547302400
+              :AvailableLogicalUnitCount: 0
+              :ServerConnection: *8
+              :ID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
+              :IsViewOnly: false
+              :ObjectType: VMHostGroup
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+            :MS:
+              :AllowUnencryptedTransfers: false
+          :ClusterReserve: 1
+          :ClusterReserveState:
+            :ToString: Unknown
+            :I32: 2
+          :ClusterReserveDetails: 
+          :CustomProperty: {}
+          :IsVMwareHAEnabled: false
+          :IsVMwareDrsEnabled: false
+          :AvailableStorageNode: 
+          :Nodes:
+          - &31
+            :ToString: cfme-esx-55-03
+            :Props:
+              :RunAsAccount: ESX Admin
+              :MostRecentTaskID: 8b7045ef-e923-4ee4-85fa-6a26eaf3a8dd
+              :MostRecentTaskUIState: Failed
+              :MostRecentTask: Add virtual machine host
+              :OverallStateString: Adding...
+              :OverallState: Adding
+              :CommunicationStateString: Connecting...
+              :CommunicationState: Connecting
+              :Name: cfme-esx-55-03
+              :FullyQualifiedDomainName: cfme-esx-55-03
+              :ComputerName: cfme-esx-55-03
+              :DomainName: cfme-esx-55-03
+              :Description: 
+              :RemoteUserName: localhost\root
+              :OverrideHostGroupReserves: false
+              :CPUPercentageReserve: 10
+              :NetworkPercentageReserve: 0
+              :DiskSpaceReserveMB: 10240
+              :MaxDiskIOReservation: 10000
+              :MemoryReserveMB: 2048
+              :VMPaths: &29 []
+              :BaseDiskPaths: &30 []
+              :PROEnabled: false
+              :MaintenanceHost: false
+              :AvailableForPlacement: true
+              :IsEmbedded: false
+              :CredentialsNeeded: true
+              :PausedForNetworkIncompatibility: false
+              :LogicalProcessorCount: 0
+              :PhysicalCPUCount: 0
+              :CoresPerCPU: 0
+              :L2CacheSize: 0
+              :L3CacheSize: 0
+              :BusSpeed: 0
+              :ProcessorSpeed: 0
+              :ProcessorModel: 
+              :ProcessorManufacturer: 
+              :ProcessorArchitecture: 0
+              :ProcessorFamily: 
+              :CpuUtilization: 0
+              :TotalMemory: 0
+              :AvailableMemory: 0
+              :OperatingSystem: Unknown
+              :OperatingSystemVersion: '0.0'
+              :DVDDrives: 
+              :DVDDriveList: []
+              :VirtualizationPlatformString: VMware ESX Server
+              :VirtualizationPlatform: VMWareESX
+              :VirtualizationPlatformDetail: VMware ESX Server
+              :IsVirtualizationSoftwareDetailUnknown: false
+              :IsViridianHost: false
+              :SupportsLiveMigration: false
+              :FloppyDrives: 
+              :FloppyDriveList: []
+              :VMHostGroup: *13
+              :HostCluster: CFME-ESX55-Cluster
+              :RemoteConnectEnabled: true
+              :RemoteConnectPort: 5900
+              :SecureRemoteConnectEnabled: false
+              :VMRCCertificateAvailable: false
+              :EnableLiveMigration: false
+              :LiveMigrationMaximum: 0
+              :LiveStorageMigrationMaximum: 0
+              :UseAnyMigrationSubnet: false
+              :MigrationSubnet: &37 []
+              :MigrationSubnetUserManaged: &38 []
+              :MigrationAuthProtocol: CredSSP
+              :MigrationPerformanceOption: Standard
+              :SslTcpPort: 443
+              :SslCertificateHash: 
+              :SshTcpPort: 22
+              :SshPublicKeyHash: 
+              :SshPublicKey: 
+              :IsRemoteFXRoleInstalled: false
+              :IsCPUSLAT: false
+              :IsNumaSpanningEnabled: 
+              :GPUMemoryTotalMB: 
+              :GPUMemoryAvailableMB: 
+              :ClusterNodeStatus: Unknown
+              :TimeZone: 
+              :HyperVState: Unknown
+              :HyperVStateString: Unknown
+              :HyperVVersion: '0.0'
+              :HyperVVersionState: UpToDate
+              :PerimeterNetworkHost: false
+              :NonTrustedDomainHost: false
+              :MaximumMemoryPerVM: 0
+              :MinimumMemoryPerVM: 0
+              :SuggestedMaximumMemoryPerVM: 0
+              :ModifiedTime: 2016-02-24 11:48:26.253000000 -05:00
+              :Agent: cfme-esx-55-03
+              :ManagedComputer: cfme-esx-55-03
+              :VMs: []
+              :Disks: []
+              :GPUs: []
+              :InstalledVirtualSwitchExtensions: []
+              :DiskVolumes: []
+              :RegisteredStorageFileShares: []
+              :FibreChannelHbas: []
+              :FibreChannelVirtualSANs: []
+              :SASHbas: []
+              :InternetSCSIHbas: []
+              :VMwareResourcePool: 
+              :IsConfiguredForOutOfBandManagement: false
+              :PhysicalMachine: 
+              :HealthMonitors: []
+              :RemoteStorageTotalCapacity: 0
+              :RemoteStorageAvailableCapacity: 0
+              :LocalStorageTotalCapacity: 0
+              :LocalStorageAvailableCapacity: 0
+              :TotalStorageCapacity: 0
+              :AvailableStorageCapacity: 0
+              :UsedStorageCapacity: 0
+              :IsDedicatedToNetworkVirtualizationGateway: false
+              :FibreChannelWorldWidePortNameMinimum: 
+              :FibreChannelWorldWidePortNameMaximum: 
+              :FibreChannelWorldWideNodeName: 
+              :VMConnectCertificateThumbprint: 
+              :Custom1: 
+              :Custom2: 
+              :Custom3: 
+              :Custom4: 
+              :Custom5: 
+              :Custom6: 
+              :Custom7: 
+              :Custom8: 
+              :Custom9: 
+              :Custom10: 
+              :CustomProperty: {}
+              :FibreChannelSANStatus: SANNotConfigured (1245)
+              :ISCSISANStatus: SANNotConfigured (1245)
+              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
+              :CertificateRequest: 
+              :ComputerState: Adding
+              :VirtualizationManager: 
+              :ServerConnection: *8
+              :ID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
+              :IsViewOnly: false
+              :ObjectType: VMHost
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: Add virtual machine host
+            :MS:
+              :FQDN: cfme-esx-55-03
+              :LogicalCPUCount: 0
+              :CPUSpeed: 0
+              :CPUModel: 
+              :CPUManufacturer: 
+              :CPUArchitecture: 0
+              :CPUFamily: 
+              :VMRCEnabled: true
+              :VMRCPort: 5900
+              :SecureVMRCEnabled: false
+              :VirtualServerState: Unknown
+              :VirtualServerStateString: Unknown
+              :VirtualServerVersion: '0.0'
+              :VirtualServerVersionState: UpToDate
+              :ServicingWindows: *9
+          - &32
+            :ToString: cfme-esx-55-02
+            :Props:
+              :RunAsAccount: ESX Admin
+              :MostRecentTaskID: af5b8a7e-da60-4b62-837c-c1e876328410
+              :MostRecentTaskUIState: Failed
+              :MostRecentTask: Add virtual machine host
+              :OverallStateString: Adding...
+              :OverallState: Adding
+              :CommunicationStateString: Connecting...
+              :CommunicationState: Connecting
+              :Name: cfme-esx-55-02
+              :FullyQualifiedDomainName: cfme-esx-55-02
+              :ComputerName: cfme-esx-55-02
+              :DomainName: cfme-esx-55-02
+              :Description: 
+              :RemoteUserName: localhost\root
+              :OverrideHostGroupReserves: false
+              :CPUPercentageReserve: 10
+              :NetworkPercentageReserve: 0
+              :DiskSpaceReserveMB: 10240
+              :MaxDiskIOReservation: 10000
+              :MemoryReserveMB: 2048
+              :VMPaths: &48 []
+              :BaseDiskPaths: &49 []
+              :PROEnabled: false
+              :MaintenanceHost: false
+              :AvailableForPlacement: true
+              :IsEmbedded: false
+              :CredentialsNeeded: true
+              :PausedForNetworkIncompatibility: false
+              :LogicalProcessorCount: 0
+              :PhysicalCPUCount: 0
+              :CoresPerCPU: 0
+              :L2CacheSize: 0
+              :L3CacheSize: 0
+              :BusSpeed: 0
+              :ProcessorSpeed: 0
+              :ProcessorModel: 
+              :ProcessorManufacturer: 
+              :ProcessorArchitecture: 0
+              :ProcessorFamily: 
+              :CpuUtilization: 0
+              :TotalMemory: 0
+              :AvailableMemory: 0
+              :OperatingSystem: Unknown
+              :OperatingSystemVersion: '0.0'
+              :DVDDrives: 
+              :DVDDriveList: []
+              :VirtualizationPlatformString: VMware ESX Server
+              :VirtualizationPlatform: VMWareESX
+              :VirtualizationPlatformDetail: VMware ESX Server
+              :IsVirtualizationSoftwareDetailUnknown: false
+              :IsViridianHost: false
+              :SupportsLiveMigration: false
+              :FloppyDrives: 
+              :FloppyDriveList: []
+              :VMHostGroup: *13
+              :HostCluster: CFME-ESX55-Cluster
+              :RemoteConnectEnabled: true
+              :RemoteConnectPort: 5900
+              :SecureRemoteConnectEnabled: false
+              :VMRCCertificateAvailable: false
+              :EnableLiveMigration: false
+              :LiveMigrationMaximum: 0
+              :LiveStorageMigrationMaximum: 0
+              :UseAnyMigrationSubnet: false
+              :MigrationSubnet: &50 []
+              :MigrationSubnetUserManaged: &51 []
+              :MigrationAuthProtocol: CredSSP
+              :MigrationPerformanceOption: Standard
+              :SslTcpPort: 443
+              :SslCertificateHash: 
+              :SshTcpPort: 22
+              :SshPublicKeyHash: 
+              :SshPublicKey: 
+              :IsRemoteFXRoleInstalled: false
+              :IsCPUSLAT: false
+              :IsNumaSpanningEnabled: 
+              :GPUMemoryTotalMB: 
+              :GPUMemoryAvailableMB: 
+              :ClusterNodeStatus: Unknown
+              :TimeZone: 
+              :HyperVState: Unknown
+              :HyperVStateString: Unknown
+              :HyperVVersion: '0.0'
+              :HyperVVersionState: UpToDate
+              :PerimeterNetworkHost: false
+              :NonTrustedDomainHost: false
+              :MaximumMemoryPerVM: 0
+              :MinimumMemoryPerVM: 0
+              :SuggestedMaximumMemoryPerVM: 0
+              :ModifiedTime: 2016-02-24 11:48:27.520000000 -05:00
+              :Agent: cfme-esx-55-02
+              :ManagedComputer: cfme-esx-55-02
+              :VMs: []
+              :Disks: []
+              :GPUs: []
+              :InstalledVirtualSwitchExtensions: []
+              :DiskVolumes: []
+              :RegisteredStorageFileShares: []
+              :FibreChannelHbas: []
+              :FibreChannelVirtualSANs: []
+              :SASHbas: []
+              :InternetSCSIHbas: []
+              :VMwareResourcePool: 
+              :IsConfiguredForOutOfBandManagement: false
+              :PhysicalMachine: 
+              :HealthMonitors: []
+              :RemoteStorageTotalCapacity: 0
+              :RemoteStorageAvailableCapacity: 0
+              :LocalStorageTotalCapacity: 0
+              :LocalStorageAvailableCapacity: 0
+              :TotalStorageCapacity: 0
+              :AvailableStorageCapacity: 0
+              :UsedStorageCapacity: 0
+              :IsDedicatedToNetworkVirtualizationGateway: false
+              :FibreChannelWorldWidePortNameMinimum: 
+              :FibreChannelWorldWidePortNameMaximum: 
+              :FibreChannelWorldWideNodeName: 
+              :VMConnectCertificateThumbprint: 
+              :Custom1: 
+              :Custom2: 
+              :Custom3: 
+              :Custom4: 
+              :Custom5: 
+              :Custom6: 
+              :Custom7: 
+              :Custom8: 
+              :Custom9: 
+              :Custom10: 
+              :CustomProperty: {}
+              :FibreChannelSANStatus: SANNotConfigured (1245)
+              :ISCSISANStatus: SANNotConfigured (1245)
+              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
+              :CertificateRequest: 
+              :ComputerState: Adding
+              :VirtualizationManager: 
+              :ServerConnection: *8
+              :ID: d4c780ae-2251-44f7-b624-111bd25e7400
+              :IsViewOnly: false
+              :ObjectType: VMHost
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: Add virtual machine host
+            :MS:
+              :FQDN: cfme-esx-55-02
+              :LogicalCPUCount: 0
+              :CPUSpeed: 0
+              :CPUModel: 
+              :CPUManufacturer: 
+              :CPUArchitecture: 0
+              :CPUFamily: 
+              :VMRCEnabled: true
+              :VMRCPort: 5900
+              :SecureVMRCEnabled: false
+              :VirtualServerState: Unknown
+              :VirtualServerStateString: Unknown
+              :VirtualServerVersion: '0.0'
+              :VirtualServerVersionState: UpToDate
+              :ServicingWindows: *9
+          - &33
+            :ToString: cfme-esx-55-01
+            :Props:
+              :RunAsAccount: ESX Admin
+              :MostRecentTaskID: 3180e43e-d149-41d9-a868-4fcafe80b680
+              :MostRecentTaskUIState: Failed
+              :MostRecentTask: Add virtual machine host
+              :OverallStateString: Adding...
+              :OverallState: Adding
+              :CommunicationStateString: Connecting...
+              :CommunicationState: Connecting
+              :Name: cfme-esx-55-01
+              :FullyQualifiedDomainName: cfme-esx-55-01
+              :ComputerName: cfme-esx-55-01
+              :DomainName: cfme-esx-55-01
+              :Description: 
+              :RemoteUserName: localhost\root
+              :OverrideHostGroupReserves: false
+              :CPUPercentageReserve: 10
+              :NetworkPercentageReserve: 0
+              :DiskSpaceReserveMB: 10240
+              :MaxDiskIOReservation: 10000
+              :MemoryReserveMB: 2048
+              :VMPaths: &101 []
+              :BaseDiskPaths: &102 []
+              :PROEnabled: false
+              :MaintenanceHost: false
+              :AvailableForPlacement: true
+              :IsEmbedded: false
+              :CredentialsNeeded: true
+              :PausedForNetworkIncompatibility: false
+              :LogicalProcessorCount: 0
+              :PhysicalCPUCount: 0
+              :CoresPerCPU: 0
+              :L2CacheSize: 0
+              :L3CacheSize: 0
+              :BusSpeed: 0
+              :ProcessorSpeed: 0
+              :ProcessorModel: 
+              :ProcessorManufacturer: 
+              :ProcessorArchitecture: 0
+              :ProcessorFamily: 
+              :CpuUtilization: 0
+              :TotalMemory: 0
+              :AvailableMemory: 0
+              :OperatingSystem: Unknown
+              :OperatingSystemVersion: '0.0'
+              :DVDDrives: 
+              :DVDDriveList: []
+              :VirtualizationPlatformString: VMware ESX Server
+              :VirtualizationPlatform: VMWareESX
+              :VirtualizationPlatformDetail: VMware ESX Server
+              :IsVirtualizationSoftwareDetailUnknown: false
+              :IsViridianHost: false
+              :SupportsLiveMigration: false
+              :FloppyDrives: 
+              :FloppyDriveList: []
+              :VMHostGroup: *13
+              :HostCluster: CFME-ESX55-Cluster
+              :RemoteConnectEnabled: true
+              :RemoteConnectPort: 5900
+              :SecureRemoteConnectEnabled: false
+              :VMRCCertificateAvailable: false
+              :EnableLiveMigration: false
+              :LiveMigrationMaximum: 0
+              :LiveStorageMigrationMaximum: 0
+              :UseAnyMigrationSubnet: false
+              :MigrationSubnet: &103 []
+              :MigrationSubnetUserManaged: &104 []
+              :MigrationAuthProtocol: CredSSP
+              :MigrationPerformanceOption: Standard
+              :SslTcpPort: 443
+              :SslCertificateHash: 
+              :SshTcpPort: 22
+              :SshPublicKeyHash: 
+              :SshPublicKey: 
+              :IsRemoteFXRoleInstalled: false
+              :IsCPUSLAT: false
+              :IsNumaSpanningEnabled: 
+              :GPUMemoryTotalMB: 
+              :GPUMemoryAvailableMB: 
+              :ClusterNodeStatus: Unknown
+              :TimeZone: 
+              :HyperVState: Unknown
+              :HyperVStateString: Unknown
+              :HyperVVersion: '0.0'
+              :HyperVVersionState: UpToDate
+              :PerimeterNetworkHost: false
+              :NonTrustedDomainHost: false
+              :MaximumMemoryPerVM: 0
+              :MinimumMemoryPerVM: 0
+              :SuggestedMaximumMemoryPerVM: 0
+              :ModifiedTime: 2016-02-24 11:48:23.407000000 -05:00
+              :Agent: cfme-esx-55-01
+              :ManagedComputer: cfme-esx-55-01
+              :VMs: []
+              :Disks: []
+              :GPUs: []
+              :InstalledVirtualSwitchExtensions: []
+              :DiskVolumes: []
+              :RegisteredStorageFileShares: []
+              :FibreChannelHbas: []
+              :FibreChannelVirtualSANs: []
+              :SASHbas: []
+              :InternetSCSIHbas: []
+              :VMwareResourcePool: 
+              :IsConfiguredForOutOfBandManagement: false
+              :PhysicalMachine: 
+              :HealthMonitors: []
+              :RemoteStorageTotalCapacity: 0
+              :RemoteStorageAvailableCapacity: 0
+              :LocalStorageTotalCapacity: 0
+              :LocalStorageAvailableCapacity: 0
+              :TotalStorageCapacity: 0
+              :AvailableStorageCapacity: 0
+              :UsedStorageCapacity: 0
+              :IsDedicatedToNetworkVirtualizationGateway: false
+              :FibreChannelWorldWidePortNameMinimum: 
+              :FibreChannelWorldWidePortNameMaximum: 
+              :FibreChannelWorldWideNodeName: 
+              :VMConnectCertificateThumbprint: 
+              :Custom1: 
+              :Custom2: 
+              :Custom3: 
+              :Custom4: 
+              :Custom5: 
+              :Custom6: 
+              :Custom7: 
+              :Custom8: 
+              :Custom9: 
+              :Custom10: 
+              :CustomProperty: {}
+              :FibreChannelSANStatus: SANNotConfigured (1245)
+              :ISCSISANStatus: SANNotConfigured (1245)
+              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
+              :CertificateRequest: 
+              :ComputerState: Adding
+              :VirtualizationManager: 
+              :ServerConnection: *8
+              :ID: 529da423-9493-4a00-9634-37c83dc1fe0e
+              :IsViewOnly: false
+              :ObjectType: VMHost
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: Add virtual machine host
+            :MS:
+              :FQDN: cfme-esx-55-01
+              :LogicalCPUCount: 0
+              :CPUSpeed: 0
+              :CPUModel: 
+              :CPUManufacturer: 
+              :CPUArchitecture: 0
+              :CPUFamily: 
+              :VMRCEnabled: true
+              :VMRCPort: 5900
+              :SecureVMRCEnabled: false
+              :VirtualServerState: Unknown
+              :VirtualServerStateString: Unknown
+              :VirtualServerVersion: '0.0'
+              :VirtualServerVersionState: UpToDate
+              :ServicingWindows: *9
+          - &34
+            :ToString: cfme-esx-55-04
+            :Props:
+              :RunAsAccount: ESX Admin
+              :MostRecentTaskID: 1a5ce85a-e208-4da0-a9a7-8374846fc94a
+              :MostRecentTaskUIState: Failed
+              :MostRecentTask: Add virtual machine host
+              :OverallStateString: Adding...
+              :OverallState: Adding
+              :CommunicationStateString: Connecting...
+              :CommunicationState: Connecting
+              :Name: cfme-esx-55-04
+              :FullyQualifiedDomainName: cfme-esx-55-04
+              :ComputerName: cfme-esx-55-04
+              :DomainName: cfme-esx-55-04
+              :Description: 
+              :RemoteUserName: localhost\root
+              :OverrideHostGroupReserves: false
+              :CPUPercentageReserve: 10
+              :NetworkPercentageReserve: 0
+              :DiskSpaceReserveMB: 10240
+              :MaxDiskIOReservation: 10000
+              :MemoryReserveMB: 2048
+              :VMPaths: &41 []
+              :BaseDiskPaths: &42 []
+              :PROEnabled: false
+              :MaintenanceHost: false
+              :AvailableForPlacement: true
+              :IsEmbedded: false
+              :CredentialsNeeded: true
+              :PausedForNetworkIncompatibility: false
+              :LogicalProcessorCount: 0
+              :PhysicalCPUCount: 0
+              :CoresPerCPU: 0
+              :L2CacheSize: 0
+              :L3CacheSize: 0
+              :BusSpeed: 0
+              :ProcessorSpeed: 0
+              :ProcessorModel: 
+              :ProcessorManufacturer: 
+              :ProcessorArchitecture: 0
+              :ProcessorFamily: 
+              :CpuUtilization: 0
+              :TotalMemory: 0
+              :AvailableMemory: 0
+              :OperatingSystem: Unknown
+              :OperatingSystemVersion: '0.0'
+              :DVDDrives: 
+              :DVDDriveList: []
+              :VirtualizationPlatformString: VMware ESX Server
+              :VirtualizationPlatform: VMWareESX
+              :VirtualizationPlatformDetail: VMware ESX Server
+              :IsVirtualizationSoftwareDetailUnknown: false
+              :IsViridianHost: false
+              :SupportsLiveMigration: false
+              :FloppyDrives: 
+              :FloppyDriveList: []
+              :VMHostGroup: *13
+              :HostCluster: CFME-ESX55-Cluster
+              :RemoteConnectEnabled: true
+              :RemoteConnectPort: 5900
+              :SecureRemoteConnectEnabled: false
+              :VMRCCertificateAvailable: false
+              :EnableLiveMigration: false
+              :LiveMigrationMaximum: 0
+              :LiveStorageMigrationMaximum: 0
+              :UseAnyMigrationSubnet: false
+              :MigrationSubnet: &44 []
+              :MigrationSubnetUserManaged: &45 []
+              :MigrationAuthProtocol: CredSSP
+              :MigrationPerformanceOption: Standard
+              :SslTcpPort: 443
+              :SslCertificateHash: 
+              :SshTcpPort: 22
+              :SshPublicKeyHash: 
+              :SshPublicKey: 
+              :IsRemoteFXRoleInstalled: false
+              :IsCPUSLAT: false
+              :IsNumaSpanningEnabled: 
+              :GPUMemoryTotalMB: 
+              :GPUMemoryAvailableMB: 
+              :ClusterNodeStatus: Unknown
+              :TimeZone: 
+              :HyperVState: Unknown
+              :HyperVStateString: Unknown
+              :HyperVVersion: '0.0'
+              :HyperVVersionState: UpToDate
+              :PerimeterNetworkHost: false
+              :NonTrustedDomainHost: false
+              :MaximumMemoryPerVM: 0
+              :MinimumMemoryPerVM: 0
+              :SuggestedMaximumMemoryPerVM: 0
+              :ModifiedTime: 2016-02-24 11:48:22.863000000 -05:00
+              :Agent: cfme-esx-55-04
+              :ManagedComputer: cfme-esx-55-04
+              :VMs: []
+              :Disks: []
+              :GPUs: []
+              :InstalledVirtualSwitchExtensions: []
+              :DiskVolumes: []
+              :RegisteredStorageFileShares: []
+              :FibreChannelHbas: []
+              :FibreChannelVirtualSANs: []
+              :SASHbas: []
+              :InternetSCSIHbas: []
+              :VMwareResourcePool: 
+              :IsConfiguredForOutOfBandManagement: false
+              :PhysicalMachine: 
+              :HealthMonitors: []
+              :RemoteStorageTotalCapacity: 0
+              :RemoteStorageAvailableCapacity: 0
+              :LocalStorageTotalCapacity: 0
+              :LocalStorageAvailableCapacity: 0
+              :TotalStorageCapacity: 0
+              :AvailableStorageCapacity: 0
+              :UsedStorageCapacity: 0
+              :IsDedicatedToNetworkVirtualizationGateway: false
+              :FibreChannelWorldWidePortNameMinimum: 
+              :FibreChannelWorldWidePortNameMaximum: 
+              :FibreChannelWorldWideNodeName: 
+              :VMConnectCertificateThumbprint: 
+              :Custom1: 
+              :Custom2: 
+              :Custom3: 
+              :Custom4: 
+              :Custom5: 
+              :Custom6: 
+              :Custom7: 
+              :Custom8: 
+              :Custom9: 
+              :Custom10: 
+              :CustomProperty: {}
+              :FibreChannelSANStatus: SANNotConfigured (1245)
+              :ISCSISANStatus: SANNotConfigured (1245)
+              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
+              :CertificateRequest: 
+              :ComputerState: Adding
+              :VirtualizationManager: 
+              :ServerConnection: *8
+              :ID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
+              :IsViewOnly: false
+              :ObjectType: VMHost
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: Add virtual machine host
+            :MS:
+              :FQDN: cfme-esx-55-04
+              :LogicalCPUCount: 0
+              :CPUSpeed: 0
+              :CPUModel: 
+              :CPUManufacturer: 
+              :CPUArchitecture: 0
+              :CPUFamily: 
+              :VMRCEnabled: true
+              :VMRCPort: 5900
+              :SecureVMRCEnabled: false
+              :VirtualServerState: Unknown
+              :VirtualServerStateString: Unknown
+              :VirtualServerVersion: '0.0'
+              :VirtualServerVersionState: UpToDate
+              :ServicingWindows: *9
+          :VMwareResourcePool: 
+          :VirtualizationPlatform:
+            :ToString: VMWareVC
+            :I32: 3
+          :HostGroupID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
+          :AvailableVolumes: []
+          :SharedVolumes: []
+          :RegisteredStorageFileShares: []
+          :RefresherErrors: &35 []
+          :IPAddresses: []
+          :QuorumDiskResourceName: 
+          :ValidationResult:
+            :ToString: TestNotRun
+            :I32: 0
+          :ValidationReportPath: 
+          :ClusterCoreResources: &36 []
+          :VMHostManagementCredential: &28
+            :ToString: ESX Admin
+            :Props:
+              :Name: ESX Admin
+              :UserName: root
+              :Domain: 
+              :Enabled: true
+              :IsBuiltIn: false
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CLOUDFORMSWIN\scvmm
+              :ObjectType: RunAsAccount
+              :Accessibility: Public
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-29 19:59:13.064694600 -05:00
+              :ModifiedTime: 2016-02-29 19:59:13.064694600 -05:00
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: 6722367d-8042-4db3-8428-55d26ad142d2
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ServerConnection: *8
+          :ID: d9a2261c-7c46-4e0f-83c1-44d779d71594
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: HostCluster
+            :I32: 13
+          :MarkedForDeletion: false
+          :IsFullyCached: true
   :images:
     :e8aae9d0-55af-4f72-b357-265b8fdd23e4:
       :Properties:
@@ -754,7 +1516,7 @@
             :I32: 2
           :Location: 
           :CreationTime: 2016-02-22 11:51:22.789125800 -05:00
-          :OperatingSystem: &15
+          :OperatingSystem: &16
             :ToString: Unknown
             :Props:
               :Name: Unknown
@@ -867,7 +1629,7 @@
           - 
           :CustomProperty: {}
           :UndoDisksEnabled: false
-          :CPUType: &14
+          :CPUType: &15
             :ToString: 3.60 GHz Xeon (2 MB L2 cache)
             :Props:
               :Name: 3.60 GHz Xeon (2 MB L2 cache)
@@ -915,7 +1677,7 @@
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualHardDisks:
-          - &13
+          - &14
             :ToString: Blank Disk - Small.vhd
             :Props:
               :OperatingSystem: None
@@ -977,7 +1739,7 @@
           - :ToString: linux_template
             :Props:
               :VirtualHardDiskId: 6507ebf8-257b-415e-8469-0bb5835f5e1e
-              :VirtualHardDisk: *13
+              :VirtualHardDisk: *14
               :PassThroughDisk: 
               :IsVHD: true
               :HasSharedStorage: false
@@ -1133,7 +1895,7 @@
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :CapabilityProfile: &17
+          :CapabilityProfile: &23
             :ToString: Hyper-V
             :Props:
               :Name: Hyper-V
@@ -1383,14 +2145,14 @@
           :VMNetwork: 
       :DVDs: *9
   :vms:
-    :c4425913-7043-4d2a-a229-75f051a8127b:
+    :6673f40b-0706-4170-92a6-5fcb4d9846f6:
       :Properties:
-        :ToString: linux2
+        :ToString: vm_linux1
         :Props:
-          :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2\Virtual Machines\95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84.xml
+          :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\Virtual Machines\FDA2093A-D44F-40A1-BB8C-0F90FCDC1528.xml
           :MarkedAsTemplate: false
           :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-          :VMId: 95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84
+          :VMId: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
           :VMResourceGroup: 
           :VMConfigResource: 
           :VMConfigResourceStatus:
@@ -1400,8 +2162,8 @@
           :VMResourceStatus:
             :ToString: ClusterResourceStateUnknown
             :I32: -1
-          :DiskResources: &50 []
-          :UnsupportedReason: &20
+          :DiskResources: &76 []
+          :UnsupportedReason: &19
             :ToString: Success (0)
             :Props:
               :Exception: 
@@ -1429,7 +2191,667 @@
               :MessageParameters: {}
               :Code: Success
               :GetMessageFormatterHandler: 
-          :RefresherErrors: &51 []
+          :RefresherErrors: &77 []
+          :VirtualMachineState:
+            :ToString: Running
+            :I32: 0
+          :HostGroupPath: All Hosts\vm_linux1
+          :TotalSize: 4194304
+          :MemoryAssignedMB: 512
+          :MemoryAvailablePercentage: '0'
+          :DynamicMemoryDemandMB: 512
+          :DynamicMemoryStatus: 
+          :AllocatedGPU: 
+          :HasPassthroughDisk: false
+          :HasSharedStorage: false
+          :Status:
+            :ToString: Running
+            :I32: 0
+          :IsOrphaned: false
+          :HasSavedState: false
+          :StatusString: Running
+          :StartAction:
+            :ToString: NeverAutoTurnOnVM
+            :I32: 0
+          :StopAction:
+            :ToString: SaveVM
+            :I32: 0
+          :RunGuestAccount: 
+          :DelayStart: 0
+          :BiosGuid: 5337594f-94a4-4446-b557-73dba213f6dc
+          :CPUUtilization: 0
+          :PerfCPUUtilization: 0
+          :PerfMemory: 512
+          :PerfDiskBytesRead: 0
+          :PerfDiskBytesWrite: 0
+          :PerfNetworkBytesRead: 0
+          :PerfNetworkBytesWrite: 0
+          :VirtualizationPlatform:
+            :ToString: HyperV
+            :I32: 2
+          :ComputerNameString: Unknown
+          :CreationSource: Temporary Templateae0b700f-8f3f-4709-b7f1-55613f33b0db
+          :IsUndergoingLiveMigration: false
+          :SourceObjectType: VM Template
+          :OperatingSystemShutdownEnabled: true
+          :TimeSynchronizationEnabled: true
+          :DataExchangeEnabled: true
+          :HeartbeatEnabled: true
+          :BackupEnabled: true
+          :ExcludeFromPRO: false
+          :FailedJobID: 
+          :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\
+          :SelfServiceUserRole: 
+          :PassThroughDisks: []
+          :ComputerTier: 
+          :ConnectToAddresses: []
+          :CloudVmRoleId: 
+          :CloudVmRoleName: 
+          :UpgradeDomain: 
+          :SCApplications: []
+          :LastRestoredCheckpointID: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
+          :LastRestoredVMCheckpoint: 
+          :ComplianceStatus: 
+          :IsFaultTolerant: false
+          :DeploymentErrorInfo: 
+          :ServiceDeploymentErrorMessage: 
+          :DeploymentState:
+            :ToString: Undeployed
+            :I32: 0
+          :TieredPerfData: &78
+            :ToString: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+            :Props:
+              :IsViewOnly: false
+              :Name: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+              :ServerConnection: *8
+              :ID: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+              :ObjectType: TieredPerfData
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :TieredCPUUtilization: 0
+              :TieredMemory: 512
+              :TieredDiskBytesRead: 0
+              :TieredDiskBytesWrite: 0
+              :TieredNetworkBytesRead: 0
+              :TieredNetworkBytesWrite: 0
+              :PerfCPUUtilization: 0
+              :PerfMemoryConsumed: 512
+              :PerfMemoryPressurePercent: 100
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :AverageDiskIO: 0
+              :data: "(TieredPerfCounterData#0) { id = 6673f45e-0706-4170-92a6-5fcb4d9846f6
+                }"
+          :ReplicationSetting: 
+          :ReplicationStatus: 
+          :IsRecoveryVM: false
+          :IsPrimaryVM: false
+          :IsTestReplicaVM: false
+          :ReplicationState: 
+          :ReplicationHealth: 
+          :ReplicationMode: 
+          :LastReplicationTime: 
+          :IsDREnabled: false
+          :DRState:
+            :ToString: Disabled
+            :I32: 0
+          :DRErrors: []
+          :HasDRError: false
+          :ClusterNonPossibleOwner: 
+          :ClusterPreferredOwner: 
+          :AvailabilitySetNames: 
+          :LiveCloningEnabled: true
+          :MostRecentTaskID: 9c32c5ad-3d6a-43c5-9c95-120296e147ce
+          :MostRecentTaskUIState:
+            :ToString: Completed
+            :I32: 5
+          :MostRecentTask: &18
+            :ToString: Refresh virtual machine
+            :Props:
+              :StepsLoaded: true
+              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :Description: Refresh virtual machine
+              :IsVisible: true
+              :Status: Completed
+              :StatusString: Completed
+              :ErrorInfo: Success (0)
+              :StartTime: 2016-02-23 19:18:07.963000000 -05:00
+              :EndTime: 2016-02-23 19:18:08.187000000 -05:00
+              :Owner: CLOUDFORMSWIN\scvmm
+              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+              :SessionOwner: CLOUDFORMSWIN\scvmm
+              :Name: Refresh virtual machine
+              :Steps:
+              - Microsoft.SystemCenter.VirtualMachineManager.Step
+              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :ProgressValue: 100
+              :Progress: 100 %
+              :WasNotifiedOfCancel: false
+              :CmdletName: "(Refresh VM - System Job)"
+              :PROTipID: 
+              :ResultObjectID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
+              :TargetObjectID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
+              :TargetObjectType: VM
+              :IsCompleted: true
+              :AreAuditRecordsAvailable: false
+              :AuditRecords: []
+              :AdditionalMessages: []
+              :Source: 
+              :Target: 
+              :ResultObjectType: VM
+              :ResultObjectTypeName: Virtual Machine
+              :ResultName: vm_linux1
+              :IsRestartable: false
+              :IsStoppable: false
+              :ServerConnection: *8
+              :ID: 9c32c5ad-3d6a-43c5-9c95-120296e147ce
+              :IsViewOnly: false
+              :ObjectType: Job
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
+          :CreationTime: 2016-02-01 13:39:24.990000000 -05:00
+          :OperatingSystem: &79
+            :ToString: CentOS Linux 6 (64 bit)
+            :Props:
+              :Name: CentOS Linux 6 (64 bit)
+              :Description: CentOS Linux 6 (64 bit)
+              :Version: 
+              :Architecture: amd64
+              :Edition: 
+              :OSType: Linux
+              :IsWindows: false
+              :ProductType: 
+              :IsCustomizationAllowed: true
+              :IsApplicationDeploymentAllowed: false
+              :RequiresAdministratorAccountNameInSysprep: false
+              :RequiresXMLSysprepFormat: false
+              :AllowsOrgNameInSysprep: false
+              :RequiresPIDInSysprep: true
+              :ServerConnection: *8
+              :ID: a095d4f1-0d8d-4c17-882e-59cfe01cf55b
+              :IsViewOnly: false
+              :ObjectType: OperatingSystem
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :HasVMAdditions: false
+          :VMAddition: Not Detected
+          :NumLockEnabled: false
+          :CPUCount: 1
+          :IsHighlyAvailable: false
+          :HAVMPriority: 
+          :IsDRProtectionRequired: false
+          :RecoveryPointObjective: 
+          :ProtectionProvider: 
+          :ReplicationGroupId: 
+          :ReplicationGroup: 
+          :LimitCPUFunctionality: false
+          :LimitCPUForMigration: false
+          :Memory: 512
+          :DynamicMemoryEnabled: false
+          :DynamicMemoryMaximumMB: 
+          :DynamicMemoryBufferPercentage: 
+          :MemoryWeight: 5000
+          :VirtualVideoAdapterEnabled: false
+          :MonitorMaximumCount: 
+          :MonitorResolutionMaximum: 
+          :BootOrder: &80
+          - :ToString: PxeBoot
+            :I32: 3
+          - :ToString: CD
+            :I32: 1
+          - :ToString: IdeHardDrive
+            :I32: 2
+          - :ToString: Floppy
+            :I32: 0
+          :FirstBootDevice: 
+          :SecureBootEnabled: 
+          :ComputerName: 
+          :UseHardwareAssistedVirtualization: true
+          :SANStatus: &81
+          - :ToString: DeployLUNNotFoundUsingStorageProvider (26207)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 26207
+              :ErrorCodeString: '26207'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : DeployLUNNotFoundUsingStorageProvider
+                ; Message : Virtual Machine vm_linux1 resides on a LUN, which is not
+                visible to any of the storage providers. ; Recommended Action : Ensure
+                that the storage provider is added to Virtual Machine Manager server.
+                Then try the operation again.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: Virtual Machine vm_linux1 resides on a LUN, which is not visible
+                to any of the storage providers.
+              :CloudProblem: Virtual Machine vm_linux1 resides on a LUN, which is
+                not visible to any of the storage providers.
+              :RecommendedAction: Ensure that the storage provider is added to Virtual
+                Machine Manager server. Then try the operation again.
+              :RecommendedActionCLI: Ensure that the storage provider is added to
+                Virtual Machine Manager server. Then try the operation again.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :VMName: vm_linux1
+              :Code: DeployLUNNotFoundUsingStorageProvider
+              :GetMessageFormatterHandler: 
+          :CostCenter: 
+          :QuotaPoint: 1
+          :IsTagEmpty: false
+          :Tag: "(none)"
+          :CustomProperties:
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          :CustomProperty: {}
+          :UndoDisksEnabled: false
+          :CPUType: *15
+          :ExpectedCPUUtilization: 20
+          :DiskIO: 0
+          :NetworkUtilization: 0
+          :RelativeWeight: 100
+          :CPUReserve: 0
+          :CPUMax: 100
+          :CPUPerVirtualNumaNodeMaximum: 4
+          :MemoryPerVirtualNumaNodeMaximumMB: 6062
+          :VirtualNumaNodesPerSocketMaximum: 1
+          :DynamicMemoryMinimumMB: 
+          :NumaIsolationRequired: false
+          :Generation: 1
+          :VirtualDVDDrives:
+          - &82
+            :ToString: vm_linux1
+            :Props:
+              :Connection: HostDrive
+              :ISOId: 
+              :ISO: 
+              :HostDrive: 'F:'
+              :BusType: IDE
+              :Bus: 1
+              :Lun: 0
+              :ISOLinked: false
+              :ObjectType: VirtualDVDDrive
+              :Accessibility: Public
+              :Name: vm_linux1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-01 13:39:25.037000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.480000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: 13e462fb-414b-4251-a3c9-857e1098ef61
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualHardDisks:
+          - &17
+            :ToString: vm_linux1_disk_1
+            :Props:
+              :OperatingSystem: *16
+              :VHDType: DynamicallyExpanding
+              :VHDFormatType: VHDX
+              :VirtualizationPlatform: HyperV
+              :MaximumSize: 42949672960
+              :ParentDisk: 
+              :SANCopyCapable: false
+              :IsCachedVhd: false
+              :ComplianceStatus: 
+              :Tag: 
+              :HasProductKey: false
+              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\vm_linux1_disk_1.vhdx
+              :Release: 
+              :State: Normal
+              :LibraryShareId: 00000000-0000-0000-0000-000000000000
+              :SharePath: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\vm_linux1_disk_1.vhdx
+              :FileShare: 
+              :Directory: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
+              :Size: 4194304
+              :IsOrphaned: false
+              :FamilyName: 
+              :Namespace: 
+              :ReleaseTime: 
+              :HostVolumeId: 284c1ea0-fc51-474a-bbec-372021806117
+              :HostVolume:
+                :S: C:\
+              :Classification: *11
+              :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+              :HostType: VMHost
+              :HostName: dell-r410-03.cloudformswin.lab.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: CLOUDFORMSWIN\scvmm
+              :ObjectType: VirtualHardDisk
+              :Accessibility: Internal
+              :Name: vm_linux1_disk_1
+              :IsViewOnly: false
+              :Description: vm_linux1_disk_1
+              :AddedTime: 2016-02-01 13:39:28.890000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.477000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: 34621bb0-b8e2-4dd2-a6ed-629e75683433
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualDiskDrives:
+          - &83
+            :ToString: vm_linux1
+            :Props:
+              :VirtualHardDiskId: 34621bb0-b8e2-4dd2-a6ed-629e75683433
+              :VirtualHardDisk: *17
+              :PassThroughDisk: 
+              :IsVHD: true
+              :HasSharedStorage: false
+              :CreateDiffDisk: false
+              :BusType: IDE
+              :Bus: 0
+              :Lun: 0
+              :PendingDiskAssociation: false
+              :Classification: *11
+              :VolumeType: BootAndSystem
+              :ObjectType: VirtualDiskDrive
+              :Accessibility: Public
+              :Name: vm_linux1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-01 13:39:28.900000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.477000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: 7aafb2b6-aa59-4831-bca7-30f3a1c17014
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ShareSCSIBus: false
+          :VirtualNetworkAdapters:
+          - &84
+            :ToString: vm_linux1
+            :Props:
+              :SlotId: 0
+              :VirtualNetwork: New Virtual Switch0
+              :VMwarePortGroup: 
+              :MACAddressType: Dynamic
+              :EthernetAddressType: Dynamic
+              :PhysicalAddressType: Dynamic
+              :MACAddress: 00:15:5D:60:19:04
+              :EthernetAddress: 00:15:5D:60:19:04
+              :PhysicalAddress: 00:15:5D:60:19:04
+              :RequiredBandwidth: 0
+              :VirtualNetworkAdapterType: Synthetic
+              :VmwAdapterIndex: 
+              :LogicalNetwork: VM_Network
+              :VMNetwork: VM_Network
+              :VMNetworkServiceSetting: 
+              :VMSubnet: 
+              :PortClassification: 
+              :VirtualNetworkAdapterPortProfileSet: 
+              :LogicalSwitch: 
+              :GuestIPNetworkVirtualizationUpdatesEnabled: false
+              :MACAddressSpoofingEnabled: false
+              :MACAddressesSpoofingEnabled: false
+              :VMNetworkOptimizationEnabled: false
+              :VLanEnabled: false
+              :VLanID: 0
+              :UsesSriov: false
+              :IsUsedForHostManagement: false
+              :VirtualNetworkAdapterComplianceStatus: Compliant
+              :TemplateNicName: 
+              :VirtualNetworkAdapterComplianceErrors: []
+              :PerfNetworkKBytesRead: 0
+              :PerfNetworkKBytesWrite: 0
+              :DeviceID: Microsoft:FDA2093A-D44F-40A1-BB8C-0F90FCDC1528\08F76628-21A6-4D14-989C-AD39F6FD0A02
+              :IPv4AddressType: Dynamic
+              :IPv6AddressType: Dynamic
+              :IPv4Addresses: []
+              :IPv6Addresses: []
+              :PortACL: 
+              :ObjectType: VirtualNetworkAdapter
+              :Accessibility: Public
+              :Name: vm_linux1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-23 11:49:32.300000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.480000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: 1062da4b-4642-4c4a-a10a-29a2bc6130bb
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualFibreChannelAdapters: []
+          :HasVirtualFibreChannelAdapters: false
+          :VirtualFloppyDrive: &85
+            :ToString: vm_linux1
+            :Props:
+              :Connection: None
+              :VirtualFloppyDisk: 
+              :ObjectType: VirtualFloppyDrive
+              :Accessibility: Public
+              :Name: vm_linux1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-01 13:39:25.037000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.480000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: 4a40d2cc-4f72-4fb1-abe0-4b6893994685
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualCOMPorts:
+          - :ToString: COM1
+            :Props:
+              :PortNumber: 1
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM1
+              :ServerConnection: *8
+              :ID: c4d1d097-0643-4965-8d01-ef5fa06ec2b7
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: COM2
+            :Props:
+              :PortNumber: 2
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM2
+              :ServerConnection: *8
+              :ID: 802aea0a-6059-4356-b1a4-6d0f6703e27b
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VirtualSCSIAdapters:
+          - &86
+            :ToString: vm_linux1
+            :Props:
+              :AdapterID: 255
+              :Bus: 0
+              :Shared: false
+              :SCSIControllerType: DefaultTypeNoType
+              :ObjectType: VirtualSCSIAdapter
+              :Accessibility: Public
+              :Name: vm_linux1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-01 13:39:25.043000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.477000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: b4b5b43f-61c4-40ed-9531-035fd2ffdeef
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :CapabilityProfile: 
+          :CapabilityProfileCompatibilityState:
+            :ToString: Compatible
+            :I32: 0
+          :VMCheckpoints: []
+          :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+          :HostType:
+            :ToString: VMHost
+            :I32: 9
+          :HostName: dell-r410-03.cloudformswin.lab.redhat.com
+          :VMHost: *1
+          :LibraryServer: 
+          :CloudId: 
+          :Cloud: 
+          :LibraryGroup: 
+          :GrantedToList: []
+          :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+          :UserRole: *3
+          :Owner: CLOUDFORMSWIN\scvmm
+          :ObjectType:
+            :ToString: VM
+            :I32: 1
+          :Accessibility:
+            :ToString: Public
+            :I32: 0
+          :Name: vm_linux1
+          :IsViewOnly: false
+          :Description: 
+          :AddedTime: 2016-02-01 13:39:24.990000000 -05:00
+          :ModifiedTime: 2016-02-29 19:18:07.470499500 -05:00
+          :Enabled: true
+          :ServerConnection: *8
+          :ID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: *18
+        :MS:
+          :ServicingWindows: *9
+      :Networks: 
+      :vmnet:
+        :MS:
+          :VMNetwork: &22
+            :ToString: VM_Network
+            :Props:
+              :Name: VM_Network
+              :LogicalNetwork: &21
+                :ToString: VM_Network
+                :Props:
+                  :Name: VM_Network
+                  :Description: 
+                  :IsViewOnly: false
+                  :NetworkVirtualizationEnabled: true
+                  :UseGRE: true
+                  :IsPVLAN: false
+                  :SupportsExternalVMNetworkProvisioning: false
+                  :SupportsIPSubnetConfigurationOnExternalVMNetworkDefinitions: false
+                  :SupportsExternalVMNetworkDefinitionCreationWithoutIPSubnets: false
+                  :IsLogicalNetworkDefinitionIsolated: false
+                  :AllowDynamicVlanOnVnic: false
+                  :DefaultNetworkManagerForVMNetworkCreation: 
+                  :ExternalId: ddacb1ce-3450-481e-95be-6ecb1d499020
+                  :LastModifiedByNetworkManager: 
+                  :ExternalSyncTime: 
+                  :ServerConnection: *8
+                  :ID: ddacb1ce-3450-481e-95be-6ecb1d499020
+                  :ObjectType: LogicalNetwork
+                  :MarkedForDeletion: false
+                  :IsFullyCached: true
+              :VMSubnet: []
+              :VMNetworkGateways: []
+              :VPNConnections: []
+              :NATConnections: []
+              :RoutingDomainId: 50fbf692-581f-4742-ae67-41450a4bd8de
+              :IsolationType:
+                :ToString: NoIsolation
+                :I32: 0
+              :UseGRE: 
+              :PAIPAddressPoolType: 
+              :CAIPAddressPoolType: 
+              :ExternalName: 
+              :NetworkEntityAccessType:
+                :ToString: VmmManaged
+                :I32: 0
+              :IsAssigned: true
+              :IsPrivateVlan: false
+              :HasGatewayConnection: false
+              :NetworkManager: 
+              :PortACL: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CLOUDFORMSWIN\Administrator
+              :ObjectType:
+                :ToString: VMNetwork
+                :I32: 172
+              :Accessibility:
+                :ToString: Public
+                :I32: 0
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-29 19:59:09.447492300 -05:00
+              :ModifiedTime: 2016-02-17 11:35:32.123000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *8
+              :ID: 3aa983df-43b3-40aa-8a5e-8a6a085a995b
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+      :DVDs: *9
+    :c4425913-7043-4d2a-a229-75f051a8127b:
+      :Properties:
+        :ToString: linux2
+        :Props:
+          :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2\Virtual Machines\95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84.xml
+          :MarkedAsTemplate: false
+          :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+          :VMId: 95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84
+          :VMResourceGroup: 
+          :VMConfigResource: 
+          :VMConfigResourceStatus:
+            :ToString: ClusterResourceStateUnknown
+            :I32: -1
+          :VMResource: 
+          :VMResourceStatus:
+            :ToString: ClusterResourceStateUnknown
+            :I32: -1
+          :DiskResources: &87 []
+          :UnsupportedReason: *19
+          :RefresherErrors: &88 []
           :VirtualMachineState:
             :ToString: Running
             :I32: 0
@@ -1488,7 +2910,7 @@
           :UpgradeDomain: 
           :SCApplications: []
           :LastRestoredCheckpointID: 406845EA-0CF6-44CD-9D96-24A157DF5736
-          :LastRestoredVMCheckpoint: &18
+          :LastRestoredVMCheckpoint: &24
             :ToString: linux2 - (02/23/2016 10:35:23)
             :Props:
               :ParentCheckpointID: 95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84
@@ -1504,7 +2926,7 @@
               :Name: linux2 - (02/23/2016 10:35:23)
               :Description: 
               :AddedTime: 2016-02-23 10:35:28.517000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.163000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.243000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
@@ -1519,7 +2941,7 @@
           :DeploymentState:
             :ToString: Undeployed
             :I32: 0
-          :TieredPerfData: &52
+          :TieredPerfData: &89
             :ToString: c4425946-7043-4d2a-a229-75f051a8127b
             :Props:
               :IsViewOnly: false
@@ -1568,7 +2990,7 @@
           :MostRecentTaskUIState:
             :ToString: Completed
             :I32: 5
-          :MostRecentTask: &19
+          :MostRecentTask: &25
             :ToString: Change properties of virtual machine
             :Props:
               :StepsLoaded: true
@@ -1614,7 +3036,7 @@
               :IsFullyCached: true
           :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
           :CreationTime: 2016-02-22 11:52:19.483000000 -05:00
-          :OperatingSystem: &53
+          :OperatingSystem: &90
             :ToString: Red Hat Enterprise Linux 7 (64 bit)
             :Props:
               :Name: Red Hat Enterprise Linux 7 (64 bit)
@@ -1658,7 +3080,7 @@
           :VirtualVideoAdapterEnabled: false
           :MonitorMaximumCount: 
           :MonitorResolutionMaximum: 
-          :BootOrder: &54
+          :BootOrder: &91
           - :ToString: CD
             :I32: 1
           - :ToString: IdeHardDrive
@@ -1671,7 +3093,7 @@
           :SecureBootEnabled: 
           :ComputerName: 
           :UseHardwareAssistedVirtualization: true
-          :SANStatus: &55
+          :SANStatus: &92
           - :ToString: DeployLUNNotFoundUsingStorageProvider (26207)
             :Props:
               :Exception: 
@@ -1724,7 +3146,7 @@
           - 
           :CustomProperty: {}
           :UndoDisksEnabled: false
-          :CPUType: *14
+          :CPUType: *15
           :ExpectedCPUUtilization: 20
           :DiskIO: 0
           :NetworkUtilization: 0
@@ -1738,7 +3160,7 @@
           :NumaIsolationRequired: false
           :Generation: 1
           :VirtualDVDDrives:
-          - &56
+          - &93
             :ToString: linux2
             :Props:
               :Connection: ISOImage
@@ -1755,7 +3177,7 @@
               :IsViewOnly: false
               :Description: 
               :AddedTime: 2016-02-22 11:52:19.583000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.160000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
@@ -1764,10 +3186,10 @@
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualHardDisks:
-          - &16
+          - &20
             :ToString: Blank Disk - Small_77376D2F-3967-476A-942A-6314A3337EEC
             :Props:
-              :OperatingSystem: *15
+              :OperatingSystem: *16
               :VHDType: Differencing
               :VHDFormatType: VHD
               :VirtualizationPlatform: HyperV
@@ -1814,7 +3236,7 @@
               :IsViewOnly: false
               :Description: auto-discovered
               :AddedTime: 2016-02-23 10:35:36.247000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.157000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.237000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
@@ -1823,11 +3245,11 @@
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualDiskDrives:
-          - &57
+          - &94
             :ToString: linux2
             :Props:
               :VirtualHardDiskId: 566be4aa-5ea9-417c-ac8a-a7c75262584f
-              :VirtualHardDisk: *16
+              :VirtualHardDisk: *20
               :PassThroughDisk: 
               :IsVHD: true
               :HasSharedStorage: false
@@ -1844,7 +3266,7 @@
               :IsViewOnly: false
               :Description: 
               :AddedTime: 2016-02-23 10:35:36.307000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.157000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.237000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
@@ -1854,7 +3276,7 @@
               :MostRecentTaskIfLocal: 
           :ShareSCSIBus: false
           :VirtualNetworkAdapters:
-          - &58
+          - &95
             :ToString: linux2
             :Props:
               :SlotId: 0
@@ -1869,8 +3291,8 @@
               :RequiredBandwidth: 0
               :VirtualNetworkAdapterType: Synthetic
               :VmwAdapterIndex: 
-              :LogicalNetwork: VM_Network
-              :VMNetwork: VM_Network
+              :LogicalNetwork: *21
+              :VMNetwork: *22
               :VMNetworkServiceSetting: 
               :VMSubnet: 
               :PortClassification: 
@@ -1901,7 +3323,7 @@
               :IsViewOnly: false
               :Description: 
               :AddedTime: 2016-02-22 11:52:19.587000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.160000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
@@ -1911,7 +3333,7 @@
               :MostRecentTaskIfLocal: 
           :VirtualFibreChannelAdapters: []
           :HasVirtualFibreChannelAdapters: false
-          :VirtualFloppyDrive: &59
+          :VirtualFloppyDrive: &96
             :ToString: linux2
             :Props:
               :Connection: None
@@ -1922,7 +3344,7 @@
               :IsViewOnly: false
               :Description: 
               :AddedTime: 2016-02-22 11:52:19.587000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.160000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
@@ -1964,7 +3386,7 @@
               :MarkedForDeletion: false
               :IsFullyCached: true
           :VirtualSCSIAdapters:
-          - &60
+          - &97
             :ToString: linux2
             :Props:
               :AdapterID: 255
@@ -1977,7 +3399,7 @@
               :IsViewOnly: false
               :Description: 
               :AddedTime: 2016-02-22 11:52:19.583000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.157000000 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.237000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
@@ -1985,12 +3407,12 @@
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :CapabilityProfile: *17
+          :CapabilityProfile: *23
           :CapabilityProfileCompatibilityState:
             :ToString: Compatible
             :I32: 0
           :VMCheckpoints:
-          - *18
+          - *24
           :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
           :HostType:
             :ToString: VMHost
@@ -2015,85 +3437,19 @@
           :IsViewOnly: false
           :Description: 
           :AddedTime: 2016-02-22 11:52:19.483000000 -05:00
-          :ModifiedTime: 2016-02-23 11:21:56.150600600 -05:00
+          :ModifiedTime: 2016-02-29 19:18:07.230000000 -05:00
           :Enabled: true
           :ServerConnection: *8
           :ID: c4425913-7043-4d2a-a229-75f051a8127b
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *19
+          :MostRecentTaskIfLocal: *25
         :MS:
           :ServicingWindows: *9
+      :Networks: 
       :vmnet:
         :MS:
-          :VMNetwork: &24
-            :ToString: VM_Network
-            :Props:
-              :Name: VM_Network
-              :LogicalNetwork: &23
-                :ToString: VM_Network
-                :Props:
-                  :Name: VM_Network
-                  :Description: 
-                  :IsViewOnly: false
-                  :NetworkVirtualizationEnabled: true
-                  :UseGRE: true
-                  :IsPVLAN: false
-                  :SupportsExternalVMNetworkProvisioning: false
-                  :SupportsIPSubnetConfigurationOnExternalVMNetworkDefinitions: false
-                  :SupportsExternalVMNetworkDefinitionCreationWithoutIPSubnets: false
-                  :IsLogicalNetworkDefinitionIsolated: false
-                  :AllowDynamicVlanOnVnic: false
-                  :DefaultNetworkManagerForVMNetworkCreation: 
-                  :ExternalId: ddacb1ce-3450-481e-95be-6ecb1d499020
-                  :LastModifiedByNetworkManager: 
-                  :ExternalSyncTime: 
-                  :ServerConnection: *8
-                  :ID: ddacb1ce-3450-481e-95be-6ecb1d499020
-                  :ObjectType: LogicalNetwork
-                  :MarkedForDeletion: false
-                  :IsFullyCached: true
-              :VMSubnet: []
-              :VMNetworkGateways: []
-              :VPNConnections: []
-              :NATConnections: []
-              :RoutingDomainId: 50fbf692-581f-4742-ae67-41450a4bd8de
-              :IsolationType:
-                :ToString: NoIsolation
-                :I32: 0
-              :UseGRE: 
-              :PAIPAddressPoolType: 
-              :CAIPAddressPoolType: 
-              :ExternalName: 
-              :NetworkEntityAccessType:
-                :ToString: VmmManaged
-                :I32: 0
-              :IsAssigned: true
-              :IsPrivateVlan: false
-              :HasGatewayConnection: false
-              :NetworkManager: 
-              :PortACL: 
-              :GrantedToList: []
-              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
-              :UserRole: *3
-              :Owner: CLOUDFORMSWIN\Administrator
-              :ObjectType:
-                :ToString: VMNetwork
-                :I32: 172
-              :Accessibility:
-                :ToString: Public
-                :I32: 0
-              :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-23 12:36:05.847421500 -05:00
-              :ModifiedTime: 2016-02-17 11:35:32.123000000 -05:00
-              :Enabled: true
-              :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 3aa983df-43b3-40aa-8a5e-8a6a085a995b
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
+          :VMNetwork: *22
       :DVDs:
         :ToString: CentOS-7-x86_64-Minimal-1511.iso
         :Props:
@@ -2111,7 +3467,7 @@
           :Namespace: 
           :ReleaseTime: 
           :HostVolumeId: 284c1ea0-fc51-474a-bbec-372021806117
-          :HostVolume: &21
+          :HostVolume: &98
             :ToString: C:\
             :Props:
               :Name: C:\
@@ -2121,7 +3477,7 @@
               :MountPoints:
               - C:\
               :Capacity: 299630587904
-              :FreeSpace: 264840351744
+              :FreeSpace: 267202084864
               :VolumeLabel: 
               :FileSystem: NTFS
               :IsSANMigrationPossible: false
@@ -2167,7 +3523,7 @@
           :IsViewOnly: false
           :Description: 
           :AddedTime: 2016-02-23 11:21:35.710000000 -05:00
-          :ModifiedTime: 2016-02-23 11:21:56.160000000 -05:00
+          :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
           :Enabled: true
           :MostRecentTask: 
           :ServerConnection: *8
@@ -2175,14 +3531,14 @@
           :MarkedForDeletion: false
           :IsFullyCached: true
           :MostRecentTaskIfLocal: 
-    :6673f40b-0706-4170-92a6-5fcb4d9846f6:
+    :3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297:
       :Properties:
-        :ToString: vm_linux1
+        :ToString: testing_provisioning
         :Props:
-          :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\Virtual Machines\FDA2093A-D44F-40A1-BB8C-0F90FCDC1528.xml
+          :VMCPath: C:\testing_provisioning\Virtual Machines\1998F65F-E02F-439B-8A5B-CD750F068020.xml
           :MarkedAsTemplate: false
           :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-          :VMId: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
+          :VMId: 1998F65F-E02F-439B-8A5B-CD750F068020
           :VMResourceGroup: 
           :VMConfigResource: 
           :VMConfigResourceStatus:
@@ -2192,48 +3548,48 @@
           :VMResourceStatus:
             :ToString: ClusterResourceStateUnknown
             :I32: -1
-          :DiskResources: &39 []
-          :UnsupportedReason: *20
-          :RefresherErrors: &40 []
+          :DiskResources: &59 []
+          :UnsupportedReason: *19
+          :RefresherErrors: &60 []
           :VirtualMachineState:
-            :ToString: Running
-            :I32: 0
-          :HostGroupPath: All Hosts\vm_linux1
-          :TotalSize: 4194304
-          :MemoryAssignedMB: 512
-          :MemoryAvailablePercentage: '0'
-          :DynamicMemoryDemandMB: 512
+            :ToString: PowerOff
+            :I32: 1
+          :HostGroupPath: All Hosts\testing_provisioning
+          :TotalSize: 35328
+          :MemoryAssignedMB: 0
+          :MemoryAvailablePercentage: 
+          :DynamicMemoryDemandMB: 0
           :DynamicMemoryStatus: 
           :AllocatedGPU: 
           :HasPassthroughDisk: false
           :HasSharedStorage: false
           :Status:
-            :ToString: Running
-            :I32: 0
+            :ToString: PowerOff
+            :I32: 1
           :IsOrphaned: false
           :HasSavedState: false
-          :StatusString: Running
+          :StatusString: Stopped
           :StartAction:
-            :ToString: NeverAutoTurnOnVM
-            :I32: 0
+            :ToString: TurnOnVMIfRunningWhenVSStopped
+            :I32: 2
           :StopAction:
             :ToString: SaveVM
             :I32: 0
           :RunGuestAccount: 
           :DelayStart: 0
-          :BiosGuid: 5337594f-94a4-4446-b557-73dba213f6dc
+          :BiosGuid: 44f2407c-cd50-4ad6-8041-208a81441f4a
           :CPUUtilization: 0
           :PerfCPUUtilization: 0
-          :PerfMemory: 512
+          :PerfMemory: 0
           :PerfDiskBytesRead: 0
           :PerfDiskBytesWrite: 0
-          :PerfNetworkBytesRead: 1039
+          :PerfNetworkBytesRead: 0
           :PerfNetworkBytesWrite: 0
           :VirtualizationPlatform:
             :ToString: HyperV
             :I32: 2
           :ComputerNameString: Unknown
-          :CreationSource: Temporary Templateae0b700f-8f3f-4709-b7f1-55613f33b0db
+          :CreationSource: linux_template
           :IsUndergoingLiveMigration: false
           :SourceObjectType: VM Template
           :OperatingSystemShutdownEnabled: true
@@ -2243,7 +3599,7 @@
           :BackupEnabled: true
           :ExcludeFromPRO: false
           :FailedJobID: 
-          :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\
+          :CheckpointLocation: C:\testing_provisioning
           :SelfServiceUserRole: 
           :PassThroughDisks: []
           :ComputerTier: 
@@ -2252,7 +3608,7 @@
           :CloudVmRoleName: 
           :UpgradeDomain: 
           :SCApplications: []
-          :LastRestoredCheckpointID: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
+          :LastRestoredCheckpointID: 1998F65F-E02F-439B-8A5B-CD750F068020
           :LastRestoredVMCheckpoint: 
           :ComplianceStatus: 
           :IsFaultTolerant: false
@@ -2261,31 +3617,31 @@
           :DeploymentState:
             :ToString: Undeployed
             :I32: 0
-          :TieredPerfData: &41
-            :ToString: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+          :TieredPerfData: &61
+            :ToString: 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
             :Props:
               :IsViewOnly: false
-              :Name: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+              :Name: 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
               :ServerConnection: *8
-              :ID: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+              :ID: 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
               :ObjectType: TieredPerfData
               :MarkedForDeletion: false
               :IsFullyCached: true
               :TieredCPUUtilization: 0
-              :TieredMemory: 512
+              :TieredMemory: 0
               :TieredDiskBytesRead: 0
               :TieredDiskBytesWrite: 0
-              :TieredNetworkBytesRead: 1039
+              :TieredNetworkBytesRead: 0
               :TieredNetworkBytesWrite: 0
               :PerfCPUUtilization: 0
-              :PerfMemoryConsumed: 512
+              :PerfMemoryConsumed: 0
               :PerfMemoryPressurePercent: 100
               :PerfDiskBytesRead: 0
               :PerfDiskBytesWrite: 0
-              :PerfNetworkBytesRead: 1039
+              :PerfNetworkBytesRead: 0
               :PerfNetworkBytesWrite: 0
               :AverageDiskIO: 0
-              :data: "(TieredPerfCounterData#0) { id = 6673f45e-0706-4170-92a6-5fcb4d9846f6
+              :data: "(TieredPerfCounterData#0) { id = 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
                 }"
           :ReplicationSetting: 
           :ReplicationStatus: 
@@ -2305,37 +3661,37 @@
           :ClusterNonPossibleOwner: 
           :ClusterPreferredOwner: 
           :AvailabilitySetNames: 
-          :LiveCloningEnabled: true
-          :MostRecentTaskID: 70f9b051-418a-4ce8-a561-6bb1e1b3092a
+          :LiveCloningEnabled: false
+          :MostRecentTaskID: 2e688429-c7cb-49c9-a577-06fb8ed48763
           :MostRecentTaskUIState:
             :ToString: Completed
             :I32: 5
-          :MostRecentTask: &25
-            :ToString: Start virtual machine
+          :MostRecentTask: &27
+            :ToString: Refresh virtual machine
             :Props:
               :StepsLoaded: true
               :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Start virtual machine
+              :Description: Refresh virtual machine
               :IsVisible: true
               :Status: Completed
               :StatusString: Completed
               :ErrorInfo: Success (0)
-              :StartTime: 2016-02-23 11:49:41.203000000 -05:00
-              :EndTime: 2016-02-23 11:49:43.613000000 -05:00
+              :StartTime: 2016-02-27 06:58:42.970000000 -05:00
+              :EndTime: 2016-02-27 06:58:46.940000000 -05:00
               :Owner: CLOUDFORMSWIN\scvmm
               :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
               :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Start virtual machine
+              :Name: Refresh virtual machine
               :Steps:
               - Microsoft.SystemCenter.VirtualMachineManager.Step
               :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
               :ProgressValue: 100
               :Progress: 100 %
               :WasNotifiedOfCancel: false
-              :CmdletName: Start-SCVirtualMachine
+              :CmdletName: "(Refresh VM - System Job)"
               :PROTipID: 
-              :ResultObjectID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
-              :TargetObjectID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
+              :ResultObjectID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
+              :TargetObjectID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
               :TargetObjectType: VM
               :IsCompleted: true
               :AreAuditRecordsAvailable: false
@@ -2345,40 +3701,18 @@
               :Target: 
               :ResultObjectType: VM
               :ResultObjectTypeName: Virtual Machine
-              :ResultName: vm_linux1
+              :ResultName: testing_provisioning
               :IsRestartable: false
               :IsStoppable: false
               :ServerConnection: *8
-              :ID: 70f9b051-418a-4ce8-a561-6bb1e1b3092a
+              :ID: 2e688429-c7cb-49c9-a577-06fb8ed48763
               :IsViewOnly: false
               :ObjectType: Job
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
-          :CreationTime: 2016-02-01 13:39:24.990000000 -05:00
-          :OperatingSystem: &42
-            :ToString: CentOS Linux 6 (64 bit)
-            :Props:
-              :Name: CentOS Linux 6 (64 bit)
-              :Description: CentOS Linux 6 (64 bit)
-              :Version: 
-              :Architecture: amd64
-              :Edition: 
-              :OSType: Linux
-              :IsWindows: false
-              :ProductType: 
-              :IsCustomizationAllowed: true
-              :IsApplicationDeploymentAllowed: false
-              :RequiresAdministratorAccountNameInSysprep: false
-              :RequiresXMLSysprepFormat: false
-              :AllowsOrgNameInSysprep: false
-              :RequiresPIDInSysprep: true
-              :ServerConnection: *8
-              :ID: a095d4f1-0d8d-4c17-882e-59cfe01cf55b
-              :IsViewOnly: false
-              :ObjectType: OperatingSystem
-              :MarkedForDeletion: false
-              :IsFullyCached: true
+          :Location: C:\testing_provisioning
+          :CreationTime: 2016-02-26 13:42:16.017000000 -05:00
+          :OperatingSystem: *16
           :HasVMAdditions: false
           :VMAddition: Not Detected
           :NumLockEnabled: false
@@ -2392,28 +3726,28 @@
           :ReplicationGroup: 
           :LimitCPUFunctionality: false
           :LimitCPUForMigration: false
-          :Memory: 512
-          :DynamicMemoryEnabled: false
-          :DynamicMemoryMaximumMB: 
-          :DynamicMemoryBufferPercentage: 
+          :Memory: 1024
+          :DynamicMemoryEnabled: true
+          :DynamicMemoryMaximumMB: 4096
+          :DynamicMemoryBufferPercentage: 20
           :MemoryWeight: 5000
           :VirtualVideoAdapterEnabled: false
           :MonitorMaximumCount: 
           :MonitorResolutionMaximum: 
-          :BootOrder: &43
-          - :ToString: PxeBoot
-            :I32: 3
+          :BootOrder: &62
           - :ToString: CD
             :I32: 1
           - :ToString: IdeHardDrive
             :I32: 2
+          - :ToString: PxeBoot
+            :I32: 3
           - :ToString: Floppy
             :I32: 0
           :FirstBootDevice: 
           :SecureBootEnabled: 
           :ComputerName: 
           :UseHardwareAssistedVirtualization: true
-          :SANStatus: &44
+          :SANStatus: &63
           - :ToString: DeployLUNNotFoundUsingStorageProvider (26207)
             :Props:
               :Exception: 
@@ -2422,10 +3756,10 @@
               :ErrorCodeString: '26207'
               :ErrorType: Error
               :CSMMessageString: 'Error Code : DeployLUNNotFoundUsingStorageProvider
-                ; Message : Virtual Machine vm_linux1 resides on a LUN, which is not
-                visible to any of the storage providers. ; Recommended Action : Ensure
-                that the storage provider is added to Virtual Machine Manager server.
-                Then try the operation again.'
+                ; Message : Virtual Machine testing_provisioning resides on a LUN,
+                which is not visible to any of the storage providers. ; Recommended
+                Action : Ensure that the storage provider is added to Virtual Machine
+                Manager server. Then try the operation again.'
               :IsSuccess: false
               :IsTerminating: false
               :IsConditionallyTerminating: false
@@ -2434,10 +3768,10 @@
               :DetailedErrorCode: 
               :IsMomAlert: false
               :MomAlertSeverity: Error
-              :Problem: Virtual Machine vm_linux1 resides on a LUN, which is not visible
-                to any of the storage providers.
-              :CloudProblem: Virtual Machine vm_linux1 resides on a LUN, which is
-                not visible to any of the storage providers.
+              :Problem: Virtual Machine testing_provisioning resides on a LUN, which
+                is not visible to any of the storage providers.
+              :CloudProblem: Virtual Machine testing_provisioning resides on a LUN,
+                which is not visible to any of the storage providers.
               :RecommendedAction: Ensure that the storage provider is added to Virtual
                 Machine Manager server. Then try the operation again.
               :RecommendedActionCLI: Ensure that the storage provider is added to
@@ -2446,7 +3780,7 @@
               :DetailedSource: None
               :ExceptionDetails: 
               :MessageParameters:
-                :VMName: vm_linux1
+                :VMName: testing_provisioning
               :Code: DeployLUNNotFoundUsingStorageProvider
               :GetMessageFormatterHandler: 
           :CostCenter: 
@@ -2466,79 +3800,80 @@
           - 
           :CustomProperty: {}
           :UndoDisksEnabled: false
-          :CPUType: *14
+          :CPUType: *15
           :ExpectedCPUUtilization: 20
           :DiskIO: 0
           :NetworkUtilization: 0
           :RelativeWeight: 100
           :CPUReserve: 0
           :CPUMax: 100
-          :CPUPerVirtualNumaNodeMaximum: 4
-          :MemoryPerVirtualNumaNodeMaximumMB: 6062
+          :CPUPerVirtualNumaNodeMaximum: 8
+          :MemoryPerVirtualNumaNodeMaximumMB: 63140
           :VirtualNumaNodesPerSocketMaximum: 1
-          :DynamicMemoryMinimumMB: 
+          :DynamicMemoryMinimumMB: 1024
           :NumaIsolationRequired: false
           :Generation: 1
           :VirtualDVDDrives:
-          - &45
-            :ToString: vm_linux1
+          - &64
+            :ToString: testing_provisioning
             :Props:
-              :Connection: HostDrive
+              :Connection: None
               :ISOId: 
               :ISO: 
-              :HostDrive: 'F:'
+              :HostDrive: 
               :BusType: IDE
               :Bus: 1
               :Lun: 0
               :ISOLinked: false
               :ObjectType: VirtualDVDDrive
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: testing_provisioning
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-01 13:39:25.037000000 -05:00
-              :ModifiedTime: 2016-02-23 11:49:38.067000000 -05:00
+              :AddedTime: 2016-02-26 13:42:16.057000000 -05:00
+              :ModifiedTime: 2016-02-29 06:58:47.093000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
-              :ID: 13e462fb-414b-4251-a3c9-857e1098ef61
+              :ID: e5440b3f-e6f4-4659-a573-9d8e93b3f4b1
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualHardDisks:
-          - &22
-            :ToString: vm_linux1_disk_1
+          - &26
+            :ToString: Blank Disk - Small.vhd
             :Props:
-              :OperatingSystem: *15
+              :OperatingSystem: *16
               :VHDType: DynamicallyExpanding
-              :VHDFormatType: VHDX
+              :VHDFormatType: VHD
               :VirtualizationPlatform: HyperV
-              :MaximumSize: 42949672960
+              :MaximumSize: 17179869184
               :ParentDisk: 
               :SANCopyCapable: false
               :IsCachedVhd: false
               :ComplianceStatus: 
               :Tag: 
               :HasProductKey: false
-              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\vm_linux1_disk_1.vhdx
+              :Location: C:\testing_provisioning\Blank Disk - Small.vhd
               :Release: 
               :State: Normal
               :LibraryShareId: 00000000-0000-0000-0000-000000000000
-              :SharePath: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\vm_linux1_disk_1.vhdx
+              :SharePath: C:\testing_provisioning\Blank Disk - Small.vhd
               :FileShare: 
-              :Directory: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
-              :Size: 4194304
+              :Directory: C:\testing_provisioning
+              :Size: 35328
               :IsOrphaned: false
               :FamilyName: 
               :Namespace: 
               :ReleaseTime: 
-              :HostVolumeId: 284c1ea0-fc51-474a-bbec-372021806117
-              :HostVolume: *21
+              :HostVolumeId: 1c00651a-ca2a-4676-976b-55875305a89f
+              :HostVolume:
+                :S: C:\
               :Classification: *11
-              :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+              :HostId: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
               :HostType: VMHost
-              :HostName: dell-r410-03.cloudformswin.lab.redhat.com
-              :VMHost: *1
+              :HostName: dell-r410-01.cloudformswin.lab.redhat.com
+              :VMHost: *10
               :LibraryServer: 
               :CloudId: 
               :Cloud: 
@@ -2546,27 +3881,28 @@
               :GrantedToList: []
               :UserRoleID: 00000000-0000-0000-0000-000000000000
               :UserRole: 
-              :Owner: CLOUDFORMSWIN\scvmm
+              :Owner: 
               :ObjectType: VirtualHardDisk
               :Accessibility: Internal
-              :Name: vm_linux1_disk_1
+              :Name: Blank Disk - Small.vhd
               :IsViewOnly: false
-              :Description: vm_linux1_disk_1
-              :AddedTime: 2016-02-01 13:39:28.890000000 -05:00
-              :ModifiedTime: 2016-02-23 11:49:38.063000000 -05:00
+              :Description: To be used as a base drive to create a new virtual machine
+                or as an additional data drive.
+              :AddedTime: 2016-02-26 13:42:16.843000000 -05:00
+              :ModifiedTime: 2016-02-29 06:58:47.090000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
-              :ID: 34621bb0-b8e2-4dd2-a6ed-629e75683433
+              :ID: 77e12b95-986d-4001-95fa-6dfa25a72067
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualDiskDrives:
-          - &46
-            :ToString: vm_linux1
+          - &65
+            :ToString: testing_provisioning
             :Props:
-              :VirtualHardDiskId: 34621bb0-b8e2-4dd2-a6ed-629e75683433
-              :VirtualHardDisk: *22
+              :VirtualHardDiskId: 77e12b95-986d-4001-95fa-6dfa25a72067
+              :VirtualHardDisk: *26
               :PassThroughDisk: 
               :IsVHD: true
               :HasSharedStorage: false
@@ -2579,37 +3915,38 @@
               :VolumeType: BootAndSystem
               :ObjectType: VirtualDiskDrive
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: testing_provisioning
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-01 13:39:28.900000000 -05:00
-              :ModifiedTime: 2016-02-23 11:49:38.063000000 -05:00
+              :AddedTime: 2016-02-26 13:42:16.837000000 -05:00
+              :ModifiedTime: 2016-02-29 06:58:47.090000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
-              :ID: 7aafb2b6-aa59-4831-bca7-30f3a1c17014
+              :ID: 48df8938-5c34-45b9-9f55-c18f09a6730b
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :ShareSCSIBus: false
           :VirtualNetworkAdapters:
-          - &47
-            :ToString: vm_linux1
+          - &66
+            :ToString: testing_provisioning
             :Props:
               :SlotId: 0
-              :VirtualNetwork: New Virtual Switch0
+              :VirtualNetwork: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
+                #33 - Virtual Switch'
               :VMwarePortGroup: 
               :MACAddressType: Dynamic
               :EthernetAddressType: Dynamic
               :PhysicalAddressType: Dynamic
-              :MACAddress: 
-              :EthernetAddress: 
-              :PhysicalAddress: 
+              :MACAddress: '00:00:00:00:00:00'
+              :EthernetAddress: '00:00:00:00:00:00'
+              :PhysicalAddress: '00:00:00:00:00:00'
               :RequiredBandwidth: 0
               :VirtualNetworkAdapterType: Synthetic
               :VmwAdapterIndex: 
-              :LogicalNetwork: *23
-              :VMNetwork: *24
+              :LogicalNetwork: *21
+              :VMNetwork: *22
               :VMNetworkServiceSetting: 
               :VMSubnet: 
               :PortClassification: 
@@ -2628,7 +3965,7 @@
               :VirtualNetworkAdapterComplianceErrors: []
               :PerfNetworkKBytesRead: 0
               :PerfNetworkKBytesWrite: 0
-              :DeviceID: Microsoft:FDA2093A-D44F-40A1-BB8C-0F90FCDC1528\08F76628-21A6-4D14-989C-AD39F6FD0A02
+              :DeviceID: Microsoft:1998F65F-E02F-439B-8A5B-CD750F068020\2BAF313D-BD78-46AD-8442-B91F7030F42D
               :IPv4AddressType: Dynamic
               :IPv6AddressType: Dynamic
               :IPv4Addresses: []
@@ -2636,36 +3973,36 @@
               :PortACL: 
               :ObjectType: VirtualNetworkAdapter
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: testing_provisioning
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-23 11:49:32.300000000 -05:00
-              :ModifiedTime: 2016-02-23 11:49:38.070000000 -05:00
+              :AddedTime: 2016-02-26 13:42:16.057000000 -05:00
+              :ModifiedTime: 2016-02-29 06:58:47.093000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
-              :ID: 1062da4b-4642-4c4a-a10a-29a2bc6130bb
+              :ID: b04144e0-46dd-49ea-a434-5e39e13a2997
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualFibreChannelAdapters: []
           :HasVirtualFibreChannelAdapters: false
-          :VirtualFloppyDrive: &48
-            :ToString: vm_linux1
+          :VirtualFloppyDrive: &67
+            :ToString: testing_provisioning
             :Props:
               :Connection: None
               :VirtualFloppyDisk: 
               :ObjectType: VirtualFloppyDrive
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: testing_provisioning
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-01 13:39:25.037000000 -05:00
-              :ModifiedTime: 2016-02-23 11:49:38.067000000 -05:00
+              :AddedTime: 2016-02-26 13:42:16.057000000 -05:00
+              :ModifiedTime: 2016-02-29 06:58:47.093000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
-              :ID: 4a40d2cc-4f72-4fb1-abe0-4b6893994685
+              :ID: d3297030-93fa-4076-b96c-f8cd17695657
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
@@ -2681,7 +4018,7 @@
               :NamedPipe: 
               :Name: COM1
               :ServerConnection: *8
-              :ID: c4d1d097-0643-4965-8d01-ef5fa06ec2b7
+              :ID: d6367962-b5d7-4034-af9f-5ccd451f87bf
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
@@ -2697,14 +4034,14 @@
               :NamedPipe: 
               :Name: COM2
               :ServerConnection: *8
-              :ID: 802aea0a-6059-4356-b1a4-6d0f6703e27b
+              :ID: b32ce2d2-c534-42f5-8bb3-fd2880a2dc02
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
               :IsFullyCached: true
           :VirtualSCSIAdapters:
-          - &49
-            :ToString: vm_linux1
+          - &68
+            :ToString: testing_provisioning
             :Props:
               :AdapterID: 255
               :Bus: 0
@@ -2712,27 +4049,29 @@
               :SCSIControllerType: DefaultTypeNoType
               :ObjectType: VirtualSCSIAdapter
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: testing_provisioning
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-01 13:39:25.043000000 -05:00
-              :ModifiedTime: 2016-02-23 11:49:38.063000000 -05:00
+              :AddedTime: 2016-02-26 13:42:16.053000000 -05:00
+              :ModifiedTime: 2016-02-29 06:58:47.090000000 -05:00
               :Enabled: true
               :MostRecentTask: 
               :ServerConnection: *8
-              :ID: b4b5b43f-61c4-40ed-9531-035fd2ffdeef
+              :ID: 299f46f3-c0e9-4c83-a5c3-32f7c08022e1
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :CapabilityProfile: 
-          :CapabilityProfileCompatibilityState: 
+          :CapabilityProfile: *23
+          :CapabilityProfileCompatibilityState:
+            :ToString: Compatible
+            :I32: 0
           :VMCheckpoints: []
-          :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+          :HostId: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
           :HostType:
             :ToString: VMHost
             :I32: 9
-          :HostName: dell-r410-03.cloudformswin.lab.redhat.com
-          :VMHost: *1
+          :HostName: dell-r410-01.cloudformswin.lab.redhat.com
+          :VMHost: *10
           :LibraryServer: 
           :CloudId: 
           :Cloud: 
@@ -2747,56 +4086,1166 @@
           :Accessibility:
             :ToString: Public
             :I32: 0
-          :Name: vm_linux1
+          :Name: testing_provisioning
           :IsViewOnly: false
           :Description: 
-          :AddedTime: 2016-02-01 13:39:24.990000000 -05:00
-          :ModifiedTime: 2016-02-23 11:49:43.558084800 -05:00
+          :AddedTime: 2016-02-26 13:42:16.017000000 -05:00
+          :ModifiedTime: 2016-02-29 06:58:47.087000000 -05:00
           :Enabled: true
           :ServerConnection: *8
-          :ID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
+          :ID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *25
+          :MostRecentTaskIfLocal: *27
         :MS:
           :ServicingWindows: *9
+      :Networks: 
       :vmnet:
         :MS:
-          :VMNetwork: *24
+          :VMNetwork: *22
       :DVDs: *9
   :hosts:
+    :21ae0784-db30-48f2-bdd5-08dfe01b6929:
+      :Properties:
+        :ToString: cfme-esx-55-03
+        :Props:
+          :RunAsAccount: *28
+          :MostRecentTaskID: 8b7045ef-e923-4ee4-85fa-6a26eaf3a8dd
+          :MostRecentTaskUIState:
+            :ToString: Failed
+            :I32: 3
+          :MostRecentTask: &40
+            :ToString: Add virtual machine host
+            :Props:
+              :StepsLoaded: true
+              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :Description: Add virtual machine host
+              :IsVisible: true
+              :Status: Failed
+              :StatusString: Failed
+              :ErrorInfo: FailedWithCriticalException (20413)
+              :StartTime: 2016-02-24 11:48:21.207000000 -05:00
+              :EndTime: 2016-02-24 11:48:28.650000000 -05:00
+              :Owner: CLOUDFORMSWIN\scvmm
+              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+              :SessionOwner: CLOUDFORMSWIN\scvmm
+              :Name: Add virtual machine host
+              :Steps:
+              - Microsoft.SystemCenter.VirtualMachineManager.Step
+              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :ProgressValue: 66
+              :Progress: 66 %
+              :WasNotifiedOfCancel: false
+              :CmdletName: Add-SCVMHostCluster
+              :PROTipID: 
+              :ResultObjectID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
+              :TargetObjectID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
+              :TargetObjectType: VMHost
+              :IsCompleted: true
+              :AreAuditRecordsAvailable: false
+              :AuditRecords: []
+              :AdditionalMessages: []
+              :Source: 
+              :Target: 
+              :ResultObjectType: VMHost
+              :ResultObjectTypeName: Host
+              :ResultName: cfme-esx-55-03
+              :IsRestartable: true
+              :IsStoppable: false
+              :ServerConnection: *8
+              :ID: 8b7045ef-e923-4ee4-85fa-6a26eaf3a8dd
+              :IsViewOnly: false
+              :ObjectType: Job
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :OverallStateString: Adding...
+          :OverallState:
+            :ToString: Adding
+            :By: 3
+          :CommunicationStateString: Connecting...
+          :CommunicationState:
+            :ToString: Connecting
+            :By: 3
+          :Name: cfme-esx-55-03
+          :FullyQualifiedDomainName: cfme-esx-55-03
+          :ComputerName: cfme-esx-55-03
+          :DomainName: cfme-esx-55-03
+          :Description: 
+          :RemoteUserName: localhost\root
+          :OverrideHostGroupReserves: false
+          :CPUPercentageReserve: 10
+          :NetworkPercentageReserve: 0
+          :DiskSpaceReserveMB: 10240
+          :MaxDiskIOReservation: 10000
+          :MemoryReserveMB: 2048
+          :VMPaths: *29
+          :BaseDiskPaths: *30
+          :PROEnabled: false
+          :MaintenanceHost: false
+          :AvailableForPlacement: true
+          :IsEmbedded: false
+          :CredentialsNeeded: true
+          :PausedForNetworkIncompatibility: false
+          :LogicalProcessorCount: 0
+          :PhysicalCPUCount: 0
+          :CoresPerCPU: 0
+          :L2CacheSize: 0
+          :L3CacheSize: 0
+          :BusSpeed: 0
+          :ProcessorSpeed: 0
+          :ProcessorModel: 
+          :ProcessorManufacturer: 
+          :ProcessorArchitecture: 0
+          :ProcessorFamily: 
+          :CpuUtilization: 0
+          :TotalMemory: 0
+          :AvailableMemory: 0
+          :OperatingSystem: *16
+          :OperatingSystemVersion: '0.0'
+          :DVDDrives: 
+          :DVDDriveList: []
+          :VirtualizationPlatformString: VMware ESX Server
+          :VirtualizationPlatform:
+            :ToString: VMWareESX
+            :I32: 4
+          :VirtualizationPlatformDetail: VMware ESX Server
+          :IsVirtualizationSoftwareDetailUnknown: false
+          :IsViridianHost: false
+          :SupportsLiveMigration: false
+          :FloppyDrives: 
+          :FloppyDriveList: []
+          :VMHostGroup: *13
+          :HostCluster: &43
+            :ToString: CFME-ESX55-Cluster
+            :Props:
+              :Name: CFME-ESX55-Cluster
+              :ClusterName: CFME-ESX55-Cluster
+              :DomainName: 
+              :Description: 
+              :HostGroup: *13
+              :ClusterReserve: 1
+              :ClusterReserveState: Unknown
+              :ClusterReserveDetails: 
+              :CustomProperty: {}
+              :IsVMwareHAEnabled: false
+              :IsVMwareDrsEnabled: false
+              :AvailableStorageNode: 
+              :Nodes:
+              - *31
+              - *32
+              - *33
+              - *34
+              :VMwareResourcePool: 
+              :VirtualizationPlatform: VMWareVC
+              :HostGroupID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
+              :AvailableVolumes: []
+              :SharedVolumes: []
+              :RegisteredStorageFileShares: []
+              :RefresherErrors: *35
+              :IPAddresses: []
+              :QuorumDiskResourceName: 
+              :ValidationResult: TestNotRun
+              :ValidationReportPath: 
+              :ClusterCoreResources: *36
+              :VMHostManagementCredential: *28
+              :ServerConnection: *8
+              :ID: d9a2261c-7c46-4e0f-83c1-44d779d71594
+              :IsViewOnly: false
+              :ObjectType: HostCluster
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :RemoteConnectEnabled: true
+          :RemoteConnectPort: 5900
+          :SecureRemoteConnectEnabled: false
+          :VMRCCertificateAvailable: false
+          :EnableLiveMigration: false
+          :LiveMigrationMaximum: 0
+          :LiveStorageMigrationMaximum: 0
+          :UseAnyMigrationSubnet: false
+          :MigrationSubnet: *37
+          :MigrationSubnetUserManaged: *38
+          :MigrationAuthProtocol:
+            :ToString: CredSSP
+            :By: 0
+          :MigrationPerformanceOption:
+            :ToString: Standard
+            :By: 0
+          :SslTcpPort: 443
+          :SslCertificateHash: 
+          :SshTcpPort: 22
+          :SshPublicKeyHash: 
+          :SshPublicKey: 
+          :IsRemoteFXRoleInstalled: false
+          :IsCPUSLAT: false
+          :IsNumaSpanningEnabled: 
+          :GPUMemoryTotalMB: 
+          :GPUMemoryAvailableMB: 
+          :ClusterNodeStatus:
+            :ToString: Unknown
+            :By: 7
+          :TimeZone: 
+          :HyperVState:
+            :ToString: Unknown
+            :By: 7
+          :HyperVStateString: Unknown
+          :HyperVVersion: '0.0'
+          :HyperVVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :PerimeterNetworkHost: false
+          :NonTrustedDomainHost: false
+          :MaximumMemoryPerVM: 0
+          :MinimumMemoryPerVM: 0
+          :SuggestedMaximumMemoryPerVM: 0
+          :ModifiedTime: 2016-02-24 11:48:26.253000000 -05:00
+          :Agent: &39
+            :ToString: cfme-esx-55-03
+            :Props:
+              :StateString: Responding
+              :RoleString: Host
+              :State: Responding
+              :VersionState: NotApplicable
+              :VersionStateString: Not Applicable
+              :MarkedForDeletion: false
+              :Name: cfme-esx-55-03
+              :MostRecentTaskID: 
+              :MostRecentTaskUIState: 
+              :MostRecentTask: 
+              :FullyQualifiedDomainName: cfme-esx-55-03
+              :FQDN: cfme-esx-55-03
+              :ComputerName: cfme-esx-55-03
+              :Description: 
+              :AgentVersion: '0.0'
+              :Role: Host
+              :UpdatedDate: 2016-02-24 11:48:21.367000000 -05:00
+              :ComplianceStatus: 
+              :ServerConnection: *8
+              :ID: 702b7fd5-6fe3-4e23-8391-f401d72e5e84
+              :IsViewOnly: false
+              :ObjectType: AgentServer
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ManagedComputer: *39
+          :VMs: []
+          :Disks: []
+          :GPUs: []
+          :InstalledVirtualSwitchExtensions: []
+          :DiskVolumes: []
+          :RegisteredStorageFileShares: []
+          :FibreChannelHbas: []
+          :FibreChannelVirtualSANs: []
+          :SASHbas: []
+          :InternetSCSIHbas: []
+          :VMwareResourcePool: 
+          :IsConfiguredForOutOfBandManagement: false
+          :PhysicalMachine:
+            :ToString: ''
+            :Props:
+              :Name: 
+              :BMCType: None
+              :BMCCustomConfigurationProvider: 
+              :BMCAddress: 
+              :BMCPort: 
+              :RunAsAccount: 
+              :SMBiosGUID: 
+              :ComputerPowerState: Unknown
+              :SystemEventLog: []
+              :ServerConnection: *8
+              :ID: 235e556e-3287-4c95-9f9f-d9182dd1eeb8
+              :IsViewOnly: false
+              :ObjectType: PhysicalMachine
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :HealthMonitors: []
+          :RemoteStorageTotalCapacity: 0
+          :RemoteStorageAvailableCapacity: 0
+          :LocalStorageTotalCapacity: 0
+          :LocalStorageAvailableCapacity: 0
+          :TotalStorageCapacity: 0
+          :AvailableStorageCapacity: 0
+          :UsedStorageCapacity: 0
+          :IsDedicatedToNetworkVirtualizationGateway: false
+          :FibreChannelWorldWidePortNameMinimum: 
+          :FibreChannelWorldWidePortNameMaximum: 
+          :FibreChannelWorldWideNodeName: 
+          :VMConnectCertificateThumbprint: 
+          :Custom1: 
+          :Custom2: 
+          :Custom3: 
+          :Custom4: 
+          :Custom5: 
+          :Custom6: 
+          :Custom7: 
+          :Custom8: 
+          :Custom9: 
+          :Custom10: 
+          :CustomProperty: {}
+          :FibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :ISCSISANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :NPIVFibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :CertificateRequest: 
+          :ComputerState:
+            :ToString: Adding
+            :By: 0
+          :VirtualizationManager: 
+          :ServerConnection: *8
+          :ID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHost
+            :I32: 9
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: *40
+        :MS:
+          :FQDN: cfme-esx-55-03
+          :LogicalCPUCount: 0
+          :CPUSpeed: 0
+          :CPUModel: 
+          :CPUManufacturer: 
+          :CPUArchitecture: 0
+          :CPUFamily: 
+          :VMRCEnabled: true
+          :VMRCPort: 5900
+          :SecureVMRCEnabled: false
+          :VirtualServerState:
+            :ToString: Unknown
+            :By: 7
+          :VirtualServerStateString: Unknown
+          :VirtualServerVersion: '0.0'
+          :VirtualServerVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :ServicingWindows: *9
+      :NetworkAdapters: []
+      :VirtualSwitch: []
+    :79fc4dfd-6a87-4840-8836-4f1096a56a75:
+      :Properties:
+        :ToString: cfme-esx-55-04
+        :Props:
+          :RunAsAccount: *28
+          :MostRecentTaskID: 1a5ce85a-e208-4da0-a9a7-8374846fc94a
+          :MostRecentTaskUIState:
+            :ToString: Failed
+            :I32: 3
+          :MostRecentTask: &47
+            :ToString: Add virtual machine host
+            :Props:
+              :StepsLoaded: true
+              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :Description: Add virtual machine host
+              :IsVisible: true
+              :Status: Failed
+              :StatusString: Failed
+              :ErrorInfo: FailedWithCriticalException (20413)
+              :StartTime: 2016-02-24 11:48:21.160000000 -05:00
+              :EndTime: 2016-02-24 11:48:27.723000000 -05:00
+              :Owner: CLOUDFORMSWIN\scvmm
+              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+              :SessionOwner: CLOUDFORMSWIN\scvmm
+              :Name: Add virtual machine host
+              :Steps:
+              - Microsoft.SystemCenter.VirtualMachineManager.Step
+              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :ProgressValue: 66
+              :Progress: 66 %
+              :WasNotifiedOfCancel: false
+              :CmdletName: Add-SCVMHostCluster
+              :PROTipID: 
+              :ResultObjectID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
+              :TargetObjectID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
+              :TargetObjectType: VMHost
+              :IsCompleted: true
+              :AreAuditRecordsAvailable: false
+              :AuditRecords: []
+              :AdditionalMessages: []
+              :Source: 
+              :Target: 
+              :ResultObjectType: VMHost
+              :ResultObjectTypeName: Host
+              :ResultName: cfme-esx-55-04
+              :IsRestartable: true
+              :IsStoppable: false
+              :ServerConnection: *8
+              :ID: 1a5ce85a-e208-4da0-a9a7-8374846fc94a
+              :IsViewOnly: false
+              :ObjectType: Job
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :OverallStateString: Adding...
+          :OverallState:
+            :ToString: Adding
+            :By: 3
+          :CommunicationStateString: Connecting...
+          :CommunicationState:
+            :ToString: Connecting
+            :By: 3
+          :Name: cfme-esx-55-04
+          :FullyQualifiedDomainName: cfme-esx-55-04
+          :ComputerName: cfme-esx-55-04
+          :DomainName: cfme-esx-55-04
+          :Description: 
+          :RemoteUserName: localhost\root
+          :OverrideHostGroupReserves: false
+          :CPUPercentageReserve: 10
+          :NetworkPercentageReserve: 0
+          :DiskSpaceReserveMB: 10240
+          :MaxDiskIOReservation: 10000
+          :MemoryReserveMB: 2048
+          :VMPaths: *41
+          :BaseDiskPaths: *42
+          :PROEnabled: false
+          :MaintenanceHost: false
+          :AvailableForPlacement: true
+          :IsEmbedded: false
+          :CredentialsNeeded: true
+          :PausedForNetworkIncompatibility: false
+          :LogicalProcessorCount: 0
+          :PhysicalCPUCount: 0
+          :CoresPerCPU: 0
+          :L2CacheSize: 0
+          :L3CacheSize: 0
+          :BusSpeed: 0
+          :ProcessorSpeed: 0
+          :ProcessorModel: 
+          :ProcessorManufacturer: 
+          :ProcessorArchitecture: 0
+          :ProcessorFamily: 
+          :CpuUtilization: 0
+          :TotalMemory: 0
+          :AvailableMemory: 0
+          :OperatingSystem: *16
+          :OperatingSystemVersion: '0.0'
+          :DVDDrives: 
+          :DVDDriveList: []
+          :VirtualizationPlatformString: VMware ESX Server
+          :VirtualizationPlatform:
+            :ToString: VMWareESX
+            :I32: 4
+          :VirtualizationPlatformDetail: VMware ESX Server
+          :IsVirtualizationSoftwareDetailUnknown: false
+          :IsViridianHost: false
+          :SupportsLiveMigration: false
+          :FloppyDrives: 
+          :FloppyDriveList: []
+          :VMHostGroup: *13
+          :HostCluster: *43
+          :RemoteConnectEnabled: true
+          :RemoteConnectPort: 5900
+          :SecureRemoteConnectEnabled: false
+          :VMRCCertificateAvailable: false
+          :EnableLiveMigration: false
+          :LiveMigrationMaximum: 0
+          :LiveStorageMigrationMaximum: 0
+          :UseAnyMigrationSubnet: false
+          :MigrationSubnet: *44
+          :MigrationSubnetUserManaged: *45
+          :MigrationAuthProtocol:
+            :ToString: CredSSP
+            :By: 0
+          :MigrationPerformanceOption:
+            :ToString: Standard
+            :By: 0
+          :SslTcpPort: 443
+          :SslCertificateHash: 
+          :SshTcpPort: 22
+          :SshPublicKeyHash: 
+          :SshPublicKey: 
+          :IsRemoteFXRoleInstalled: false
+          :IsCPUSLAT: false
+          :IsNumaSpanningEnabled: 
+          :GPUMemoryTotalMB: 
+          :GPUMemoryAvailableMB: 
+          :ClusterNodeStatus:
+            :ToString: Unknown
+            :By: 7
+          :TimeZone: 
+          :HyperVState:
+            :ToString: Unknown
+            :By: 7
+          :HyperVStateString: Unknown
+          :HyperVVersion: '0.0'
+          :HyperVVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :PerimeterNetworkHost: false
+          :NonTrustedDomainHost: false
+          :MaximumMemoryPerVM: 0
+          :MinimumMemoryPerVM: 0
+          :SuggestedMaximumMemoryPerVM: 0
+          :ModifiedTime: 2016-02-24 11:48:22.863000000 -05:00
+          :Agent: &46
+            :ToString: cfme-esx-55-04
+            :Props:
+              :StateString: Responding
+              :RoleString: Host
+              :State: Responding
+              :VersionState: NotApplicable
+              :VersionStateString: Not Applicable
+              :MarkedForDeletion: false
+              :Name: cfme-esx-55-04
+              :MostRecentTaskID: 
+              :MostRecentTaskUIState: 
+              :MostRecentTask: 
+              :FullyQualifiedDomainName: cfme-esx-55-04
+              :FQDN: cfme-esx-55-04
+              :ComputerName: cfme-esx-55-04
+              :Description: 
+              :AgentVersion: '0.0'
+              :Role: Host
+              :UpdatedDate: 2016-02-24 11:48:21.327000000 -05:00
+              :ComplianceStatus: 
+              :ServerConnection: *8
+              :ID: 12e73edd-5efd-4b9a-95ab-19ca601d7be1
+              :IsViewOnly: false
+              :ObjectType: AgentServer
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ManagedComputer: *46
+          :VMs: []
+          :Disks: []
+          :GPUs: []
+          :InstalledVirtualSwitchExtensions: []
+          :DiskVolumes: []
+          :RegisteredStorageFileShares: []
+          :FibreChannelHbas: []
+          :FibreChannelVirtualSANs: []
+          :SASHbas: []
+          :InternetSCSIHbas: []
+          :VMwareResourcePool: 
+          :IsConfiguredForOutOfBandManagement: false
+          :PhysicalMachine:
+            :ToString: ''
+            :Props:
+              :Name: 
+              :BMCType: None
+              :BMCCustomConfigurationProvider: 
+              :BMCAddress: 
+              :BMCPort: 
+              :RunAsAccount: 
+              :SMBiosGUID: 
+              :ComputerPowerState: Unknown
+              :SystemEventLog: []
+              :ServerConnection: *8
+              :ID: 57bdf3fa-97cb-4fa7-b6ab-c8580cb9ba92
+              :IsViewOnly: false
+              :ObjectType: PhysicalMachine
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :HealthMonitors: []
+          :RemoteStorageTotalCapacity: 0
+          :RemoteStorageAvailableCapacity: 0
+          :LocalStorageTotalCapacity: 0
+          :LocalStorageAvailableCapacity: 0
+          :TotalStorageCapacity: 0
+          :AvailableStorageCapacity: 0
+          :UsedStorageCapacity: 0
+          :IsDedicatedToNetworkVirtualizationGateway: false
+          :FibreChannelWorldWidePortNameMinimum: 
+          :FibreChannelWorldWidePortNameMaximum: 
+          :FibreChannelWorldWideNodeName: 
+          :VMConnectCertificateThumbprint: 
+          :Custom1: 
+          :Custom2: 
+          :Custom3: 
+          :Custom4: 
+          :Custom5: 
+          :Custom6: 
+          :Custom7: 
+          :Custom8: 
+          :Custom9: 
+          :Custom10: 
+          :CustomProperty: {}
+          :FibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :ISCSISANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :NPIVFibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :CertificateRequest: 
+          :ComputerState:
+            :ToString: Adding
+            :By: 0
+          :VirtualizationManager: 
+          :ServerConnection: *8
+          :ID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHost
+            :I32: 9
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: *47
+        :MS:
+          :FQDN: cfme-esx-55-04
+          :LogicalCPUCount: 0
+          :CPUSpeed: 0
+          :CPUModel: 
+          :CPUManufacturer: 
+          :CPUArchitecture: 0
+          :CPUFamily: 
+          :VMRCEnabled: true
+          :VMRCPort: 5900
+          :SecureVMRCEnabled: false
+          :VirtualServerState:
+            :ToString: Unknown
+            :By: 7
+          :VirtualServerStateString: Unknown
+          :VirtualServerVersion: '0.0'
+          :VirtualServerVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :ServicingWindows: *9
+      :NetworkAdapters: []
+      :VirtualSwitch: []
+    :d4c780ae-2251-44f7-b624-111bd25e7400:
+      :Properties:
+        :ToString: cfme-esx-55-02
+        :Props:
+          :RunAsAccount: *28
+          :MostRecentTaskID: af5b8a7e-da60-4b62-837c-c1e876328410
+          :MostRecentTaskUIState:
+            :ToString: Failed
+            :I32: 3
+          :MostRecentTask: &53
+            :ToString: Add virtual machine host
+            :Props:
+              :StepsLoaded: true
+              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :Description: Add virtual machine host
+              :IsVisible: true
+              :Status: Failed
+              :StatusString: Failed
+              :ErrorInfo: FailedWithCriticalException (20413)
+              :StartTime: 2016-02-24 11:48:21.263000000 -05:00
+              :EndTime: 2016-02-24 11:48:30.253000000 -05:00
+              :Owner: CLOUDFORMSWIN\scvmm
+              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+              :SessionOwner: CLOUDFORMSWIN\scvmm
+              :Name: Add virtual machine host
+              :Steps:
+              - Microsoft.SystemCenter.VirtualMachineManager.Step
+              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :ProgressValue: 66
+              :Progress: 66 %
+              :WasNotifiedOfCancel: false
+              :CmdletName: Add-SCVMHostCluster
+              :PROTipID: 
+              :ResultObjectID: d4c780ae-2251-44f7-b624-111bd25e7400
+              :TargetObjectID: d4c780ae-2251-44f7-b624-111bd25e7400
+              :TargetObjectType: VMHost
+              :IsCompleted: true
+              :AreAuditRecordsAvailable: false
+              :AuditRecords: []
+              :AdditionalMessages: []
+              :Source: 
+              :Target: 
+              :ResultObjectType: VMHost
+              :ResultObjectTypeName: Host
+              :ResultName: cfme-esx-55-02
+              :IsRestartable: true
+              :IsStoppable: false
+              :ServerConnection: *8
+              :ID: af5b8a7e-da60-4b62-837c-c1e876328410
+              :IsViewOnly: false
+              :ObjectType: Job
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :OverallStateString: Adding...
+          :OverallState:
+            :ToString: Adding
+            :By: 3
+          :CommunicationStateString: Connecting...
+          :CommunicationState:
+            :ToString: Connecting
+            :By: 3
+          :Name: cfme-esx-55-02
+          :FullyQualifiedDomainName: cfme-esx-55-02
+          :ComputerName: cfme-esx-55-02
+          :DomainName: cfme-esx-55-02
+          :Description: 
+          :RemoteUserName: localhost\root
+          :OverrideHostGroupReserves: false
+          :CPUPercentageReserve: 10
+          :NetworkPercentageReserve: 0
+          :DiskSpaceReserveMB: 10240
+          :MaxDiskIOReservation: 10000
+          :MemoryReserveMB: 2048
+          :VMPaths: *48
+          :BaseDiskPaths: *49
+          :PROEnabled: false
+          :MaintenanceHost: false
+          :AvailableForPlacement: true
+          :IsEmbedded: false
+          :CredentialsNeeded: true
+          :PausedForNetworkIncompatibility: false
+          :LogicalProcessorCount: 0
+          :PhysicalCPUCount: 0
+          :CoresPerCPU: 0
+          :L2CacheSize: 0
+          :L3CacheSize: 0
+          :BusSpeed: 0
+          :ProcessorSpeed: 0
+          :ProcessorModel: 
+          :ProcessorManufacturer: 
+          :ProcessorArchitecture: 0
+          :ProcessorFamily: 
+          :CpuUtilization: 0
+          :TotalMemory: 0
+          :AvailableMemory: 0
+          :OperatingSystem: *16
+          :OperatingSystemVersion: '0.0'
+          :DVDDrives: 
+          :DVDDriveList: []
+          :VirtualizationPlatformString: VMware ESX Server
+          :VirtualizationPlatform:
+            :ToString: VMWareESX
+            :I32: 4
+          :VirtualizationPlatformDetail: VMware ESX Server
+          :IsVirtualizationSoftwareDetailUnknown: false
+          :IsViridianHost: false
+          :SupportsLiveMigration: false
+          :FloppyDrives: 
+          :FloppyDriveList: []
+          :VMHostGroup: *13
+          :HostCluster: *43
+          :RemoteConnectEnabled: true
+          :RemoteConnectPort: 5900
+          :SecureRemoteConnectEnabled: false
+          :VMRCCertificateAvailable: false
+          :EnableLiveMigration: false
+          :LiveMigrationMaximum: 0
+          :LiveStorageMigrationMaximum: 0
+          :UseAnyMigrationSubnet: false
+          :MigrationSubnet: *50
+          :MigrationSubnetUserManaged: *51
+          :MigrationAuthProtocol:
+            :ToString: CredSSP
+            :By: 0
+          :MigrationPerformanceOption:
+            :ToString: Standard
+            :By: 0
+          :SslTcpPort: 443
+          :SslCertificateHash: 
+          :SshTcpPort: 22
+          :SshPublicKeyHash: 
+          :SshPublicKey: 
+          :IsRemoteFXRoleInstalled: false
+          :IsCPUSLAT: false
+          :IsNumaSpanningEnabled: 
+          :GPUMemoryTotalMB: 
+          :GPUMemoryAvailableMB: 
+          :ClusterNodeStatus:
+            :ToString: Unknown
+            :By: 7
+          :TimeZone: 
+          :HyperVState:
+            :ToString: Unknown
+            :By: 7
+          :HyperVStateString: Unknown
+          :HyperVVersion: '0.0'
+          :HyperVVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :PerimeterNetworkHost: false
+          :NonTrustedDomainHost: false
+          :MaximumMemoryPerVM: 0
+          :MinimumMemoryPerVM: 0
+          :SuggestedMaximumMemoryPerVM: 0
+          :ModifiedTime: 2016-02-24 11:48:27.520000000 -05:00
+          :Agent: &52
+            :ToString: cfme-esx-55-02
+            :Props:
+              :StateString: Responding
+              :RoleString: Host
+              :State: Responding
+              :VersionState: NotApplicable
+              :VersionStateString: Not Applicable
+              :MarkedForDeletion: false
+              :Name: cfme-esx-55-02
+              :MostRecentTaskID: 
+              :MostRecentTaskUIState: 
+              :MostRecentTask: 
+              :FullyQualifiedDomainName: cfme-esx-55-02
+              :FQDN: cfme-esx-55-02
+              :ComputerName: cfme-esx-55-02
+              :Description: 
+              :AgentVersion: '0.0'
+              :Role: Host
+              :UpdatedDate: 2016-02-24 11:48:21.430000000 -05:00
+              :ComplianceStatus: 
+              :ServerConnection: *8
+              :ID: 0dcd1d21-c08c-47db-b590-54ae757a20e6
+              :IsViewOnly: false
+              :ObjectType: AgentServer
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ManagedComputer: *52
+          :VMs: []
+          :Disks: []
+          :GPUs: []
+          :InstalledVirtualSwitchExtensions: []
+          :DiskVolumes: []
+          :RegisteredStorageFileShares: []
+          :FibreChannelHbas: []
+          :FibreChannelVirtualSANs: []
+          :SASHbas: []
+          :InternetSCSIHbas: []
+          :VMwareResourcePool: 
+          :IsConfiguredForOutOfBandManagement: false
+          :PhysicalMachine:
+            :ToString: ''
+            :Props:
+              :Name: 
+              :BMCType: None
+              :BMCCustomConfigurationProvider: 
+              :BMCAddress: 
+              :BMCPort: 
+              :RunAsAccount: 
+              :SMBiosGUID: 
+              :ComputerPowerState: Unknown
+              :SystemEventLog: []
+              :ServerConnection: *8
+              :ID: 7df87cde-7567-41ca-b292-fa6547fc436b
+              :IsViewOnly: false
+              :ObjectType: PhysicalMachine
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :HealthMonitors: []
+          :RemoteStorageTotalCapacity: 0
+          :RemoteStorageAvailableCapacity: 0
+          :LocalStorageTotalCapacity: 0
+          :LocalStorageAvailableCapacity: 0
+          :TotalStorageCapacity: 0
+          :AvailableStorageCapacity: 0
+          :UsedStorageCapacity: 0
+          :IsDedicatedToNetworkVirtualizationGateway: false
+          :FibreChannelWorldWidePortNameMinimum: 
+          :FibreChannelWorldWidePortNameMaximum: 
+          :FibreChannelWorldWideNodeName: 
+          :VMConnectCertificateThumbprint: 
+          :Custom1: 
+          :Custom2: 
+          :Custom3: 
+          :Custom4: 
+          :Custom5: 
+          :Custom6: 
+          :Custom7: 
+          :Custom8: 
+          :Custom9: 
+          :Custom10: 
+          :CustomProperty: {}
+          :FibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :ISCSISANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :NPIVFibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :CertificateRequest: 
+          :ComputerState:
+            :ToString: Adding
+            :By: 0
+          :VirtualizationManager: 
+          :ServerConnection: *8
+          :ID: d4c780ae-2251-44f7-b624-111bd25e7400
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHost
+            :I32: 9
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: *53
+        :MS:
+          :FQDN: cfme-esx-55-02
+          :LogicalCPUCount: 0
+          :CPUSpeed: 0
+          :CPUModel: 
+          :CPUManufacturer: 
+          :CPUArchitecture: 0
+          :CPUFamily: 
+          :VMRCEnabled: true
+          :VMRCPort: 5900
+          :SecureVMRCEnabled: false
+          :VirtualServerState:
+            :ToString: Unknown
+            :By: 7
+          :VirtualServerStateString: Unknown
+          :VirtualServerVersion: '0.0'
+          :VirtualServerVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :ServicingWindows: *9
+      :NetworkAdapters: []
+      :VirtualSwitch: []
     :7805b0eb-dffa-4f62-b38d-c6fa624b0ee9:
       :Properties:
         :ToString: dell-r410-01.cloudformswin.lab.redhat.com
         :Props:
           :RunAsAccount: 
-          :MostRecentTaskID: ce27e33b-e181-4c0c-b961-99d3dec067be
+          :MostRecentTaskID: 06be14e2-b6f3-4f53-a7e6-1124908f1d2c
           :MostRecentTaskUIState:
-            :ToString: Completed
-            :I32: 5
-          :MostRecentTask: &31
-            :ToString: Refresh host
+            :ToString: Failed
+            :I32: 3
+          :MostRecentTask: &69
+            :ToString: Refresh Performance Data
             :Props:
               :StepsLoaded: true
               :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Refresh host
+              :Description: Refresh Performance Data
               :IsVisible: true
-              :Status: Completed
-              :StatusString: Completed
-              :ErrorInfo: Success (0)
-              :StartTime: 2016-02-22 09:35:49.793000000 -05:00
-              :EndTime: 2016-02-22 09:35:49.930000000 -05:00
+              :Status: Failed
+              :StatusString: Failed
+              :ErrorInfo: 'HostAgentFail (2912); HR: 0x80070576'
+              :StartTime: 2016-02-26 21:03:46.440000000 -05:00
+              :EndTime: 2016-02-26 21:03:46.450000000 -05:00
               :Owner: CLOUDFORMSWIN\scvmm
               :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
               :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Refresh host
+              :Name: Refresh Performance Data
               :Steps:
               - Microsoft.SystemCenter.VirtualMachineManager.Step
               :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 100
-              :Progress: 100 %
+              :ProgressValue: 0
+              :Progress: 0 %
               :WasNotifiedOfCancel: false
-              :CmdletName: "(Refresh Host - System Job)"
+              :CmdletName: Performance Data Refresher (System Job)
               :PROTipID: 
               :ResultObjectID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
               :TargetObjectID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
@@ -2813,7 +5262,7 @@
               :IsRestartable: false
               :IsStoppable: false
               :ServerConnection: *8
-              :ID: ce27e33b-e181-4c0c-b961-99d3dec067be
+              :ID: 06be14e2-b6f3-4f53-a7e6-1124908f1d2c
               :IsViewOnly: false
               :ObjectType: Job
               :MarkedForDeletion: false
@@ -2838,8 +5287,8 @@
           :DiskSpaceReserveMB: 10240
           :MaxDiskIOReservation: 10000
           :MemoryReserveMB: 2048
-          :VMPaths: *26
-          :BaseDiskPaths: *27
+          :VMPaths: *54
+          :BaseDiskPaths: *55
           :PROEnabled: false
           :MaintenanceHost: false
           :AvailableForPlacement: true
@@ -2859,7 +5308,7 @@
           :ProcessorFamily: '179'
           :CpuUtilization: 0
           :TotalMemory: 137425408000
-          :AvailableMemory: 127763
+          :AvailableMemory: 127532
           :OperatingSystem:
             :ToString: 'Microsoft Windows Server 2012 R2 Datacenter '
             :Props:
@@ -2878,7 +5327,7 @@
               :AllowsOrgNameInSysprep: false
               :RequiresPIDInSysprep: true
               :ServerConnection: 
-              :ID: bb15c378-4a2e-4d48-992a-a35ea9043a43
+              :ID: d9e77efb-d99a-40d8-8e85-939b3fcb1638
               :IsViewOnly: false
               :ObjectType: OperatingSystem
               :MarkedForDeletion: false
@@ -2898,47 +5347,7 @@
           :SupportsLiveMigration: true
           :FloppyDrives: 
           :FloppyDriveList: []
-          :VMHostGroup: &35
-            :ToString: All Hosts
-            :Props:
-              :IsRoot: true
-              :CreationDate: 2016-01-20 15:45:54.683000000 -05:00
-              :Creator: 
-              :Description: 
-              :ModificationDate: 2016-01-20 15:45:54.683000000 -05:00
-              :ModifiedBy: 
-              :Name: All Hosts
-              :ParentVMHostGroup: 
-              :ParentHostGroup: 
-              :Path: All Hosts
-              :Hosts:
-              - *1
-              - *10
-              :AllChildHosts:
-              - *1
-              - *10
-              :AllChildGroups: []
-              :ChildGroups: []
-              :CustomProperty: {}
-              :AllChildClusters: []
-              :ChildClusters: []
-              :IsUnencryptedFileTransferEnabled: false
-              :InheritNetworkSettings: false
-              :AllocatedLogicalUnitTotalCapacity: 0
-              :AllocatedLogicalUnitAvailableCapacity: 0
-              :HostRemoteStorageTotalCapacity: 0
-              :HostRemoteStorageAvailableCapacity: 0
-              :HostLocalStorageTotalCapacity: 800107862016
-              :HostLocalStorageAvailableCapacity: 732527407104
-              :AvailableLogicalUnitCount: 0
-              :ServerConnection: *8
-              :ID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
-              :IsViewOnly: false
-              :ObjectType: VMHostGroup
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-            :MS:
-              :AllowUnencryptedTransfers: false
+          :VMHostGroup: *13
           :HostCluster: 
           :RemoteConnectEnabled: true
           :RemoteConnectPort: 2179
@@ -2948,8 +5357,8 @@
           :LiveMigrationMaximum: 2
           :LiveStorageMigrationMaximum: 2
           :UseAnyMigrationSubnet: true
-          :MigrationSubnet: *28
-          :MigrationSubnetUserManaged: *29
+          :MigrationSubnet: *56
+          :MigrationSubnetUserManaged: *57
           :MigrationAuthProtocol:
             :ToString: CredSSP
             :By: 0
@@ -2983,8 +5392,8 @@
           :MaximumMemoryPerVM: 1048576
           :MinimumMemoryPerVM: 32
           :SuggestedMaximumMemoryPerVM: 512
-          :ModifiedTime: 2016-02-23 12:35:47.701376000 -05:00
-          :Agent: &30
+          :ModifiedTime: 2016-02-29 19:51:46.917145200 -05:00
+          :Agent: &58
             :ToString: dell-r410-01.cloudformswin.lab.redhat.com
             :Props:
               :StateString: Responding
@@ -3011,8 +5420,204 @@
               :ObjectType: AgentServer
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :ManagedComputer: *30
-          :VMs: []
+          :ManagedComputer: *58
+          :VMs:
+          - :ToString: testing_provisioning
+            :Props:
+              :VMCPath: C:\testing_provisioning\Virtual Machines\1998F65F-E02F-439B-8A5B-CD750F068020.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+              :VMId: 1998F65F-E02F-439B-8A5B-CD750F068020
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: *59
+              :UnsupportedReason: *19
+              :RefresherErrors: *60
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\testing_provisioning
+              :TotalSize: 35328
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 44f2407c-cd50-4ad6-8041-208a81441f4a
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 0
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: linux_template
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\testing_provisioning
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 1998F65F-E02F-439B-8A5B-CD750F068020
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: *61
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 2e688429-c7cb-49c9-a577-06fb8ed48763
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: *27
+              :Location: C:\testing_provisioning
+              :CreationTime: 2016-02-26 13:42:16.017000000 -05:00
+              :OperatingSystem: *16
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 1024
+              :DynamicMemoryEnabled: true
+              :DynamicMemoryMaximumMB: 4096
+              :DynamicMemoryBufferPercentage: 20
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder: *62
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus: *63
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *15
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 63140
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 1024
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives:
+              - *64
+              :VirtualHardDisks:
+              - *26
+              :VirtualDiskDrives:
+              - *65
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - *66
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: *67
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - *68
+              :CapabilityProfile: *23
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
+              :HostType: VMHost
+              :HostName: dell-r410-01.cloudformswin.lab.redhat.com
+              :VMHost: *10
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CLOUDFORMSWIN\scvmm
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: testing_provisioning
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-26 13:42:16.017000000 -05:00
+              :ModifiedTime: 2016-02-29 06:58:47.087000000 -05:00
+              :Enabled: true
+              :ServerConnection: *8
+              :ID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: *27
+            :MS:
+              :ServicingWindows: *9
           :Disks:
           - :ToString: "\\\\.\\PHYSICALDRIVE1"
             :Props:
@@ -3161,7 +5766,7 @@
               :MountPoints:
               - C:\
               :Capacity: 499738734592
-              :FreeSpace: 467535630336
+              :FreeSpace: 463193792512
               :VolumeLabel: 
               :FileSystem: 
               :IsSANMigrationPossible: false
@@ -3230,7 +5835,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.230000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.930000000 -05:00
               :ServerConnection: *8
               :ID: 45056b73-029c-478f-aac7-1bc58bb7f65e
               :IsViewOnly: false
@@ -3251,7 +5856,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.207000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.910000000 -05:00
               :ServerConnection: *8
               :ID: 19106a9f-674e-46de-ac0b-46344054a28c
               :IsViewOnly: false
@@ -3272,7 +5877,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.250000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.953000000 -05:00
               :ServerConnection: *8
               :ID: 5a93ae04-0b4f-49ca-b67a-7ed0650395fd
               :IsViewOnly: false
@@ -3293,7 +5898,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.197000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.897000000 -05:00
               :ServerConnection: *8
               :ID: 7507a153-717a-4005-a398-b32c470898ef
               :IsViewOnly: false
@@ -3314,7 +5919,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.240000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.943000000 -05:00
               :ServerConnection: *8
               :ID: 055b7786-9bea-4fca-aaea-c195490d9960
               :IsViewOnly: false
@@ -3335,7 +5940,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.260000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.963000000 -05:00
               :ServerConnection: *8
               :ID: 13fc58a7-bf5f-4327-a18c-d34759607655
               :IsViewOnly: false
@@ -3356,7 +5961,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.273000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.973000000 -05:00
               :ServerConnection: *8
               :ID: 5e9a41c3-b05c-436a-b675-e2faa0b37338
               :IsViewOnly: false
@@ -3377,7 +5982,7 @@
               :SerialNumber: 
               :VMHost: *10
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:35:45.217000000 -05:00
+              :ModifiedTime: 2016-02-29 19:35:45.920000000 -05:00
               :ServerConnection: *8
               :ID: 50a1cc33-df0e-4e51-93f5-fa97fdbeafb1
               :IsViewOnly: false
@@ -3569,10 +6174,10 @@
           :RemoteStorageTotalCapacity: 0
           :RemoteStorageAvailableCapacity: 0
           :LocalStorageTotalCapacity: 500107862016
-          :LocalStorageAvailableCapacity: 467611275264
+          :LocalStorageAvailableCapacity: 463269437440
           :TotalStorageCapacity: 500107862016
-          :AvailableStorageCapacity: 467611275264
-          :UsedStorageCapacity: 32496586752
+          :AvailableStorageCapacity: 463269437440
+          :UsedStorageCapacity: 36838424576
           :IsDedicatedToNetworkVirtualizationGateway: false
           :FibreChannelWorldWidePortNameMinimum: C003FF831E9E0000
           :FibreChannelWorldWidePortNameMaximum: C003FF831E9EFFFF
@@ -3712,7 +6317,7 @@
             :I32: 9
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *31
+          :MostRecentTaskIfLocal: *69
         :MS:
           :FQDN: dell-r410-01.cloudformswin.lab.redhat.com
           :LogicalCPUCount: 16
@@ -3796,7 +6401,7 @@
           :MacAddress: D4:AE:52:6A:02:43
           :PhysicalAddress: D4:AE:52:6A:02:43
           :NetworkLocation: VM_Network
-          :VirtualNetwork: &32
+          :VirtualNetwork: &70
             :ToString: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33
               - Virtual Switch'
             :Props:
@@ -3809,7 +6414,7 @@
               :BoundToVMHost: true
               :Description: 
               :LogicalNetworks:
-              - *23
+              - *21
               :VMHostNetworkAdapters:
               - 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
                 #33'
@@ -3873,7 +6478,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -3963,7 +6568,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -4053,7 +6658,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -4143,7 +6748,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -4186,7 +6791,7 @@
           :BoundToVMHost: true
           :Description: 
           :LogicalNetworks:
-          - *23
+          - *21
           :VMHostNetworkAdapters:
           - :ToString: 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD
               Client) #33'
@@ -4234,7 +6839,7 @@
               :MacAddress: D4:AE:52:6A:02:43
               :PhysicalAddress: D4:AE:52:6A:02:43
               :NetworkLocation: VM_Network
-              :VirtualNetwork: *32
+              :VirtualNetwork: *70
               :NetworkSwitchPort: 
               :UplinkPortProfileSet: 
               :VLanTags: []
@@ -4257,7 +6862,7 @@
                 ! '':
                 - '0'
               :LogicalNetworks:
-              - *23
+              - *21
               :SubnetVLans:
               - '0'
               :UnassignedVLans: []
@@ -4295,33 +6900,33 @@
         :ToString: dell-r410-03.cloudformswin.lab.redhat.com
         :Props:
           :RunAsAccount: 
-          :MostRecentTaskID: bab77f7b-0552-44c4-a6a6-9f3161213689
+          :MostRecentTaskID: a45a922f-7815-46bd-9116-b47ad83ffc1f
           :MostRecentTaskUIState:
-            :ToString: Completed
-            :I32: 5
-          :MostRecentTask: &61
-            :ToString: Change properties of virtual machine host
+            :ToString: Failed
+            :I32: 3
+          :MostRecentTask: &99
+            :ToString: Refresh Performance Data
             :Props:
               :StepsLoaded: true
               :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Change properties of virtual machine host
+              :Description: Refresh Performance Data
               :IsVisible: true
-              :Status: Completed
-              :StatusString: Completed
-              :ErrorInfo: Success (0)
-              :StartTime: 2016-02-22 09:15:50.947000000 -05:00
-              :EndTime: 2016-02-22 09:17:10.090000000 -05:00
-              :Owner: CLOUDFORMSWIN\Administrator
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-500
-              :SessionOwner: CLOUDFORMSWIN\Administrator
-              :Name: Change properties of virtual machine host
+              :Status: Failed
+              :StatusString: Failed
+              :ErrorInfo: 'HostAgentFail (2912); HR: 0x80070576'
+              :StartTime: 2016-02-26 21:05:07.510000000 -05:00
+              :EndTime: 2016-02-26 21:05:07.530000000 -05:00
+              :Owner: CLOUDFORMSWIN\scvmm
+              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+              :SessionOwner: CLOUDFORMSWIN\scvmm
+              :Name: Refresh Performance Data
               :Steps:
               - Microsoft.SystemCenter.VirtualMachineManager.Step
               :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 100
-              :Progress: 100 %
+              :ProgressValue: 0
+              :Progress: 0 %
               :WasNotifiedOfCancel: false
-              :CmdletName: Set-SCVMHost
+              :CmdletName: Performance Data Refresher (System Job)
               :PROTipID: 
               :ResultObjectID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
               :TargetObjectID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
@@ -4338,7 +6943,7 @@
               :IsRestartable: false
               :IsStoppable: false
               :ServerConnection: *8
-              :ID: bab77f7b-0552-44c4-a6a6-9f3161213689
+              :ID: a45a922f-7815-46bd-9116-b47ad83ffc1f
               :IsViewOnly: false
               :ObjectType: Job
               :MarkedForDeletion: false
@@ -4363,8 +6968,8 @@
           :DiskSpaceReserveMB: 10240
           :MaxDiskIOReservation: 10000
           :MemoryReserveMB: 2048
-          :VMPaths: *33
-          :BaseDiskPaths: *34
+          :VMPaths: *71
+          :BaseDiskPaths: *72
           :PROEnabled: false
           :MaintenanceHost: false
           :AvailableForPlacement: true
@@ -4384,7 +6989,7 @@
           :ProcessorFamily: '179'
           :CpuUtilization: 0
           :TotalMemory: 137425408000
-          :AvailableMemory: 127210
+          :AvailableMemory: 127010
           :OperatingSystem:
             :ToString: 'Microsoft Windows Server 2012 R2 Datacenter '
             :Props:
@@ -4403,7 +7008,7 @@
               :AllowsOrgNameInSysprep: false
               :RequiresPIDInSysprep: true
               :ServerConnection: 
-              :ID: 3e05943e-d319-4aba-acf4-fd7b3ea084ee
+              :ID: d57123c4-cc5b-4dbe-992c-ca1ad6fd42ba
               :IsViewOnly: false
               :ObjectType: OperatingSystem
               :MarkedForDeletion: false
@@ -4423,7 +7028,7 @@
           :SupportsLiveMigration: false
           :FloppyDrives: 
           :FloppyDriveList: []
-          :VMHostGroup: *35
+          :VMHostGroup: *13
           :HostCluster: 
           :RemoteConnectEnabled: true
           :RemoteConnectPort: 2179
@@ -4433,8 +7038,8 @@
           :LiveMigrationMaximum: 2
           :LiveStorageMigrationMaximum: 2
           :UseAnyMigrationSubnet: false
-          :MigrationSubnet: *36
-          :MigrationSubnetUserManaged: *37
+          :MigrationSubnet: *73
+          :MigrationSubnetUserManaged: *74
           :MigrationAuthProtocol:
             :ToString: CredSSP
             :By: 0
@@ -4468,8 +7073,8 @@
           :MaximumMemoryPerVM: 1048576
           :MinimumMemoryPerVM: 32
           :SuggestedMaximumMemoryPerVM: 512
-          :ModifiedTime: 2016-02-23 12:32:07.928791500 -05:00
-          :Agent: &38
+          :ModifiedTime: 2016-02-29 19:53:09.520876000 -05:00
+          :Agent: &75
             :ToString: dell-r410-03.cloudformswin.lab.redhat.com
             :Props:
               :StateString: Responding
@@ -4496,7 +7101,7 @@
               :ObjectType: AgentServer
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :ManagedComputer: *38
+          :ManagedComputer: *75
           :VMs:
           - :ToString: vm_linux1
             :Props:
@@ -4510,9 +7115,9 @@
               :VMConfigResourceStatus: ClusterResourceStateUnknown
               :VMResource: 
               :VMResourceStatus: ClusterResourceStateUnknown
-              :DiskResources: *39
-              :UnsupportedReason: *20
-              :RefresherErrors: *40
+              :DiskResources: *76
+              :UnsupportedReason: *19
+              :RefresherErrors: *77
               :VirtualMachineState: Running
               :HostGroupPath: All Hosts\vm_linux1
               :TotalSize: 4194304
@@ -4537,7 +7142,7 @@
               :PerfMemory: 512
               :PerfDiskBytesRead: 0
               :PerfDiskBytesWrite: 0
-              :PerfNetworkBytesRead: 1039
+              :PerfNetworkBytesRead: 0
               :PerfNetworkBytesWrite: 0
               :VirtualizationPlatform: HyperV
               :ComputerNameString: Unknown
@@ -4567,7 +7172,7 @@
               :DeploymentErrorInfo: 
               :ServiceDeploymentErrorMessage: 
               :DeploymentState: Undeployed
-              :TieredPerfData: *41
+              :TieredPerfData: *78
               :ReplicationSetting: 
               :ReplicationStatus: 
               :IsRecoveryVM: false
@@ -4585,12 +7190,12 @@
               :ClusterPreferredOwner: 
               :AvailabilitySetNames: 
               :LiveCloningEnabled: true
-              :MostRecentTaskID: 70f9b051-418a-4ce8-a561-6bb1e1b3092a
+              :MostRecentTaskID: 9c32c5ad-3d6a-43c5-9c95-120296e147ce
               :MostRecentTaskUIState: Completed
-              :MostRecentTask: *25
+              :MostRecentTask: *18
               :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
               :CreationTime: 2016-02-01 13:39:24.990000000 -05:00
-              :OperatingSystem: *42
+              :OperatingSystem: *79
               :HasVMAdditions: false
               :VMAddition: Not Detected
               :NumLockEnabled: false
@@ -4612,12 +7217,12 @@
               :VirtualVideoAdapterEnabled: false
               :MonitorMaximumCount: 
               :MonitorResolutionMaximum: 
-              :BootOrder: *43
+              :BootOrder: *80
               :FirstBootDevice: 
               :SecureBootEnabled: 
               :ComputerName: 
               :UseHardwareAssistedVirtualization: true
-              :SANStatus: *44
+              :SANStatus: *81
               :CostCenter: 
               :QuotaPoint: 1
               :IsTagEmpty: false
@@ -4635,7 +7240,7 @@
               - 
               :CustomProperty: {}
               :UndoDisksEnabled: false
-              :CPUType: *14
+              :CPUType: *15
               :ExpectedCPUUtilization: 20
               :DiskIO: 0
               :NetworkUtilization: 0
@@ -4649,24 +7254,24 @@
               :NumaIsolationRequired: false
               :Generation: 1
               :VirtualDVDDrives:
-              - *45
+              - *82
               :VirtualHardDisks:
-              - *22
+              - *17
               :VirtualDiskDrives:
-              - *46
+              - *83
               :ShareSCSIBus: false
               :VirtualNetworkAdapters:
-              - *47
+              - *84
               :VirtualFibreChannelAdapters: []
               :HasVirtualFibreChannelAdapters: false
-              :VirtualFloppyDrive: *48
+              :VirtualFloppyDrive: *85
               :VirtualCOMPorts:
               - COM1
               - COM2
               :VirtualSCSIAdapters:
-              - *49
+              - *86
               :CapabilityProfile: 
-              :CapabilityProfileCompatibilityState: 
+              :CapabilityProfileCompatibilityState: Compatible
               :VMCheckpoints: []
               :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
               :HostType: VMHost
@@ -4686,13 +7291,13 @@
               :IsViewOnly: false
               :Description: 
               :AddedTime: 2016-02-01 13:39:24.990000000 -05:00
-              :ModifiedTime: 2016-02-23 11:49:43.558084800 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.470499500 -05:00
               :Enabled: true
               :ServerConnection: *8
               :ID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
               :MarkedForDeletion: false
               :IsFullyCached: true
-              :MostRecentTaskIfLocal: *25
+              :MostRecentTaskIfLocal: *18
             :MS:
               :ServicingWindows: *9
           - :ToString: linux2
@@ -4706,9 +7311,9 @@
               :VMConfigResourceStatus: ClusterResourceStateUnknown
               :VMResource: 
               :VMResourceStatus: ClusterResourceStateUnknown
-              :DiskResources: *50
-              :UnsupportedReason: *20
-              :RefresherErrors: *51
+              :DiskResources: *87
+              :UnsupportedReason: *19
+              :RefresherErrors: *88
               :VirtualMachineState: Running
               :HostGroupPath: All Hosts\linux2
               :TotalSize: 665147392
@@ -4757,13 +7362,13 @@
               :UpgradeDomain: 
               :SCApplications: []
               :LastRestoredCheckpointID: 406845EA-0CF6-44CD-9D96-24A157DF5736
-              :LastRestoredVMCheckpoint: *18
+              :LastRestoredVMCheckpoint: *24
               :ComplianceStatus: 
               :IsFaultTolerant: false
               :DeploymentErrorInfo: 
               :ServiceDeploymentErrorMessage: 
               :DeploymentState: Undeployed
-              :TieredPerfData: *52
+              :TieredPerfData: *89
               :ReplicationSetting: 
               :ReplicationStatus: 
               :IsRecoveryVM: false
@@ -4783,10 +7388,10 @@
               :LiveCloningEnabled: true
               :MostRecentTaskID: f0cbd7d9-322b-429e-84b2-919a5cdcc979
               :MostRecentTaskUIState: Completed
-              :MostRecentTask: *19
+              :MostRecentTask: *25
               :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
               :CreationTime: 2016-02-22 11:52:19.483000000 -05:00
-              :OperatingSystem: *53
+              :OperatingSystem: *90
               :HasVMAdditions: false
               :VMAddition: Not Detected
               :NumLockEnabled: false
@@ -4808,12 +7413,12 @@
               :VirtualVideoAdapterEnabled: false
               :MonitorMaximumCount: 
               :MonitorResolutionMaximum: 
-              :BootOrder: *54
+              :BootOrder: *91
               :FirstBootDevice: 
               :SecureBootEnabled: 
               :ComputerName: 
               :UseHardwareAssistedVirtualization: true
-              :SANStatus: *55
+              :SANStatus: *92
               :CostCenter: 
               :QuotaPoint: 1
               :IsTagEmpty: false
@@ -4831,7 +7436,7 @@
               - 
               :CustomProperty: {}
               :UndoDisksEnabled: false
-              :CPUType: *14
+              :CPUType: *15
               :ExpectedCPUUtilization: 20
               :DiskIO: 0
               :NetworkUtilization: 0
@@ -4845,26 +7450,26 @@
               :NumaIsolationRequired: false
               :Generation: 1
               :VirtualDVDDrives:
-              - *56
+              - *93
               :VirtualHardDisks:
-              - *16
+              - *20
               :VirtualDiskDrives:
-              - *57
+              - *94
               :ShareSCSIBus: false
               :VirtualNetworkAdapters:
-              - *58
+              - *95
               :VirtualFibreChannelAdapters: []
               :HasVirtualFibreChannelAdapters: false
-              :VirtualFloppyDrive: *59
+              :VirtualFloppyDrive: *96
               :VirtualCOMPorts:
               - COM1
               - COM2
               :VirtualSCSIAdapters:
-              - *60
-              :CapabilityProfile: *17
+              - *97
+              :CapabilityProfile: *23
               :CapabilityProfileCompatibilityState: Compatible
               :VMCheckpoints:
-              - *18
+              - *24
               :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
               :HostType: VMHost
               :HostName: dell-r410-03.cloudformswin.lab.redhat.com
@@ -4883,13 +7488,13 @@
               :IsViewOnly: false
               :Description: 
               :AddedTime: 2016-02-22 11:52:19.483000000 -05:00
-              :ModifiedTime: 2016-02-23 11:21:56.150600600 -05:00
+              :ModifiedTime: 2016-02-29 19:18:07.230000000 -05:00
               :Enabled: true
               :ServerConnection: *8
               :ID: c4425913-7043-4d2a-a229-75f051a8127b
               :MarkedForDeletion: false
               :IsFullyCached: true
-              :MostRecentTaskIfLocal: *19
+              :MostRecentTaskIfLocal: *25
             :MS:
               :ServicingWindows: *9
           :Disks:
@@ -5031,7 +7636,7 @@
               :MarkedForDeletion: false
               :IsFullyCached: true
           :DiskVolumes:
-          - *21
+          - *98
           - :ToString: "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
             :Props:
               :Name: "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
@@ -5080,7 +7685,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.453000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.923000000 -05:00
               :ServerConnection: *8
               :ID: 5b2b1dac-fd59-49a5-ad51-02e8eb5a5948
               :IsViewOnly: false
@@ -5101,7 +7706,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.513000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.983000000 -05:00
               :ServerConnection: *8
               :ID: 6c160fac-fe9d-4fc8-b8b2-03c16b27e9ed
               :IsViewOnly: false
@@ -5122,7 +7727,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.523000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.993000000 -05:00
               :ServerConnection: *8
               :ID: 77755ae5-45bd-44a1-85e3-362a05fa935f
               :IsViewOnly: false
@@ -5143,7 +7748,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.473000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.943000000 -05:00
               :ServerConnection: *8
               :ID: f237e81e-5390-48a4-be6a-379324fbc503
               :IsViewOnly: false
@@ -5164,7 +7769,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.463000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.933000000 -05:00
               :ServerConnection: *8
               :ID: 137c551f-bc10-468e-9cd6-71e6898bde8a
               :IsViewOnly: false
@@ -5185,7 +7790,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.493000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.963000000 -05:00
               :ServerConnection: *8
               :ID: f3dbd95e-d003-409b-b6e7-c94bc54ca94f
               :IsViewOnly: false
@@ -5206,7 +7811,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.483000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.953000000 -05:00
               :ServerConnection: *8
               :ID: ee1a2ac4-7015-4e29-af03-d3b371e82ee4
               :IsViewOnly: false
@@ -5227,7 +7832,7 @@
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-23 12:30:01.503000000 -05:00
+              :ModifiedTime: 2016-02-29 19:30:01.973000000 -05:00
               :ServerConnection: *8
               :ID: 8e8fe4e5-ff94-4d2a-aa97-fbe27a460fc2
               :IsViewOnly: false
@@ -5419,10 +8024,10 @@
           :RemoteStorageTotalCapacity: 0
           :RemoteStorageAvailableCapacity: 0
           :LocalStorageTotalCapacity: 300000000000
-          :LocalStorageAvailableCapacity: 264916131840
+          :LocalStorageAvailableCapacity: 267277864960
           :TotalStorageCapacity: 300000000000
-          :AvailableStorageCapacity: 264916131840
-          :UsedStorageCapacity: 35083868160
+          :AvailableStorageCapacity: 267277864960
+          :UsedStorageCapacity: 32722135040
           :IsDedicatedToNetworkVirtualizationGateway: false
           :FibreChannelWorldWidePortNameMinimum: C003FF3CB93B0000
           :FibreChannelWorldWidePortNameMaximum: C003FF3CB93BFFFF
@@ -5562,7 +8167,7 @@
             :I32: 9
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *61
+          :MostRecentTaskIfLocal: *99
         :MS:
           :FQDN: dell-r410-03.cloudformswin.lab.redhat.com
           :LogicalCPUCount: 16
@@ -5644,7 +8249,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -5734,7 +8339,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -5826,7 +8431,7 @@
           :MacAddress: 78:2B:CB:40:7B:A4
           :PhysicalAddress: 78:2B:CB:40:7B:A4
           :NetworkLocation: VM_Network
-          :VirtualNetwork: &62
+          :VirtualNetwork: &100
             :ToString: New Virtual Switch0
             :Props:
               :Name: New Virtual Switch0
@@ -5837,7 +8442,7 @@
               :BoundToVMHost: true
               :Description: 
               :LogicalNetworks:
-              - *23
+              - *21
               :VMHostNetworkAdapters:
               - 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
                 #33'
@@ -5901,7 +8506,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -5991,7 +8596,7 @@
                 :ID: 
                 :IsAssignedToVMSubnet: false
           :LogicalNetworks:
-          - *23
+          - *21
           :SubnetVLans:
           - :ToString: '0'
             :Props:
@@ -6032,7 +8637,7 @@
           :BoundToVMHost: true
           :Description: 
           :LogicalNetworks:
-          - *23
+          - *21
           :VMHostNetworkAdapters:
           - :ToString: 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD
               Client) #33'
@@ -6080,7 +8685,7 @@
               :MacAddress: 78:2B:CB:40:7B:A4
               :PhysicalAddress: 78:2B:CB:40:7B:A4
               :NetworkLocation: VM_Network
-              :VirtualNetwork: *62
+              :VirtualNetwork: *100
               :NetworkSwitchPort: 
               :UplinkPortProfileSet: 
               :VLanTags: []
@@ -6103,7 +8708,7 @@
                 ! '':
                 - '0'
               :LogicalNetworks:
-              - *23
+              - *21
               :SubnetVLans:
               - '0'
               :UnassignedVLans: []
@@ -6136,3 +8741,360 @@
             :I32: 15
           :MarkedForDeletion: false
           :IsFullyCached: true
+    :529da423-9493-4a00-9634-37c83dc1fe0e:
+      :Properties:
+        :ToString: cfme-esx-55-01
+        :Props:
+          :RunAsAccount: *28
+          :MostRecentTaskID: 3180e43e-d149-41d9-a868-4fcafe80b680
+          :MostRecentTaskUIState:
+            :ToString: Failed
+            :I32: 3
+          :MostRecentTask: &106
+            :ToString: Add virtual machine host
+            :Props:
+              :StepsLoaded: true
+              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :Description: Add virtual machine host
+              :IsVisible: true
+              :Status: Failed
+              :StatusString: Failed
+              :ErrorInfo: FailedWithCriticalException (20413)
+              :StartTime: 2016-02-24 11:48:21.327000000 -05:00
+              :EndTime: 2016-02-24 11:48:27.723000000 -05:00
+              :Owner: CLOUDFORMSWIN\scvmm
+              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
+              :SessionOwner: CLOUDFORMSWIN\scvmm
+              :Name: Add virtual machine host
+              :Steps:
+              - Microsoft.SystemCenter.VirtualMachineManager.Step
+              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :ProgressValue: 66
+              :Progress: 66 %
+              :WasNotifiedOfCancel: false
+              :CmdletName: Add-SCVMHostCluster
+              :PROTipID: 
+              :ResultObjectID: 529da423-9493-4a00-9634-37c83dc1fe0e
+              :TargetObjectID: 529da423-9493-4a00-9634-37c83dc1fe0e
+              :TargetObjectType: VMHost
+              :IsCompleted: true
+              :AreAuditRecordsAvailable: false
+              :AuditRecords: []
+              :AdditionalMessages: []
+              :Source: 
+              :Target: 
+              :ResultObjectType: VMHost
+              :ResultObjectTypeName: Host
+              :ResultName: cfme-esx-55-01
+              :IsRestartable: true
+              :IsStoppable: false
+              :ServerConnection: *8
+              :ID: 3180e43e-d149-41d9-a868-4fcafe80b680
+              :IsViewOnly: false
+              :ObjectType: Job
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :OverallStateString: Adding...
+          :OverallState:
+            :ToString: Adding
+            :By: 3
+          :CommunicationStateString: Connecting...
+          :CommunicationState:
+            :ToString: Connecting
+            :By: 3
+          :Name: cfme-esx-55-01
+          :FullyQualifiedDomainName: cfme-esx-55-01
+          :ComputerName: cfme-esx-55-01
+          :DomainName: cfme-esx-55-01
+          :Description: 
+          :RemoteUserName: localhost\root
+          :OverrideHostGroupReserves: false
+          :CPUPercentageReserve: 10
+          :NetworkPercentageReserve: 0
+          :DiskSpaceReserveMB: 10240
+          :MaxDiskIOReservation: 10000
+          :MemoryReserveMB: 2048
+          :VMPaths: *101
+          :BaseDiskPaths: *102
+          :PROEnabled: false
+          :MaintenanceHost: false
+          :AvailableForPlacement: true
+          :IsEmbedded: false
+          :CredentialsNeeded: true
+          :PausedForNetworkIncompatibility: false
+          :LogicalProcessorCount: 0
+          :PhysicalCPUCount: 0
+          :CoresPerCPU: 0
+          :L2CacheSize: 0
+          :L3CacheSize: 0
+          :BusSpeed: 0
+          :ProcessorSpeed: 0
+          :ProcessorModel: 
+          :ProcessorManufacturer: 
+          :ProcessorArchitecture: 0
+          :ProcessorFamily: 
+          :CpuUtilization: 0
+          :TotalMemory: 0
+          :AvailableMemory: 0
+          :OperatingSystem: *16
+          :OperatingSystemVersion: '0.0'
+          :DVDDrives: 
+          :DVDDriveList: []
+          :VirtualizationPlatformString: VMware ESX Server
+          :VirtualizationPlatform:
+            :ToString: VMWareESX
+            :I32: 4
+          :VirtualizationPlatformDetail: VMware ESX Server
+          :IsVirtualizationSoftwareDetailUnknown: false
+          :IsViridianHost: false
+          :SupportsLiveMigration: false
+          :FloppyDrives: 
+          :FloppyDriveList: []
+          :VMHostGroup: *13
+          :HostCluster: *43
+          :RemoteConnectEnabled: true
+          :RemoteConnectPort: 5900
+          :SecureRemoteConnectEnabled: false
+          :VMRCCertificateAvailable: false
+          :EnableLiveMigration: false
+          :LiveMigrationMaximum: 0
+          :LiveStorageMigrationMaximum: 0
+          :UseAnyMigrationSubnet: false
+          :MigrationSubnet: *103
+          :MigrationSubnetUserManaged: *104
+          :MigrationAuthProtocol:
+            :ToString: CredSSP
+            :By: 0
+          :MigrationPerformanceOption:
+            :ToString: Standard
+            :By: 0
+          :SslTcpPort: 443
+          :SslCertificateHash: 
+          :SshTcpPort: 22
+          :SshPublicKeyHash: 
+          :SshPublicKey: 
+          :IsRemoteFXRoleInstalled: false
+          :IsCPUSLAT: false
+          :IsNumaSpanningEnabled: 
+          :GPUMemoryTotalMB: 
+          :GPUMemoryAvailableMB: 
+          :ClusterNodeStatus:
+            :ToString: Unknown
+            :By: 7
+          :TimeZone: 
+          :HyperVState:
+            :ToString: Unknown
+            :By: 7
+          :HyperVStateString: Unknown
+          :HyperVVersion: '0.0'
+          :HyperVVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :PerimeterNetworkHost: false
+          :NonTrustedDomainHost: false
+          :MaximumMemoryPerVM: 0
+          :MinimumMemoryPerVM: 0
+          :SuggestedMaximumMemoryPerVM: 0
+          :ModifiedTime: 2016-02-24 11:48:23.407000000 -05:00
+          :Agent: &105
+            :ToString: cfme-esx-55-01
+            :Props:
+              :StateString: Responding
+              :RoleString: Host
+              :State: Responding
+              :VersionState: NotApplicable
+              :VersionStateString: Not Applicable
+              :MarkedForDeletion: false
+              :Name: cfme-esx-55-01
+              :MostRecentTaskID: 
+              :MostRecentTaskUIState: 
+              :MostRecentTask: 
+              :FullyQualifiedDomainName: cfme-esx-55-01
+              :FQDN: cfme-esx-55-01
+              :ComputerName: cfme-esx-55-01
+              :Description: 
+              :AgentVersion: '0.0'
+              :Role: Host
+              :UpdatedDate: 2016-02-24 11:48:21.473000000 -05:00
+              :ComplianceStatus: 
+              :ServerConnection: *8
+              :ID: 55f6ca46-6e71-4ff1-8da9-5e6c14e4fe47
+              :IsViewOnly: false
+              :ObjectType: AgentServer
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ManagedComputer: *105
+          :VMs: []
+          :Disks: []
+          :GPUs: []
+          :InstalledVirtualSwitchExtensions: []
+          :DiskVolumes: []
+          :RegisteredStorageFileShares: []
+          :FibreChannelHbas: []
+          :FibreChannelVirtualSANs: []
+          :SASHbas: []
+          :InternetSCSIHbas: []
+          :VMwareResourcePool: 
+          :IsConfiguredForOutOfBandManagement: false
+          :PhysicalMachine:
+            :ToString: ''
+            :Props:
+              :Name: 
+              :BMCType: None
+              :BMCCustomConfigurationProvider: 
+              :BMCAddress: 
+              :BMCPort: 
+              :RunAsAccount: 
+              :SMBiosGUID: 
+              :ComputerPowerState: Unknown
+              :SystemEventLog: []
+              :ServerConnection: *8
+              :ID: 10b85f63-dbb8-498a-8a0d-c31f048c4382
+              :IsViewOnly: false
+              :ObjectType: PhysicalMachine
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :HealthMonitors: []
+          :RemoteStorageTotalCapacity: 0
+          :RemoteStorageAvailableCapacity: 0
+          :LocalStorageTotalCapacity: 0
+          :LocalStorageAvailableCapacity: 0
+          :TotalStorageCapacity: 0
+          :AvailableStorageCapacity: 0
+          :UsedStorageCapacity: 0
+          :IsDedicatedToNetworkVirtualizationGateway: false
+          :FibreChannelWorldWidePortNameMinimum: 
+          :FibreChannelWorldWidePortNameMaximum: 
+          :FibreChannelWorldWideNodeName: 
+          :VMConnectCertificateThumbprint: 
+          :Custom1: 
+          :Custom2: 
+          :Custom3: 
+          :Custom4: 
+          :Custom5: 
+          :Custom6: 
+          :Custom7: 
+          :Custom8: 
+          :Custom9: 
+          :Custom10: 
+          :CustomProperty: {}
+          :FibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :ISCSISANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :NPIVFibreChannelSANStatus:
+            :ToString: SANNotConfigured (1245)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1245
+              :ErrorCodeString: '1245'
+              :ErrorType: Info
+              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
+                not configured for this server. ; Recommended Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN is not configured for this server.
+              :CloudProblem: SAN is not configured for this server.
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: SANNotConfigured
+              :GetMessageFormatterHandler: 
+          :CertificateRequest: 
+          :ComputerState:
+            :ToString: Adding
+            :By: 0
+          :VirtualizationManager: 
+          :ServerConnection: *8
+          :ID: 529da423-9493-4a00-9634-37c83dc1fe0e
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHost
+            :I32: 9
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: *106
+        :MS:
+          :FQDN: cfme-esx-55-01
+          :LogicalCPUCount: 0
+          :CPUSpeed: 0
+          :CPUModel: 
+          :CPUManufacturer: 
+          :CPUArchitecture: 0
+          :CPUFamily: 
+          :VMRCEnabled: true
+          :VMRCPort: 5900
+          :SecureVMRCEnabled: false
+          :VirtualServerState:
+            :ToString: Unknown
+            :By: 7
+          :VirtualServerStateString: Unknown
+          :VirtualServerVersion: '0.0'
+          :VirtualServerVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :ServicingWindows: *9
+      :NetworkAdapters: []
+      :VirtualSwitch: []


### PR DESCRIPTION
The functionality in this PR is as follows:

* If the VirtualizationPlatform property on a host indicates it is a VMware ESX server then skip that host.
* Add a check for nil in the process_collection method - this will avoid a nil value being stored in the @data[:hosts] array for each ESX server that was skipped ( I didn't limit this to the host type since we should not store nil for any type)
* If a cluster is left hanging without any hosts, for example if a cluster contains only ESX servers, we do not process that cluster.
* A spec test was added to ensure the ESX servers are not being managed.





https://bugzilla.redhat.com/show_bug.cgi?id=1153706