### PR TITLE
Remove unused variables :scissors:

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,11 +40,6 @@ class User < ApplicationRecord
 
   include ReportableMixin
 
-  @@role_ns  = "/managed/user"
-  @@role_cat = "role"
-
-  @role_changed = false
-
   serialize     :settings, Hash   # Implement settings column as a hash
   default_value_for(:settings) { Hash.new }
 


### PR DESCRIPTION
Remove more cruft when looking at MiqGroup split.

role_changed was added in 955f6577cf.
role_cat and role_ns were added in 8595ae714b.

All three were no longer referenced when we implemented roles and ui tasks
in a3bbde22b0.