### PR TITLE
Use ApplicationRecord for calling my_region_number

### DIFF
--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -32,7 +32,7 @@ module ApplianceConsole
     def self.db_host_database_region
       result = AwesomeSpawn.run(
         "bin/rails runner",
-        :params => ["puts MiqDbConfig.current.options.values_at(:host, :database), ActiveRecord::Base.my_region_number"],
+        :params => ["puts MiqDbConfig.current.options.values_at(:host, :database), ApplicationRecord.my_region_number"],
         :chdir  => RAILS_ROOT
       )
 


### PR DESCRIPTION
This was failing as `ActiveRecord::Base` no longer has `.my_region_number`

This was causing the region on the console to always be 0 and the database name to be blank.

@kbrock please review