### PR TITLE
MiqAction#action_evm_event should raise MiqEvent instead of EmsEvent.

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -283,7 +283,7 @@ module ApplicationController::Timelines
       @tl_options[:tl_show_options].push(["Policy Events", "policy_timeline"])
       @tl_options[:tl_show] = "timeline"
     end
-    evt_type = @tl_options[:tl_show] == "timeline" ? "ems_events" : "policy_events"
+    evt_type = @tl_options[:tl_show] == "timeline" ? "event_streams" : "policy_events"
     sdate, edate = @tl_record.first_and_last_event(evt_type.to_sym)
     if !sdate.nil? && !edate.nil?
       @tl_options[:sdate] = [sdate.year.to_s, (sdate.month - 1).to_s, sdate.day.to_s].join(", ")
@@ -340,7 +340,7 @@ module ApplicationController::Timelines
   end
 
   def tl_build_timeline_report_options
-    evt_type = @tl_options[:tl_show] == "timeline" ? "ems_events" : "policy_events"
+    evt_type = @tl_options[:tl_show] == "timeline" ? "event_streams" : "policy_events"
     sdate, edate = @tl_record.first_and_last_event(evt_type.to_sym)
     if !@tl_options[:sdate].nil? && !@tl_options[:edate].nil?
       case @tl_options[:typ]

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -28,7 +28,7 @@ class Container < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
-    when :ems_events
+    when :ems_events, :event_streams
       # TODO: improve relationship using the id
       ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ? AND container_name = ?",
        container_project.name, ext_management_system.id, name]

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -58,7 +58,7 @@ class ContainerGroup < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
-    when :ems_events
+    when :ems_events, :event_streams
       # TODO: improve relationship using the id
       ["container_namespace = ? AND container_group_name = ? AND #{events_table_name(assoc)}.ems_id = ?",
        container_project.name, name, ems_id]

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -48,7 +48,7 @@ class ContainerNode < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
-    when :ems_events
+    when :ems_events, :event_streams
       # TODO: improve relationship using the id
       ["container_node_name = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
     when :policy_events

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -57,7 +57,7 @@ class ContainerProject < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
-    when :ems_events
+    when :ems_events, :event_streams
       # TODO: improve relationship using the id
       ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
     when :policy_events

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -24,7 +24,7 @@ class ContainerReplicator < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
-    when :ems_events
+    when :ems_events, :event_streams
       # TODO: improve relationship using the id
       ["container_namespace = ? AND container_replicator_name = ? AND #{events_table_name(assoc)}.ems_id = ?",
        container_project.name, name, ems_id]

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1601,7 +1601,7 @@ class Host < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
-    when :ems_events
+    when :ems_events, :event_streams
       ["host_id = ? OR dest_host_id = ?", id, id]
     when :policy_events
       ["host_id = ?", id]

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -353,6 +353,7 @@ class MiqAction < ApplicationRecord
       :timestamp  => Time.now.utc
     }
     opts = default_options.merge(action.options || {})
+    opts[:target] = rec
 
     opts[:ems_id] = rec.ext_management_system.id if rec.respond_to?(:ext_management_system) && rec.ext_management_system
     case rec
@@ -373,7 +374,7 @@ class MiqAction < ApplicationRecord
       opts[:ems_cluster_uid]   = rec.uid_ems
     end
 
-    EmsEvent.create(opts)
+    MiqEvent.create(opts)
   end
 
   def action_compliance_failed(action, rec, _inputs)

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -72,7 +72,7 @@ class MiqEvent < EventStream
   end
 
   def self.build_evm_event(event, target)
-    MiqEvent.create(:event_type => event, :target => target, :source => 'POLICY')
+    MiqEvent.create(:event_type => event, :target => target, :source => 'POLICY', :timestamp => Time.now.utc)
   end
 
   def update_with_policy_result(result = {})

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1426,7 +1426,7 @@ class VmOrTemplate < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
-    when :ems_events
+    when :ems_events, :event_streams
       return ["vm_or_template_id = ? OR dest_vm_or_template_id = ? ", id, id]
     when :policy_events
       return ["target_id = ? and target_class = ? ", id, self.class.base_class.name]

--- a/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
+++ b/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
@@ -1,0 +1,53 @@
+class FixEventClassForEvmAlertEvent < ActiveRecord::Migration
+  class EventStream < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class EmsCluster < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Vm < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Converting event class for EVMAlertEvent to MiqEvent") do
+      EventStream.where(:type => 'EmsEvent', :event_type => 'EVMAlertEvent').each do |event|
+        attrs = {:type => 'MiqEvent'}
+
+        if event.ems_cluster_id
+          attrs[:target_type] = 'EmsCluster'
+          attrs[:target_id]   = event.ems_cluster_id
+        elsif event.vm_or_template_id
+          attrs[:target_type] = 'VmOrTemplate'
+          attrs[:target_id]   = event.vm_or_template_id
+        elsif event.host_id && event.vm_or_template_id.nil?
+          attrs[:target_type] = 'Host'
+          attrs[:target_id]   = event.host_id
+        end
+        event.update_attributes(attrs)
+      end
+    end
+
+    say_with_time("Setting timestamp for MiqEvent") do
+      MiqEvent.where(:timestamp => nil).each { |e| e.update_attributes(:timestamp => e.created_on) }
+    end
+  end
+
+  def down
+    say_with_time("Converting event class for EVMAlertEvent to EmsEvent") do
+      EventStream.where(:type => 'MiqEvent', :event_type => 'EVMAlertEvent').update_all(
+        :type => 'EmsEvent', :target_id => nil, :target_type => nil
+      )
+    end
+
+    say_with_time("Deleting timestamp for MiqEvent") do
+      MiqEvent.update_all(:timestamp => nil)
+    end
+  end
+end

--- a/product/alerts/rss/all_alert_event.yml
+++ b/product/alerts/rss/all_alert_event.yml
@@ -7,28 +7,23 @@ feed_link: "/alert/rss?feed=all_alert_event"
 # Item metadata
 item_title: |-
     <script>
-      if rec.ems_cluster_id && rec.host_id.nil?
-        "Cluster: #{rec.ems_cluster_name}"
-      elsif rec.host_id && rec.vm_or_template_id.nil?
-        "Host: #{rec.host_name}"
-      else
-        "VM: #{rec.vm_name}"
-      end
+      "#{rec.target.class.name}: #{rec.target.name}"
     </script>
    
 # item_description: "#{rec.vm_name} was #{rec.event_type == "VmPoweredOnEvent" ? "powered on" : "powered off"} on #{rec.created_on}"
 item_description: "#{rec.message} was raised on #{rec.timestamp}"
 item_link: |-
     <script>
-    if rec.ems_cluster_id && rec.host_id.nil?
-      "/ems_cluster/show/#{rec.ems_cluster_id}"
-    elsif rec.host_id && rec.vm_or_template_id.nil?
-      "/host/show/#{rec.host_id}"
+    case rec.target
+    when ManageIQ::Providers::InfraManager
+      "/ems_infra/show/#{rec.target.id}"
+    when ManageIQ::Providers::CloudManager
+      "/ems_cloud/show/#{rec.target.id}"
     else
-      "/vm/show/#{rec.vm_or_template_id}"
+      "/#{rec.target.class.table_name.singularize}/show/#{rec.target.id}"
     end
     </script>
-item_class: EmsEvent
+item_class: MiqEvent
 
 # Search criteria
 #   search_method: find, nil or a custom method name

--- a/product/alerts/rss/cluster_alert_event.yml
+++ b/product/alerts/rss/cluster_alert_event.yml
@@ -5,25 +5,25 @@ feed_description: "Cluster Alert Events"
 feed_link: "/alert/rss?feed=cluster_alert_event"
 
 # Item metadata
-item_title: "#{rec.ems_cluster_name}"
-   
+item_title: "#{rec.target.name}"
+
 # item_description: "#{rec.vm_name} was #{rec.event_type == "VmPoweredOnEvent" ? "powered on" : "powered off"} on #{rec.created_on}"
 item_description: "#{rec.message} was raised on #{rec.timestamp}"
-item_link: "/ems_cluster/show/#{rec.ems_cluster_id}"
-item_class: EmsEvent
+item_link: "/ems_cluster/show/#{rec.target.id}"
+item_class: MiqEvent
 
 # Search criteria
 #   search_method: find, nil or a custom method name
 #   Custom method is called the following way:
 #     <item_class>.method(<search_method>).<name>, <options>)
 #   A nil value or a value of "find" use the default class find method
-search_method: 
-search_conditions: "event_type = 'EVMAlertEvent' AND ems_cluster_id IS NOT NULL AND host_id IS NULL"
-limit_to_time: 
-limit_to_count: 
+search_method:
+search_conditions: "event_type = 'EVMAlertEvent' AND target_type = 'EmsCluster'"
+limit_to_time:
+limit_to_count:
 orderby: "timestamp DESC"
 
 # tags_include: any or all
-tag_ns: 
-tags_include: 
-tags: 
+tag_ns:
+tags_include:
+tags:

--- a/product/alerts/rss/host_alert_event.yml
+++ b/product/alerts/rss/host_alert_event.yml
@@ -5,25 +5,25 @@ feed_description: "Host Alert Events"
 feed_link: "/alert/rss?feed=host_alert_event"
 
 # Item metadata
-item_title: "#{rec.host_name}"
-   
+item_title: "#{rec.target.name}"
+
 # item_description: "#{rec.vm_name} was #{rec.event_type == "VmPoweredOnEvent" ? "powered on" : "powered off"} on #{rec.created_on}"
 item_description: "#{rec.message} was raised on #{rec.timestamp}"
-item_link: "/host/show/#{rec.host_id}"
-item_class: EmsEvent
+item_link: "/host/show/#{rec.target.id}"
+item_class: MiqEvent
 
 # Search criteria
 #   search_method: find, nil or a custom method name
 #   Custom method is called the following way:
 #     <item_class>.method(<search_method>).<name>, <options>)
 #   A nil value or a value of "find" use the default class find method
-search_method: 
-search_conditions: "event_type = 'EVMAlertEvent' AND host_id IS NOT NULL AND vm_or_template_id IS NULL"
-limit_to_time: 
-limit_to_count: 
+search_method:
+search_conditions: "event_type = 'EVMAlertEvent' AND target_type = 'Host'"
+limit_to_time:
+limit_to_count:
 orderby: "timestamp DESC"
 
 # tags_include: any or all
-tag_ns: 
-tags_include: 
-tags: 
+tag_ns:
+tags_include:
+tags:

--- a/product/alerts/rss/vm_alert_event.yml
+++ b/product/alerts/rss/vm_alert_event.yml
@@ -5,25 +5,25 @@ feed_description: "VM Alert Events"
 feed_link: "/alert/rss?feed=vm_alert_event"
 
 # Item metadata
-item_title: "#{rec.vm_name}"
-   
+item_title: "#{rec.target.name}"
+
 # item_description: "#{rec.vm_name} was #{rec.event_type == "VmPoweredOnEvent" ? "powered on" : "powered off"} on #{rec.created_on}"
 item_description: "#{rec.message} was raised on #{rec.timestamp}"
-item_link: "/vm/show/#{rec.vm_or_template_id}"
-item_class: EmsEvent
+item_link: "/vm/show/#{rec.target.id}"
+item_class: MiqEvent
 
 # Search criteria
 #   search_method: find, nil or a custom method name
 #   Custom method is called the following way:
 #     <item_class>.method(<search_method>).<name>, <options>)
 #   A nil value or a value of "find" use the default class find method
-search_method: 
-search_conditions: "event_type = 'EVMAlertEvent' AND vm_or_template_id IS NOT NULL"
-limit_to_time: 
-limit_to_count: 
+search_method:
+search_conditions: "event_type = 'EVMAlertEvent' AND target_type = 'VmOrTemplate'"
+limit_to_time:
+limit_to_count:
 orderby: "timestamp DESC"
 
 # tags_include: any or all
-tag_ns: 
-tags_include: 
-tags: 
+tag_ns:
+tags_include:
+tags:

--- a/spec/migrations/20160307205816_fix_event_class_for_evm_alert_event_spec.rb
+++ b/spec/migrations/20160307205816_fix_event_class_for_evm_alert_event_spec.rb
@@ -1,0 +1,161 @@
+require_migration
+
+describe FixEventClassForEvmAlertEvent do
+  let(:event_stream_stub) { migration_stub(:EventStream) }
+
+  migration_context :up do
+    it "converts EmsCluster alert events from EmsEvent to MiqEvent" do
+      cluster_id = 123
+      event = event_stream_stub.create!(
+        :type             => 'EmsEvent',
+        :event_type       => 'EVMAlertEvent',
+        :ems_cluster_id   => cluster_id,
+        :ems_cluster_name => 'test_cluster',
+        :ems_cluster_uid  => 'domain-c12'
+      )
+
+      migrate
+      event.reload
+
+      expect(event).to have_attributes(
+        :type             => 'MiqEvent',
+        :target_type      => 'EmsCluster',
+        :target_id        => cluster_id,
+        :ems_cluster_id   => cluster_id,
+        :ems_cluster_name => 'test_cluster',
+        :ems_cluster_uid  => 'domain-c12'
+      )
+    end
+
+    it "converts Host alert events from EmsEvent to MiqEvent" do
+      host_id = 233
+      event = event_stream_stub.create!(
+        :type       => 'EmsEvent',
+        :event_type => 'EVMAlertEvent',
+        :host_id    => host_id,
+        :host_name  => 'test_host'
+      )
+
+      migrate
+      event.reload
+
+      expect(event).to have_attributes(
+        :type        => 'MiqEvent',
+        :target_type => 'Host',
+        :target_id   => host_id,
+        :host_id     => host_id,
+        :host_name   => 'test_host'
+      )
+    end
+
+    it "converts VmOrTemplate alert events from EmsEvent to MiqEvent" do
+      vm_id = 335
+      event = event_stream_stub.create!(
+        :type              => 'EmsEvent',
+        :event_type        => 'EVMAlertEvent',
+        :vm_or_template_id => vm_id,
+        :vm_name           => 'test_vm',
+        :vm_location       => 'test_vm/test_vm.vmx'
+      )
+
+      migrate
+      event.reload
+
+      expect(event).to have_attributes(
+        :type              => 'MiqEvent',
+        :target_type       => 'VmOrTemplate',
+        :target_id         => vm_id,
+        :vm_or_template_id => vm_id,
+        :vm_name           => 'test_vm',
+        :vm_location       => 'test_vm/test_vm.vmx'
+      )
+    end
+
+    it "sets timestamp for MiqEvent" do
+      now = Time.now.utc
+      event = event_stream_stub.create!(:type => 'MiqEvent', :event_type => 'test', :created_on => now)
+
+      migrate
+      expect(event.reload).to have_attributes(:timestamp => now)
+    end
+  end
+
+  migration_context :down do
+    let(:cluster_stub) { migration_stub(:EmsCluster) }
+    let(:host_stub)    { migration_stub(:Host) }
+    let(:vm_stub)      { migration_stub(:Vm) }
+
+    it "converts EmsCluster alert events from MiqEvent to EmsEvent" do
+      cluster = cluster_stub.create!(:name => 'test_cluster', :uid_ems => 'domain-c12')
+      event = event_stream_stub.create!(
+        :type             => 'MiqEvent',
+        :event_type       => 'EVMAlertEvent',
+        :target_type      => 'EmsCluster',
+        :target_id        => cluster.id,
+        :ems_cluster_id   => cluster.id,
+        :ems_cluster_name => cluster.name,
+        :ems_cluster_uid  => cluster.uid_ems
+      )
+
+      migrate
+      event.reload
+
+      expect(event).to have_attributes(
+        :type             => 'EmsEvent',
+        :target_type      => nil,
+        :target_id        => nil,
+        :ems_cluster_id   => cluster.id,
+        :ems_cluster_name => cluster.name,
+        :ems_cluster_uid  => cluster.uid_ems
+      )
+    end
+
+    it "converts Host alert events from MiqEvent to EmsEvent" do
+      host = host_stub.create!(:name => 'test_host')
+      event = event_stream_stub.create!(
+        :type        => 'MiqEvent',
+        :event_type  => 'EVMAlertEvent',
+        :target_type => 'Host',
+        :target_id   => host.id,
+        :host_id     => host.id,
+        :host_name   => host.name
+      )
+
+      migrate
+      event.reload
+
+      expect(event).to have_attributes(
+        :type        => 'EmsEvent',
+        :target_type => nil,
+        :target_id   => nil,
+        :host_id     => host.id,
+        :host_name   => host.name
+      )
+    end
+
+    it "converts VmOrTemplate alert events from MiqEvent to EmsEvent" do
+      vm = vm_stub.create!(:name => 'test_vm', :location => 'test_vm/test_vm.vmx')
+      event = event_stream_stub.create!(
+        :type              => 'MiqEvent',
+        :event_type        => 'EVMAlertEvent',
+        :target_type       => 'VmOrTemplate',
+        :target_id         => vm.id,
+        :vm_or_template_id => vm.id,
+        :vm_name           => vm.name,
+        :vm_location       => vm.location
+      )
+
+      migrate
+      event.reload
+
+      expect(event).to have_attributes(
+        :type              => 'EmsEvent',
+        :target_type       => nil,
+        :target_id         => nil,
+        :vm_or_template_id => vm.id,
+        :vm_name           => vm.name,
+        :vm_location       => vm.location
+      )
+    end
+  end
+end

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -42,17 +42,26 @@ describe MiqAction do
     end
   end
 
-  it "#action_evm_event" do
-    ems = FactoryGirl.create(:ems_vmware)
-    host = FactoryGirl.create(:host_vmware)
-    vm = FactoryGirl.create(:vm_vmware, :host => host, :ext_management_system => ems)
-    action = FactoryGirl.create(:miq_action)
-    expect_any_instance_of(EmsEvent).to receive(:handle_event).never
-    res = action.action_evm_event(action, vm, :policy => MiqPolicy.new)
+  context "#action_evm_event" do
+    it "for Vm" do
+      ems = FactoryGirl.create(:ems_vmware)
+      host = FactoryGirl.create(:host_vmware)
+      vm = FactoryGirl.create(:vm_vmware, :host => host, :ext_management_system => ems)
+      action = FactoryGirl.create(:miq_action)
+      res = action.action_evm_event(action, vm, :policy => FactoryGirl.create(:miq_policy))
 
-    expect(res).to be_kind_of EmsEvent
-    expect(res.host_id).to eq(host.id)
-    expect(res.ems_id).to eq(ems.id)
+      expect(res).to be_kind_of(MiqEvent)
+      expect(res.target).to eq(vm)
+    end
+
+    it "for Datastore" do
+      storage = FactoryGirl.create(:storage)
+      action  = FactoryGirl.create(:miq_action)
+      result  = action.action_evm_event(action, storage, :policy => FactoryGirl.create(:miq_policy))
+
+      expect(result).to be_kind_of(MiqEvent)
+      expect(result.target).to eq(storage)
+    end
   end
 
   context "#raise_automation_event" do


### PR DESCRIPTION
Usually EmsEvent is used for provider events and MiqEvent is used for MIQ events.

Alert can be set based on Datastores. But EmsEvent has fields for vm, host and ems_cluster but not for datastore.
    
https://bugzilla.redhat.com/show_bug.cgi?id=1306308
