### PR TITLE
Turn off Lookup button when Email field is empty.

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -42,6 +42,13 @@ module ApplicationController::MiqRequestMethods
           page << "ManageIQ.calendar.calDateFrom = new Date(#{@timezone_offset});"
           page << "miqBuildCalendar();"
         end
+        if @edit.fetch_path(:new, :owner_email).blank?
+          page << javascript_hide("lookup_button_on")
+          page << javascript_show("lookup_button_off")
+        else
+          page << javascript_hide("lookup_button_off")
+          page << javascript_show("lookup_button_on")
+        end
         if changed != session[:changed]
           session[:changed] = changed
           page << javascript_for_miq_button_visibility(changed)

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -112,14 +112,17 @@
           - if field == :owner_email
             - fh = wf.get_field(:owner_load_ldap, dialog)
             - if @edit && field_hash[:display] == :edit && fh[:display] == :show && !@edit[:stamp_typ]
-              = button_tag(_('Lookup'),
-                           :class   => "btn btn-primary",
-                           :alt     => t = _("LDAP Group Lookup"),
-                           :title   => t,
-                           :onclick => "miqAjaxButton('#{url_for(:controller => 'miq_request',
-                                                                 :action     => 'retrieve_email',
-                                                                 :field      => fh[:pressed][:method],
-                                                                 :button     => 'submit')}');")
+              #lookup_button_off{:style => "#{options[field].blank? ? '' : 'display:none'}"}
+                = button_tag(_("Lookup"), :class => "btn btn-default btn-disabled")
+              #lookup_button_on{:style => "#{options[field].blank? ? 'display:none' : ''}"}
+                = button_tag(_('Lookup'),
+                             :class   => "btn btn-primary",
+                             :alt     => t = _("LDAP Group Lookup"),
+                             :title   => t,
+                             :onclick => "miqAjaxButton('#{url_for(:controller => 'miq_request',
+                                                                   :action     => 'retrieve_email',
+                                                                   :field      => fh[:pressed][:method],
+                                                                   :button     => 'submit')}');")
       - elsif [:vm_prefix].include?(field)
         -# text field for vm prefix/suffix
         .col-md-8


### PR DESCRIPTION
Turn Lookup button on/off based upon entry in email field.

https://bugzilla.redhat.com/show_bug.cgi?id=1301469

@dclarizio please review

before:
lookup button was always enabled:
![lookup_button_always_enabled_before_fix](https://cloud.githubusercontent.com/assets/3450808/13509009/6bedbd14-e157-11e5-9c9c-f10e04b9bff9.png)


after:
![lookup_disabled](https://cloud.githubusercontent.com/assets/3450808/13508922/0206c238-e157-11e5-821c-e92d42f02288.png)

![lookup_enabled](https://cloud.githubusercontent.com/assets/3450808/13508900/f3649e1c-e156-11e5-904d-95375339e09b.png)

![lookup_results](https://cloud.githubusercontent.com/assets/3450808/13508925/0614ef62-e157-11e5-91bb-b32fefe49ab5.png)
