### PR TITLE
URI::Generic.build cleanup

### DIFF
--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -91,10 +91,7 @@ module OpenstackHandle
     end
 
     def self.url(address, port = 5000, scheme = "http", path = "")
-      port = port.to_i
-      uri = URI::Generic.build(:scheme => scheme, :port => port, :path => path)
-      uri.hostname = address
-      uri.to_s
+      URI::Generic.build(:scheme => scheme, :host => address, :port => port.to_i, :path => path).to_s
     end
 
     class << self

--- a/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
+++ b/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
@@ -11,6 +11,10 @@ describe OpenstackHandle::Handle do
     $fog_log = @original_log
   end
 
+  it ".url" do
+    expect(described_class.url("::1")).to eq "http://[::1]:5000"
+  end
+
   context "errors from services" do
     before do
       @openstack_svc = double('network_service')

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -9,8 +9,7 @@ class MiqWinRM
   end
 
   def build_uri
-    uri = URI::HTTP.build(:port => @port, :path => "/wsman", :host => @hostname)
-    uri.to_s
+    URI::HTTP.build(:port => @port, :path => "/wsman", :host => @hostname).to_s
   end
 
   def connect(options = {})


### PR DESCRIPTION
Build accepts [::1] or ::1 hostnames inline in modern rubies.

There is no need to use the hostname= method anymore:
ruby/ruby#765

Related:  7e00354