### PR TITLE
Don't be lazy to fetch miq_task_id, it's needed for icon

### DIFF
--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -41,7 +41,7 @@ class TreeBuilderChargebackReports < TreeBuilder
     objects = MiqReportResult.auto_generated.where(
       :miq_report_id => from_cid(object[:id].split('-').first),
       :userid        => User.current_user.userid
-    ).order("created_on DESC").select("id, miq_report_id, name, last_run_on")
+    ).order("created_on DESC").select("id, miq_report_id, name, last_run_on, miq_task_id")
 
     count_only_or_objects(count_only, objects, "name")
   end


### PR DESCRIPTION
Reproducer
ChargeBack -> Reports -> Saved Chargeback Reports -> Expand

```
Addressing error like:
Error caught: [ActiveModel::MissingAttributeError] missing attribute: miq_task_id
app/models/miq_report_result.rb:39:in `status'
app/presenters/tree_node_builder.rb:132:in `get_rr_status_image'
app/presenters/tree_node_builder.rb:89:in `build'
app/presenters/tree_node_builder.rb:29:in `build'
app/presenters/tree_builder.rb:436:in `x_build_single_node'
app/presenters/tree_builder.rb:412:in `x_build_node'
app/presenters/tree_builder.rb:441:in `x_build_node_dynatree'
app/presenters/tree_builder.rb:202:in `block in x_get_child_nodes'
app/presenters/tree_builder.rb:201:in `map'
app/presenters/tree_builder.rb:201:in `x_get_child_nodes'
app/presenters/tree_builder.rb:483:in `tree_add_child_nodes'
app/controllers/application_controller/tree_support.rb:26:in `tree_autoload_dynatree'
```