### PR TITLE
Add Ansible Tower Inventories

### DIFF
--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -7,10 +7,11 @@ class ConfiguredSystem < ApplicationRecord
   belongs_to :configuration_manager, :class_name => 'ManageIQ::Providers::ConfigurationManager'
   belongs_to :configuration_organization
   belongs_to :configuration_profile
-  has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
-  belongs_to :customization_script_ptable
   belongs_to :customization_script_medium
+  belongs_to :customization_script_ptable
+  belongs_to :inventory_root_group, :class_name => "EmsFolder"
   belongs_to :operating_system_flavor
+  has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
   has_and_belongs_to_many :configuration_tags
 
   alias_attribute :name,    :hostname

--- a/app/models/ems_refresh/save_inventory_configuration.rb
+++ b/app/models/ems_refresh/save_inventory_configuration.rb
@@ -13,7 +13,7 @@ module EmsRefresh
   module SaveInventoryConfiguration
     def save_configuration_manager_inventory(manager, hashes, target = nil)
       return if hashes.nil?
-      save_child_inventory(manager, hashes, [:configuration_profiles, :configured_systems, :configuration_scripts], target)
+      save_child_inventory(manager, hashes, [:ems_folders, :configuration_profiles, :configured_systems, :configuration_scripts], target)
       manager.save
     end
 
@@ -30,14 +30,19 @@ module EmsRefresh
       # get the id out and store in this record
       hashes.each do |hash|
         hash[:configuration_profile_id] = hash.fetch_path(:configuration_profile, :id)
+        hash[:inventory_root_group_id]  = hash.fetch_path(:inventory_root_group, :id)
       end
-      save_inventory_assoc(manager.configured_systems, hashes, delete_missing_records, [:manager_ref], nil,
-                           [:configuration_profile])
+      save_inventory_assoc(manager.configured_systems, hashes, delete_missing_records, [:manager_ref], nil, [:configuration_profile, :inventory_root_group])
     end
 
     def save_configuration_scripts_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
       save_inventory_assoc(manager.configuration_scripts, hashes, delete_missing_records, [:manager_ref], nil, [:configuration_script])
+    end
+
+    def save_ems_folders_inventory(manager, hashes, target)
+      delete_missing_records = target.nil? || manager == target
+      save_inventory_assoc(manager.inventory_groups, hashes, delete_missing_records, [:ems_ref], nil, [:ems_folder])
     end
   end
 end

--- a/app/models/manageiq/providers/configuration_manager.rb
+++ b/app/models/manageiq/providers/configuration_manager.rb
@@ -1,7 +1,11 @@
 class ManageIQ::Providers::ConfigurationManager < ::ExtManagementSystem
+  require_nested :InventoryGroup
+  require_nested :InventoryRootGroup
+
   has_many :configured_systems,     :dependent => :destroy
   has_many :configuration_profiles, :dependent => :destroy
   has_many :configuration_scripts,  :dependent => :destroy
+  has_many :inventory_groups,       :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
 
   virtual_column  :total_configuration_profiles, :type => :integer
   virtual_column  :total_configured_systems, :type => :integer

--- a/app/models/manageiq/providers/configuration_manager/inventory_group.rb
+++ b/app/models/manageiq/providers/configuration_manager/inventory_group.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::ConfigurationManager::InventoryGroup < EmsFolder
+  belongs_to :manager, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::ConfigurationManager"
+end

--- a/app/models/manageiq/providers/configuration_manager/inventory_root_group.rb
+++ b/app/models/manageiq/providers/configuration_manager/inventory_root_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::ConfigurationManager::InventoryRootGroup < ManageIQ::Providers::ConfigurationManager::InventoryGroup
+end

--- a/db/migrate/20160302214232_add_inventory_root_group_id_to_configured_systems.rb
+++ b/db/migrate/20160302214232_add_inventory_root_group_id_to_configured_systems.rb
@@ -1,0 +1,5 @@
+class AddInventoryRootGroupIdToConfiguredSystems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :configured_systems, :inventory_root_group_id, :bigint
+  end
+end

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/refresh_parser_spec.rb
@@ -4,14 +4,16 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshParser 
   let(:connection) do
     double(:connection,
            :api => double(:api,
-                          :hosts         => double(:hosts, :all => all_hosts),
+                          :hosts         => double(:hosts,         :all => all_hosts),
+                          :inventories   => double(:inventories,   :all => all_inventories),
                           :job_templates => double(:job_templates, :all => all_job_templates)
                          )
           )
   end
   let(:parser)            { described_class.new(manager) }
   let(:manager)           { FactoryGirl.create(:configuration_manager_ansible_tower, :provider) }
-  let(:all_hosts)         { (1..2).collect { |i| AnsibleTowerClient::Host.new("id" => i, "name" => "h#{i}") } }
+  let(:all_hosts)         { (1..2).collect { |i| AnsibleTowerClient::Host.new("id" => i, "name" => "host#{i}", "inventory" => i) } }
+  let(:all_inventories)   { (1..2).collect { |i| AnsibleTowerClient::Inventory.new("id" => i, "name" => "inventory#{i}") } }
   let(:all_job_templates) { (1..2).collect { |i| AnsibleTowerClient::JobTemplate.new("id" => i, "name" => "template#{i}", "description" => "description#{i}", "extra_vars" => "some_json_payload") } }
 
   it "#configuration_manager_inv_to_hashes" do
@@ -22,9 +24,10 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshParser 
 
     expect(parser.instance_variable_get(:@data)[:configured_systems].count).to eq(2)
     expect(parser.instance_variable_get(:@data)[:configured_systems].first).to eq(
-      :manager_ref => "1",
-      :hostname    => "h1",
-      :type        => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem"
+      :manager_ref          => "1",
+      :hostname             => "host1",
+      :inventory_root_group => {:ems_ref => "1", :name => "inventory1", :type => "ManageIQ::Providers::ConfigurationManager::InventoryRootGroup"},
+      :type                 => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem"
     )
 
     expect(parser.instance_variable_get(:@data)[:configuration_scripts].count).to eq(2)
@@ -34,6 +37,13 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshParser 
       :description => "description1",
       :variables   => "some_json_payload",
       :survey_spec => "some_hash_payload"
+    )
+
+    expect(parser.instance_variable_get(:@data)[:ems_folders].count).to eq(2)
+    expect(parser.instance_variable_get(:@data)[:ems_folders].first).to eq(
+      :ems_ref => "1",
+      :name    => "inventory1",
+      :type    => "ManageIQ::Providers::ConfigurationManager::InventoryRootGroup"
     )
   end
 end

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/refresher_spec.rb
@@ -25,6 +25,7 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Refresher do
       assert_configured_system
       assert_configuration_script_with_nil_survey_spec
       assert_configuration_script_with_survey_spec
+      assert_inventory_root_group
     end
   end
 
@@ -33,21 +34,20 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Refresher do
     expect(configuration_manager).to                             have_attributes(:api_version => "2.4.2")
     expect(configuration_manager.configured_systems.count).to    eq(75)
     expect(configuration_manager.configuration_scripts.count).to eq(7)
+    expect(configuration_manager.inventory_groups.count).to      eq(7)
   end
 
   def assert_configured_system
-    system = configuration_manager.configured_systems.where(:hostname => "Ansible-Host").first
-
-    expect(system).to have_attributes(
+    expect(expected_configured_system).to have_attributes(
       :type        => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem",
       :hostname    => "Ansible-Host",
       :manager_ref => "48",
     )
+    expect(expected_configured_system.inventory_root_group).to eq(expected_inventory_root_group)
   end
 
   def assert_configuration_script_with_nil_survey_spec
-    system = configuration_manager.configuration_scripts.where(:name => "Ansible-JobTemplate").first
-    expect(system).to have_attributes(
+    expect(expected_configuration_script).to have_attributes(
       :name        => "Ansible-JobTemplate",
       :description => "Ansible-JobTemplate-Description",
       :manager_ref => "149",
@@ -67,5 +67,27 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Refresher do
     survey = JSON.parse(system.survey_spec)
     expect(survey).to be_a Hash
     expect(survey['spec'].first['index']).to eq 0
+  end
+
+  def assert_inventory_root_group
+    expect(expected_inventory_root_group).to have_attributes(
+      :name    => "VC 6.0",
+      :ems_ref => "5",
+      :type    => "ManageIQ::Providers::ConfigurationManager::InventoryRootGroup",
+    )
+  end
+
+  private
+
+  def expected_configured_system
+    @expected_configured_system ||= configuration_manager.configured_systems.where(:hostname => "Ansible-Host").first
+  end
+
+  def expected_configuration_script
+    @expected_configuration_script ||= configuration_manager.configuration_scripts.where(:name => "Ansible-JobTemplate").first
+  end
+
+  def expected_inventory_root_group
+    @expected_inventory_root_group ||= configuration_manager.inventory_groups.where(:name => "VC 6.0").first
   end
 end

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/configuration_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/configuration_manager/refresher.yml
@@ -100,7 +100,179 @@ http_interactions:
         "/var/lib/awx/projects", "time_zone": "America/New_York", "ansible_version":
         "1.9.4", "project_local_paths": []}'
     http_version: 
-  recorded_at: Thu, 03 Mar 2016 16:40:50 GMT
+  recorded_at: Thu, 03 Mar 2016 21:02:29 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 03 Mar 2016 21:02:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/inventories/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 21:02:29 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Mar 2016 21:02:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.068s
+      Content-Length:
+      - '9000'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 7, "next": null, "previous": null, "results": [{"id": 2,
+        "type": "inventory", "url": "/api/v1/inventories/2/", "related": {"created_by":
+        "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/2/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/2/variable_data/", "root_groups": "/api/v1/inventories/2/root_groups/",
+        "script": "/api/v1/inventories/2/script/", "ad_hoc_commands": "/api/v1/inventories/2/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/2/tree/", "hosts": "/api/v1/inventories/2/hosts/",
+        "groups": "/api/v1/inventories/2/groups/", "activity_stream": "/api/v1/inventories/2/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/2/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T18:04:27.635Z", "modified":
+        "2016-02-18T21:52:36.556Z", "name": "AWS", "description": "CFME AWS Lab",
+        "organization": 1, "variables": "---", "has_active_failures": true, "total_hosts":
+        8, "hosts_with_active_failures": 8, "total_groups": 53, "groups_with_active_failures":
+        51, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        0}, {"id": 6, "type": "inventory", "url": "/api/v1/inventories/6/", "related":
+        {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "scan_job_templates":
+        "/api/v1/inventories/6/scan_job_templates/", "variable_data": "/api/v1/inventories/6/variable_data/",
+        "root_groups": "/api/v1/inventories/6/root_groups/", "script": "/api/v1/inventories/6/script/",
+        "ad_hoc_commands": "/api/v1/inventories/6/ad_hoc_commands/", "tree": "/api/v1/inventories/6/tree/",
+        "hosts": "/api/v1/inventories/6/hosts/", "groups": "/api/v1/inventories/6/groups/",
+        "activity_stream": "/api/v1/inventories/6/activity_stream/", "inventory_sources":
+        "/api/v1/inventories/6/inventory_sources/", "organization": "/api/v1/organizations/1/"},
+        "summary_fields": {"organization": {"name": "Default", "description": ""},
+        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}}, "created": "2016-01-06T22:16:35.875Z", "modified": "2016-01-06T22:16:35.875Z",
+        "name": "bd", "description": "", "organization": 1, "variables": "---", "has_active_failures":
+        false, "total_hosts": 0, "hosts_with_active_failures": 0, "total_groups":
+        0, "groups_with_active_failures": 0, "has_inventory_sources": false, "total_inventory_sources":
+        0, "inventory_sources_with_failures": 0}, {"id": 9, "type": "inventory", "url":
+        "/api/v1/inventories/9/", "related": {"created_by": "/api/v1/users/1/", "modified_by":
+        "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/9/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/9/variable_data/", "root_groups": "/api/v1/inventories/9/root_groups/",
+        "script": "/api/v1/inventories/9/script/", "ad_hoc_commands": "/api/v1/inventories/9/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/9/tree/", "hosts": "/api/v1/inventories/9/hosts/",
+        "groups": "/api/v1/inventories/9/groups/", "activity_stream": "/api/v1/inventories/9/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/9/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
+        "", "last_name": ""}, "modified_by": {"id": 1, "username": "testuser", "first_name":
+        "", "last_name": ""}}, "created": "2016-02-01T19:44:58.850Z", "modified":
+        "2016-02-09T22:39:26.451Z", "name": "db-test-inventory-put", "description":
+        "", "organization": 1, "variables": "---", "has_active_failures": false, "total_hosts":
+        1, "hosts_with_active_failures": 0, "total_groups": 1, "groups_with_active_failures":
+        0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
+        0}, {"id": 1, "type": "inventory", "url": "/api/v1/inventories/1/", "related":
+        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/1/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/1/variable_data/", "root_groups": "/api/v1/inventories/1/root_groups/",
+        "script": "/api/v1/inventories/1/script/", "ad_hoc_commands": "/api/v1/inventories/1/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/1/tree/", "hosts": "/api/v1/inventories/1/hosts/",
+        "groups": "/api/v1/inventories/1/groups/", "activity_stream": "/api/v1/inventories/1/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/1/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T16:51:16.902Z", "modified":
+        "2015-12-17T16:56:21.511Z", "name": "Openstack", "description": "", "organization":
+        1, "variables": "---", "has_active_failures": false, "total_hosts": 0, "hosts_with_active_failures":
+        0, "total_groups": 1, "groups_with_active_failures": 0, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        {"id": 3, "type": "inventory", "url": "/api/v1/inventories/3/", "related":
+        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/3/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/3/variable_data/", "root_groups": "/api/v1/inventories/3/root_groups/",
+        "script": "/api/v1/inventories/3/script/", "ad_hoc_commands": "/api/v1/inventories/3/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/3/tree/", "hosts": "/api/v1/inventories/3/hosts/",
+        "groups": "/api/v1/inventories/3/groups/", "activity_stream": "/api/v1/inventories/3/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/3/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T18:08:49.861Z", "modified":
+        "2016-01-15T21:12:24.696Z", "name": "Openstack RH Support", "description":
+        "RH Support Openstack Hosts", "organization": 1, "variables": "---", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, {"id": 8, "type": "inventory", "url":
+        "/api/v1/inventories/8/", "related": {"created_by": "/api/v1/users/1/", "scan_job_templates":
+        "/api/v1/inventories/8/scan_job_templates/", "variable_data": "/api/v1/inventories/8/variable_data/",
+        "root_groups": "/api/v1/inventories/8/root_groups/", "script": "/api/v1/inventories/8/script/",
+        "ad_hoc_commands": "/api/v1/inventories/8/ad_hoc_commands/", "tree": "/api/v1/inventories/8/tree/",
+        "hosts": "/api/v1/inventories/8/hosts/", "groups": "/api/v1/inventories/8/groups/",
+        "activity_stream": "/api/v1/inventories/8/activity_stream/", "inventory_sources":
+        "/api/v1/inventories/8/inventory_sources/", "organization": "/api/v1/organizations/1/"},
+        "summary_fields": {"organization": {"name": "Default", "description": ""},
+        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}}, "created": "2016-01-29T21:15:35.295Z", "modified": "2016-02-01T19:40:08.952Z",
+        "name": "Single AWS Host", "description": "54.86.210.90", "organization":
+        1, "variables": "---", "has_active_failures": false, "total_hosts": 1, "hosts_with_active_failures":
+        0, "total_groups": 0, "groups_with_active_failures": 0, "has_inventory_sources":
+        false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0},
+        {"id": 5, "type": "inventory", "url": "/api/v1/inventories/5/", "related":
+        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/5/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/5/variable_data/", "root_groups": "/api/v1/inventories/5/root_groups/",
+        "script": "/api/v1/inventories/5/script/", "ad_hoc_commands": "/api/v1/inventories/5/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/5/tree/", "hosts": "/api/v1/inventories/5/hosts/",
+        "groups": "/api/v1/inventories/5/groups/", "activity_stream": "/api/v1/inventories/5/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/5/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
+        "", "last_name": ""}}, "created": "2016-01-04T22:14:10.907Z", "modified":
+        "2016-03-02T19:49:24.307Z", "name": "VC 6.0", "description": "", "organization":
+        1, "variables": "---", "has_active_failures": true, "total_hosts": 59, "hosts_with_active_failures":
+        34, "total_groups": 26, "groups_with_active_failures": 23, "has_inventory_sources":
+        true, "total_inventory_sources": 3, "inventory_sources_with_failures": 0}]}'
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 21:02:29 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts
@@ -495,8 +667,8 @@ http_interactions:
         "description": "", "has_active_failures": false, "total_hosts": 1, "hosts_with_active_failures":
         0, "total_groups": 1, "groups_with_active_failures": 0, "has_inventory_sources":
         false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0},
-        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "recent_jobs": []}, "created": "2016-02-01T19:47:45.695Z", "modified":
         "2016-02-01T19:47:45.695Z", "name": "127.0.0.1", "description": "db-test-host",
         "inventory": 9, "enabled": true, "instance_id": "", "variables": "", "has_active_failures":
@@ -760,8 +932,8 @@ http_interactions:
         AWS Host", "description": "54.86.210.90", "has_active_failures": false, "total_hosts":
         1, "hosts_with_active_failures": 0, "total_groups": 0, "groups_with_active_failures":
         0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
-        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        0}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "recent_jobs": []}, "created": "2016-02-01T19:40:08.824Z", "modified":
         "2016-02-01T19:40:08.824Z", "name": "169.0.0.1", "description": "Test Host",
         "inventory": 8, "enabled": true, "instance_id": "", "variables": "---", "has_active_failures":
@@ -917,7 +1089,7 @@ http_interactions:
         false, "instance_id": "4233080d-7467-de61-76c9-c8307b6e4830", "variables":
         "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\":
         0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"Some Company Enterprise Linux 7 (64-bit)\",
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
         \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
         1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"test-vc60-host2.example.com\",
@@ -993,7 +1165,7 @@ http_interactions:
         "inventory": 5, "enabled": false, "instance_id": "42331992-dd8f-2206-62f8-0798fea378c8",
         "variables": "{\"vmware_vmPathName\": \"[VC60_Data01] bd-test-1/bd-test-1.vmtx\",
         \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"Some Company Enterprise Linux 6 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
         \"dell-r430-02.example.com\", \"vmware_instanceUuid\":
         \"5033f7d9-539f-4f2b-0bf0-916084fb7589\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_unshared\": 2648619255, \"vmware_guestState\": \"notRunning\",
@@ -1087,7 +1259,7 @@ http_interactions:
         "instance_id": "42336838-180b-34fc-8df0-c5e0af76d743", "variables": "{\"vmware_privateMemory\":
         1891, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\":
         0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"Some Company Enterprise Linux 7 (64-bit)\",
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
         \"vmware_maxCpuUsage\": 4594, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
         0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 39,
@@ -1246,13 +1418,13 @@ http_interactions:
         "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
         \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
         \"5033b189-cf3e-a764-375f-b48f0e8a6ba5\", \"vmware_distributedCpuEntitlement\":
-        239, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Some Company
+        239, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Red Hat
         Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
         4916, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
         \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
         8192, \"vmware_overallCpuUsage\": 239, \"vmware_overallStatus\": \"green\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 4667695824, \"vmware_product_vendor\": \"Some Company, Inc.\",
+        \"vmware_committed\": 4667695824, \"vmware_product_vendor\": \"Red Hat, Inc.\",
         \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
         \"CFME 4.0-1201 (HSONG)\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
         8093, \"vmware_overallCpuDemand\": 263, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
@@ -1267,7 +1439,7 @@ http_interactions:
         2759, \"vmware_uncommitted\": 55463243776, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
         -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 32,
         \"vmware_privateMemory\": 8030, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
-        \"Some Company CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
         9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
         \"vmware_hostName\": \"dhcp-8-99-203.example.com\",
         \"vmware_uptimeSeconds\": 169995, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
@@ -1306,22 +1478,22 @@ http_interactions:
         \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
         6144, \"vmware_overallCpuUsage\": 383, \"vmware_overallStatus\": \"green\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Some Company, Inc.\",
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
         \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
         \"CloudForms 4.0 Beta2.1 (hsong)\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
         6035, \"vmware_overallCpuDemand\": 431, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
         [\"VC60_Data01\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
         53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[VC60_Data01]
-        Some Company CloudForms 4.0 Beta2.1/Some Company CloudForms 4.0 Beta2.1.vmx\", \"vmware_ipAddress\":
+        Red Hat CloudForms 4.0 Beta2.1/Red Hat CloudForms 4.0 Beta2.1.vmx\", \"vmware_ipAddress\":
         \"10.8.99.248\", \"vmware_guestMemoryUsage\": 3010, \"vmware_guestFullName\":
-        \"Some Company Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
         \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.248\", \"vmware_product_key\":
         0, \"vmware_unshared\": 5805824496, \"vmware_staticMemoryEntitlement\": 6252,
         \"vmware_toolsStatus\": \"toolsOk\", \"vmware_uuid\": \"4233cc0a-b678-93df-cf9b-f8cc446e862d\",
         \"vmware_staticCpuEntitlement\": 2759, \"vmware_uncommitted\": 58452631552,
         \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
         \"inactive\", \"vmware_sharedMemory\": 36, \"vmware_privateMemory\": 5978,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Some Company
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
         CloudForms 4.0 Beta2.1\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
         9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
         \"vmware_hostName\": \"dhcp-8-99-248.example.com\",
@@ -2036,13 +2208,13 @@ http_interactions:
         "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
         0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
         \"vmware_instanceUuid\": \"50333a6c-1372-37db-53ed-d9787919594a\", \"vmware_distributedCpuEntitlement\":
-        95, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Some Company
+        95, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Red Hat
         Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"3.2\", \"vmware_distributedMemoryEntitlement\":
         2572, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
         \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
         6144, \"vmware_overallCpuUsage\": 95, \"vmware_overallStatus\": \"green\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 10630141358, \"vmware_product_vendor\": \"Some Company, Inc.\",
+        \"vmware_committed\": 10630141358, \"vmware_product_vendor\": \"Red Hat, Inc.\",
         \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
         \"lucy_54\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 6054,
         \"vmware_overallCpuDemand\": 95, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
@@ -2056,7 +2228,7 @@ http_interactions:
         \"vmware_staticCpuEntitlement\": 2759, \"vmware_uncommitted\": 49500766208,
         \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
         \"inactive\", \"vmware_sharedMemory\": 42, \"vmware_privateMemory\": 5988,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Some Company
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
         CloudForms 3.2\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
         \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
         \"dhcp-8-99-247.example.com\", \"vmware_uptimeSeconds\":
@@ -2095,7 +2267,7 @@ http_interactions:
         [\"VC60_Data01\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
         47, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[VC60_Data01]
         lucy_capablanca_rc2/lucy_capablanca_rc2.vmx\", \"vmware_ipAddress\": \"10.8.99.244\",
-        \"vmware_guestMemoryUsage\": 798, \"vmware_guestFullName\": \"Some Company Enterprise
+        \"vmware_guestMemoryUsage\": 798, \"vmware_guestFullName\": \"Red Hat Enterprise
         Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
         null, \"ansible_ssh_host\": \"10.8.99.244\", \"vmware_product_key\": 0, \"vmware_unshared\":
         4526371355, \"vmware_staticMemoryEntitlement\": 6252, \"vmware_toolsStatus\":
@@ -2127,7 +2299,7 @@ http_interactions:
         "inventory": 5, "enabled": false, "instance_id": "42339cf8-413f-1ab4-c121-dcf212558525",
         "variables": "{\"vmware_vmPathName\": \"[VC60_Data01] lucy_test_template/lucy_test_template.vmtx\",
         \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"Some Company Enterprise Linux 6 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
         \"dell-r430-01.example.com\", \"vmware_instanceUuid\":
         \"50334663-67cd-2b84-47af-7f4e43a2668c\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_unshared\": 2495390251, \"vmware_guestState\": \"notRunning\",
@@ -2185,7 +2357,7 @@ http_interactions:
         [\"VC60_Data01\"], \"vmware_swappedMemory\": 64, \"vmware_consumedOverheadMemory\":
         51, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[VC60_Data01]
         ManageIQ(JozefZ)/ManageIQ(JozefZ).vmx\", \"vmware_ipAddress\": \"10.8.99.235\",
-        \"vmware_guestMemoryUsage\": 61, \"vmware_guestFullName\": \"Some Company Enterprise
+        \"vmware_guestMemoryUsage\": 61, \"vmware_guestFullName\": \"Red Hat Enterprise
         Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
         null, \"ansible_ssh_host\": \"10.8.99.235\", \"vmware_product_key\": 0, \"vmware_unshared\":
         5140861464, \"vmware_staticMemoryEntitlement\": 6252, \"vmware_toolsStatus\":
@@ -2225,7 +2397,7 @@ http_interactions:
         "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
         0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
         \"vmware_instanceUuid\": \"50339c86-d3a6-d278-1edd-f44757038e9f\", \"vmware_distributedCpuEntitlement\":
-        551, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Some Company
+        551, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Red Hat
         Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
         3229, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
         \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
@@ -2289,7 +2461,7 @@ http_interactions:
         [\"VC60_Data01\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
         54, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[VC60_Data01]
         ManageIQ(TinaF)/ManageIQ(TinaF).vmx\", \"vmware_ipAddress\": \"10.8.99.208\",
-        \"vmware_guestMemoryUsage\": 1105, \"vmware_guestFullName\": \"Some Company Enterprise
+        \"vmware_guestMemoryUsage\": 1105, \"vmware_guestFullName\": \"Red Hat Enterprise
         Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
         null, \"ansible_ssh_host\": \"10.8.99.208\", \"vmware_product_key\": 0, \"vmware_unshared\":
         12701598231, \"vmware_staticMemoryEntitlement\": 6252, \"vmware_toolsStatus\":
@@ -2506,7 +2678,7 @@ http_interactions:
         71, \"vmware_unshared\": 3873805309, \"vmware_guestState\": \"notRunning\",
         \"vmware_staticMemoryEntitlement\": 33184, \"vmware_toolsStatus\": \"toolsNotInstalled\",
         \"vmware_suspendInterval\": 0, \"vmware_uuid\": \"4233077a-f815-46e3-54ff-3a91ae194b5a\",
-        \"vmware_guestFullName\": \"Some Company Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
         5518, \"vmware_uncommitted\": 556619427840, \"vmware_distributedMemoryEntitlement\":
         1191, \"vmware_template\": false, \"vmware_overallCpuDemand\": 71, \"vmware_ftSecondaryLatency\":
         -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
@@ -2634,14 +2806,14 @@ http_interactions:
         \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
         6144, \"vmware_overallCpuUsage\": 95, \"vmware_overallStatus\": \"green\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Some Company, Inc.\",
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
         \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
         \"Prod-CloudForms\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
         6066, \"vmware_overallCpuDemand\": 95, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
         [\"VC60_Data01\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
         51, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[VC60_Data01]
         Prod-CloudForms/Prod-CloudForms.vmx\", \"vmware_ipAddress\": \"10.8.96.111\",
-        \"vmware_guestMemoryUsage\": 1536, \"vmware_guestFullName\": \"Some Company Enterprise
+        \"vmware_guestMemoryUsage\": 1536, \"vmware_guestFullName\": \"Red Hat Enterprise
         Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
         null, \"ansible_ssh_host\": \"10.8.96.111\", \"vmware_product_key\": 0, \"vmware_unshared\":
         15138886672, \"vmware_staticMemoryEntitlement\": 6252, \"vmware_toolsStatus\":
@@ -2649,7 +2821,7 @@ http_interactions:
         2759, \"vmware_uncommitted\": 70760460288, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
         -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 14,
         \"vmware_privateMemory\": 6012, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
-        \"Some Company CloudForms 3.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        \"Red Hat CloudForms 3.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
         9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
         \"vmware_hostName\": \"prod-cloudforms.example.com\",
         \"vmware_uptimeSeconds\": 420644, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
@@ -2675,7 +2847,7 @@ http_interactions:
         "{\"vmware_privateMemory\": 3707, \"vmware_resourcePool\": \"Resources\",
         \"vmware_guestMemoryUsage\": 268, \"vmware_overallCpuUsage\": 45, \"vmware_suspendInterval\":
         0, \"vmware_networks\": [\"VM NFS Network\", \"VM Network\"], \"vmware_guestFullName\":
-        \"Some Company Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\":
         false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4594, \"vmware_numMksConnections\":
         0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 2, \"vmware_consumedOverheadMemory\":
         31, \"vmware_hostName\": \"converter\", \"vmware_instanceUuid\": \"50330a32-ee53-9dec-fde7-5804fa3907a7\",
@@ -2890,7 +3062,7 @@ http_interactions:
         0, \"vmware_unshared\": 11432616468, \"vmware_guestState\": \"notRunning\",
         \"vmware_staticMemoryEntitlement\": 20780, \"vmware_toolsStatus\": \"toolsNotInstalled\",
         \"vmware_suspendInterval\": 0, \"vmware_uuid\": \"42332749-6af4-db4b-6ed0-c00aea621d2a\",
-        \"vmware_guestFullName\": \"Some Company Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
         5518, \"vmware_uncommitted\": 538323197952, \"vmware_distributedMemoryEntitlement\":
         706, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
         -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
@@ -2936,7 +3108,7 @@ http_interactions:
         0, \"vmware_unshared\": 5967000083, \"vmware_guestState\": \"notRunning\",
         \"vmware_staticMemoryEntitlement\": 33184, \"vmware_toolsStatus\": \"toolsNotInstalled\",
         \"vmware_suspendInterval\": 0, \"vmware_uuid\": \"42338e5b-4e4e-5915-b711-2b94d9b91b70\",
-        \"vmware_guestFullName\": \"Some Company Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
         5518, \"vmware_uncommitted\": 4770418688, \"vmware_distributedMemoryEntitlement\":
         898, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
         -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
@@ -3451,7 +3623,7 @@ http_interactions:
         false, "instance_id": "42332a2a-adff-d678-2be7-2488c3300e9a", "variables":
         "{\"vmware_vmPathName\": \"[VC60_Data01] vmware_svc_vm_0007/vmware_svc_vm_0007.vmx\",
         \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"Some Company Enterprise Linux 6 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
         \"dell-r430-02.example.com\", \"vmware_instanceUuid\":
         \"5033340f-71b7-5542-83d1-eb206517baf8\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_unshared\": 3044016683, \"vmware_guestState\": \"notRunning\",
@@ -3599,7 +3771,7 @@ http_interactions:
         "CFME AWS Lab", "has_active_failures": true, "total_hosts": 8, "hosts_with_active_failures":
         8, "total_groups": 53, "groups_with_active_failures": 51, "has_inventory_sources":
         true, "total_inventory_sources": 1, "inventory_sources_with_failures": 0},
-        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
         "finished": "2016-02-18T21:52:36.072Z", "id": 119}]}, "created": "2016-02-05T23:09:47.943Z",
         "modified": "2016-02-18T21:52:21.165Z", "name": "Ansible-JobTemplate", "description":
@@ -3621,8 +3793,8 @@ http_interactions:
         "has_active_failures": true, "total_hosts": 8, "hosts_with_active_failures":
         8, "total_groups": 53, "groups_with_active_failures": 51, "has_inventory_sources":
         true, "total_inventory_sources": 1, "inventory_sources_with_failures": 0},
-        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
         true, "recent_jobs": []}, "created": "2016-03-02T22:13:09.055Z", "modified":
         "2016-03-02T22:13:49.206Z", "name": "Ansible-JobTemplate-Survey", "description":
@@ -3650,7 +3822,7 @@ http_interactions:
         {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures": true,
         "total_hosts": 8, "hosts_with_active_failures": 8, "total_groups": 53, "groups_with_active_failures":
         51, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        0}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "successful",
         "finished": "2016-03-02T20:00:12.803Z", "id": 138}, {"status": "successful",
         "finished": "2016-02-23T22:02:40.397Z", "id": 133}, {"status": "successful",
@@ -3688,8 +3860,8 @@ http_interactions:
         {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures": true,
         "total_hosts": 8, "hosts_with_active_failures": 8, "total_groups": 53, "groups_with_active_failures":
         51, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        0}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
         true, "recent_jobs": [{"status": "successful", "finished": "2016-02-23T22:06:51.465Z",
         "id": 135}, {"status": "successful", "finished": "2016-02-23T21:58:49.566Z",
@@ -3724,7 +3896,7 @@ http_interactions:
         "VC 6.0", "description": "", "has_active_failures": true, "total_hosts": 59,
         "hosts_with_active_failures": 34, "total_groups": 26, "groups_with_active_failures":
         23, "has_inventory_sources": true, "total_inventory_sources": 3, "inventory_sources_with_failures":
-        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        0}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
         "finished": "2016-02-01T18:56:03.412Z", "id": 86}, {"status": "failed", "finished":
         "2016-01-05T21:04:19.877Z", "id": 16}, {"status": "failed", "finished": "2016-01-05T21:02:38.834Z",
@@ -3752,7 +3924,7 @@ http_interactions:
         "description": "CFME AWS Lab", "has_active_failures": true, "total_hosts":
         8, "hosts_with_active_failures": 8, "total_groups": 53, "groups_with_active_failures":
         51, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        0}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
         true, "recent_jobs": [{"status": "successful", "finished": "2016-02-19T23:02:51.102Z",
         "id": 120}]}, "created": "2016-02-19T22:53:36.623Z", "modified": "2016-02-19T23:02:04.376Z",
@@ -3782,8 +3954,8 @@ http_interactions:
         Host", "description": "54.86.210.90", "has_active_failures": false, "total_hosts":
         1, "hosts_with_active_failures": 0, "total_groups": 0, "groups_with_active_failures":
         0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
-        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        0}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
         ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "successful",
         "finished": "2016-01-29T21:28:19.553Z", "id": 82}, {"status": "successful",
         "finished": "2016-01-29T21:21:34.597Z", "id": 80}, {"status": "failed", "finished":


### PR DESCRIPTION
Represent AnsibleTower Inventories as an `InventoryRootGroup` (subclass of EmsFolder) which will allow for other `InventoryGroups` (Ansible Tower Groups) to be related.