### PR TITLE
Add missing automate service models

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_datacenter.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_datacenter.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceDatacenter < MiqAeServiceEmsFolder
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-base_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-base_manager.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_BaseManager < MiqAeServiceExtManagementSystem
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_CloudManager < MiqAeServiceExtManagementSystem
+  class MiqAeServiceManageIQ_Providers_CloudManager < MiqAeServiceManageIQ_Providers_BaseManager
     expose :availability_zones,     :association => true
     expose :cloud_networks,         :association => true
     expose :public_networks,        :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-container_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-container_manager.rb
@@ -1,4 +1,4 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_ContainerManager < MiqAeServiceExtManagementSystem
+  class MiqAeServiceManageIQ_Providers_ContainerManager < MiqAeServiceManageIQ_Providers_BaseManager
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-google-cloud_manager-security_group.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-google-cloud_manager-security_group.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Google_CloudManager_SecurityGroup < MiqAeServiceSecurityGroup
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-infra_manager.rb
@@ -1,4 +1,4 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_InfraManager < MiqAeServiceExtManagementSystem
+  class MiqAeServiceManageIQ_Providers_InfraManager < MiqAeServiceManageIQ_Providers_BaseManager
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-middleware_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-middleware_manager.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_MiddlewareManager < MiqAeServiceManageIQ_Providers_BaseManager
+  end
+end


### PR DESCRIPTION
Missing models:
Datacenter
Google_CloudManager_SecurityGroup
MiddlewareManager

Created BaseManager and fixed class inheritance for the child classes.