### PR TITLE
Fixing issue where running migration on empty DB leaves a single row in chargeback_rate_detail_currencies table.

### DIFF
--- a/db/migrate/20160115111829_chargeback_rate_detail_currency_not_nil.rb
+++ b/db/migrate/20160115111829_chargeback_rate_detail_currency_not_nil.rb
@@ -4,19 +4,21 @@ class ChargebackRateDetailCurrencyNotNil < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
+  class ChargebackRateDetailCurrency < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
   def up
-    currency = ChargebackRateDetailCurrency.find_by_name("Dollars")
-    if currency
-      currency_id = currency.id
-    else
-      cbc = ChargebackRateDetailCurrency.create(:code        => "USD",
-                                                :name        => "Dollars",
-                                                :full_name   => "United States Dollars",
-                                                :symbol      => "$",
-                                                :unicode_hex => "36"
-                                               )
-      currency_id = cbc.id
+    chargeback_rate_details = ChargebackRateDetail.where(:chargeback_rate_detail_currency_id => nil)
+    if !chargeback_rate_details.count.zero?
+      currency = ChargebackRateDetailCurrency.find_by_name("Dollars") ||
+                 ChargebackRateDetailCurrency.create(:code        => "USD",
+                                                     :name        => "Dollars",
+                                                     :full_name   => "United States Dollars",
+                                                     :symbol      => "$",
+                                                     :unicode_hex => "36"
+      )
+      chargeback_rate_details.update_all(:chargeback_rate_detail_currency_id => currency.id)
     end
-    ChargebackRateDetail.where(:chargeback_rate_detail_currency_id => nil).update_all(:chargeback_rate_detail_currency_id => currency_id)
   end
 end

--- a/spec/migrations/20160115111829_chargeback_rate_detail_currency_not_nil_spec.rb
+++ b/spec/migrations/20160115111829_chargeback_rate_detail_currency_not_nil_spec.rb
@@ -3,6 +3,7 @@ require_migration
 
 describe ChargebackRateDetailCurrencyNotNil do
   let(:chargeback_rate_detail_stub) { migration_stub(:ChargebackRateDetail) }
+  let(:chargeback_rate_detail_currency_stub) { migration_stub(:ChargebackRateDetailCurrency) }
 
   migration_context :up do
     it "changes existing rate detail without currency to the default currency" do
@@ -17,6 +18,12 @@ describe ChargebackRateDetailCurrencyNotNil do
       migrate
 
       expect(chargeback_rate_detail.reload.chargeback_rate_detail_currency_id).to eq(5)
+    end
+
+    it "does nothing if no chargeback_rate_details exist" do
+      migrate
+
+      expect(chargeback_rate_detail_currency_stub.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
- It should only create chargeback_rate_detail_currencies instance for "Dollars" if there are existing rates that do not have a currency.
- Also made a small refactor to the migration.

