### PR TITLE
Remove the run_as_postgres method

### DIFF
--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -167,7 +167,7 @@ module ApplianceConsole
 
     def block_until_postgres_accepts_connections
       loop do
-        break if run_as_postgres("psql -c 'select 1';").exit_status == 0
+        break if AwesomeSpawn.run("psql -U postgres -c 'select 1'").success?
       end
     end
 
@@ -178,12 +178,8 @@ module ApplianceConsole
     end
 
     def create_postgres_database
-      run_as_postgres("createdb -E utf8 -O #{username} #{database}")
-    end
-
-    # some overlap with PostgresAdmin
-    def run_as_postgres(cmd)
-      AwesomeSpawn.run("su", :params => {"-" => nil, nil => "postgres", "-c" => "#{PostgresAdmin.scl_enable_prefix} \"#{cmd}\""})
+      conn = PG.connect(:user => "postgres", :dbname => "postgres")
+      conn.exec("CREATE DATABASE #{database} OWNER #{username} ENCODING 'utf8'")
     end
 
     def relabel_postgresql_dir


### PR DESCRIPTION
This method is unnecessary and quite complicated.
Because the root system user can log in as the postgres database user we can create the database from a SQL call.
We can also run the connection check by connecting to the postgres database using the postgres user.

@kbrock @jrafanie please review.