### PR TITLE
Upgrade WinRM Gem version to 1.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "ruport",                         "=1.7.0",                       :git => "g
 gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/matthewd/rubyrep.git", :branch => "rails5"
 gem "simple-rss",                     "~>1.3.1",   :require => false
-gem "winrm",                          "~>1.7.0",   :require => false
+gem "winrm",                          "~>1.7.2",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required


### PR DESCRIPTION
WinRM Gem Version 1.7.2 fixes a BOM regression issue in 2008R2

Requested by @djberg96.  Simply a gem version update.
@djberg96 @jrafanie @Fryguy please review and merge.  Gracias.