### PR TITLE
Allow policies defined against container image openscap results

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -186,10 +186,9 @@ module ApplicationController::PolicySupport
       end
     end
   end
-  alias_method :image_protect, :assign_policies
-  alias_method :instance_protect, :assign_policies
-  alias_method :vm_protect, :assign_policies
-  alias_method :miq_template_protect, :assign_policies
+  %w(image instance vm miq_template container_image ems_container).each do |old_name|
+    alias_method "#{old_name}_protect".to_sym, :assign_policies
+  end
 
   # Build the policy assignment screen
   def protect_build_screen

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -2,7 +2,7 @@ module ApplicationController::TreeSupport
   extend ActiveSupport::Concern
 
   def squash_toggle
-    @record = identify_record(params[:id], controller_name == "host" ? Host : VmOrTemplate)
+    @record = find_record
     item = "h_#{@record.name}"
     render :update do |page|
       if session[:squash_open] == false
@@ -17,6 +17,14 @@ module ApplicationController::TreeSupport
         page << "miqDynatreeActivateNodeSilently('#{j_str(session[:tree_name])}', '#{item}');"
         session[:squash_open] = false
       end
+    end
+  end
+
+  def find_record
+    if %w(container_image host).include? controller_name
+      identify_record(params[:id], controller_name.classify)
+    else
+      identify_record(params[:id], VmOrTemplate)
     end
   end
 

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -943,7 +943,9 @@ class MiqPolicyController < ApplicationController
     @sb[:folder] = nodeid.nil? ? nodetype.split("-").last : nodeid
     if x_active_tree == :policy_tree
       if nodeid.nil? && ["compliance", "control"].include?(nodetype.split('-').last)
-        @folders = ["Host #{nodetype.split('-').last.titleize}", "Vm #{nodetype.split('-').last.titleize}"]
+        @folders = MiqPolicy::UI_FOLDERS.collect do |model|
+          "#{model.name.titleize} #{nodetype.split('-').last.titleize}"
+        end
         @right_cell_text = _("%{typ} %{model}") % {:typ => nodetype.split('-').last.titleize, :model => ui_lookup(:models => "MiqPolicy")}
       else
         @sb[:mode] = nodeid.split("-")[1]

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -186,7 +186,7 @@ module MiqPolicyController::Policies
     @edit[:new][:description] = @policy.description
     @edit[:new][:active] = @policy.active.nil? ? true : @policy.active                    # Set active, default to true
     @edit[:new][:notes] = @policy.notes
-    @edit[:new][:towhat] = @policy.id ? @policy.towhat : @sb[:folder].split('-').last.titleize                    # Set the towhat model
+    @edit[:new][:towhat] = @policy.id ? @policy.towhat : @sb[:folder].split('-').last.camelize # Set the towhat model
 
     case @edit[:typ]  # Build fields based on what is being edited
     when "conditions" # Editing condition assignments
@@ -225,7 +225,7 @@ module MiqPolicyController::Policies
 
   def policy_get_all_folders(parent = nil)
     if !parent.nil?
-      @folders = %w(Host Vm)
+      @folders = MiqPolicy::UI_FOLDERS.collect(&:name)
       @right_cell_text = _("%{typ} %{model}") % {:typ => parent, :model => ui_lookup(:models => "MiqPolicy")}
       @right_cell_div = "policy_folders"
     else

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -27,6 +27,7 @@ module ContainersCommonMixin
     @refresh_div = "main_div" # Default div for button.rjs to refresh
     tag(self.class.model) if params[:pressed] == "#{params[:controller]}_tag"
     assign_policies(ContainerImage) if params[:pressed] == "container_image_protect"
+    check_compliance_images if params[:pressed] == "container_image_check_compliance"
     return if ["#{params[:controller]}_tag"].include?(params[:pressed]) && @flash_array.nil? # Tag screen showing
 
     # Handle scan
@@ -153,6 +154,22 @@ module ContainersCommonMixin
     images.count
   end
 
+  def check_compliance_images
+    assert_privileges("container_image_check_compliance")
+    showlist = @lastaction == "show_list"
+    images = showlist ? find_checked_items : find_scan_item
+
+    if images.empty?
+      add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "container_image"),
+                                                              :task  => "Conpliance Check"}, :error)
+    else
+      process_check_images_compliance(images)
+    end
+
+    showlist ? show_list : show
+    images.count
+  end
+
   def find_scan_item
     images = []
     if params[:id].nil? || ContainerImage.find_by_id(params[:id]).nil?
@@ -176,6 +193,21 @@ module ContainersCommonMixin
                   :error) # Push msg and error flag
       else
         add_flash(_("\"%{record}\": Analysis successfully initiated") % {:record => image_name})
+      end
+    end
+  end
+
+  def process_check_images_compliance(images)
+    ContainerImage.where(:id => images).order("lower(name)").each do |image|
+      begin
+        image.check_compliance
+      rescue StandardError => bang
+        add_flash(_("%{model} \"%{name}\": Error during 'Check Compliance': ") %
+                  {:model => ui_lookup(:model => "ContainerImage"),
+                   :name  => image.name} << bang.message,
+                  :error) # Push msg and error flag
+      else
+        add_flash(_("\"%{record}\": Compliance check successfully initiated") % {:record => image.name})
       end
     end
   end

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -81,6 +81,11 @@ module ContainersCommonMixin
                       :url  => "/#{controller_name}/show/#{record.id}" \
                                "?display=#{@display}&refresh=n")
       perf_gen_init_options # Intialize options, charts are generated async
+    elsif @display == "compliance_history"
+      count = params[:count] ? params[:count].to_i : 10
+      update_session_for_compliance_history(record, count)
+      drop_breadcrumb_for_compliance_history(record, controller_name)
+      @showtype = @display
     elsif @display == "container_groups" || session[:display] == "container_groups" && params[:display].nil?
       show_container_display(record, "container_groups", ContainerGroup)
     elsif @display == "containers"
@@ -109,6 +114,23 @@ module ContainersCommonMixin
     # Came in from outside show_list partial
     if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]
       replace_gtl_main_div
+    end
+  end
+
+  def update_session_for_compliance_history(record, count)
+    session[:ch_tree] = compliance_history_tree(record, count).to_json
+    session[:tree_name] = "ch_tree"
+    session[:squash_open] = (count == 1)
+  end
+
+  def drop_breadcrumb_for_compliance_history(record, controller_name)
+    if count == 1
+      drop_breadcrumb(:name => _("%{name} (Latest Compliance Check)") % {:name => record.name},
+                      :url  => "/#{controller_name}/show/#{record.id}?display=#{@display}&refresh=n")
+    else
+      drop_breadcrumb(
+        :name => _("%{name} (Compliance History - Last %{number} Checks)") % {:name => record.name, :number => count},
+        :url  => "/#{controller_name}/show/#{record.id}?display=#{@display}&refresh=n")
     end
   end
 

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -26,6 +26,7 @@ module ContainersCommonMixin
     # Handle Toolbar Policy Tag Button
     @refresh_div = "main_div" # Default div for button.rjs to refresh
     tag(self.class.model) if params[:pressed] == "#{params[:controller]}_tag"
+    assign_policies(ContainerImage) if params[:pressed] == "container_image_protect"
     return if ["#{params[:controller]}_tag"].include?(params[:pressed]) && @flash_array.nil? # Tag screen showing
 
     # Handle scan

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -567,6 +567,9 @@ module OpsController::Settings::Schedules
     if role_allows(:feature => "host_check_compliance")
       @action_type_options_for_select.push([_("Host Compliance Check"), "host_check_compliance"])
     end
+    if role_allows(:feature => "container_image_check_compliance")
+      @action_type_options_for_select.push([_("Container Image Compliance Check"), "container_image_check_compliance"])
+    end
     @action_type_options_for_select.push([_("Database Backup"), "db_backup"])
 
     @vm_options_for_select = [

--- a/app/helpers/application_helper/toolbar/container_image_center.rb
+++ b/app/helpers/application_helper/toolbar/container_image_center.rb
@@ -31,7 +31,13 @@ class ApplicationHelper::Toolbar::ContainerImageCenter < ApplicationHelper::Tool
           :container_image_protect,
           'pficon pficon-edit fa-lg',
           N_('Manage Policies for this #{ui_lookup(:table=>"container_image")}'),
-          N_('Manage Policies'))
+          N_('Manage Policies')),
+        button(
+          :container_image_check_compliance,
+          'fa fa-search fa-lg',
+          N_('Check Compliance of the last known configuration for this item'),
+          N_('Check Compliance of Last Known Configuration'),
+          :confirm => N_("Initiate Check Compliance of the last known configuration for this item?"))
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_image_center.rb
+++ b/app/helpers/application_helper/toolbar/container_image_center.rb
@@ -27,6 +27,11 @@ class ApplicationHelper::Toolbar::ContainerImageCenter < ApplicationHelper::Tool
           'pficon pficon-edit fa-lg',
           N_('Edit Tags for this #{ui_lookup(:table=>"container_image")}'),
           N_('Edit Tags')),
+        button(
+          :container_image_protect,
+          'pficon pficon-edit fa-lg',
+          N_('Manage Policies for this #{ui_lookup(:table=>"container_image")}'),
+          N_('Manage Policies'))
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_images_center.rb
+++ b/app/helpers/application_helper/toolbar/container_images_center.rb
@@ -43,6 +43,15 @@ class ApplicationHelper::Toolbar::ContainerImagesCenter < ApplicationHelper::Too
           :url_parms => "main_div",
           :enabled   => "false",
           :onwhen    => "1+"),
+        button(
+          :container_image_check_compliance,
+          'fa fa-search fa-lg',
+          N_('Check Compliance of the last known configuration for the selected items'),
+          N_('Check Compliance of Last Known Configuration'),
+          :url_parms => "main_div",
+          :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
+          :enabled   => "false",
+          :onwhen    => "1+")
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_images_center.rb
+++ b/app/helpers/application_helper/toolbar/container_images_center.rb
@@ -35,6 +35,14 @@ class ApplicationHelper::Toolbar::ContainerImagesCenter < ApplicationHelper::Too
           :url_parms => "main_div",
           :enabled   => false,
           :onwhen    => "1+"),
+        button(
+          :container_image_protect,
+          'pficon pficon-edit fa-lg',
+          N_('Manage Policies for this #{ui_lookup(:table=>"container_images")}'),
+          N_('Manage Policies'),
+          :url_parms => "main_div",
+          :enabled   => "false",
+          :onwhen    => "1+"),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -70,6 +70,11 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
           'pficon pficon-edit fa-lg',
           N_('Edit Tags for this #{ui_lookup(:table=>"ems_container")}'),
           N_('Edit Tags')),
+        button(
+          :ems_container_protect,
+          'pficon pficon-edit fa-lg',
+          N_('Manage Policies for this #{ui_lookup(:table=>"ems_container")}'),
+          N_('Manage Policies')),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -59,6 +59,14 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           :url_parms => "main_div",
           :enabled   => false,
           :onwhen    => "1+"),
+        button(
+          :ems_container_protect,
+          'pficon pficon-edit fa-lg',
+          N_('Manage Policies for this #{ui_lookup(:table=>"ems_container")}'),
+          N_('Manage Policies'),
+          :url_parms => "main_div",
+          :enabled   => "false",
+          :onwhen    => "1+"),
       ]
     ),
   ])

--- a/app/helpers/container_image_helper.rb
+++ b/app/helpers/container_image_helper.rb
@@ -1,4 +1,5 @@
 module  ContainerImageHelper
+  include_concern 'ComplianceSummaryHelper'
   include_concern 'ContainerSummaryHelper'
   include_concern 'TextualSummary'
 end

--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -8,6 +8,10 @@ module ContainerImageHelper
       %i(name tag id full_name os_distribution product_type product_name)
     end
 
+    def textual_group_compliance
+      %i(compliance_status compliance_history)
+    end
+
     def textual_group_relationships
       %i(ems container_image_registry container_projects container_groups containers container_nodes)
     end
@@ -50,6 +54,24 @@ module ContainerImageHelper
     def textual_product_name
       name = @record.operating_system.try(:product_name)
       {:label => _("Product Name"), :value => name} if name
+    end
+
+    def textual_compliance_history
+      h = {:label => _("History")}
+      if @record.number_of(:compliances) == 0
+        h[:value] = _("Not Available")
+      else
+        h[:image] = "compliance"
+        h[:value] = _("Available")
+        h[:title] = _("Show Compliance History of this Container Image (Last 10 Checks)")
+        h[:explorer] = true
+        h[:link] = url_for(
+          :controller => controller.controller_name,
+          :action     => 'show',
+          :id         => @record,
+          :display    => 'compliance_history')
+      end
+      h
     end
   end
 end

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -1,4 +1,5 @@
 class ContainerImage < ApplicationRecord
+  include ComplianceMixin
   include MiqPolicyMixin
   include ReportableMixin
   include ScanningMixin
@@ -74,6 +75,11 @@ class ContainerImage < ApplicationRecord
 
   def raise_creation_event
     MiqEvent.raise_evm_event(self, 'containerimage_created', {})
+  end
+
+  def has_compliance_policies?
+    _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "containerimage_compliance_check")
+    !plist.blank?
   end
 
   alias_method :perform_metadata_sync, :sync_stashed_metadata

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -14,6 +14,7 @@ class MiqExpression
     ManageIQ::Providers::ConfigurationManager
     Container
     ContainerGroup
+    ContainerImages
     ContainerNode
     ContainerProject
     ContainerService
@@ -118,6 +119,8 @@ class MiqExpression
     ontap_raid_group_extents
     ontap_storage_systems
     ontap_storage_volumes
+    openscap_results
+    openscap_rule_results
     orchestration_stack_outputs
     orchestration_stack_parameters
     orchestration_stack_resources
@@ -218,6 +221,7 @@ class MiqExpression
     capacity_profile_2_vcpu_per_vm_with_min_max
     chain_id
     guid
+    openscap_id
   )
 
   TAG_CLASSES = {

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -36,6 +36,8 @@ class MiqPolicy < ApplicationRecord
 
   @@built_in_policies = nil
 
+  UI_FOLDERS = [Host, Vm, ContainerImage].freeze
+
   def self.built_in_policies
     return @@built_in_policies.dup unless @@built_in_policies.nil?
 

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -14,10 +14,12 @@ class TreeBuilderPolicy < TreeBuilder
   end
 
   def compliance_control_kids(pid)
-    text_i18n = {:compliance => {:host => N_("Host Compliance Policies"),
-                                 :vm   => N_("Vm Compliance Policies")},
-                 :control    => {:host => N_("Host Control Policies"),
-                                 :vm   => N_("Vm Control Policies")}}
+    text_i18n = {:compliance => {:host            => N_("Host Compliance Policies"),
+                                 :vm              => N_("Vm Compliance Policies"),
+                                 :container_image => N_("Container Image Compliance Policies")},
+                 :control    => {:host            => N_("Host Control Policies"),
+                                 :vm              => N_("Vm Control Policies"),
+                                 :container_image => N_("Container Image Control Policies")}}
 
     [{:id    => "#{pid}-host",
       :text  => text_i18n[pid.to_sym][:host],
@@ -26,7 +28,12 @@ class TreeBuilderPolicy < TreeBuilder
      {:id    => "#{pid}-vm",
       :text  => text_i18n[pid.to_sym][:vm],
       :image => "vm",
-      :tip   => N_("Vm Policies")}]
+      :tip   => N_("Vm Policies")},
+     {:id    => "#{pid}-containerImage",
+      :text  => text_i18n[pid.to_sym][:container_image],
+      :image => "container_image",
+      :tip   => N_("Container Image Policies")
+     }]
   end
 
   # level 0 - root
@@ -55,16 +62,16 @@ class TreeBuilderPolicy < TreeBuilder
       pid = parent[:id]
 
       # Push folder node ids onto open_nodes array
-      %W(xx-#{pid}_xx-#{pid}-host xx-#{pid}_xx-#{pid}-vm).each { |n| open_node(n) }
+      %W(xx-#{pid}_xx-#{pid}-host xx-#{pid}_xx-#{pid}-vm xx-#{pid}_xx-#{pid}-containerImage).each { |n| open_node(n) }
 
       objects = compliance_control_kids(pid)
       count_only_or_objects(count_only, objects)
     # level 3 - actual policies
-    elsif %w(host vm).include?(parent[:id].split('-').last)
+    elsif %w(host vm containerImage).include?(parent[:id].split('-').last)
       mode, towhat = parent[:id].split('-')
 
       objects = MiqPolicy.where(:mode   => mode.downcase,
-                                :towhat => towhat.titleize)
+                                :towhat => towhat.camelize)
 
       count_only_or_objects(count_only, objects, :description)
     else

--- a/app/views/container_image/_main.html.haml
+++ b/app/views/container_image/_main.html.haml
@@ -3,6 +3,8 @@
  .col-sm-12.col-md-12.col-lg-6
   = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"),
                                                              :items => textual_group_properties}
+  = render :partial => "shared/summary/textual", :locals => {:title => _("Compliance"),
+                                                             :items => textual_group_compliance}
  .col-sm-12.col-md-12.col-lg-6
   = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                              :items => textual_group_relationships}

--- a/app/views/container_image/show.html.haml
+++ b/app/views/container_image/show.html.haml
@@ -6,5 +6,8 @@
     = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
   - when "item"
     = render(:partial => "layouts/#{@showtype}")
+  - when "compliance_history"
+    = render(:partial => "shared/views/#{@showtype}")
+
   - else
     = render :partial => @showtype

--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -4,11 +4,14 @@
     %tbody
       - @folders.each do |f|
         - if %w(Compliance Control).include?(f)
+          - model_name = f.split.first
           - click = f.downcase
         - else
-          - click = "#{f.split.last.downcase}_xx-#{f.split[1].downcase}-#{f.split[0].downcase}"
+          - model_name = f.split[0..-2].join.camelize(:lower)
+          - type = f.split[-1].downcase
+          - click = "#{type}_xx-#{type}-#{model_name}"
         %tr{:onclick => "miqDynatreeActivateNode('policy_tree', 'xx-#{click}');", :title => _("Open Folder")}
           %td.narrow
-            %img{:src => image_path("100/#{f.split.first.downcase}.png")}
+            %img{:src => image_path("100/#{model_name.underscore}.png")}
           %td
             = _("%s Policies") % h(f == "Vm" ? ui_lookup(:model => f) : f)

--- a/app/views/ops/_schedule_form_filter.html.haml
+++ b/app/views/ops/_schedule_form_filter.html.haml
@@ -45,6 +45,12 @@
               "ng-change"      => "filterTypeChanged()",
               "checkchange"    => "",
               "selectpicker-for-select-tag"   => "")
+            = select_tag('filter_typ', options_for_select(@container_image_options_for_select),
+              "ng-switch-when" => "container_image_check_compliance",
+              "ng-model"       => "$parent.scheduleModel.filter_typ",
+              "ng-change"      => "filterTypeChanged()",
+              "checkchange"    => "",
+              "selectpicker-for-select-tag"   => "")
             = select_tag('filter_typ', options_for_select(@cluster_options_for_select),
               "ng-switch-when" => "emscluster",
               "ng-model"       => "$parent.scheduleModel.filter_typ",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,6 +579,7 @@ Vmdb::Application.routes.draw do
         openscap_rule_results
         openscap_html
         protect
+        squash_toggle
       ),
       :post => %w(
         button
@@ -597,6 +598,7 @@ Vmdb::Application.routes.draw do
         guest_applications
         openscap_rule_results
         protect
+        squash_toggle
       ) + adv_search_post + exp_post + save_post
     },
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -976,6 +976,7 @@ Vmdb::Application.routes.draw do
         index
         new
         perf_top_chart
+        protect
         show
         show_list
         tagging_edit
@@ -989,6 +990,7 @@ Vmdb::Application.routes.draw do
         form_field_changed
         listnav_search_selected
         panel_control
+        protect
         quick_search
         sections_field_changed
         show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -578,6 +578,7 @@ Vmdb::Application.routes.draw do
         guest_applications
         openscap_rule_results
         openscap_html
+        protect
       ),
       :post => %w(
         button
@@ -595,6 +596,7 @@ Vmdb::Application.routes.draw do
         tag_edit_form_field_changed
         guest_applications
         openscap_rule_results
+        protect
       ) + adv_search_post + exp_post + save_post
     },
 

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -165,3 +165,6 @@ service_stopped,Service Stopped,Default,service_process
 #
 containerimage_scan_complete,Container Image Analysis Complete,Default,container_operations
 containerimage_created,New Container Image created,Default,container_operations
+containerimage_compliance_check,Container Image Compliance Check,Default,compliance
+containerimage_compliance_passed,Container Image Compliance Passed,Default,compliance
+containerimage_compliance_failed,Container Image Compliance Failed,Default,compliance

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3730,6 +3730,10 @@
       :description: Perform SmartState Analysis on Containers
       :feature_type: control
       :identifier: container_image_scan
+    - :name: Check Compliance
+      :description: Check Compliance of Last Known Configuration
+      :feature_type: control
+      :identifier: container_image_check_compliance
 
 # ContainerImageRegistry
 - :name: Registries

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3718,8 +3718,12 @@
       :description: Edit Tags of Container Images
       :feature_type: control
       :identifier: container_image_tag
+    - :name: Manage Policies
+      :description: Manage Policies of Container Images
+      :feature_type: control
+      :identifier: container_image_protect
     - :name: Analysis
-      :description: Perform SmartState Analysis on VMs
+      :description: Perform SmartState Analysis on Containers
       :feature_type: control
       :identifier: container_image_scan
 

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3177,6 +3177,10 @@
       :description: Edit Tags of Containers Providers
       :feature_type: control
       :identifier: ems_container_tag
+    - :name: Manage Policies
+      :description: Manage Policies of Containers Providers
+      :feature_type: control
+      :identifier: ems_container_protect
   - :name: Modify
     :description: Modify Containers Providers
     :feature_type: admin

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -12,6 +12,14 @@ describe ContainerImageController do
     expect(controller.send(:flash_errors?)).not_to be_truthy
   end
 
+  it 'renders edit container image tags' do
+    ApplicationController.handle_exceptions = true
+
+    post :button, :params => {:pressed => "container_image_protect", :format => :js}
+    expect(response.status).to eq(200)
+    expect(response.body).to_not be_empty
+  end
+
   it "renders index" do
     get :index
     expect(response.status).to eq(302)

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -9,6 +9,9 @@ describe MiqPolicy do
       @ps = FactoryGirl.create(:miq_policy_set)
       @p  = FactoryGirl.create(:miq_policy)
       @ps.add_member(@p)
+
+      @ps2 = FactoryGirl.create(:miq_policy_set)
+      @p2  = FactoryGirl.create(:miq_policy)
     end
 
     it "should return the correct conditions" do

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1000 }
+  let(:expected_feature_count) { 1001 }
 
   # - container_dashboard
   # - miq_report_widget_editor

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 999 }
+  let(:expected_feature_count) { 1000 }
 
   # - container_dashboard
   # - miq_report_widget_editor

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 998 }
+  let(:expected_feature_count) { 999 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
~~Depends on #6839 .~~ Adds container images to the 'control' subsystem and allows defining control and compliance policies against container images.

Images split by commits in case this pr would be further split.

containers: add images to the control subsystem

![1](https://cloud.githubusercontent.com/assets/3010449/13781390/d861c170-eacb-11e5-94ba-7612752c913a.png)

![2](https://cloud.githubusercontent.com/assets/3010449/13783450/319426a4-ead4-11e5-8f7a-799f317a232e.png)

![3](https://cloud.githubusercontent.com/assets/3010449/13783420/185e15c8-ead4-11e5-98ab-7b4e4d75bb7a.png)

![screenshot from 2016-03-15 18-12-18](https://cloud.githubusercontent.com/assets/3010449/13784873/991539c6-ead9-11e5-871d-b8617d846505.png)

![screenshot from 2016-03-15 18-12-26](https://cloud.githubusercontent.com/assets/3010449/13784874/9b5a3b3c-ead9-11e5-984a-4970555e6666.png)

containers: allow scheduling image ssa
![3](https://cloud.githubusercontent.com/assets/3010449/13783667/ec13b9ae-ead4-11e5-923a-0afee0e05ed0.png)

containers: allow running compliance check against images
![screenshot from 2016-03-15 17-41-36](https://cloud.githubusercontent.com/assets/3010449/13783763/4f2f5e94-ead5-11e5-852c-320e9236f5c9.png)

![screenshot from 2016-03-15 17-41-56](https://cloud.githubusercontent.com/assets/3010449/13783765/5104a940-ead5-11e5-904d-643ab7524021.png)

containers: show compliance status and history for images
![5](https://cloud.githubusercontent.com/assets/3010449/13784724/0826f01c-ead9-11e5-910d-b4dd528033fc.png)

![6](https://cloud.githubusercontent.com/assets/3010449/13784758/2171bade-ead9-11e5-87df-9f322150aa3b.png)

containers: allow attaching policies to container providers
![screenshot from 2016-03-15 18-10-34](https://cloud.githubusercontent.com/assets/3010449/13784792/4c277354-ead9-11e5-9879-11b3f36aa29b.png)

![screenshot from 2016-03-15 18-10-47](https://cloud.githubusercontent.com/assets/3010449/13784797/4fcf411c-ead9-11e5-8169-a611b264f143.png)

containers: allow scheduling image compliance
![5](https://cloud.githubusercontent.com/assets/3010449/13783639/d1e9de28-ead4-11e5-9202-45bafe4db061.png)

