### PR TITLE
Move VmdbDatabaseConnection specific code out of MiqDbConfig.

### DIFF
--- a/app/models/miq_db_config.rb
+++ b/app/models/miq_db_config.rb
@@ -198,32 +198,6 @@ class MiqDbConfig
     false
   end
 
-  def self.log_statistics
-    log_activity_statistics
-  end
-
-  def self.log_activity_statistics(output = $log)
-    require 'csv'
-
-    begin
-      stats = VmdbDatabaseConnection.all.map(&:to_csv_hash)
-
-      keys = stats.first.keys
-
-      csv = CSV.generate do |rows|
-        rows << keys
-        stats.each do |s|
-          vals = s.values_at(*keys)
-          rows << vals
-        end
-      end
-
-      output.info("MIQ(DbConfig.log_activity_statistics) <<-ACTIVITY_STATS_CSV\n#{csv}ACTIVITY_STATS_CSV")
-    rescue => err
-      output.warn("MIQ(DbConfig.log_activity_statistics) Unable to log stats, '#{err.message}'")
-    end
-  end
-
   private
 
   def with_temporary_connection

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -16,8 +16,8 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
-  def miq_db_config_log_statistics
-    queue_work(:class_name  => "MiqDbConfig", :method_name => "log_statistics", :server_guid => MiqServer.my_guid)
+  def vmdb_database_connection_log_statistics
+    queue_work(:class_name  => "VmdbDatabaseConnection", :method_name => "log_statistics", :server_guid => MiqServer.my_guid)
   end
 
   def miq_server_queue_update_registration_status

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -123,7 +123,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       interval,
       :first_in => 1.minute,
       :tags     => [:log_statistics, schedule_category]
-    ) { enqueue :miq_db_config_log_statistics }
+    ) { enqueue :vmdb_database_connection_log_statistics }
 
     # Schedule - Periodic check for updates on appliances only
     if MiqEnvironment::Command.is_appliance?

--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -32,6 +32,28 @@ class VmdbDatabaseConnection < ApplicationRecord
     false
   end
 
+  def self.log_statistics(output = $log)
+    require 'csv'
+
+    begin
+      stats = all.map(&:to_csv_hash)
+
+      keys = stats.first.keys
+
+      csv = CSV.generate do |rows|
+        rows << keys
+        stats.each do |s|
+          vals = s.values_at(*keys)
+          rows << vals
+        end
+      end
+
+      output.info("MIQ(#{name}.#{__method__}) <<-ACTIVITY_STATS_CSV\n#{csv}ACTIVITY_STATS_CSV")
+    rescue => err
+      output.warn("MIQ(#{name}.#{__method__}) Unable to log stats, '#{err.message}'")
+    end
+  end
+
   def vmdb_database_id
     @vmdb_database_id ||= self.class.vmdb_database.id
   end

--- a/spec/models/miq_db_config_spec.rb
+++ b/spec/models/miq_db_config_spec.rb
@@ -1,49 +1,4 @@
 describe MiqDbConfig do
-  CSV_HEADER = %w( session_id
-                   xact_start
-                   last_request_start_time
-                   command
-                   task_state
-                   login
-                   application
-                   request_id
-                   net_address
-                   host_name
-                   client_port
-                   wait_time_ms
-                   blocked_by )
-
-  context ".log_activity_statistics" do
-    before do
-      @buffer = StringIO.new
-      class << @buffer
-        alias_method :info, :write
-        alias_method :warn, :write
-      end
-    end
-
-    it "normal" do
-      MiqDbConfig.log_activity_statistics(@buffer)
-      lines = @buffer.string.lines
-      expect(lines.shift).to eq "MIQ(DbConfig.log_activity_statistics) <<-ACTIVITY_STATS_CSV\n"
-      expect(lines.pop).to eq "ACTIVITY_STATS_CSV"
-
-      header, *rows = CSV.parse lines.join
-      expect(header).to eq(CSV_HEADER)
-
-      expect(rows.length).to be > 0
-      rows.each do |row|
-        expect(row.first).to be_truthy
-      end
-    end
-
-    it "exception" do
-      allow(VmdbDatabaseConnection).to receive(:all).and_raise("FAILURE")
-      MiqDbConfig.log_activity_statistics(@buffer)
-      expect(@buffer.string.lines.first).to eq("MIQ(DbConfig.log_activity_statistics) Unable to log stats, 'FAILURE'")
-    end
-  end
-
   it ".get_db_types" do
     expected = {
       "internal"     => "Internal Database on this CFME Appliance",


### PR DESCRIPTION
This code doesn't make any sense in MiqDbConfig as it uses *none* of its functionality...it just gets in the way of refactorting MiqDbConfig.

@jrafanie Please review.