### PR TITLE
Rbac id filters as a scope pt1

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -104,7 +104,7 @@ module MiqProvisionQuotaMixin
     vms = []
     prov_owner = get_owner
     unless prov_owner.nil?
-      vms = Vm.user_or_group_owned(prov_owner)
+      vms = Vm.user_or_group_owned(prov_owner, prov_owner.current_group).to_a
       MiqPreloader.preload(vms, :hardware => :disks)
       vms.reject! do |vm|
         result = vm.template? || vm.host_id.nil?

--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -108,8 +108,7 @@ module MiqProvisionQuotaMixin
       scope = scope.where.not(:retired => true)
     end
 
-    vms = scope.user_or_group_owned(prov_owner, prov_owner.current_group).to_a
-    MiqPreloader.preload(vms, :hardware => :disks)
+    scope.user_or_group_owned(prov_owner, prov_owner.current_group).includes(:hardware => :disks).to_a
   end
 
   def quota_find_vms_by_owner(options)

--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -47,6 +47,8 @@ module OwnershipMixin
         where("evm_owner_id" => user.id)
       elsif miq_group
         where("miq_group_id" => miq_group.id)
+      else
+        none
       end
     end
   end

--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -40,32 +40,6 @@ module OwnershipMixin
       errors.empty? ? true : errors
     end
 
-    def conditions_for_owned(user_or_group = nil)
-      user_or_group ||= User.current_user
-
-      case user_or_group
-      when User
-        ["evm_owner_id = ?", user_or_group.id]
-      when MiqGroup
-        ["miq_group_id = ?", user_or_group.id]
-      end
-    end
-
-    def conditions_for_owned_or_group_owned(user_or_group = nil)
-      user_or_group ||= User.current_user
-
-      cond = conditions_for_owned(user_or_group)
-      case user_or_group
-      when MiqGroup
-        cond
-      when User
-        group_cond = conditions_for_owned(user_or_group.current_group)
-        cond[0] += " OR #{group_cond[0]}"
-        cond << group_cond[1]
-        cond
-      end
-    end
-
     def user_or_group_owned(user, miq_group)
       if user && miq_group
         where("evm_owner_id" => user.id).or(where("miq_group_id" => miq_group.id))

--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -66,8 +66,14 @@ module OwnershipMixin
       end
     end
 
-    def user_or_group_owned(user = nil)
-      where(conditions_for_owned_or_group_owned(user)).to_a
+    def user_or_group_owned(user, miq_group)
+      if user && miq_group
+        where("evm_owner_id" => user.id).or(where("miq_group_id" => miq_group.id))
+      elsif user
+        where("evm_owner_id" => user.id)
+      elsif miq_group
+        where("miq_group_id" => miq_group.id)
+      end
     end
   end
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -132,7 +132,8 @@ module Rbac
     u_filtered_ids = get_self_service_object_ids(user, miq_group, klass)
     b_filtered_ids = get_belongsto_filter_object_ids(klass, user_filters['belongsto'])
     m_filtered_ids = get_managed_filter_object_ids(scope, user_filters['managed'])
-    d_filtered_ids = user_filters['ids_via_descendants']
+    d_filtered_ids = ids_via_descendants(rbac_class(klass), user_filters['match_via_descendants'],
+                                         :user => user, :miq_group => miq_group)
 
     filtered_ids = combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids)
     [filtered_ids, u_filtered_ids]
@@ -496,7 +497,7 @@ module Rbac
       end
     end
 
-    user_filters['ids_via_descendants'] = ids_via_descendants(rbac_class(klass), options.delete(:match_via_descendants), :user => user, :miq_group => miq_group)
+    user_filters['match_via_descendants'] = options.delete(:match_via_descendants)
 
     exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.respond_to?(:instances_are_derived?)
     conditions, include_for_find = MiqExpression.merge_where_clauses_and_includes([conditions, sub_filter, where_clause, exp_sql, ids_clause], [include_for_find, exp_includes])

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -253,14 +253,15 @@ module Rbac
   def self.find_targets_with_user_group_rbac(scope, _rbac_filters, find_options, user, miq_group)
     klass = scope.respond_to?(:klass) ? scope.klass : scope
     if klass == User && user
-      cond = ["id = ?", user.id]
+      cond = {:id => user.id}
     elsif klass == MiqGroup
-      cond = ["id = ?", miq_group.id]
+      cond = {:id => miq_group.id}
     end
 
-    cond, incl = MiqExpression.merge_where_clauses_and_includes([find_options[:condition], cond].compact, [find_options[:include]].compact)
-    targets = klass.where(cond).includes(incl).references(incl).group(find_options[:group])
-                   .order(find_options[:order]).offset(find_options[:offset]).limit(find_options[:limit]).to_a
+    targets = klass.where(cond).where(find_options[:condition])
+                .includes(find_options[:include]).references(find_options[:include])
+                .group(find_options[:group]).order(find_options[:order])
+                .offset(find_options[:offset]).limit(find_options[:limit]).to_a
 
     [targets, targets.length, targets.length]
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -283,12 +283,19 @@ module Rbac
   end
 
   def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options, user_or_group)
-    find_options = find_options_for_tenant(scope, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
+    if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
+      find_options = find_options_for_tenant(scope, user_or_group, find_options)
+    end
 
-    return find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)
-    return find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user_or_group)   if apply_rbac_to_associated_class?(klass)
-    return find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user_or_group) if apply_user_group_rbac_to_class?(klass)
-    find_targets_without_rbac(scope, find_options)
+    if apply_rbac_to_class?(klass)
+      find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)
+    elsif apply_rbac_to_associated_class?(klass)
+      find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user_or_group)
+    elsif apply_user_group_rbac_to_class?(klass)
+      find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user_or_group)
+    else
+      find_targets_without_rbac(scope, find_options)
+    end
   end
 
   def self.find_targets_without_rbac(scope, find_options)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -255,8 +255,7 @@ module Rbac
     if klass == User && user
       cond = ["id = ?", user.id]
     elsif klass == MiqGroup
-      group_id = miq_group.try!(:id) || user.try!(:current_group_id)
-      cond = ["id = ?", group_id] if group_id
+      cond = ["id = ?", miq_group.id]
     end
 
     cond, incl = MiqExpression.merge_where_clauses_and_includes([find_options[:condition], cond].compact, [find_options[:include]].compact)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -173,7 +173,7 @@ module Rbac
     filtered_ids
   end
 
-  def self.find_targets_with_indirect_rbac(scope, rbac_filters, find_options = {}, user_or_group = nil)
+  def self.find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user_or_group)
     parent_class = rbac_class(scope)
     filtered_ids, _ = calc_filtered_ids(parent_class, rbac_filters, user_or_group)
 
@@ -242,12 +242,12 @@ module Rbac
     scope.find_tags_by_grouping(filter, :ns => '*', :select => minimum_columns_for(klass)).reorder(nil).collect(&:id)
   end
 
-  def self.find_targets_with_direct_rbac(scope, rbac_filters, find_options = {}, user_or_group = nil)
+  def self.find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)
     filtered_ids, u_filtered_ids = calc_filtered_ids(scope, rbac_filters, user_or_group)
     find_targets_filtered_by_ids(scope, find_options, u_filtered_ids, filtered_ids)
   end
 
-  def self.find_targets_with_user_group_rbac(scope, _rbac_filters, find_options = {}, user_or_group = nil)
+  def self.find_targets_with_user_group_rbac(scope, _rbac_filters, find_options, user_or_group)
     klass = scope.respond_to?(:klass) ? scope.klass : scope
     if user_or_group && user_or_group.self_service?
       if klass == User && user_or_group.kind_of?(User)
@@ -270,7 +270,7 @@ module Rbac
     end
   end
 
-  def self.find_options_for_tenant(scope, user_or_group, find_options = {})
+  def self.find_options_for_tenant(scope, user_or_group, find_options)
     klass = scope.respond_to?(:klass) ? scope.klass : scope
     tenant_id_clause = klass.tenant_id_clause(user_or_group)
 
@@ -282,7 +282,7 @@ module Rbac
     TENANT_ACCESS_STRATEGY[klass.base_model.to_s]
   end
 
-  def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options = {}, user_or_group = nil)
+  def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options, user_or_group)
     find_options = find_options_for_tenant(scope, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
 
     return find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)
@@ -291,7 +291,7 @@ module Rbac
     find_targets_without_rbac(scope, find_options)
   end
 
-  def self.find_targets_without_rbac(scope, find_options = {})
+  def self.find_targets_without_rbac(scope, find_options)
     targets     = method_with_scope(scope, find_options)
     total_count = find_options[:limit] ? scope.where(find_options[:conditions]).includes(find_options[:include]).references(find_options[:include]).count : targets.length
 
@@ -341,17 +341,17 @@ module Rbac
     matches
   end
 
-  def self.find_descendants(descendant_klass, options = {})
+  def self.find_descendants(descendant_klass, options)
     search(options.merge(:class => descendant_klass, :results_format => :objects)).first
   end
 
-  def self.ids_via_descendants(klass, descendant_types, options = {})
+  def self.ids_via_descendants(klass, descendant_types, options)
     objects = matches_via_descendants(klass, descendant_types, options)
     return nil if objects.blank?
     objects.collect(&:id)
   end
 
-  def self.matches_via_descendants(klass, descendant_types, options = {})
+  def self.matches_via_descendants(klass, descendant_types, options)
     return nil if descendant_types.nil?
 
     matches = []

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1204,7 +1204,7 @@ describe Rbac do
 
     it "works with no filters" do
       all_vms
-      result = Rbac.find_targets_with_direct_rbac(Vm, {})
+      result = Rbac.find_targets_with_direct_rbac(Vm, {}, nil)
       expect_counts(result, all_vms, all_vms.size, all_vms.size)
     end
 
@@ -1212,7 +1212,7 @@ describe Rbac do
     # including :conditions, :include, :order, :limit
     it "applies find_options[:conditions, :include]" do
       all_vms
-      result = Rbac.find_targets_with_direct_rbac(Vm, {}, host_filter_find_options)
+      result = Rbac.find_targets_with_direct_rbac(Vm, {}, host_filter_find_options, nil)
       expect_counts(result, vms_match, 2, 2)
     end
   end

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -268,7 +268,7 @@ describe Rbac do
 
       context "with self-service user" do
         before(:each) do
-          allow_any_instance_of(User).to receive_messages(:self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
         end
 
         it "returns only the current user" do
@@ -460,7 +460,7 @@ describe Rbac do
         end
 
         it "search on VMs and Templates should return no objects if self-service user" do
-          allow_any_instance_of(User).to receive_messages(:self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
           User.with_user(user) do
             results = Rbac.search(:class => "VmOrTemplate", :results_format => :objects)
             objects = results.first
@@ -667,7 +667,7 @@ describe Rbac do
 
         context "with self-service user" do
           before(:each) do
-            allow_any_instance_of(User).to receive_messages(:self_service? => true)
+            allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
           end
 
           it "works when targets are empty" do
@@ -688,8 +688,8 @@ describe Rbac do
 
         context "with limited self-service user" do
           before(:each) do
-            allow_any_instance_of(User).to receive_messages(:self_service? => true)
-            allow_any_instance_of(User).to receive_messages(:limited_self_service? => true)
+            allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
+            allow_any_instance_of(MiqGroup).to receive_messages(:limited_self_service? => true)
           end
 
           it "works when targets are empty" do
@@ -749,7 +749,7 @@ describe Rbac do
 
         context "with self-service user" do
           before(:each) do
-            allow_any_instance_of(User).to receive_messages(:self_service? => true)
+            allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
           end
 
           it "works when targets are empty" do
@@ -777,8 +777,8 @@ describe Rbac do
 
         context "with limited self-service user" do
           before(:each) do
-            allow_any_instance_of(User).to receive_messages(:self_service? => true)
-            allow_any_instance_of(User).to receive_messages(:limited_self_service? => true)
+            allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
+            allow_any_instance_of(MiqGroup).to receive_messages(:limited_self_service? => true)
           end
 
           it "works when targets are empty" do
@@ -1082,7 +1082,10 @@ describe Rbac do
             value: connected
             field: MiqGroup.vms-connection_state
         '
-        results, attrs = described_class.search(:class => "MiqGroup", :filter => filter, :results_format => :objects)
+        results, attrs = described_class.search(:class          => "MiqGroup",
+                                                :filter         => filter,
+                                                :miq_group      => group,
+                                                :results_format => :objects)
 
         expect(results.length).to eq(2)
         expect(attrs[:total_count]).to eq(2)
@@ -1096,8 +1099,10 @@ describe Rbac do
             value: false
             field: MiqGroup.vms-disconnected
         '
-        results, attrs = described_class.search(:class => "MiqGroup", :filter => filter, :results_format => :objects)
-
+        results, attrs = described_class.search(:class          => "MiqGroup",
+                                                :filter         => filter,
+                                                :miq_group      => group,
+                                                :results_format => :objects)
         expect(results.length).to eq(2)
         expect(attrs[:total_count]).to eq(2)
       end

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1205,7 +1205,7 @@ describe Rbac do
 
     it "works with no filters" do
       all_vms
-      result = Rbac.find_targets_with_direct_rbac(Vm, {}, nil)
+      result = Rbac.find_targets_with_direct_rbac(Vm, {}, {}, nil, nil)
       expect_counts(result, all_vms, all_vms.size, all_vms.size)
     end
 
@@ -1213,7 +1213,7 @@ describe Rbac do
     # including :conditions, :include, :order, :limit
     it "applies find_options[:conditions, :include]" do
       all_vms
-      result = Rbac.find_targets_with_direct_rbac(Vm, {}, host_filter_find_options, nil)
+      result = Rbac.find_targets_with_direct_rbac(Vm, {}, host_filter_find_options, nil, nil)
       expect_counts(result, vms_match, 2, 2)
     end
   end

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1186,8 +1186,9 @@ describe Rbac do
   end
 
   it ".apply_user_group_rbac_to_class?" do
-    expect(Rbac.apply_user_group_rbac_to_class?(User)).to be_truthy
-    expect(Rbac.apply_user_group_rbac_to_class?(Vm)).not_to be
+    expect(Rbac.apply_user_group_rbac_to_class?(User, double("MiqGroup", :self_service? => true))).to be_truthy
+    expect(Rbac.apply_user_group_rbac_to_class?(User, double("MiqGroup", :self_service? => false))).not_to be_truthy
+    expect(Rbac.apply_user_group_rbac_to_class?(Vm, double("MiqGroup", :self_service? => true))).not_to be_truthy
   end
 
   # find_targets_with_direct_rbac(klass, scope, rbac_filters, find_options, user_or_group)


### PR DESCRIPTION
Currently we fetch `Vm` ids and then run a query on those ids.

We then ship the ids to and from the server, and for a larger installation this gets quite big - in one installation the sql is 151k.

@matthewd this started getting too big. Let me know if you want smaller, or if you want bigger and I can put the rest of the work to make ids into a scope and not shipping them around
