### PR TITLE
Remove a protection around Process.pid in $SAFE 2+.

### DIFF
--- a/lib/extensions/ar_process.rb
+++ b/lib/extensions/ar_process.rb
@@ -1,8 +1,0 @@
-class << Process
-  prepend(Module.new {
-    def pid
-      warn "Remove me: #{__FILE__}:#{__LINE__}.  Safe level 2-4 are no longer supported as of ruby 2.3!" if RUBY_VERSION >= "2.3"
-      $SAFE < 2 ? super : 0
-    end
-  })
-end


### PR DESCRIPTION
We no longer log a message with Process.pid while in $SAFE 2+.

This was removed in commit: 9e5ba7dcf

Note, $SAFE 2-4 are gone in ruby 2.3.0 so this would have to be removed anyway.

:bow: to @matthewd for tracking down the commit that removed the last place where we set `$SAFE`