### PR TITLE
Fix name of menu of custom reports

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -950,7 +950,7 @@ class ApplicationController < ActionController::Base
 
   def reports_group_title
     tenant_name = current_tenant.name
-    if @sb[:grp_title] = current_user.admin_user?
+    if current_user.admin_user?
       _("%{tenant_name} (All %{groups})") % {:tenant_name => tenant_name, :groups => ui_lookup(:models => "MiqGroup")}
     else
       _("%{tenant_name} (%{group}): %{group_description}") %
@@ -965,7 +965,7 @@ class ApplicationController < ActionController::Base
     reports = []
     folders = []
     user = current_user
-    reports_group_title
+    @sb[:grp_title] = reports_group_title
     @data = []
     if (!group.settings || !group.settings[:report_menus] || group.settings[:report_menus].blank?) || mode == "default"
       # array of all reports if menu not configured

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -651,11 +651,8 @@ class ReportController < ApplicationController
 
     trees                = {}
     rebuild              = @in_a_form ? false : rebuild_trees
-    if replace_trees.include?(:reports) || rebuild
-      reports_menu_in_sb
-      trees[:reports] = TreeBuilderReportReports.new('reports_tree', 'reports', @sb)
-    end
-    trees[:schedules]    = build_schedules_tree    if replace_trees.include?(:schedules)
+    trees[:reports]      = build_reports_tree      if replace_trees.include?(:reports) || rebuild
+    trees[:schedules]    = build_schedules_tree    if replace_trees.include?(:schedules) || rebuild
     trees[:savedreports] = build_savedreports_tree if replace_trees.include?(:savedreports) || rebuild
     trees[:db]           = build_db_tree           if replace_trees.include?(:db) || rebuild
     trees[:widgets]      = build_widgets_tree      if replace_trees.include?(:widgets) || rebuild

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1284,4 +1284,23 @@ describe ReportController do
       end
     end
   end
+
+  describe "#reports_menu_in_sb" do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    subject! { FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group) }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      login_as user
+    end
+
+    it "it returns corrent name for custom folder" do
+      controller.instance_variable_set(:@_params, :controller => "report", :action => "explorer")
+      controller.instance_variable_set(:@sb, {})
+      allow(controller).to receive(:get_node_info)
+      controller.send(:reports_menu_in_sb)
+      rpt_menu = controller.instance_variable_get(:@sb)[:rpt_menu]
+      expect(rpt_menu.first.first).to eq("#{user.current_tenant.name} (EVM Group): #{user.current_group.name}")
+    end
+  end
 end


### PR DESCRIPTION
we had name 'true' instead of correct name for folder for custom reports
variable `@sb[:rpt_title]` has been badly populated.

before
![screen shot 2016-03-02 at 14 15 51](https://cloud.githubusercontent.com/assets/14937244/13461396/5f4d7c60-e081-11e5-988a-91ad765313cb.png)

after

![screen shot 2016-03-02 at 14 17 48](https://cloud.githubusercontent.com/assets/14937244/13461440/a44ce152-e081-11e5-8e91-708bbd16c9d0.png)

@gtanzillo @himdel @mzazrivec