### PR TITLE
Add volume and snapshot relationships to Cloud Tenant detail view

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -80,6 +80,24 @@ class CloudTenantController < ApplicationController
       @view, @pages = get_view(kls, :parent => @cloud_tenant)  # Get the records (into a view) and the paginator
       @showtype = @display
       notify_about_unauthorized_items(title, ui_lookup(:tables => "cloud_tenant"))
+    when "cloud_volumes"
+      table = "cloud_volumes"
+      title = ui_lookup(:tables => table)
+      kls   = CloudVolume
+      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @cloud_tenant.name, :title => title},
+                      :url  => "/cloud_tenant/show/#{@cloud_tenant.id}?display=#{@display}")
+      @view, @pages = get_view(kls, :parent => @cloud_tenant)  # Get the records (into a view) and the paginator
+      @showtype = @display
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "cloud_tenant"))
+    when "cloud_volume_snapshots"
+      table = "cloud_volume_snapshots"
+      title = ui_lookup(:tables => table)
+      kls   = CloudVolumeSnapshot
+      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @cloud_tenant.name, :title => title},
+                      :url  => "/cloud_tenant/show/#{@cloud_tenant.id}?display=#{@display}")
+      @view, @pages = get_view(kls, :parent => @cloud_tenant)  # Get the records (into a view) and the paginator
+      @showtype = @display
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "cloud_tenant"))
     end
 
     # Came in from outside show_list partial

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -3,7 +3,7 @@ module CloudTenantHelper::TextualSummary
   # Groups
   #
   def textual_group_relationships
-    %i(ems_cloud security_groups instances images)
+    %i(ems_cloud security_groups instances images cloud_volumes cloud_volume_snapshots)
   end
 
   def textual_group_tags
@@ -58,5 +58,27 @@ module CloudTenantHelper::TextualSummary
 
   def quota_label(service_name, quota_name)
     "#{service_name.titleize} - #{quota_name.titleize}"
+  end
+
+  def textual_cloud_volumes
+    label = ui_lookup(:tables => "cloud_volumes")
+    num   = @record.number_of(:cloud_volumes)
+    h     = {:label => label, :image => "cloud_volume", :value => num}
+    if num > 0 && role_allows(:feature => "cloud_volume_show_list")
+      h[:title] = _("Show all %{label}") % {:label => label}
+      h[:link]  = url_for(:action => 'show', :id => @cloud_tenant, :display => "cloud_volumes")
+    end
+    h
+  end
+
+  def textual_cloud_volume_snapshots
+    label = ui_lookup(:tables => "cloud_volume_snapshots")
+    num   = @record.number_of(:cloud_volume_snapshots)
+    h     = {:label => label, :image => "cloud_volume_snapshot", :value => num}
+    if num > 0 && role_allows(:feature => "cloud_volume_snapshot_show_list")
+      h[:title] = _("Show all %{label}") % {:label => label}
+      h[:link]  = url_for(:action => 'show', :id => @cloud_tenant, :display => "cloud_volume_snapshots")
+    end
+    h
   end
 end

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -61,7 +61,7 @@ module CloudTenantHelper::TextualSummary
   end
 
   def textual_cloud_volumes
-    label = ui_lookup(:tables => "cloud_volumes")
+    label = _('Volumes')
     num   = @record.number_of(:cloud_volumes)
     h     = {:label => label, :image => "cloud_volume", :value => num}
     if num > 0 && role_allows(:feature => "cloud_volume_show_list")
@@ -72,7 +72,7 @@ module CloudTenantHelper::TextualSummary
   end
 
   def textual_cloud_volume_snapshots
-    label = ui_lookup(:tables => "cloud_volume_snapshots")
+    label = _('Volume Snapshots')
     num   = @record.number_of(:cloud_volume_snapshots)
     h     = {:label => label, :image => "cloud_volume_snapshot", :value => num}
     if num > 0 && role_allows(:feature => "cloud_volume_snapshot_show_list")

--- a/app/views/cloud_tenant/show.html.haml
+++ b/app/views/cloud_tenant/show.html.haml
@@ -6,7 +6,7 @@
   - elsif @showtype == "download_pdf"
     = render :partial => "layouts/show_pdf"
   - else
-    - if %w(instances images security_groups).include?(@display) && @showtype != "compare"
+    - if %w(instances images security_groups cloud_volumes cloud_volume_snapshots).include?(@display) && @showtype != "compare"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@cloud_tenant.id}"}
     - elsif @showtype == "compare"
       = render :partial => "layouts/compare"

--- a/app/views/layouts/listnav/_cloud_tenant.html.haml
+++ b/app/views/layouts/listnav/_cloud_tenant.html.haml
@@ -33,3 +33,15 @@
             :record_id     => @record.id,
             :display       => 'images',
             :title         => _("Show all Images"))
+        - if role_allows(:feature => "cloud_volume_show_list")
+          = li_link(:count => @record.number_of(:cloud_volumes),
+            :text          => _("Cloud Volumes"),
+            :record_id     => @record.id,
+            :display       => 'cloud_volumes',
+            :title         => _("Show all Cloud Volumes"))
+        - if role_allows(:feature => "cloud_volume_snapshot_show_list")
+          = li_link(:count => @record.number_of(:cloud_volume_snapshots),
+            :text          => _("Cloud Volume Snapshots"),
+            :record_id     => @record.id,
+            :display       => 'cloud_volume_snapshots',
+            :title         => _("Show all Cloud Volume Snapshots"))

--- a/app/views/layouts/listnav/_cloud_tenant.html.haml
+++ b/app/views/layouts/listnav/_cloud_tenant.html.haml
@@ -35,13 +35,13 @@
             :title         => _("Show all Images"))
         - if role_allows(:feature => "cloud_volume_show_list")
           = li_link(:count => @record.number_of(:cloud_volumes),
-            :text          => _("Cloud Volumes"),
+            :text          => _("Volumes"),
             :record_id     => @record.id,
             :display       => 'cloud_volumes',
-            :title         => _("Show all Cloud Volumes"))
+            :title         => _("Show all Volumes"))
         - if role_allows(:feature => "cloud_volume_snapshot_show_list")
           = li_link(:count => @record.number_of(:cloud_volume_snapshots),
-            :text          => _("Cloud Volume Snapshots"),
+            :text          => _("Volume Snapshots"),
             :record_id     => @record.id,
             :display       => 'cloud_volume_snapshots',
-            :title         => _("Show all Cloud Volume Snapshots"))
+            :title         => _("Show all Volume Snapshots"))


### PR DESCRIPTION
Add relationships for Cloud Volumes and Cloud Volume Snapshots to the Cloud Tenant detail view and listnav.

Screenshot updated 3/17

![revised_tenant_links](https://cloud.githubusercontent.com/assets/628956/13857146/f8a22c3e-ec4e-11e5-8867-d891c936e106.png)


@dclarizio 
@loicavenel