### PR TITLE
[WIP] rhevm provider - add an 'API version' select-box in UI

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -612,6 +612,8 @@ module EmsCommon
 
     @edit[:openstack_api_versions] = retrieve_openstack_api_versions
 
+    @edit[:ovirt_api_versions] = retrieve_ovirt_api_versions
+
     @edit[:new][:default_userid] = @ems.authentication_userid
     @edit[:new][:default_password] = @ems.authentication_password
     @edit[:new][:default_verify] = @ems.authentication_password
@@ -658,6 +660,7 @@ module EmsCommon
     @openstack_infra_providers = retrieve_openstack_infra_providers
     @openstack_api_versions = retrieve_openstack_api_versions
     @openstack_security_protocols = retrieve_openstack_security_protocols
+    @ovirt_api_versions = retrieve_ovirt_api_versions
     @emstype_display = model.supported_types_and_descriptions_hash[@ems.emstype]
   end
 
@@ -681,6 +684,10 @@ module EmsCommon
     [['SSL without validation', 'ssl'], ['SSL', 'ssl-with-validation'], ['Non-SSL', 'non-ssl']]
   end
 
+  def retrieve_ovirt_api_versions
+    [['v3', 'v3'], ['v4', 'v4']]
+  end
+
   # Get variables from edit form
   def get_form_vars
     @ems = @edit[:ems_id] ? model.find_by_id(@edit[:ems_id]) : model.new
@@ -696,6 +703,8 @@ module EmsCommon
         @edit[:new][:port] = @ems.port ? @ems.port : 5000
         @edit[:new][:api_version] = @ems.api_version ? @ems.api_version : 'v2'
         @edit[:new][:security_protocol] = @ems.security_protocol ? @ems.security_protocol : 'ssl'
+      elsif ["rhevm"].include?(params[:server_emstype])
+          @edit[:new][:api_version] = @ems.api_version ? @ems.api_version : 'v3'
       elsif params[:server_emstype] == ManageIQ::Providers::Kubernetes::ContainerManager.ems_type
         @edit[:new][:port] = @ems.port ? @ems.port : ManageIQ::Providers::Kubernetes::ContainerManager::DEFAULT_PORT
       elsif params[:server_emstype] == ManageIQ::Providers::Openshift::ContainerManager.ems_type

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -37,6 +37,10 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     true
   end
 
+  def supports_api_version?
+    true
+  end
+
   def supported_auth_types
     %w(default metrics)
   end
@@ -45,16 +49,17 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     supported_auth_types.include?(authtype.to_s)
   end
 
-  def self.raw_connect(server, port, username, password, service = "Service")
+  def self.raw_connect(server, port, username, password, api_version, service = "Service")
     require 'ovirt'
     Ovirt.logger = $rhevm_log
 
     params = {
-      :server     => server,
-      :port       => port.presence && port.to_i,
-      :username   => username,
-      :password   => password,
-      :verify_ssl => false
+      :server        => server,
+      :port          => port.presence && port.to_i,
+      :username      => username,
+      :password      => password,
+      :api_version   => api_version,
+      :verify_ssl    => false
     }
 
     read_timeout, open_timeout = ems_timeouts(:ems_redhat, service)
@@ -67,13 +72,14 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   def connect(options = {})
     raise "no credentials defined" if self.missing_credentials?(options[:auth_type])
 
-    server   = options[:ip] || address
-    port     = options[:port] || self.port
-    username = options[:user] || authentication_userid(options[:auth_type])
-    password = options[:pass] || authentication_password(options[:auth_type])
-    service  = options[:service] || "Service"
+    server      = options[:ip] || address
+    port        = options[:port] || self.port
+    username    = options[:user] || authentication_userid(options[:auth_type])
+    password    = options[:pass] || authentication_password(options[:auth_type])
+    api_version = options[:api_version] || self.api_version
+    service     = options[:service] || "Service"
 
-    self.class.raw_connect(server, port, username, password, service)
+    self.class.raw_connect(server, port, username, password, api_version, service)
   end
 
   def rhevm_service

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -6,11 +6,12 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
 
   def event_monitor_options
     {
-      :server     => @ems.hostname,
-      :port       => @ems.port.blank? ? nil : @ems.port.to_i,
-      :username   => @ems.authentication_userid,
-      :password   => @ems.authentication_password,
-      :verify_ssl => false
+      :server      => @ems.hostname,
+      :port        => @ems.port.blank? ? nil : @ems.port.to_i,
+      :username    => @ems.authentication_userid,
+      :password    => @ems.authentication_password,
+      :api_version => @ems.api_version,
+      :verify_ssl  => false
     }
   end
 

--- a/app/views/shared/views/ems_common/_form.html.haml
+++ b/app/views/shared/views/ems_common/_form.html.haml
@@ -37,13 +37,14 @@
                             :maxlength         => 15,
                             "class"            => "form-control",
                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    - if @edit[:new][:emstype] && %w(openstack openstack_infra).include?(@edit[:new][:emstype])
+    - if @edit[:new][:emstype] && %w(rhevm openstack openstack_infra).include?(@edit[:new][:emstype])
+    - api_versions = %w(openstack openstack_infra).include?(@edit[:new][:emstype]) ? :openstack_api_versions : :ovirt_api_versions
       .form-group
         %label.control-label.col-md-2
           = _('API Version')
         .col-md-8
           = select_tag("api_version",
-                       options_for_select(@edit[:openstack_api_versions], @edit[:new][:api_version]),
+                       options_for_select(@edit[api_versions], @edit[:new][:api_version]),
                        "class" => "selectpicker")
           :javascript
             miqInitSelectPicker();

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -139,12 +139,12 @@
         %span.help-block{"ng-show" => "angularForm.api_port.$error.required"}
           = _("Required")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}
+    .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'rhevm'"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
         = _("API Version")
       .col-md-8
         = select_tag('api_version',
-                     options_for_select(@openstack_api_versions),
+                     options_for_select(@emsCommonModel.emstype == 'rhevm' ? @ovirt_api_versions : @openstack_api_versions),
                      "ng-model"                    => "emsCommonModel.api_version",
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -35,7 +35,7 @@ gem "net-sftp",                "~>2.1.2",           :require => false
 gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=0.3.0",            :require => false
-gem "ovirt",                   "~>0.7.2",           :require => false
+gem "ovirt",                   "~>0.7.3",           :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false


### PR DESCRIPTION
Pending merge and release of https://github.com/ManageIQ/ovirt/pull/47

Added an 'API Version' select-box on 'Add/Edit New
Infrastructure Provider' form.

Differentiating between the new v4 API and older versions
is needed as v4 is now located at '/ovirt-engine/api'
(as opposed to the previously '/api').