### PR TITLE
Rspec is not showing the proper error

### DIFF
--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -55,4 +55,23 @@ describe ResourcePoolController do
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
   end
+
+  describe "#show" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      @user = FactoryGirl.create(:user)
+      login_as @user
+      @resource_pool = FactoryGirl.create(:resource_pool)
+    end
+
+    subject { get :show, :id => @resource_pool.id }
+
+    context "render" do
+      render_views
+      it "listnav" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_resource_pool")
+      end
+    end
+  end
 end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -85,4 +85,24 @@ describe StorageController do
       end
     end
   end
+
+  describe "#show" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      @user = FactoryGirl.create(:user)
+      login_as @user
+      session[:settings] = {:views => {:vm_summary_cool => "summary"}}
+      @storage = FactoryGirl.create(:storage)
+    end
+
+    subject { get :show, :id => @storage.id }
+
+    context "render" do
+      render_views
+      it "listnav" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_storage")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Those tests are not showing proper errors when they're failing. I noticed that during my work on basic rspec examples as a part of GH Issue https://github.com/ManageIQ/manageiq/issues/6324

i.e. spec/controllers/resource_pool_controller_spec.rb - use ```rake test``` or just ```rspec``` and you can see output backtrace but no hint where the error appears. The proper error you can see only in log/test.log.

It's inconvenient so as a developer, I want to see the error in output log.