### PR TITLE
i18n: translated accordion titles

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -827,22 +827,22 @@ class CatalogController < ApplicationController
     [{:role     => "svc_catalog_accord",
       :role_any => true,
       :name     => :svccat,
-      :title    => N_("Service Catalogs")},
+      :title    => _("Service Catalogs")},
 
      {:role     => "catalog_items_accord",
       :role_any => true,
       :name     => :sandt,
-      :title    => N_("Catalog Items")},
+      :title    => _("Catalog Items")},
 
      {:role     => "orchestration_templates_accord",
       :role_any => true,
       :name     => :ot,
-      :title    => N_("Orchestration Templates")},
+      :title    => _("Orchestration Templates")},
 
      {:role     => "st_catalog_accord",
       :role_any => true,
       :name     => :stcat,
-      :title    => N_("Catalogs")},
+      :title    => _("Catalogs")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -350,17 +350,17 @@ class ChargebackController < ApplicationController
   private ############################
 
   def features
-    [{:role     => "chargeback_reports",
-      :name     => :cb_reports,
-      :title    => N_("Reports")},
+    [{:role  => "chargeback_reports",
+      :name  => :cb_reports,
+      :title => _("Reports")},
 
-     {:role     => "chargeback_rates",
-      :name     => :cb_rates,
-      :title    => N_("Rates")},
+     {:role  => "chargeback_rates",
+      :name  => :cb_rates,
+      :title => _("Rates")},
 
-     {:role     => "chargeback_assignments",
-      :name     => :cb_assignments,
-      :title    => N_("Assignments")},
+     {:role  => "chargeback_assignments",
+      :name  => :cb_assignments,
+      :title => _("Assignments")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -182,12 +182,12 @@ class ContainerController < ApplicationController
     [{:role     => "container_accord",
       :role_any => true,
       :name     => :containers,
-      :title    => N_("Relationships")},
+      :title    => _("Relationships")},
 
      {:role     => "container_filter_accord",
       :role_any => true,
       :name     => :containers_filter,
-      :title    => N_("All Containers")},
+      :title    => _("All Containers")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1637,7 +1637,7 @@ class MiqAeClassController < ApplicationController
                                                   :role_any    => true,
                                                   :name        => :ae,
                                                   :accord_name => "datastores",
-                                                  :title       => N_("Datastore"))]
+                                                  :title       => _("Datastore"))]
   end
 
   def initial_setup_for_instances_form_vars(ae_inst_id)

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -192,21 +192,21 @@ class MiqAeCustomizationController < ApplicationController
     [{:role     => "old_dialogs_accord",
       :role_any => true,
       :name     => :old_dialogs,
-      :title    => N_("Provisioning Dialogs")},
+      :title    => _("Provisioning Dialogs")},
 
      {:role     => "dialog_accord",
       :role_any => true,
       :name     => :dialogs,
-      :title    => N_("Service Dialogs")},
+      :title    => _("Service Dialogs")},
 
      {:role     => "ab_buttons_accord",
       :role_any => true,
       :name     => :ab,
-      :title    => N_("Buttons")},
+      :title    => _("Buttons")},
 
      {:role     => "miq_ae_class_import_export",
       :name     => :dialog_import_export,
-      :title    => N_("Import/Export")},
+      :title    => _("Import/Export")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1129,13 +1129,13 @@ class MiqPolicyController < ApplicationController
   end
 
   def features
-    [{:name  => :policy_profile, :title => N_("Policy Profiles")},
-     {:name  => :policy, :title => N_("Policies")},
-     {:name  => :event, :title => N_("Events")},
-     {:name  => :condition, :title => N_("Conditions")},
-     {:name  => :action, :title => N_("Actions")},
-     {:name  => :alert_profile, :title => N_("Alert Profiles")},
-     {:name  => :alert, :title => N_("Alerts")},
+    [{:name  => :policy_profile, :title => _("Policy Profiles")},
+     {:name  => :policy, :title => _("Policies")},
+     {:name  => :event, :title => _("Events")},
+     {:name  => :condition, :title => _("Conditions")},
+     {:name  => :action, :title => _("Actions")},
+     {:name  => :alert_profile, :title => _("Alert Profiles")},
+     {:name  => :alert, :title => _("Alerts")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -207,24 +207,24 @@ class OpsController < ApplicationController
   def features
     [{:role     => "ops_settings",
       :name     => :settings,
-      :title    => N_("Settings")},
+      :title    => _("Settings")},
 
      {:role     => "ops_rbac",
       :role_any => true,
       :name     => :rbac,
-      :title    => N_("Access Control")},
+      :title    => _("Access Control")},
 
      {:role     => "ops_diagnostics",
       :name     => :diagnostics,
-      :title    => N_("Diagnostics")},
+      :title    => _("Diagnostics")},
 
      {:role     => "ops_analytics",
       :name     => :analytics,
-      :title    => N_("Analytics")},
+      :title    => _("Analytics")},
 
      {:role     => "ops_db",
       :name     => :vmdb,
-      :title    => N_("Database")},
+      :title    => _("Database")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -445,11 +445,11 @@ class ProviderForemanController < ApplicationController
     [{:role     => "providers_accord",
       :role_any => true,
       :name     => :configuration_manager_providers,
-      :title    => N_("Providers")},
+      :title    => _("Providers")},
      {:role     => "configured_systems_filter_accord",
       :role_any => true,
       :name     => :cs_filter,
-      :title    => N_("Configured Systems")}
+      :title    => _("Configured Systems")}
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -77,22 +77,22 @@ class PxeController < ApplicationController
     [{:role     => "pxe_server_accord",
       :role_any => true,
       :name     => :pxe_servers,
-      :title    => N_("PXE Servers")},
+      :title    => _("PXE Servers")},
 
      {:role     => "customization_template_accord",
       :role_any => true,
       :name     => :customization_templates,
-      :title    => N_("Customization Templates")},
+      :title    => _("Customization Templates")},
 
      {:role     => "pxe_image_type_accord",
       :role_any => true,
       :name     => :pxe_image_types,
-      :title    => N_("System Image Types")},
+      :title    => _("System Image Types")},
 
      {:role     => "iso_datastore_accord",
       :role_any => true,
       :name     => :iso_datastores,
-      :title    => N_("ISO Datastores")},
+      :title    => _("ISO Datastores")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -274,33 +274,33 @@ class ReportController < ApplicationController
     [{:role     => "miq_report_saved_reports",
       :role_any => true,
       :name     => :savedreports,
-      :title    => N_("Saved Reports")},
+      :title    => _("Saved Reports")},
 
      {:role     => "miq_report_reports",
       :role_any => true,
       :name     => :reports,
-      :title    => N_("Reports")},
+      :title    => _("Reports")},
 
      {:role     => "miq_report_schedules",
       :role_any => true,
       :name     => :schedules,
-      :title    => N_("Schedules")},
+      :title    => _("Schedules")},
 
      {:role  => "miq_report_dashboard_editor",
       :name  => :db,
-      :title => N_("Dashboards")},
+      :title => _("Dashboards")},
 
      {:role  => "miq_report_widget_editor",
       :name  => :widgets,
-      :title => N_("Dashboard Widgets")},
+      :title => _("Dashboard Widgets")},
 
      {:role  => "miq_report_menu_editor",
       :name  => :roles,
-      :title => N_("Edit Report Menus")},
+      :title => _("Edit Report Menus")},
 
      {:role  => "miq_report_export",
       :name  => :export,
-      :title => N_("Import/Export")},
+      :title => _("Import/Export")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -192,7 +192,7 @@ class ServiceController < ApplicationController
     [ApplicationController::Feature.new_with_hash(:role     => "service",
                                                   :role_any => true,
                                                   :name     => :svcs,
-                                                  :title    => N_("Services"))]
+                                                  :title    => _("Services"))]
   end
 
   def service_set_record_vars(svc)


### PR DESCRIPTION
We need to use `_()` instead of `N_()`, otherwise the translated accordion titles will never show.