### PR TITLE
Remove redundant private statement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -816,7 +816,6 @@ class ApplicationController < ActionController::Base
       params[:id] == 'new' ? 'show_list' : lastaction
     end
   end
-  private :calculate_lastaction
 
   def report_edit_aborted(lastaction)
     add_flash(_("Edit aborted!  CFME does not support the browser's back button or access from multiple tabs or windows of the same browser.  Please close any duplicate sessions before proceeding."), :error)
@@ -835,7 +834,6 @@ class ApplicationController < ActionController::Base
       redirect_to :action => lastaction, :id => params[:id], :escape => false
     end
   end
-  private :report_edit_aborted
 
   def load_edit(key, lastaction = @lastaction)
     lastaction = calculate_lastaction(lastaction)
@@ -1163,7 +1161,6 @@ class ApplicationController < ActionController::Base
       klass.find(id)    # Read the record from the db
     end
   end
-  private :listicon_item
 
   # Return the icon classname for the list view icon of a db,id pair
   # this always supersedes listicon_image if not nil
@@ -1634,7 +1631,6 @@ class ApplicationController < ActionController::Base
     gtl_type ||= 'list' # return a sane default
     gtl_type
   end
-  private :get_view_calculate_gtl_type
 
   def get_view_process_search_text(view)
     # Check for new search by name text entered
@@ -1674,12 +1670,10 @@ class ApplicationController < ActionController::Base
     end
     sub_filter
   end
-  private :get_view_process_search_text
 
   def perpage_key(dbname)
     %w(job miqtask).include?(dbname) ? :job_task : PERPAGE_TYPES[@gtl_type]
   end
-  private :perpage_key
 
   # Create view and paginator for a DB records with/without tags
   def get_view(db, options = {})
@@ -1821,7 +1815,6 @@ class ApplicationController < ActionController::Base
       default_where_clause
     end
   end
-  private :get_view_where_clause
 
   def get_view_filter(default_filter)
     # Get the advanced search filter
@@ -1834,7 +1827,6 @@ class ApplicationController < ActionController::Base
     # show_list, can't be used with advanced search or other list view screens
     filter || default_filter
   end
-  private :get_view_filter
 
   def get_view_pages_perpage(dbname)
     perpage = 10 # return a sane default
@@ -1845,7 +1837,6 @@ class ApplicationController < ActionController::Base
 
     perpage
   end
-  private :get_view_pages_perpage
 
   # Create the pages hash and return with the view
   def get_view_pages(dbname, view)
@@ -1857,7 +1848,6 @@ class ApplicationController < ActionController::Base
     pages[:total] = (pages[:items] + pages[:perpage] - 1) / pages[:perpage]
     pages
   end
-  private :get_view_pages
 
   def get_db_view(db, options = {})
     view_yaml = view_yaml_filename(db, options)

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -315,7 +315,6 @@ module ApplicationController::Buttons
     ab_get_node_info(x_node) if x_active_tree == :ab_tree
     replace_right_cell(x_node)
   end
-  private :group_button_cancel
 
   def group_button_add_save(typ)
     assert_privileges(params[:button] == "add" ? "ab_group_new" : "ab_group_edit")
@@ -399,7 +398,6 @@ module ApplicationController::Buttons
       end
     end
   end
-  private :group_button_add_save
 
   def group_button_reset
     group_set_form_vars
@@ -410,7 +408,6 @@ module ApplicationController::Buttons
     @layout     = "miq_ae_automate_button"
     replace_right_cell("button_edit")
   end
-  private :group_button_reset
 
   def group_create_update(typ)
     @edit = session[:edit]

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -2097,8 +2097,6 @@ module ApplicationController::Compare
       (@sb[:miq_drift_params] == "different" && !@same)
   end
 
-  private
-
   def collapsed_state(id)
     s = session[:compare_state] || []
     !s.include?(id)

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1521,7 +1521,6 @@ module ApplicationController::Filter
     global_expressions.each { |ge| ge[0] = "Global - #{ge[0]}" }
     @edit[@expkey][:exp_search_expressions] = global_expressions + user_expressions
   end
-  private :adv_search_build_lists
 
   # Build a string from an array of expression symbols by recursively traversing the MiqExpression object
   #   and inserting sequential tokens for each expression part
@@ -1657,7 +1656,6 @@ module ApplicationController::Filter
       end
     end
   end
-  private :process_datetime_expression_field
 
   def process_datetime_selector(param_key_suffix, exp_key = nil)
     param_date_key  = "miq_date_#{param_key_suffix}".to_sym
@@ -1680,7 +1678,6 @@ module ApplicationController::Filter
 
     exp[exp_value_key][exp_value_index] = "#{date}#{time}"
   end
-  private :process_datetime_selector
 
   ENABLE_CALENDAR = "miqBuildCalendar();".freeze
   def calendar_needed?

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1617,5 +1617,4 @@ module ApplicationController::Performance
       end.join("\r") unless trendcol.nil?
     end
   end
-  private :process_chart_trends
 end

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -230,7 +230,6 @@ module ApplicationController::Tags
   else
     add_flash(_("Tag edits were successfully saved"))
   end
-  private :tagging_save_tags
 
   # Build the tagging assignment screen
   def tagging_build_screen

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -663,7 +663,6 @@ class ConfigurationController < ApplicationController
     end
     settings
   end
-  private :merge_in_user_settings
 
   # * start with DEFAULT_SETTINGS
   # * merge in current session changes
@@ -671,7 +670,6 @@ class ConfigurationController < ApplicationController
   def init_settings
     merge_in_user_settings(copy_hash(DEFAULT_SETTINGS))
   end
-  private :init_settings
 
   def set_form_vars
     case @tabform


### PR DESCRIPTION
These specific methods are already preceded by `private` invocation
without any arguments.