### PR TITLE
i18n: add missing model names to en yml & update dictionary_strings.rb

### DIFF
--- a/config/dictionary_strings.rb
+++ b/config/dictionary_strings.rb
@@ -1275,6 +1275,10 @@ _("Storage - Extents")
 _("Category")
 # TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
 _("Categories")
+# TRANSLATORS: en.yml key: dictionary.model.CloudTenant
+_("Cloud Tenant")
+# TRANSLATORS: en.yml key: dictionary.model.CloudTenant (plural form)
+_("Cloud Tenants")
 # TRANSLATORS: en.yml key: dictionary.model.Compliance
 _("Compliance History")
 # TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
@@ -1445,6 +1449,10 @@ _("Virtual Machines")
 _("Template")
 # TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
 _("Templates")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::MiddlewareManager
+_("Middleware Manager")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::MiddlewareManager (plural form)
+_("Middleware Managers")
 # TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager
 _("Infrastructure Provider (Openstack)")
 # TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager (plural form)
@@ -1489,6 +1497,14 @@ _("Container Providers (Openshift)")
 _("Container Provider (Openshift Enterprise)")
 # TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager (plural form)
 _("Container Providers (Openshift Enterprise)")
+# TRANSLATORS: en.yml key: dictionary.model.MiddlewareDeployment
+_("Middleware Deployment")
+# TRANSLATORS: en.yml key: dictionary.model.MiddlewareDeployment (plural form)
+_("Middleware Deployments")
+# TRANSLATORS: en.yml key: dictionary.model.MiddlewareServer
+_("Middleware Server")
+# TRANSLATORS: en.yml key: dictionary.model.MiddlewareServer (plural form)
+_("Middleware Servers")
 # TRANSLATORS: en.yml key: dictionary.model.MiqAction
 _("Action")
 # TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
@@ -1753,6 +1769,14 @@ _("Key Pairs")
 _("Availability Zone")
 # TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
 _("Availability Zones")
+# TRANSLATORS: en.yml key: dictionary.table.base_snapshot
+_("Base Snapshot")
+# TRANSLATORS: en.yml key: dictionary.table.base_snapshot (plural form)
+_("Base Snapshots")
+# TRANSLATORS: en.yml key: dictionary.table.based_volumes
+_("Cloud Volumes Based on Snapshot")
+# TRANSLATORS: en.yml key: dictionary.table.based_volumes (plural form)
+_("Cloud Volumes Based on Snapshots")
 # TRANSLATORS: en.yml key: dictionary.table.cdroms
 _("CD/DVD Drives")
 # TRANSLATORS: en.yml key: dictionary.table.cim_base_storage_extent
@@ -1763,6 +1787,12 @@ _("Cloud Volume")
 _("Cloud Volumes")
 # TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
 _("Cloud Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.cloud_volume_snapshot
+_("Cloud Volume Snapshot")
+# TRANSLATORS: en.yml key: dictionary.table.cloud_volume_snapshot (plural form)
+_("Cloud Volume Snapshots")
+# TRANSLATORS: en.yml key: dictionary.table.cloud_volume_snapshots
+_("Cloud Volume Snapshots")
 # TRANSLATORS: en.yml key: dictionary.table.compliance_details
 _("Details")
 # TRANSLATORS: en.yml key: dictionary.table.compliances

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -682,6 +682,7 @@ en:
       ChargebackRate:           Chargeback Rate
       CimStorageExtent:         Storage - Extent
       Classification:           Category
+      CloudTenant:              Cloud Tenant
       Compliance:               Compliance History
       Compliances:              Compliance History
       Condition:                Condition
@@ -741,6 +742,8 @@ en:
       ManageIQ::Providers::Kubernetes::ContainerManager:                    Container Provider (Kubernetes)
       ManageIQ::Providers::Openshift::ContainerManager:                     Container Provider (Openshift)
       ManageIQ::Providers::OpenshiftEnterprise::ContainerManager:           Container Provider (Openshift Enterprise)
+      MiddlewareDeployment:     Middleware Deployment
+      MiddlewareServer:         Middleware Server
       MiqAction:                Action
       MiqAeClass:               Automate Class
       MiqAeDomain:              Automate Domain


### PR DESCRIPTION
Changes:
* added new model names used in our application to `en.yml` (these need to be present and correctly translated)
* updated `dictionary_strings.rb` with the new stuff from `en.yml`