### PR TITLE
Remove User::all_users_of_group

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,10 +195,6 @@ class User < ApplicationRecord
     self.current_group = groups.first if current_group.nil? || !groups.include?(current_group)
   end
 
-  def self.all_users_of_group(group)
-    User.includes(:miq_groups).select { |u| u.miq_groups.include?(group) }
-  end
-
   def admin?
     userid == "admin"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -484,20 +484,6 @@ describe User do
     end
   end
 
-  describe ".all_users_of_group" do
-    it "finds users" do
-      g  = FactoryGirl.create(:miq_group)
-      g2 = FactoryGirl.create(:miq_group)
-
-      FactoryGirl.create(:user)
-      u_one  = FactoryGirl.create(:user, :miq_groups => [g])
-      u_two  = FactoryGirl.create(:user, :miq_groups => [g, g2], :current_group => g)
-
-      expect(described_class.all_users_of_group(g)).to match_array([u_one, u_two])
-      expect(described_class.all_users_of_group(g2)).to match_array([u_two])
-    end
-  end
-
   describe "#current_group_by_description=" do
     subject { FactoryGirl.create(:user, :miq_groups => [g1, g2], :current_group => g1) }
     let(:g1) { FactoryGirl.create(:miq_group) }


### PR DESCRIPTION
It isn't being used anywhere and this is easily done with a proper scope or more Rails-native query if needed in the future, anyway.

Ironically the last place it was referenced was removed because...it also wasn't being used ;)

@miq-bot add_labels core, cleanup/rubocop

cc/ @Fryguy