### PR TITLE
Fix deprecation warning on .create_volume when the EMS is nil.

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -26,10 +26,12 @@ class CloudVolume < ApplicationRecord
   def self.class_by_ems(ext_management_system)
     # TODO(lsmola) taken from OrchesTration stacks, correct approach should be to have a factory on ExtManagementSystem
     # side, that would return correct class for each provider
-    ext_management_system.class::CloudVolume
+    ext_management_system && ext_management_system.class::CloudVolume
   end
 
   def self.create_volume(ext_management_system, options = {})
+    raise ArgumentError, "ext_management_system cannot be nil" if ext_management_system.nil?
+
     klass = class_by_ems(ext_management_system)
     tenant = options[:cloud_tenant]
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -56,6 +56,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
         expect(volume.cloud_tenant).to eq tenant
       end
 
+      it "raises an error when the ems is missing" do
+        expect { CloudVolume.create_volume(nil) }.to raise_error(ArgumentError)
+      end
+
       it "validates the volume create operation" do
         validation = CloudVolume.validate_create_volume(ems)
         expect(validation[:available]).to be true


### PR DESCRIPTION
The fixed warning is:
  app/models/cloud_volume.rb:25: warning: toplevel constant CloudVolume
  referenced by NilClass::CloudVolume

Fixes #6618 

@Ladas @chessbyte Please review