### PR TITLE
[cloud|google] Only using Service Accounts for GCE credentials

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -14,8 +14,6 @@
         = _("AMQP")
       = miq_tab_header('ssh_keypair') do
         = _("RSA key pair")
-      = miq_tab_header('service_account') do
-        = _("Service Account")
     - else
       = miq_tab_header('remote') do
         = _("Remote Login")
@@ -45,10 +43,13 @@
                                               :verify_title_off       => _("Access Key ID and matching Secret Access Key fields are needed to perform verification of credentials"),
                                               :basic_info_needed      => true}
         .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'gce'"}
-          = render :partial => "layouts/angular/oauth_button_angular", 
-                   :locals  => {:ng_show           => true,
-                                :title             => "Google OAuth 2.0",
-                                :auth_url          => "google_oauth2"}
+          = render :partial => "layouts/angular/auth_service_account_angular",
+                               :locals  => {:ng_show                => true,
+                                            :ng_model               => "#{ng_model}",
+                                            :validate_url           => validate_url,
+                                            :id                     => record.id,
+                                            :prefix                 => "service_account",
+                                            :basic_info_needed      => true}
         .col-md-12{"ng-if" => "#{ng_model}.emstype != 'gce' && #{ng_model}.emstype != 'ec2'" || "#{ng_model}" != "emsCommonModel"}
           = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show           => true,
@@ -60,7 +61,10 @@
                                               :prefix            => "default",
                                               :basic_info_needed => true}
       .form-group
-        .col-md-12
+        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'gce'"}
+          %span{:style => "color:black"}
+            = _("Copy and paste the contents of your Service Account JSON file above.")
+        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype != 'gce'"}
           %span{:style => "color:black"}
             = _("Required. Should have privileged access, such as root or administrator.")
 
@@ -119,16 +123,6 @@
           .col-md-12
             %span{:style => "color:black"}
               = _("Used for SSH connection to all %s in this provider.") % title_for_hosts
-      = miq_tab_content('service_account', 'default') do
-        .form-group
-          .col-md-12
-            = render :partial => "layouts/angular/auth_service_account_angular",
-                                 :locals  => {:ng_show                => true,
-                                              :ng_model               => "#{ng_model}",
-                                              :validate_url           => validate_url,
-                                              :id                     => record.id,
-                                              :prefix                 => "service_account",
-                                              :basic_info_needed      => true}
         .form-group
           .col-md-12
             %span{:style => "color:black"}
@@ -181,20 +175,11 @@
 %div{"ng-if" => "emsCommonModel.emstype == ''"}
   :javascript
     $('#auth_tabs').hide();
-%div{"ng-if" => "emsCommonModel.emstype == 'ec2'"}
+%div{"ng-if" => "emsCommonModel.emstype == 'ec2' || emsCommonModel.emstype == 'gce'"}
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
-    miq_tabs_show_hide("#service_account_tab", false);
-    miq_tabs_init('#auth_tabs');
-    $('#auth_tabs').show();
-%div{"ng-if" => "emsCommonModel.emstype == 'gce'"}
-  :javascript
-    miq_tabs_show_hide("#amqp_tab", false);
-    miq_tabs_show_hide("#metrics_tab", false);
-    miq_tabs_show_hide("#ssh_keypair_tab", false);
-    miq_tabs_show_hide("#service_account_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "emsCommonModel.emstype == 'rhevm'"}
@@ -202,7 +187,6 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", true);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
-    miq_tabs_show_hide("#service_account_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "emsCommonModel.emstype == 'openstack'"}
@@ -210,7 +194,6 @@
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
-    miq_tabs_show_hide("#service_account_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "emsCommonModel.emstype == 'openstack_infra'"}
@@ -218,7 +201,6 @@
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", true);
-    miq_tabs_show_hide("#service_account_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 


### PR DESCRIPTION
This addresses issue #6966.

Since GCE is only going to use Service Accounts in the short-term, this change drops the specific Service Account credentials tab and moves that functionality up as the Default.

I also took a stab at a custom message but don't yet know what to do about l10n.

/cc @blomquisg, @agrare