### PR TITLE
Remove directly accessing models in migration specs.

### DIFF
--- a/spec/migrations/20140409134713_move_log_collection_depot_settings_to_file_depot_spec.rb
+++ b/spec/migrations/20140409134713_move_log_collection_depot_settings_to_file_depot_spec.rb
@@ -1,7 +1,9 @@
 require_migration
 
 describe MoveLogCollectionDepotSettingsToFileDepot do
+  let(:authentication_stub) { migration_stub(:Authentication) }
   let(:configuration_stub) { migration_stub(:Configuration) }
+  let(:file_depot_stub) { migration_stub(:FileDepot) }
   let(:zone_stub) { migration_stub(:Zone) }
 
   migration_context :up do
@@ -27,13 +29,13 @@ describe MoveLogCollectionDepotSettingsToFileDepot do
 
       migrate
 
-      expect(Authentication.count).to eq(2)
-      expect(Configuration.count).to  eq(1)
-      expect(FileDepot.count).to      eq(2)
-      expect(Zone.count).to           eq(1)
+      expect(authentication_stub.count).to eq(2)
+      expect(configuration_stub.count).to  eq(1)
+      expect(file_depot_stub.count).to     eq(2)
+      expect(zone_stub.count).to           eq(1)
 
-      expect(Configuration.first.settings).to be_blank
-      expect(Zone.first.settings).to          be_blank
+      expect(configuration_stub.first.settings).to be_blank
+      expect(zone_stub.first.settings).to          be_blank
     end
   end
 end

--- a/spec/migrations/20150806194147_migrate_filtered_events_to_blacklisted_events_spec.rb
+++ b/spec/migrations/20150806194147_migrate_filtered_events_to_blacklisted_events_spec.rb
@@ -2,6 +2,7 @@ require_migration
 
 describe MigrateFilteredEventsToBlacklistedEvents do
   let(:configuration_stub)     { migration_stub(:Configuration) }
+  let(:blacklisted_event_stub) { migration_stub(:BlacklistedEvent) }
 
   migration_context :up do
     it 'when filtered events section exists with system events' do
@@ -15,8 +16,8 @@ describe MigrateFilteredEventsToBlacklistedEvents do
 
       migrate
 
-      expect(Configuration.first.settings.fetch_path('filtered_events')).to be_blank
-      expect(BlacklistedEvent.count).to eq(0)
+      expect(configuration_stub.first.settings.fetch_path('filtered_events')).to be_blank
+      expect(blacklisted_event_stub.count).to eq(0)
     end
 
     it 'when filtered events section exists with user added events' do
@@ -29,8 +30,8 @@ describe MigrateFilteredEventsToBlacklistedEvents do
 
       migrate
 
-      expect(Configuration.first.settings.fetch_path('filtered_events')).to be_blank
-      expect(BlacklistedEvent.count).to eq(MigrateFilteredEventsToBlacklistedEvents::PROVIDER_NAMES.size)
+      expect(configuration_stub.first.settings.fetch_path('filtered_events')).to be_blank
+      expect(blacklisted_event_stub.count).to eq(described_class::PROVIDER_NAMES.size)
     end
 
     it 'when filtered events section does not exist in configuration' do
@@ -38,14 +39,14 @@ describe MigrateFilteredEventsToBlacklistedEvents do
 
       migrate
 
-      expect(Configuration.first.settings.fetch_path('filtered_events')).to be_blank
-      expect(BlacklistedEvent.count).to eq(0)
+      expect(configuration_stub.first.settings.fetch_path('filtered_events')).to be_blank
+      expect(blacklisted_event_stub.count).to eq(0)
     end
 
     it 'when event handling configuration does not exist' do
       migrate
 
-      expect(BlacklistedEvent.count).to eq(0)
+      expect(blacklisted_event_stub.count).to eq(0)
     end
 
     it 'when multiple event handling configurations exist' do
@@ -54,8 +55,8 @@ describe MigrateFilteredEventsToBlacklistedEvents do
 
       migrate
 
-      expect(Configuration.first.settings.fetch_path('filtered_events')).to be_blank
-      expect(BlacklistedEvent.count).to eq(2 * MigrateFilteredEventsToBlacklistedEvents::PROVIDER_NAMES.size)
+      expect(configuration_stub.first.settings.fetch_path('filtered_events')).to be_blank
+      expect(blacklisted_event_stub.count).to eq(2 * described_class::PROVIDER_NAMES.size)
     end
   end
 end


### PR DESCRIPTION
@lpichler @jrafanie @chessbyte  Please review.

This is biting me in the configuration revamp because the Configuration model is *gone* in that branch.