### PR TITLE
fix dashboard trend chart tooltips

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
@@ -1,14 +1,10 @@
 angular.module('miq.util').factory('chartsMixin', function() {
   'use strict';
 
-  var hourlyTimeTooltip = function(d) {
-    var theMoment = moment(d[0].x);
-    return _.template('<table class="c3-tooltip">' +
-    '  <tbody>' +
-    '    <td class="value"><%- col1 %></td>' +
-    '    <td class="value text-nowrap"><%- col2 %></td>' +
-    '  </tbody>' +
-    '</table>')({col1: theMoment.format('h:mm A'), col2: d[0].value + ' ' + d[0].name});
+  var hourlyTimeTooltip = function (data) {
+    var theMoment = moment(data[0].x);
+    return _.template('<div class="tooltip-inner"><%- col1 %>: <%- col2 %></div>')
+      ({col1: theMoment.format('h:mm A'), col2: data[0].value + ' ' + data[0].name});
   };
 
   var chartConfig = {


### PR DESCRIPTION
Trend chart tooltips in container overview dashboard are white text on white background.
Changed tooltip css class.

Before:
![screenshot from 2016-03-02 15-17-09_01](https://cloud.githubusercontent.com/assets/2181522/13462047/10240c32-e08e-11e5-9671-4dbc4483e80b.jpg)

After: 
![screenshot from 2016-03-02 15-18-08](https://cloud.githubusercontent.com/assets/2181522/13462051/14935d72-e08e-11e5-9a7b-bd9f32de4e14.jpg)
