### PR TITLE
Remove extraneous dialog information from the expanded serialized hash

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -41,11 +41,7 @@ class CustomButton < ApplicationRecord
   def expanded_serializable_hash
     button_hash = serializable_hash
     if resource_action
-      resource_action_hash = resource_action.serializable_hash
-      if resource_action.dialog
-        resource_action_hash.merge!(:dialog => DialogSerializer.new.serialize([resource_action.dialog]).first)
-      end
-      button_hash.merge!(:resource_action => resource_action_hash)
+      button_hash[:resource_action] = resource_action.serializable_hash
     end
     button_hash
   end

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -219,4 +219,47 @@ describe CustomButton do
       expect(new_vm_button).to be_valid
     end
   end
+
+  describe "#expanded_serializable_hash" do
+    let(:test_button) { described_class.new(:resource_action => resource_action) }
+    let(:expected_hash) do
+      {
+        "id"                => nil,
+        "guid"              => nil,
+        "description"       => nil,
+        "applies_to_class"  => nil,
+        "applies_to_exp"    => nil,
+        "options"           => nil,
+        "userid"            => nil,
+        "wait_for_complete" => nil,
+        "created_on"        => nil,
+        "updated_on"        => nil,
+        "name"              => nil,
+        "visibility"        => nil,
+        "applies_to_id"     => nil
+      }
+    end
+
+    context "when a resource action exists" do
+      let(:resource_action) { ResourceAction.new }
+
+      before do
+        allow(resource_action).to receive(:serializable_hash).and_return("resource_action_hash")
+      end
+
+      it "returns the button as a serializable hash with the resource action serialized hash" do
+        expect(test_button.expanded_serializable_hash).to eq(
+          expected_hash.merge(:resource_action => "resource_action_hash")
+        )
+      end
+    end
+
+    context "when a resource action does not exist" do
+      let(:resource_action) { nil }
+
+      it "returns the button as a serializable hash" do
+        expect(test_button.expanded_serializable_hash).to eq(expected_hash)
+      end
+    end
+  end
 end

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -189,9 +189,8 @@ describe ApiController do
       button = @result["custom_actions"]["buttons"].first
       expect_hash_to_have_keys(button, %w(id resource_action))
       ra = button["resource_action"]
-      expect_hash_to_have_keys(ra, %w(id dialog_id dialog))
+      expect_hash_to_have_keys(ra, %w(id dialog_id))
       expect_result_to_match_hash(ra, "id" => ra2.id, "dialog_id" => ra2.dialog_id)
-      expect(ra["dialog"]["label"]).to eq(dialog2.label)
     end
   end
 end


### PR DESCRIPTION
This is being used by the SSUI when loading a service, and if the service has a bunch of custom buttons, it was sending down all of the dialog data for each custom button. This causes two issues, the first of which is just a lot of extra data, but the second is that the dialogs would be evaluated before necessary, so any dynamic dialogs may or may not have incorrect data (for example time sensitive information could be incorrect).

The resource action itself already contains a dialog_id that is now used by the SSUI to pull down the dialog when the custom button is actually clicked.

/cc @gmcculloug 