### PR TITLE
[WIP] UI changes after adding orderable column to orchestration templates

### DIFF
--- a/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
+++ b/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
@@ -1,0 +1,43 @@
+ManageIQ.angular.app.controller('orchestrationTemplateCopyController', ['$http', '$scope', '$timeout', 'stackId', 'miqService', function($http, $scope, $timeout, stackId, miqService) {
+  $scope.stackId = stackId;
+  $scope.templateInfo = {
+    templateId: null,
+    templateName: null,
+    templateDescription: null,
+    templateDraft: null,
+    templateContent: null
+  };
+  $scope.modelCopy = _.extend({}, $scope.templateInfo);
+  $scope.model = 'templateInfo';
+  $scope.newRecord = true;
+  $scope.saveable = miqService.saveable;
+
+  $http.get('/orchestration_stack/stacks_orchestration_template_info/' + stackId).success(function(response) {
+    $scope.templateInfo.templateId = response.template_id;
+    $scope.templateInfo.templateName = "Copy of " + response.template_name;
+    $scope.templateInfo.templateDescription = response.template_description;
+    $scope.templateInfo.templateDraft = response.template_draft;
+    $scope.templateInfo.templateContent = response.template_content;
+    $scope.modelCopy = _.extend({}, $scope.templateInfo);
+  });
+
+  $scope.$watch('templateInfo.templateContent', function() {
+    if ($scope.templateInfo.templateContent != null) {
+      ManageIQ.editor.getDoc().setValue($scope.templateInfo.templateContent);
+    }
+  });
+
+  $scope.cancelClicked = function() {
+    miqService.sparkleOn();
+    miqService.miqAjaxButton('/orchestration_stack/stacks_ot_copy?button=cancel', {});
+  };
+
+  $scope.addClicked = function() {
+    miqService.sparkleOn();
+    miqService.miqAjaxButton('/orchestration_stack/stacks_ot_copy?button=add', $scope.templateInfo);
+  };
+
+  $scope.contentChanged = function() {
+    return ($scope.modelCopy.templateContent != $scope.templateInfo.templateContent);
+  }
+}]);

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1677,13 +1677,18 @@ class CatalogController < ApplicationController
             condition = ["display=? and service_template_catalog_id IS NOT NULL", true]
             service_template_list(condition, :no_checkboxes => true)
           else
-            process_show_list(:model => typ.constantize)
+            options = {:model => typ.constantize}
+            options[:where_clause] = ["orderable=?", true] if x_active_tree == :ot_tree
+            process_show_list(options)
           end
           @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => typ)}
         elsif ["xx-otcfn", "xx-othot", "xx-otazu"].include?(x_node)
           typ = node_name_to_template_name(x_node)
           @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => typ)}
-          process_show_list(:model => typ.constantize, :gtl_dbname => :orchestrationtemplate)
+          options = {:model        => typ.constantize,
+                     :gtl_dbname   => :orchestrationtemplate,
+                     :where_clause => ["orderable=?", true]}
+          process_show_list(options)
         else
           if x_active_tree == :stcat_tree
             @record = ServiceTemplateCatalog.find_by_id(from_cid(id))

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -43,6 +43,11 @@ class OrchestrationStackController < ApplicationController
       @view, @pages = get_view(kls, :parent => @orchestration_stack)  # Get the records (into a view) and the paginator
       @showtype = @display
       notify_about_unauthorized_items(title, ui_lookup(:tables => 'orchestration_stack'))
+    when "stack_orchestration_template"
+      drop_breadcrumb(:name => "%{model_name} \"%{name}\"" % {
+        :model_name => ui_lookup(:model => "OrchestrationTemplate"),
+        :name       => @orchestration_stack.orchestration_template.name},
+                      :url  => "/orchestration_stack/show/#{@orchestration_stack.id}?display=#{@display}")
     end
 
     # Came in from outside show_list partial

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -102,6 +102,9 @@ class OrchestrationStackController < ApplicationController
       end
     elsif params[:pressed] == "make_ot_orderable"
       make_ot_orderable
+    elsif params[:pressed] == "orchestration_template_copy"
+      orchestration_template_copy
+      return
     else
       params[:page] = @current_page if @current_page.nil?                     # Save current page for list refresh
       @refresh_div = "main_div" # Default div for button.rjs to refresh
@@ -145,6 +148,26 @@ class OrchestrationStackController < ApplicationController
     end
   end
 
+  def stacks_orchestration_template_info
+    ot = find_by_id_filtered(OrchestrationStack, params[:id]).orchestration_template
+    render :json => {
+      :template_id          => ot.id,
+      :template_name        => ot.name,
+      :template_description => ot.description,
+      :template_draft       => ot.draft,
+      :template_content     => ot.content
+    }
+  end
+
+  def stacks_ot_copy
+    case params[:button]
+    when "cancel"
+      stacks_ot_copy_cancel
+    when "add"
+      stacks_ot_copy_submit
+    end
+  end
+
   private ############################
 
   def make_ot_orderable
@@ -161,6 +184,28 @@ class OrchestrationStackController < ApplicationController
         add_flash(_("Orchestration template \"%{name}\" is now orderable") % {:name => template.name})
       end
     end
+  end
+
+  def orchestration_template_copy
+    @record = find_by_id_filtered(OrchestrationStack, params[:id])
+    if false # @record.orchestration_template.orderable?
+      add_flash(_("Orchestration template \"%{name}\" is already orderable") % {:name => @record.orchestration_template.name}, :error)
+      render_flash
+    else
+      render :update do |page|
+        page.replace(:main_div, :partial => "copy_orchestration_template")
+      end
+    end
+  end
+
+  def stacks_ot_copy_cancel
+    add_flash(_("Copy of Orchestration Template was cancelled by the user"))
+    # FIXME: ot copy cancel code comes here
+  end
+
+  def stacks_ot_copy_submit
+    assert_privileges('orchestration_template_copy')
+    # FIXME: ot copy & save code comes here
   end
 
   def get_session_data

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -100,6 +100,8 @@ class OrchestrationStackController < ApplicationController
         @refresh_partial = "layouts/gtl"
         show                                                        # Handle VMs buttons
       end
+    elsif params[:pressed] == "make_ot_orderable"
+      make_ot_orderable
     else
       params[:page] = @current_page if @current_page.nil?                     # Save current page for list refresh
       @refresh_div = "main_div" # Default div for button.rjs to refresh
@@ -144,6 +146,22 @@ class OrchestrationStackController < ApplicationController
   end
 
   private ############################
+
+  def make_ot_orderable
+    template = find_by_id_filtered(OrchestrationStack, params[:id]).orchestration_template
+    if template.orderable?
+      add_flash(_("Orchestration template \"%{name}\" is already orderable") % {:name => template.name}, :error)
+    else
+      begin
+        template.save_as_orderable!
+      rescue StandardError => bang
+        add_flash(_("An error occured when changing orchestratino template \"%{name}\" to orderable: %{err_msg}") %
+          {:name => template.name, :err_msg => bang.message}, :error)
+      else
+        add_flash(_("Orchestration template \"%{name}\" is now orderable") % {:name => template.name})
+      end
+    end
+  end
 
   def get_session_data
     @title      = _("Stack")

--- a/app/helpers/application_helper/button/orchestration_template_orderable.rb
+++ b/app/helpers/application_helper/button/orchestration_template_orderable.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::OrchestrationTemplateOrderable < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self["title"] = N_("This Template is already orderable") if @record.orchestration_template.orderable?
+  end
+
+  def disabled?
+    @record.orchestration_template.orderable?
+  end
+end

--- a/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
+++ b/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
@@ -1,0 +1,23 @@
+class ApplicationHelper::Toolbar::StackOrchestrationTemplateCenter < ApplicationHelper::Toolbar::Basic
+  button_group('stack_orchestration_template_vmdb', [
+    select(
+      :stack_orchestration_template_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :make_ot_orderable,
+          'pficon pficon-edit fa-lg',
+          t = N_('Make the Orchestration Template orderable'),
+          t,
+          :klass => ApplicationHelper::Button::OrchestrationTemplateOrderable),
+        button(
+          :orchestration_template_copy,
+          'fa fa-files-o fa-lg',
+          t = N_('Copy this Orchestration Template as orderable'),
+          t),
+      ]
+    )
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -429,6 +429,8 @@ class ApplicationHelper::ToolbarChooser
         return "resource_pools_center_tb"
       elsif @display == "storages"
         return "storages_center_tb"
+      elsif @display == "stack_orchestration_template"
+        return "stack_orchestration_template_center"
       elsif (@layout == "vm" || @layout == "host") && @display == "performance"
         return "#{@explorer ? "x_" : ""}vm_performance_tb"
       elsif @display == "dashboard"

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -56,6 +56,7 @@ module OrchestrationStackHelper::TextualSummary
   def textual_orchestration_template
     template = @record.orchestration_template
     return nil if template.nil?
+    return nil unless template.orderable
     label = ui_lookup(:table => "orchestration_template")
     h = {:label => label, :image => "orchestration_template", :value => template.name}
     if role_allows(:feature => "orchestration_templates_view")

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -61,7 +61,7 @@ module OrchestrationStackHelper::TextualSummary
     h = {:label => label, :image => "orchestration_template", :value => template.name}
     if role_allows(:feature => "orchestration_templates_view")
       h[:title] = _("Show this Orchestration Template")
-      h[:link] = url_for(:controller => 'catalog', :action => 'ot_show', :id => template.id)
+      h[:link] = url_for(:action => 'show', :id => @orchestration_stack, :display => 'stack_orchestration_template')
     end
     h
   end

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -41,7 +41,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
       "othot" => OrchestrationTemplateHot,
       "otazu" => OrchestrationTemplateAzure
     }
-    objects = rbac_filtered_objects(classes[object[:id]].all).sort_by { |o| o.name.downcase }
+    objects = rbac_filtered_objects(classes[object[:id]].where(["orderable=?", true])).sort_by { |o| o.name.downcase }
     count_only_or_objects(count_only, objects, nil)
   end
 end

--- a/app/views/layouts/_my_code_mirror.html.haml
+++ b/app/views/layouts/_my_code_mirror.html.haml
@@ -8,6 +8,7 @@
 - read_only ||= false
 - multi_mode ||= false
 - no_focus ||= false
+- angular ||= false
 
 - if multi_mode
   - modes.each do |mode|
@@ -32,7 +33,12 @@
       readOnly:      #{read_only ? "'nocursor'".html_safe : false}
     });
     ManageIQ.editor.on('change', function (cm, change) {
-      miqSendOneTrans('#{url}');
+      if (#{angular}) {
+        ManageIQ.editor.save();
+        $(textarea).trigger("change");
+      } else {
+        miqSendOneTrans('#{url}');
+      }
     });
     ManageIQ.editor.on('blur', function (cm, change) {
       ManageIQ.editor.save();

--- a/app/views/orchestration_stack/_copy_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_copy_orchestration_template.html.haml
@@ -1,0 +1,48 @@
+%form#form_div.form-horizontal{:name => 'angularForm', 'ng-controller' => 'orchestrationTemplateCopyController'}
+  = render :partial => 'layouts/flash_msg'
+  %h3
+    = _('New Orchestration Template Information')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Name')
+      .col-md-8
+        %input.form-control{:type          => 'text',
+                            :name          => 'ot_name',
+                            'ng-model'     => 'templateInfo.templateName',
+                            'ng-maxlength' => 255,
+                            :miqrequired   => true,
+                            :checkchange   => true}
+    .form-group
+      %label.col-md-2.control-label
+        = _('Description')
+      .col-md-8
+        %textarea.form-control{:name         => 'ot_description',
+                               :rows         => 8,
+                               'ng-model'    => 'templateInfo.templateDescription',
+                               'miqrequired' => true,
+                               :checkchange  => true}
+    .form-group
+      %label.col-md-2.control-label
+        = _('Draft')
+      .col-md-10
+        %input{:type         => 'checkbox',
+               :name         => 'ot_draft',
+               'ng-model'    => 'templateInfo.templateDraft'}
+
+  %hr
+
+  = text_area_tag("template_content", '', 'ng-model' => 'templateInfo.templateContent', :style => "display:none;")
+  = render :partial => "/layouts/my_code_mirror",
+  :locals       => {:text_area_id => "template_content",
+    :mode         => "yaml",
+    :line_numbers => true,
+    :read_only    => false,
+    :angular      => true}
+
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
+
+:javascript
+  ManageIQ.editor.refresh();
+  ManageIQ.angular.app.value('stackId', #{@record.id});
+  miq_bootstrap('#form_div');

--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -1,0 +1,35 @@
+%table.table.table-bordered.table-striped
+  %thead
+    %tr
+      %th{:colspan => "2"}= _('Details')
+  %tbody
+    - {:name        => _("Name"),
+       :description => _("Description"),
+       :draft       => _("Draft"),
+       :read_only   => _("Read Only"),
+       :orderable?  => _("Orderable"),
+       :created_at  => _("Created On"),
+       :updated_at  => _("Updated On")}.each do |sym, label|
+      %tr
+        %td.label
+          = label
+        %td
+          - case sym
+          - when :draft, :orderable?
+            = @record.orchestration_template.send(sym) ? _("True") : _("False")
+          - when :read_only
+            = @record.orchestration_template.stacks.empty? ? _("False") : _("True")
+          - else
+            = @record.orchestration_template.send(sym)
+
+- if @record.orchestration_template.content
+  %hr
+  #form_div
+    = text_area_tag("template_content", @record.orchestration_template.content, :style => "display:none;")
+    = render :partial => "/layouts/my_code_mirror",
+      :locals => {:text_area_id => "template_content",
+                  :mode         => "yaml",
+                  :line_numbers => true,
+                  :read_only    => true}
+    :javascript
+      ManageIQ.editor.refresh();

--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -1,35 +1,38 @@
-%table.table.table-bordered.table-striped
-  %thead
-    %tr
-      %th{:colspan => "2"}= _('Details')
-  %tbody
-    - {:name        => _("Name"),
-       :description => _("Description"),
-       :draft       => _("Draft"),
-       :read_only   => _("Read Only"),
-       :orderable?  => _("Orderable"),
-       :created_at  => _("Created On"),
-       :updated_at  => _("Updated On")}.each do |sym, label|
+#form_div
+  #basic_info_div
+  = render :partial => "layouts/flash_msg"
+  %table.table.table-bordered.table-striped
+    %thead
       %tr
-        %td.label
-          = label
-        %td
-          - case sym
-          - when :draft, :orderable?
-            = @record.orchestration_template.send(sym) ? _("True") : _("False")
-          - when :read_only
-            = @record.orchestration_template.stacks.empty? ? _("False") : _("True")
-          - else
-            = @record.orchestration_template.send(sym)
+        %th{:colspan => "2"}= _('Details')
+    %tbody
+      - {:name        => _("Name"),
+         :description => _("Description"),
+         :draft       => _("Draft"),
+         :read_only   => _("Read Only"),
+         :orderable?  => _("Orderable"),
+         :created_at  => _("Created On"),
+         :updated_at  => _("Updated On")}.each do |sym, label|
+        %tr
+          %td.label
+            = label
+          %td
+            - case sym
+            - when :draft, :orderable?
+              = @record.orchestration_template.send(sym) ? _("True") : _("False")
+            - when :read_only
+              = @record.orchestration_template.stacks.empty? ? _("False") : _("True")
+            - else
+              = @record.orchestration_template.send(sym)
 
-- if @record.orchestration_template.content
-  %hr
-  #form_div
-    = text_area_tag("template_content", @record.orchestration_template.content, :style => "display:none;")
-    = render :partial => "/layouts/my_code_mirror",
-      :locals => {:text_area_id => "template_content",
-                  :mode         => "yaml",
-                  :line_numbers => true,
-                  :read_only    => true}
-    :javascript
-      ManageIQ.editor.refresh();
+  - if @record.orchestration_template.content
+    %hr
+    #form_div
+      = text_area_tag("template_content", @record.orchestration_template.content, :style => "display:none;")
+      = render :partial => "/layouts/my_code_mirror",
+        :locals => {:text_area_id => "template_content",
+                    :mode         => "yaml",
+                    :line_numbers => true,
+                    :read_only    => true}
+      :javascript
+        ManageIQ.editor.refresh();

--- a/app/views/orchestration_stack/show.html.haml
+++ b/app/views/orchestration_stack/show.html.haml
@@ -7,5 +7,7 @@
   - else
     - if %w(instances security_groups).include?(@display)
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@orchestration_stack.id}"}
+    - elsif @display == 'stack_orchestration_template'
+      = render :partial => "stack_orchestration_template"
     - elsif @showtype == 'main'
       = render :partial => 'main'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1860,6 +1860,7 @@ Vmdb::Application.routes.draw do
         retire
         show
         show_list
+        stacks_orchestration_template_info
         tagging_edit
         protect
       ),
@@ -1876,6 +1877,7 @@ Vmdb::Application.routes.draw do
         sections_field_changed
         show
         show_list
+        stacks_ot_copy
         protect
         tagging_edit
         tag_edit_form_field_changed

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -260,6 +260,11 @@
         :description: Edit Orchestration Templates Tags
         :feature_type: control
         :identifier: orchestration_template_tag
+      - :name: Make Template Orderable
+        :description: Make Orchestration Template orderable
+        :feature_type: control
+        :identifier: make_ot_orderable
+
     - :name: Create Service Dialog from Orchestration Template
       :description: Create Service Dialog from Orchestration Template
       :identifier: service_dialog_from_ot

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -9,23 +9,46 @@ describe OrchestrationStackController do
   render_views
 
   describe '#show' do
-    let(:record) { FactoryGirl.create(:orchestration_stack_cloud) }
+    context "instances" do
+      let(:record) { FactoryGirl.create(:orchestration_stack_cloud) }
 
-    before do
-      session[:settings] = {
-        :views => {:manageiq_providers_cloudmanager_vm => "grid"}
-      }
-      get :show, :params => {:id => record.id, :display => "instances"}
+      before do
+        session[:settings] = {
+          :views => {:manageiq_providers_cloudmanager_vm => "grid"}
+        }
+        get :show, :params => {:id => record.id, :display => "instances"}
+      end
+
+      it 'does not render compliance check and comparison buttons' do
+        expect(response.body).not_to include('instance_check_compliance')
+        expect(response.body).not_to include('instance_compare')
+      end
+
+      it "renders the listnav" do
+        expect(response.status).to eq(200)
+        expect(response.status).to render_template(:partial => "layouts/listnav/_orchestration_stack")
+      end
     end
 
-    it 'does not render compliance check and comparison buttons' do
-      expect(response.body).not_to include('instance_check_compliance')
-      expect(response.body).not_to include('instance_compare')
-    end
+    context "orchestration templates" do
+      let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template) }
 
-    it "renders the listnav" do
-      expect(response.status).to eq(200)
-      expect(response.status).to render_template(:partial => "layouts/listnav/_orchestration_stack")
+      before do
+        session[:settings] = {
+          :views => {:manageiq_providers_cloudmanager_vm => "grid"}
+        }
+        get :show, :params => {:id => record.id, :display => "stack_orchestration_template"}
+      end
+
+      it "renders the listnav" do
+        expect(response.status).to eq(200)
+        expect(response.status).to render_template(:partial => "layouts/listnav/_orchestration_stack")
+      end
+
+      it "renders the orchestration template details" do
+        expect(response.status).to eq(200)
+        expect(response.status).to render_template(:partial => "orchestration_stack/_stack_orchestration_template")
+      end
     end
   end
 end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -51,4 +51,26 @@ describe OrchestrationStackController do
       end
     end
   end
+
+  describe "#button" do
+    context "make stack's orchestration template orderable" do
+      it "won't allow making stack's orchestration template orderable when already orderable" do
+        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+        post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
+        expect(record.orchestration_template.orderable?).to be_truthy
+        expect(response.status).to eq(200)
+        expect(response.status).to render_template(:partial => "layouts/_flash_msg")
+        expect(assigns(:flash_array).first[:message]).to include('is already orderable')
+      end
+
+      it "makes stack's orchestration template orderable" do
+        record = FactoryGirl.create(:orchestration_stack_amazon_with_non_orderable_template)
+        post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
+        expect(record.orchestration_template.orderable?).to be_falsey
+        expect(response.status).to eq(200)
+        expect(response.status).to render_template(:partial => "layouts/_flash_msg")
+        expect(assigns(:flash_array).first[:message]).to include('is now orderable')
+      end
+    end
+  end
 end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -12,6 +12,10 @@ FactoryGirl.define do
   factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
   end
 
+  factory :orchestration_stack_amazon_with_non_orderable_template, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
+    orchestration_template { FactoryGirl.create(:orchestration_template_cfn, :orderable => false) }
+  end
+
   factory :orchestration_stack_azure, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Azure::CloudManager::OrchestrationStack" do
   end
 

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -5,6 +5,10 @@ FactoryGirl.define do
   factory :orchestration_stack_cloud, :parent => :orchestration_stack, :class => "ManageIQ::Providers::CloudManager::OrchestrationStack" do
   end
 
+  factory :orchestration_stack_cloud_with_template, :parent => :orchestration_stack, :class => "ManageIQ::Providers::CloudManager::OrchestrationStack" do
+    orchestration_template { FactoryGirl.create(:orchestration_template) }
+  end
+
   factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
   end
 


### PR DESCRIPTION
Implemented:

* don't display non-orderable orchestration templates in orch. templates catalogs view
* new read-only screen showing stack's orchestration template
* new button to make a template orderable

Fixes: #6600

https://bugzilla.redhat.com/show_bug.cgi?id=1302810