### PR TITLE
Refactor: Extract common notice setting to a mixin

### DIFF
--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -1,4 +1,5 @@
 class AuthKeyPairCloudController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -65,14 +66,7 @@ class AuthKeyPairCloudController < ApplicationController
       )
       @view, @pages = get_view(kls, :parent => @auth_key_pair_cloud) # Get the records (into a view) and the paginator
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        count = @view.extras[:total_count] - @view.extras[:auth_count]
-        @bottom_msg = _("* You are not authorized to view %{children} on this %{model}") % {
-          :children => pluralize(count, "other #{title.singularize}"),
-          :model    => ui_lookup(:tables => "auth_key_pair_cloud")
-        }
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "auth_key_pair_cloud"))
     end
 
     # Came in from outside show_list partial

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -1,4 +1,5 @@
 class AvailabilityZoneController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -47,16 +48,7 @@ class AvailabilityZoneController < ApplicationController
                       :url  => "/availability_zone/show/#{@availability_zone.id}?display=#{@display}")
       @view, @pages = get_view(ManageIQ::Providers::CloudManager::Vm, :parent => @availability_zone)  # Get the records (into a view) and the paginator
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this %{tables}") %
-                          {:titles => title.pluralize, :tables => ui_lookup(:tables => "availability_zone")}
-                      else
-                        _("* You are not authorized to view other %{title} on this %{tables}") %
-                          {:title => title.singularize, :tables => ui_lookup(:tables => "availability_zone")}
-                      end
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "availability_zone"))
 
     when "cloud_volumes"
       title = ui_lookup(:tables => "cloud_volumes")
@@ -67,16 +59,7 @@ class AvailabilityZoneController < ApplicationController
       # Get the records (into a view) and the paginator
       @view, @pages = get_view(CloudVolume, :parent => @availability_zone)
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this %{tables}") %
-                          {:title => title.pluralize, :tables => ui_lookup(:tables => "availability_zone")}
-                      else
-                        _("* You are not authorized to view other %{title} on this %{tables}") %
-                          {:title => title.singularize, :tables => ui_lookup(:tables => "availability_zone")}
-                      end
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "availability_zone"))
 
     when "timeline"
       @showtype = "timeline"

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -1,4 +1,5 @@
 class CloudTenantController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -69,16 +70,7 @@ class CloudTenantController < ApplicationController
                       :url  => "/cloud_tenant/show/#{@cloud_tenant.id}?display=#{@display}")
       @view, @pages = get_view(kls, :parent => @cloud_tenant)  # Get the records (into a view) and the paginator
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this %{tables}") %
-                            {:titles => title.pluralize, :tables => ui_lookup(:tables => "cloud_tenant")}
-                      else
-                        _("* You are not authorized to view other %{title} on this %{tables}") %
-                            {:title => title.singularize, :tables => ui_lookup(:tables => "cloud_tenant")}
-                      end
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "cloud_tenant"))
     when "security_groups"
       table = "security_groups"
       title = ui_lookup(:tables => table)
@@ -87,16 +79,7 @@ class CloudTenantController < ApplicationController
                       :url  => "/cloud_tenant/show/#{@cloud_tenant.id}?display=#{@display}")
       @view, @pages = get_view(kls, :parent => @cloud_tenant)  # Get the records (into a view) and the paginator
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this %{tables}") %
-                            {:titles => title.pluralize, :tables => ui_lookup(:tables => "cloud_tenant")}
-                      else
-                        _("* You are not authorized to view other %{title} on this %{tables}") %
-                            {:title => title.singularize, :tables => ui_lookup(:tables => "cloud_tenant")}
-                      end
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "cloud_tenant"))
     end
 
     # Came in from outside show_list partial

--- a/app/controllers/cloud_volume_snapshot_controller.rb
+++ b/app/controllers/cloud_volume_snapshot_controller.rb
@@ -1,4 +1,5 @@
 class CloudVolumeSnapshotController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -55,14 +56,7 @@ class CloudVolumeSnapshotController < ApplicationController
       )
       @view, @pages = get_view(kls, :parent => @snapshot, :association => :based_volumes)
       @showtype = "based_volumes"
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        unauthorized_count = @view.extras[:total_count] - @view.extras[:auth_count]
-        @bottom_msg = _("* You are not authorized to view %{children} on this %{model}") % {
-          :children => pluralize(unauthorized_count, "other #{title.singularize}"),
-          :model    => ui_lookup(:tables => "cloud_volume_snapshot")
-        }
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "cloud_volume_snapshot"))
     end
 
     if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -1,5 +1,6 @@
 module EmsCommon
   extend ActiveSupport::Concern
+  include AuthorizationMessagesMixin
 
   def show
     @display = params[:display] || "main" unless control_selected?
@@ -107,13 +108,7 @@ module EmsCommon
     opts[:parent_method] = parent_method if parent_method
     @view, @pages = get_view(kls, **opts)
     @showtype = @display
-    if @view.extras[:total_count] && @view.extras[:auth_count] &&
-       @view.extras[:total_count] > @view.extras[:auth_count]
-      @bottom_msg = _("* You are not authorized to view ") +
-                    pluralize(@view.extras[:total_count] - @view.extras[:auth_count],
-                              _("other %{message}") % {:message => bottom_msg_name}) +
-                    _(" on this ") + ui_lookup(:tables => @table_name)
-    end
+    notify_about_unauthorized_items(bottom_msg_name, ui_lookup(:tables => @table_name))
   end
 
   # Show the main MS list view

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -101,14 +101,14 @@ module EmsCommon
     end
   end
 
-  def view_setup_helper(kls, title, bottom_msg_name, parent_method = nil)
+  def view_setup_helper(kls, title, view_item_name, parent_method = nil)
     drop_breadcrumb(:name => @ems.name + _(" (All %{title})") % {:title => title},
                     :url  => show_link(@ems, :display => @display))
     opts = {:parent => @ems}
     opts[:parent_method] = parent_method if parent_method
     @view, @pages = get_view(kls, **opts)
     @showtype = @display
-    notify_about_unauthorized_items(bottom_msg_name, ui_lookup(:tables => @table_name))
+    notify_about_unauthorized_items(view_item_name, ui_lookup(:tables => @table_name))
   end
 
   # Show the main MS list view

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -1,4 +1,5 @@
 class FlavorController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -38,16 +39,7 @@ class FlavorController < ApplicationController
                       :url  => "/flavor/show/#{@flavor.id}?display=#{@display}")
       @view, @pages = get_view(ManageIQ::Providers::CloudManager::Vm, :parent => @flavor) # Get the records (into a view) and the paginator
       @showtype   = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this %{tables}") %
-                          {:titles => title.pluralize, :tables => ui_lookup(:tables => "flavor")}
-                      else
-                        _("* You are not authorized to view other %{titles} on this %{tables}") %
-                          {:titles => title.singularize, :tables => ui_lookup(:tables => "flavor")}
-                      end
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "flavor"))
     end
 
     # Came in from outside show_list partial

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -1,4 +1,5 @@
 class HostController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
 
@@ -95,14 +96,7 @@ class HostController < ApplicationController
                       :url  => "/host/show/#{@host.id}?display=#{@display}")
       @view, @pages = get_view(kls, :parent => @host) # Get the records (into a view) and the paginator
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this Host") % {:titles => title.pluralize}
-                      else
-                        _("* You are not authorized to view other %{title} on this Host") % {:title => title.singularize}
-                      end
-      end
+      notify_about_unauthorized_items(title, _('Host'))
 
     when "cloud_tenants"
       drop_breadcrumb(:name => _("%{name} (All cloud tenants present on this host)") % {:name => @host.name},
@@ -122,16 +116,7 @@ class HostController < ApplicationController
                       :url  => "/host/show/#{@host.id}?display=storages")
       @view, @pages = get_view(Storage, :parent => @host) # Get the records (into a view) and the paginator
       @showtype = "storages"
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{tables} on this Host") %
-                            {:tables => ui_lookup(:tables => "storages")}
-                      else
-                        _("* You are not authorized to view other %{table} on this Host") %
-                            {:table => ui_lookup(:table => "storages")}
-                      end
-      end
+      notify_about_unauthorized_items(ui_lookup(:tables => "storages"), _('Host'))
 
     when "ontap_logical_disks"
       drop_breadcrumb(:name => _("%{name} (All %{tables})") % {:name   => @host.name,

--- a/app/controllers/mixins/authorization_messages_mixin.rb
+++ b/app/controllers/mixins/authorization_messages_mixin.rb
@@ -2,12 +2,14 @@ module AuthorizationMessagesMixin
   private
 
   def notify_about_unauthorized_items(item, table)
-    if @view.extras[:total_count] && @view.extras[:auth_count] &&
-       @view.extras[:total_count] > @view.extras[:auth_count]
+    if unauthorized_count > 0
       @bottom_msg = _('* You are not authorized to view ') +
-                    pluralize(@view.extras[:total_count] - @view.extras[:auth_count],
-                              _("other %{items}") % {:items => item.singularize}) +
+                    pluralize(unauthorized_count, _("other %{items}") % {:items => item.singularize}) +
                     _(' on this ') + table
     end
+  end
+
+  def unauthorized_count
+    @view.extras[:total_count] && @view.extras[:auth_count] ? @view.extras[:total_count] - @view.extras[:auth_count] : 0
   end
 end

--- a/app/controllers/mixins/authorization_messages_mixin.rb
+++ b/app/controllers/mixins/authorization_messages_mixin.rb
@@ -1,0 +1,13 @@
+module AuthorizationMessagesMixin
+  private
+
+  def notify_about_unauthorized_items(item, table)
+    if @view.extras[:total_count] && @view.extras[:auth_count] &&
+       @view.extras[:total_count] > @view.extras[:auth_count]
+      @bottom_msg = _('* You are not authorized to view ') +
+                    pluralize(@view.extras[:total_count] - @view.extras[:auth_count],
+                              _("other %{items}") % {:items => item.singularize}) +
+                    _(' on this ') + table
+    end
+  end
+end

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -1,5 +1,6 @@
 module ContainersCommonMixin
   extend ActiveSupport::Concern
+  include AuthorizationMessagesMixin
 
   def index
     redirect_to :action => 'show_list'
@@ -129,14 +130,7 @@ module ContainersCommonMixin
                     :url  => "/#{alt_controller_name || controller_name}/show/#{record.id}?display=#{@display}")
     @view, @pages = get_view(clazz, :parent => record)  # Get the records (into a view) and the paginator
     @showtype = @display
-
-    total_count = @view.extras.fetch(:total_count, 0)
-    auth_count = @view.extras.fetch(:auth_count, 0)
-    if total_count > auth_count
-      @bottom_msg = "* You are not authorized to view " +
-                    pluralize(total_count - auth_count, "other #{title.singularize}") +
-                    " on this #{ui_lookup(:tables => @table_name)}"
-    end
+    notify_about_unauthorized_items(title, ui_lookup(:tables => @table_name))
   end
 
   # Scan all selected or single displayed image(s)

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -1,4 +1,5 @@
 class OrchestrationStackController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -32,12 +33,7 @@ class OrchestrationStackController < ApplicationController
                       :url  => "/orchestration_stack/show/#{@orchestration_stack.id}?display=#{@display}")
       @view, @pages = get_view(ManageIQ::Providers::CloudManager::Vm, :parent => @orchestration_stack)
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        count_text = pluralize(@view.extras[:total_count] - @view.extras[:auth_count], "other #{title.singularize}")
-        @bottom_msg = _("* You are not authorized to view %{items} on this %{tables}") %
-                        {:items => count_text, :tables => ui_lookup(:tables => 'orchestration_stack')}
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => 'orchestration_stack'))
     when "security_groups"
       table = "security_groups"
       title = ui_lookup(:tables => table)
@@ -46,12 +42,7 @@ class OrchestrationStackController < ApplicationController
                       :url  => "/orchestration_stack/show/#{@orchestration_stack.id}?display=#{@display}")
       @view, @pages = get_view(kls, :parent => @orchestration_stack)  # Get the records (into a view) and the paginator
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        count_text = pluralize(@view.extras[:total_count] - @view.extras[:auth_count], "other #{title.singularize}")
-        @bottom_msg = _("* You are not authorized to view %{items} on this %{tables}") %
-                        {:items => count_text, :tables => ui_lookup(:tables => 'orchestration_stack')}
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => 'orchestration_stack'))
     end
 
     # Came in from outside show_list partial

--- a/app/controllers/repository_controller.rb
+++ b/app/controllers/repository_controller.rb
@@ -1,4 +1,5 @@
 class RepositoryController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -23,16 +24,7 @@ class RepositoryController < ApplicationController
       @view, @pages = get_view(kls, :parent => @repo) # Get the records (into a view) and the paginator
       @showtype = @display
       @gtl_url = "/repository/show/" << @repo.id.to_s << "?"
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this Repository") %
-                          {:titles => title.pluralize}
-                      else
-                        _("* You are not authorized to view other %{title} on this Repository") %
-                          {:title => title.singularize}
-                      end
-      end
+      notify_about_unauthorized_items(title, _('Repository'))
 
     when "download_pdf", "main", "summary_only"
       get_tagdata(@repo)

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -1,4 +1,5 @@
 class ResourcePoolController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -34,14 +35,7 @@ class ResourcePoolController < ApplicationController
                       :url  => "/resource_pool/show/#{@record.id}?display=vms")
       @view, @pages = get_view(Vm, :parent => @record)  # Get the records (into a view) and the paginator
       @showtype = "vms"
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count]
-                        _("* You are not authorized to view other VMs in this Resource Pool")
-                      else
-                        _("* You are not authorized to view other VM in this Resource Pool")
-                      end
-      end
+      notify_about_unauthorized_items(_('VM'), _('Resource Pool'))
 
     when "descendant_vms"
       drop_breadcrumb(:name => _("%{name} (All VMs - Tree View)") % {:name => @record.name},
@@ -54,14 +48,7 @@ class ResourcePoolController < ApplicationController
                       :url  => "/resource_pool/show/#{@record.id}?display=all_vms")
       @view, @pages = get_view(Vm, :parent => @record, :association => "all_vms") # Get the records (into a view) and the paginator
       @showtype = "vms"
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count]
-                        _("* You are not authorized to view other VMs in this Resource Pool")
-                      else
-                        _("* You are not authorized to view other VM in this Resource Pool")
-                      end
-      end
+      notify_about_unauthorized_items(_('VM'), _('Resource Pool'))
 
     when "clusters"
       drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @record.name, :title => title_for_clusters},

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -1,4 +1,5 @@
 class SecurityGroupController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -43,16 +44,7 @@ class SecurityGroupController < ApplicationController
                       :url  => "/security_group/show/#{@security_group.id}?display=#{@display}")
       @view, @pages = get_view(ManageIQ::Providers::CloudManager::Vm, :parent => @security_group)  # Get the records (into a view) and the paginator
       @showtype = @display
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        @bottom_msg = if @view.extras[:total_count] - @view.extras[:auth_count] > 1
-                        _("* You are not authorized to view other %{titles} on this %{tables}") %
-                          {:titles => title.pluralize, :tables => ui_lookup(:tables => "security_group")}
-                      else
-                        _("* You are not authorized to view other %{title} on this %{tables}") %
-                          {:title => title.singularize, :tables => ui_lookup(:tables => "security_group")}
-                      end
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:tables => "security_group"))
     end
 
     # Came in from outside show_list partial


### PR DESCRIPTION
I have been wandering through the controllers and I have seen some common code repeated many times.

Often, there are subtle differences. One instance is more or less internationalized, another is slightly reworded.

I have tested change on almost all the pages. I have skipped testing on containers* pages, as I do not have any in my db yet.

@miq-bot add_label ui, refactoring