### PR TITLE
Fix broken generation of chargeback reports

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -155,7 +155,7 @@ module MiqReport::Formatting
   end
 
   def format_mhz_to_human_size(val, options = {})
-    val = ActionView::Base.new.mhz_to_human_size(val, options[:precision])
+    val = NumberHelper.instance_method(:mhz_to_human_size).bind(self).call(val, options[:precision])
     apply_prefix_and_suffix(val, options)
   end
 

--- a/spec/models/miq_report/formating_spec.rb
+++ b/spec/models/miq_report/formating_spec.rb
@@ -1,0 +1,19 @@
+describe MiqReport do
+  context 'Formatting' do
+    context '#mhz_to_human_size' do
+      let(:report) { MiqReport.new }
+      it 'takes precision as argument' do
+        expect(report.format_mhz_to_human_size(1234, :precision => 2)).to eq('1.23 GHz')
+      end
+      it 'works with default precision' do
+        expect(report.format_mhz_to_human_size(1234)).to eq('1.2 GHz')
+      end
+      it 'applies cool prefix' do
+        expect(report.format_mhz_to_human_size(-1234, :prefix => 'cool')).to eq('cool-1.2 GHz')
+      end
+      it 'applies hot suffix' do
+        expect(report.format_mhz_to_human_size(1234, :suffix => 'hot')).to eq('1.2 GHzhot')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reproducer:
ChargeBack -> Reports -> Saved Chargeback Reports -> expand & pick one
-> Generate PDF

```
Addressung error like:
FATAL -- :Error caught: [NoMethodError] undefined method `mhz_to_human_size' for #<ActionView::Base:0x005646a7e5d6e0>
app/models/miq_report/formatting.rb:158:in `format_mhz_to_human_size'
app/models/miq_report/formatting.rb:110:in `apply_format_function'
app/models/miq_report/formatting.rb:95:in `format'
app/models/miq_report/generator/html.rb:118:in `block (2 levels) in build_html_rows'
app/models/miq_report/generator/html.rb:66:in `each'
app/models/miq_report/generator/html.rb:66:in `each_with_index'
app/models/miq_report/generator/html.rb:66:in `block in build_html_rows'
app/models/miq_report/generator/html.rb:44:in `each'
app/models/miq_report/generator/html.rb:44:in `each_with_index'
app/models/miq_report/generator/html.rb:44:in `build_html_rows'
app/models/miq_report/generator.rb:330:in `build_create_results'
app/controllers/application_controller.rb:245:in `render_pdf'
```

Note, when reproduce this issue you will first encounter problem #7112.

I am not proud of the instance_method, bind, call sequence. How can we improve this?