### PR TITLE
Fix MIQ_SPARTAN noui -> no_ui

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -25,11 +25,7 @@ module MiqServer::EnvironmentManagement
     MIQ_SPARTAN_ROLE_SEPARATOR = ":"
     def minimal_env_options
       @minimal_env_options ||= begin
-        options = self.minimal_env? ? spartan_mode.split(MIQ_SPARTAN_ROLE_SEPARATOR) : []
-        options.shift # remove the "minimal" from the front of the array
-
-        # Special case where Netbeans is handling the UI worker for debugging
-        options.collect { |o| o.downcase == "netbeans" ? %w(schedule reporting no_ui) : o }.flatten
+        minimal_env? ? spartan_mode.split(MIQ_SPARTAN_ROLE_SEPARATOR)[1..-1] : []
       end
     end
 

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -29,7 +29,7 @@ module MiqServer::EnvironmentManagement
         options.shift # remove the "minimal" from the front of the array
 
         # Special case where Netbeans is handling the UI worker for debugging
-        options.collect { |o| o.downcase == "netbeans" ? %w(schedule reporting noui) : o }.flatten
+        options.collect { |o| o.downcase == "netbeans" ? %w(schedule reporting no_ui) : o }.flatten
       end
     end
 

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -6,9 +6,9 @@ class MiqUiWorker < MiqWorker
   self.check_for_minimal_role = false
   self.workers = lambda do
     if MiqServer.minimal_env?
-      # Force 1 UI worker in minimal mode, unless 'noui' is an option, which is
+      # Force 1 UI worker in minimal mode, unless 'no_ui' is an option, which is
       # done when the UI worker is debugged externally, such as in Netbeans.
-      MiqServer.minimal_env_options.include?("noui") ? 0 : 1
+      MiqServer.minimal_env_options.include?("no_ui") ? 0 : 1
     else
       worker_settings[:count]
     end

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -58,11 +58,6 @@ describe "Server Environment Management" do
       expect(MiqServer.minimal_env_options).to eq(%w(foo bar))
     end
 
-    it "when spartan_mode starts with 'minimal' and has various roles, including netbeans" do
-      allow(MiqServer).to receive(:spartan_mode).and_return("minimal:foo:netbeans:bar")
-      expect(MiqServer.minimal_env_options).to eq(%w(foo schedule reporting no_ui bar))
-    end
-
     it "when spartan_mode does not start with 'minimal'" do
       allow(MiqServer).to receive(:spartan_mode).and_return("foo:bar")
       expect(MiqServer.minimal_env_options).to eq([])

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -60,7 +60,7 @@ describe "Server Environment Management" do
 
     it "when spartan_mode starts with 'minimal' and has various roles, including netbeans" do
       allow(MiqServer).to receive(:spartan_mode).and_return("minimal:foo:netbeans:bar")
-      expect(MiqServer.minimal_env_options).to eq(%w(foo schedule reporting noui bar))
+      expect(MiqServer.minimal_env_options).to eq(%w(foo schedule reporting no_ui bar))
     end
 
     it "when spartan_mode does not start with 'minimal'" do


### PR DESCRIPTION
[According to our current documentation the option is 'no_ui', not 'noui'](http://manageiq.org/documentation/development/developer_setup/minimal_mode/)

This changes the code rather than the documentation because no_ui seems to fit conventions like server_roles better.

(see https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/server_roles.csv)