### PR TITLE
Use unix sockets, not IPv4, for the dummy DB configuration.

### DIFF
--- a/lib/tasks/evm_rake_helper.rb
+++ b/lib/tasks/evm_rake_helper.rb
@@ -3,7 +3,7 @@ module EvmRakeHelper
   # For some rake tasks, the database.yml may not yet be setup and is not required anyway.
   # Note: Rails will not actually use the configuration and connect until you issue a query.
   def self.with_dummy_database_url_configuration
-    before, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgresql://user:pass@127.0.0.1/dbname"
+    before, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgresql:///not_existing_db?host=/var/lib/postgresql"
     yield
   ensure
     # ENV['x'] = nil deletes the key because ENV accepts only string values


### PR DESCRIPTION
By default, we trust local unix socket connections[1], but not
127.0.0.1 or ::1.   Therefore, we should use unix sockets for the rake task
that ensures we don't try to connect using a badly configured
database URL when we try to load rails environment.

[1] https://github.com/ManageIQ/guides/blob/master/developer_setup.md

Fixes #6915