### PR TITLE
SmartState: Changed to count symlinks in services scanning

### DIFF
--- a/gems/pending/metadata/linux/LinuxSystemd.rb
+++ b/gems/pending/metadata/linux/LinuxSystemd.rb
@@ -72,6 +72,7 @@ module MiqLinux
 
     rescue
       warn "Error parsing: #{file}"
+      nil	      # make sure no intermediate result is returned!
     end
 
     def parse_description(inif)
@@ -90,7 +91,6 @@ module MiqLinux
     end
 
     def parse_target(file)
-      return if @fs.fileSymLink?(file)
       debug "Parsing target unit: #{file}"
 
       unit = @fs.fileBasename(file)
@@ -104,6 +104,7 @@ module MiqLinux
        :description => desc}
     rescue
       warn "Error parsing: #{file}"
+      nil	      # make sure no intermediate result is returned!
     end
 
     def service_xml(service)


### PR DESCRIPTION
Remove the symbolic link filter during services scanning

https://bugzilla.redhat.com/show_bug.cgi?id=1312971