### PR TITLE
Show network adapter info for a virtual machine

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -118,7 +118,13 @@ module VmHelper::TextualSummary
 
   def textual_ipaddress
     ips = @record.ipaddresses
-    {:label => n_("IP Address", "IP Addresses", ips.size), :value => ips.join(", ")}
+    h = {:label    => n_("IP Address", "IP Addresses", ips.size),
+         :value    => ips.join(", "),
+         :explorer => true}
+    if @record.hardware.try(:networks) && @record.hardware.networks.present?
+      h[:link] = url_for(:action => 'show', :id => @record, :display => 'networks')
+    end
+    h
   end
 
   def textual_custom_1

--- a/app/views/vm_common/_config.html.haml
+++ b/app/views/vm_common/_config.html.haml
@@ -89,28 +89,25 @@
 
 - when "networks"
   - if @vmminfo
-    .modbox{:style => "margin: 0px 0px 20px 30px"}
-      %h2.modtitle= _('Network Adapters')
+    - @record.hardware.networks.each do |adapter|
       %table.table.table-bordered.table-striped
-        - if @record.hardware.networks.blank?
-          %tbody
+        %thead
+          %tr
+            %th{:colspan => "2"}= _('Network Adapter')
+        %tbody
+          - {:ipaddress       => _('IP Address'),
+             :ipv6address     => _('IPv6 Address'),
+             :description     => _('Description'),
+             :dhcp_server     => _('DHCP Server'),
+             :dhcp_enabled    => _('DHCP Enabled'),
+             :default_gateway => _('Default Gateway'),
+             :subnet_mask     => _('Subnet Mask'),
+             :dns_server      => _('DNS Server')}.each do |sym, label|
             %tr
+              %td.label
+                = label
               %td
-                %strong
-                  = _("%s has no network adapters") % @record.name
-        - else
-          %thead
-            %tr
-              - [_("IPAddress"), _("Description"), _("DHCP Server"), _("DHCP Enabled"), _("Default Gateway"), _("Subnet Mask"), _("DNS Server")].each do |title|
-                %th
-                  = h(title)
-          %tbody
-            %tr
-              - @record.hardware.networks.each do |v|
-                %tr
-                  - [:ipaddress, :description, :dhcp_server, :dhcp_enabled, :default_gateway, :subnet_mask, :dns_server].each do |item|
-                    %td
-                      = v[item]
+                = adapter.send(sym)
 - when "resources_info"
   %table.table.table-bordered.table-striped
     %thead


### PR DESCRIPTION
Virtual Machine summary -> click on IP Address -> the following screen shows (if there is any actual
network adapter information obtained by SSA):

![vm-networks](https://cloud.githubusercontent.com/assets/6648365/13571286/550b5f1e-e474-11e5-8a24-157da2cad585.jpg)
