### PR TITLE
Make registry configurable with image 'image-inspector'

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -302,8 +302,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def inspector_image
-    registry = @ems_configs.fetch_path(:ems_kubernetes, :image_inspector_registry)
-    return "#{registry}/openshift/image-inspector:v1.0.z" unless registry.empty?
-    return 'openshift/image-inspector:v1.0.z'
+    image = 'image-inspector:v1.0.z'
+    registry_repo = @ems_configs.fetch_path(:ems_kubernetes, :image_inspector_registry_repo)
+    return "#{registry_repo}/#{image}" unless registry_repo.blank?
+    image
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -37,9 +37,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     return queue_signal(:abort_job, "no image found", "error") unless image
     return queue_signal(:abort_job, "cannont analyze non-docker images", "error") unless image.docker_id
 
-    ems_configs = VMDB::Config.new('vmdb').config[:ems]
+    @ems_configs = VMDB::Config.new('vmdb').config[:ems]
 
-    namespace = ems_configs.fetch_path(:ems_kubernetes, :miq_namespace)
+    namespace = @ems_configs.fetch_path(:ems_kubernetes, :miq_namespace)
     namespace = INSPECTOR_NAMESPACE if namespace.blank?
 
     update!(:options => options.merge(
@@ -302,6 +302,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def inspector_image
-    'docker.io/openshift/image-inspector:v1.0.z'
+    registry = @ems_configs.fetch_path(:ems_kubernetes, :image_inspector_registry)
+    return "#{registry}/openshift/image-inspector:v1.0.z" unless registry.empty?
+    return 'openshift/image-inspector:v1.0.z'
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -4,6 +4,7 @@ require 'kubeclient'
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager
   INSPECTOR_NAMESPACE = 'management-infra'
+  INSPECTOR_IMAGE = 'image-inspector:v1.0.z'
   INSPECTOR_PORT = 8080
   DOCKER_SOCKET = '/var/run/docker.sock'
   SCAN_CATEGORIES = %w(system software)
@@ -302,9 +303,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def inspector_image
-    image = 'image-inspector:v1.0.z'
     registry_repo = @ems_configs.fetch_path(:ems_kubernetes, :image_inspector_registry_repo)
-    return "#{registry_repo}/#{image}" unless registry_repo.blank?
-    image
+    return "#{registry_repo}/#{INSPECTOR_IMAGE}" unless registry_repo.blank?
+    INSPECTOR_IMAGE
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -4,7 +4,6 @@ require 'kubeclient'
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager
   INSPECTOR_NAMESPACE = 'management-infra'
-  INSPECTOR_IMAGE = 'image-inspector:v1.0.z'
   INSPECTOR_PORT = 8080
   DOCKER_SOCKET = '/var/run/docker.sock'
   SCAN_CATEGORIES = %w(system software)
@@ -303,8 +302,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def inspector_image
-    registry_repo = @ems_configs.fetch_path(:ems_kubernetes, :image_inspector_registry_repo)
-    return "#{registry_repo}/#{INSPECTOR_IMAGE}" unless registry_repo.blank?
-    INSPECTOR_IMAGE
+    fq_inspector_image = @ems_configs.fetch_path(:ems_kubernetes, :image_inspector)
+    return fq_inspector_image unless fq_inspector_image.blank?
+    _log.warn('image_inspector not explicitly configured.')
+    'image-inspector:latest'
   end
 end

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -61,7 +61,7 @@ ems:
       :read_timeout: 1.hour
   ems_kubernetes:
     :miq_namespace: management-infra
-    :image_inspector_registry_repo: 'docker.io/openshift'
+    :image_inspector: 'docker.io/openshift/image-inspector:v1.0.z'
 ems_events:
   history:
     :keep_ems_events: 6.months

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -61,7 +61,7 @@ ems:
       :read_timeout: 1.hour
   ems_kubernetes:
     :miq_namespace: management-infra
-    :image_inspector_registry: docker.io
+    :image_inspector_registry_repo: 'docker.io/openshift'
 ems_events:
   history:
     :keep_ems_events: 6.months

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -61,6 +61,7 @@ ems:
       :read_timeout: 1.hour
   ems_kubernetes:
     :miq_namespace: management-infra
+    :image_inspector_registry: docker.io
 ems_events:
   history:
     :keep_ems_events: 6.months


### PR DESCRIPTION
Currently, job.rb has a hardcoded reference to the image-inspector. It assumes that it can be retrievable from docker.io.

In some instances, the docker.io registry is inaccessible, so we need to be able to configure a different registry (local or other reachable registry).

I recommend putting the registry definition in the configuration under ems:ems_kubernetes:image_inspector_registry. We keep it defaulted to docker.io.

CC: @simon3z 
