### PR TITLE
Automation Engine Mutex and spec

### DIFF
--- a/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/lib/miq_automation_engine/miq_ae_exception.rb
@@ -21,6 +21,7 @@ module MiqAeException
   class MethodNotFound < MiqAeEngineError; end
   class MethodParmMissing < MiqAeEngineError; end
   class WorkspaceNotFound < MiqAeEngineError; end
+  class LockAcquisitionFailed < MiqAeEngineError; end
 
   class MiqAeDatastoreError < Error; end
   class DomainNotFound < MiqAeDatastoreError; end

--- a/lib/miq_concurrency.rb
+++ b/lib/miq_concurrency.rb
@@ -1,0 +1,46 @@
+module MiqConcurrency
+  module PGMutex
+    class << self
+      require 'zlib'
+      require 'securerandom'
+
+      def try_advisory_lock(lock_name)
+        execute_successful?('pg_try_advisory_lock', lock_name)
+      end
+
+      def release_advisory_lock(lock_name)
+        execute_successful?('pg_advisory_unlock', lock_name)
+      end
+
+      def count_advisory_lock(lock_name)
+        establish_connection
+        hashcode = stable_hashcode(lock_name)
+        sql = "SELECT count(*) from pg_locks "\
+              "WHERE locktype = 'advisory' "\
+              "AND objid = #{hashcode} "\
+              "AND pid = pg_backend_pid()"
+        @connection.select_value(sql).to_i
+      end
+
+      private
+
+      def establish_connection
+        unless ActiveRecord::Base.connected?
+          ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])
+        end
+        @connection ||= ActiveRecord::Base.connection
+      end
+
+      def execute_successful?(pg_function, lock_name)
+        establish_connection
+        sql = "SELECT #{pg_function}(#{stable_hashcode(lock_name)})"
+        result = @connection.select_value(sql)
+        (result == 't' || result == true)
+      end
+
+      def stable_hashcode(input)
+        Zlib.crc32(input.to_s)
+      end
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -98,5 +98,86 @@ module MiqAeServiceSpec
         end
       end
     end
+
+    context "#acquire_lock" do
+      let(:miq_ae_service) { MiqAeService.new(double('ws', :persist_state_hash => {})) }
+      let(:lock_name) { 'conch' }
+      let(:lock_hash) { Zlib.crc32(lock_name) }
+
+      before do
+        miq_ae_service.release_lock(lock_name)
+      end
+
+      it "succeeds in acquiring a free lock" do
+        expect(miq_ae_service.acquire_lock(lock_name)).to be true
+      end
+
+      it "succeeds in locking" do
+        expect(miq_ae_service.locked?(lock_name)).to be false
+        miq_ae_service.acquire_lock(lock_name)
+        expect(miq_ae_service.locked?(lock_name)).to be true
+      end
+    end
+
+    context "#release_lock" do
+      let(:miq_ae_service) { MiqAeService.new(double('ws', :persist_state_hash => {})) }
+      let(:lock_name) { 'conch' }
+
+      before do
+        miq_ae_service.release_lock(lock_name)
+      end
+
+      it "succeeds in releasing single lock" do
+        miq_ae_service.acquire_lock(lock_name)
+        expect(miq_ae_service.locked?(lock_name)).to be true
+        expect(miq_ae_service.release_lock(lock_name)).to be true
+        expect(miq_ae_service.locked?(lock_name)).to be false
+      end
+
+      it "succeeds in releasing multiple locks" do
+        miq_ae_service.acquire_lock(lock_name)
+        miq_ae_service.acquire_lock(lock_name)
+        miq_ae_service.acquire_lock(lock_name)
+        expect(miq_ae_service.locked?(lock_name)).to be true
+        expect(miq_ae_service.release_lock(lock_name)).to be true
+        expect(miq_ae_service.locked?(lock_name)).to be false
+      end
+    end
+
+    context "#locked?" do
+      let(:miq_ae_service) { MiqAeService.new(double('ws', :persist_state_hash => {})) }
+      let(:lock_name) { 'conch' }
+
+      before do
+        miq_ae_service.release_lock(lock_name)
+      end
+
+      it "verifies locks" do
+        expect(miq_ae_service.locked?(lock_name)).to be false
+        miq_ae_service.acquire_lock(lock_name)
+        expect(miq_ae_service.locked?(lock_name)).to be true
+        miq_ae_service.release_lock(lock_name)
+        expect(miq_ae_service.locked?(lock_name)).to be false
+      end
+    end
+
+    context "#with_acquired_lock" do
+      let(:miq_ae_service) { MiqAeService.new(double('ws', :persist_state_hash => {})) }
+      let(:lock_name) { 'conch' }
+      let(:lock_hash) { Zlib.crc32(lock_name) }
+
+      before do
+        miq_ae_service.release_lock(lock_name)
+      end
+
+      it "succeeds in acquiring lock and enters codeblock" do
+        expect(miq_ae_service.locked?(lock_name)).to be false
+        miq_ae_service.with_acquired_lock(lock_name) do
+          # Enters this codeblock
+          expect(miq_ae_service.locked?(lock_name)).to be true
+        end
+        expect(miq_ae_service.locked?(lock_name)).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Trying to create a good PR for the 3rd time...

(1) Fixed stylistic issues as reported by folks and rubocop.
(2) Added spec
(3) Changed the sleep call to be not randomized, but a fraction of the max_retry_time.
(4) Utilized the 64bit pg_try_advisory_lock, but couldn't find a suitable 64bit hash.

Various comments are in the original PR #6577
