### PR TITLE
move registration of Amazon::CloudManager as a type to itself

### DIFF
--- a/app/models/orchestration_template_cfn.rb
+++ b/app/models/orchestration_template_cfn.rb
@@ -30,8 +30,12 @@ class OrchestrationTemplateCfn < OrchestrationTemplate
     end
   end
 
+  def self.register_eligible_manager(cloud_manager_class)
+    eligible_manager_types << cloud_manager_class
+  end
+
   def self.eligible_manager_types
-    [ManageIQ::Providers::Amazon::CloudManager, ManageIQ::Providers::Openstack::CloudManager]
+    @eligible_manager_types ||= [ManageIQ::Providers::Openstack::CloudManager]
   end
 
   # return the parsing error message if not valid JSON; otherwise nil

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -20,6 +20,8 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :Template
   require_nested :Vm
 
+  OrchestrationTemplateCfn.register_eligible_manager(self)
+
   def self.ems_type
     @ems_type ||= "ec2".freeze
   end


### PR DESCRIPTION
@bzwei can you have a look, if I'm missing anything?

@miq-bot add_label providers