### PR TITLE
Added method to return provision_dialog for ServiceRequest records.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -473,7 +473,7 @@ class ApplicationHelper::ToolbarBuilder
   def build_toolbar_hide_button_service(id)
     case id
     when "service_reconfigure"
-      return @record.validate_reconfigure
+      return true unless @record.validate_reconfigure
     end
     false
   end

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -147,4 +147,13 @@ module MiqRequestMixin
   def workflow(request_options = options, flags = {})
     workflow_class.new(request_options, get_user, flags) if workflow_class
   end
+
+  def request_dialog(action_name)
+    st = service_template
+    return {} if st.blank?
+    ra = st.resource_actions.find_by_action(action_name)
+    values = options[:dialog]
+    dialog = ResourceActionWorkflow.new(values, get_user, ra, {}).dialog
+    DialogSerializer.new.serialize(Array[dialog]).first
+  end
 end

--- a/app/models/service_reconfigure_request.rb
+++ b/app/models/service_reconfigure_request.rb
@@ -5,6 +5,8 @@ class ServiceReconfigureRequest < MiqRequest
   validates_inclusion_of :request_state, :in      => %w(pending finished) + ACTIVE_STATES,
                                          :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"
   validate :must_have_user
+  delegate :service_template, :to => :source, :allow_nil => true
+  virtual_has_one :provision_dialog
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
   default_value_for :source_type,  SOURCE_CLASS_NAME
@@ -15,5 +17,9 @@ class ServiceReconfigureRequest < MiqRequest
 
   def requested_task_idx
     [options[:src_id]]
+  end
+
+  def provision_dialog
+    request_dialog("Reconfigure")
   end
 end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -36,11 +36,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
   end
 
   def provision_dialog
-    st = service_template
-    return {} if st.blank?
-    ra = st.resource_actions.find_by_action("Provision")
-    dialog = ResourceActionWorkflow.new(options[:dialog], get_user, ra, {}).dialog
-    DialogSerializer.new.serialize(Array[dialog]).first
+    request_dialog("Provision")
   end
 
   def requested_task_idx


### PR DESCRIPTION
Need provision_dialog to return a dialog to be displayed in ssui on ServiceReconfigure Request details screen.
Fixed a condition to return true to hide service reconfigure button when validate_reconfigure is false

@abellotti please review.