### PR TITLE
MiqUserRole factory to use system defaults

### DIFF
--- a/spec/factories/miq_user_role.rb
+++ b/spec/factories/miq_user_role.rb
@@ -13,8 +13,8 @@ FactoryGirl.define do
 
     after(:build) do |user, evaluator|
       if evaluator.role.present?
-        system_roles = YAML.load_file(MiqUserRole::FIXTURE_YAML)
-        seeded_role = system_roles.detect { |role| role[:name] == "EvmRole-#{evaluator.role}" }
+        @system_roles ||= YAML.load_file(MiqUserRole::FIXTURE_YAML)
+        seeded_role = @system_roles.detect { |role| role[:name] == "EvmRole-#{evaluator.role}" }
 
         if seeded_role.present?
           user.read_only = seeded_role[:read_only]

--- a/spec/factories/miq_user_role.rb
+++ b/spec/factories/miq_user_role.rb
@@ -12,6 +12,16 @@ FactoryGirl.define do
     name { |ur| ur.role ? "EvmRole-#{ur.role}" : generate(:miq_user_role_name) }
 
     after(:build) do |user, evaluator|
+      if evaluator.role.present?
+        system_roles = YAML.load_file(MiqUserRole::FIXTURE_YAML)
+        seeded_role = system_roles.detect { |role| role[:name] == "EvmRole-#{evaluator.role}" }
+
+        if seeded_role.present?
+          user.read_only = seeded_role[:read_only]
+          user.settings = seeded_role[:settings]
+        end
+      end
+
       if evaluator.features.present?
         user.miq_product_features = Array.wrap(evaluator.features).map do |f|
           if f.kind_of?(MiqProductFeature) # TODO: remove class reference

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ describe User do
   end
 
   describe "#change_password" do
-    let(:user) { FactoryGirl.create(:user, :first_name => "Bob", :last_name => "Smith", :password => "smartvm") }
+    let(:user) { FactoryGirl.create(:user, :password => "smartvm") }
 
     it "should change user password" do
       password    = user.password
@@ -45,12 +45,7 @@ describe User do
   end
 
   context "filter methods" do
-    let(:user) do
-      FactoryGirl.create(:user,
-                         :first_name => "Bob",
-                         :last_name  => "Smith",
-                         :miq_groups => [miq_group])
-    end
+    let(:user) { FactoryGirl.create(:user, :miq_groups => [miq_group]) }
     let(:mfilters) { {"managed"   => "m"} }
     let(:bfilters) { {"belongsto" => "b"} }
     let(:miq_group) { FactoryGirl.create(:miq_group) }
@@ -69,143 +64,78 @@ describe User do
     end
   end
 
-  describe "role methods" do
-    context "id set as Administrator" do
-      let(:miq_user_role) do
-        FactoryGirl.create(
-          :miq_user_role,
-          :name      => "EvmRole-super_administrator",
-          :read_only => true,
-          :settings  => nil
-        )
-      end
+  context "timezone methods" do
+    let!(:miq_server) { EvmSpecHelper.local_miq_server }
+    let(:user) { FactoryGirl.create(:user) }
 
-      let(:miq_group) do
-        FactoryGirl.create(
-          :miq_group,
-          :description   => "EvmGroup-super_administrator",
-          :group_type    => "system",
-          :miq_user_role => miq_user_role
-        )
-      end
-
-      let!(:miq_server) { EvmSpecHelper.local_miq_server }
-
-      let(:user) do
-        FactoryGirl.create(
-          :user_admin,
-          :email      => "admin@email.com",
-          :password   => "smartvm",
-          :settings   => {"Setting1" => 1, "Setting2" => 2, "Setting3" => 3},
-          :miq_groups => [miq_group],
-          :first_name => "Bob",
-          :last_name  => "Smith"
-        )
-      end
-
-      let(:self_service_role) do
-        FactoryGirl.create(
-          :miq_user_role,
-          :name     => "ss_role",
-          :settings => {:restrictions => {:vms => :user_or_group}}
-        )
-      end
-
-      let(:self_service_group) do
-        FactoryGirl.create(
-          :miq_group,
-          :description   => "EvmGroup-self_service",
-          :miq_user_role => self_service_role
-        )
-      end
-
-      let(:limited_self_service_role) do
-        FactoryGirl.create(
-          :miq_user_role,
-          :name     => "lss_role",
-          :settings => {:restrictions => {:vms => :user}}
-        )
-      end
-
-      let(:limited_self_service_group) do
-        FactoryGirl.create(
-          :miq_group,
-          :description   => "EvmGroup-limited_self_service",
-          :miq_user_role => limited_self_service_role
-        )
-      end
-
-      let(:miq_admin_role) do
-        FactoryGirl.create(
-          :miq_user_role,
-          :name      => "EvmRole-administrator",
-          :read_only => true,
-          :settings  => nil
-        )
-      end
-
-      let(:admin_group) do
-        FactoryGirl.create(
-          :miq_group,
-          :description   => "EvmGroup-administrator",
-          :miq_user_role => miq_admin_role
-        )
-      end
-
-      it "should check Self Service Roles" do
-        user.current_group = self_service_group
-        expect(user.self_service?).to be_truthy
-
-        user.current_group = limited_self_service_group
-        expect(user.self_service?).to be_truthy
-
-        miq_group.miq_user_role = nil
-        user.current_group = miq_group
-        expect(user.self_service?).to be_falsey
-
-        user.current_group = nil
-        expect(user.self_service?).to be_falsey
-      end
-
-      it "should check Limited Self Service Roles" do
-        user.current_group = limited_self_service_group
-        expect(user.limited_self_service?).to be_truthy
-
-        user.current_group = nil
-        user.current_group = miq_group
-        expect(user.limited_self_service?).to be_falsey
-      end
-
-      it "should check Super Admin Roles" do
-        expect(user.super_admin_user?).to be_truthy
-
-        user.current_group = admin_group
-        expect(user.super_admin_user?).to be_falsey
-
-        user.current_group = limited_self_service_group
-        expect(user.super_admin_user?).to be_falsey
-      end
-
-      it "should check Admin Roles" do
-        expect(user.admin_user?).to be_truthy
-
-        user.current_group = admin_group
-        expect(user.admin_user?).to be_truthy
-
-        user.current_group = limited_self_service_group
-        expect(user.admin_user?).to be_falsey
-      end
-
-      it "should get Server time zone setting" do
+    describe "#get_timezone" do
+      it "gets Server time zone setting" do
         expect(user.get_timezone).to eq("UTC")
       end
+    end
 
-      it "with_my_timezone sets the user's zone in a block" do
+    describe "#with_my_timezone" do
+      it "sets the user's zone in a block" do
         user.settings.store_path(:display, :timezone, "Hawaii")
         user.with_my_timezone do
           expect(Time.zone.to_s).to eq("(GMT-10:00) Hawaii")
         end
         expect(Time.zone.to_s).to eq("(GMT+00:00) UTC")
+      end
+    end
+  end
+
+  describe "role methods" do
+    let(:user) do
+      FactoryGirl.create(:user,
+                         :settings => {"Setting1" => 1, "Setting2" => 2, "Setting3" => 3},
+                         :role     => role_name)
+    end
+
+    describe "#self_service?" do
+      let(:role_name) { "user_self_service" }
+
+      it "checks Self Service roles" do
+        expect(user.self_service?).to be_truthy
+        expect(user.super_admin_user?).to be_falsey
+
+        user.current_group = nil
+        expect(user.self_service?).to be_falsey
+      end
+    end
+
+    describe "#limited_self_service?" do
+      let(:role_name) { "user_limited_self_service" }
+
+      it "checks Self Service roles" do
+        expect(user.limited_self_service?).to be_truthy
+        expect(user.super_admin_user?).to be_falsey
+
+        user.current_group = nil
+        expect(user.limited_self_service?).to be_falsey
+      end
+    end
+
+    describe "#super_admin_user?" do
+      let(:role_name) { "super_administrator" }
+
+      it "checks Super Admin roles" do
+        expect(user.super_admin_user?).to be_truthy
+
+        user.current_group = nil
+        expect(user.super_admin_user?).to be_falsey
+      end
+    end
+
+    describe "#admin_user?" do
+      let(:role_name) { "administrator" }
+
+      it "should check Admin Roles" do
+        expect(user.admin_user?).to be_truthy
+        expect(user.super_admin_user?).to be_falsey
+
+        user.current_group = nil
+        expect(user.admin_user?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
* Allows the top level passing of :user, :role => "role" to actually use the seeded settings at the factory level so you don't need to do so much manual assignments in the spec. Allows for easier changes later (_cough_ user groups _cough_) and easier spec writing anyway.
* Untangles `#authorize_ldap` and timezone testing from the group assignment context (groups being created needlessly)