### PR TITLE
Dead code removal in Chargeback model

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -233,10 +233,6 @@ class Chargeback < ActsAsArModel
     end
   end
 
-  def self.default_rates
-    ChargebackRate.where(:default => true).flat_map(&:chargeback_rate_details)
-  end
-
   def self.get_report_time_range(options, interval, tz)
     return [options[:start_time], options[:end_time]] if options[:start_time]
 

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -330,23 +330,4 @@ describe Chargeback do
       end
     end
   end
-
-  describe ".default_rates" do
-    it "works" do
-      expect(Chargeback.default_rates.map(&:description)).to match_array([
-        "Used CPU",
-        "Allocated CPU Count",
-        "Used Memory",
-        "Allocated Memory",
-        "Used Network I/O",
-        "Used Disk I/O",
-        "Fixed Compute Cost 1",
-        "Fixed Compute Cost 2",
-        "Allocated Disk Storage",
-        "Used Disk Storage",
-        "Fixed Storage Cost 1",
-        "Fixed Storage Cost 2",
-      ])
-    end
-  end
 end


### PR DESCRIPTION
No longer used, both .default_rates method and spec test for it removed.

Part 2 of 2, related to https://github.com/ManageIQ/manageiq/pull/7045 and should go together