### PR TITLE
Load productization after rails initializes

### DIFF
--- a/config/initializers/productization.rb
+++ b/config/initializers/productization.rb
@@ -1,1 +1,3 @@
-Vmdb::Productization.new.prepare
+Rails.application.config.to_prepare do
+  Vmdb::Productization.new.prepare
+end


### PR DESCRIPTION
Delay configuring paths until after rails has loaded
and all the asset paths have already been loaded.

This will allow us to add ourselves ahead of the path setup by `railsties`.

/cc @simaishi 