### PR TITLE
Clear selected filter after it is deleted or reset button is pressed.

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -755,6 +755,7 @@ module ApplicationController::Filter
       @edit[@expkey][:exp_last_loaded] = nil                    # Clear the last search loaded
       @edit[:adv_search_name] = nil                             # Clear search name
       @edit[:adv_search_report] = nil                           # Clear the report name
+      @edit[@expkey][:selected] = nil                           # Clear selected search
     elsif params[:button] == "save"
       @edit[:search_type] = nil
     end


### PR DESCRIPTION
Not clearing the filter after filter is deleted is causing to show "Delete" as enabled after filter is deleted and pressing it again throws an error.
This also removes empty parenthesis in the title on Advanced search modal when Delete/Reset is pressed.

https://bugzilla.redhat.com/show_bug.cgi?id=1298645
https://bugzilla.redhat.com/show_bug.cgi?id=1314434

@dclarizio please review.

![before_delete](https://cloud.githubusercontent.com/assets/3450808/13498439/f9dcab7e-e127-11e5-9354-1e035c3d6a2d.png)

before:
Delete button is still available and filter title still shows the title of deleted filter

![before_fix](https://cloud.githubusercontent.com/assets/3450808/13498446/02b0e7a6-e128-11e5-9472-cdfb65044b15.png)

after:
![adv_search_after_filter_delete2](https://cloud.githubusercontent.com/assets/3450808/13498452/0863f206-e128-11e5-96ed-d6bdaab194ad.png)


