### PR TITLE
http_proxy support for authenticating to Azure

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -32,11 +32,14 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     ManageIQ::Providers::Azure::Regions.find_by_name(provider_region)[:description]
   end
 
-  def self.raw_connect(clientid, clientkey, azuretenantid)
+  def self.raw_connect(clientid, clientkey, azuretenantid, proxy_uri = nil)
+    proxy_uri ||= VMDB::Util.http_proxy_uri
+
     ::Azure::Armrest::ArmrestService.configure(
       :client_id  => clientid,
       :client_key => clientkey,
-      :tenant_id  => azuretenantid
+      :tenant_id  => azuretenantid,
+      :proxy      => proxy_uri.to_s
     )
   end
 
@@ -45,7 +48,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
     clientid  = options[:user] || authentication_userid(options[:auth_type])
     clientkey = options[:pass] || authentication_password(options[:auth_type])
-    self.class.raw_connect(clientid, clientkey, azure_tenant_id)
+    self.class.raw_connect(clientid, clientkey, azure_tenant_id, options[:proxy_uri])
   end
 
   def verify_credentials(_auth_type = nil, options = {})

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -32,13 +32,13 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     ManageIQ::Providers::Azure::Regions.find_by_name(provider_region)[:description]
   end
 
-  def self.raw_connect(clientid, clientkey, azuretenantid, proxy_uri = nil)
+  def self.raw_connect(client_id, client_key, azure_tenant_id, proxy_uri = nil)
     proxy_uri ||= VMDB::Util.http_proxy_uri
 
     ::Azure::Armrest::ArmrestService.configure(
-      :client_id  => clientid,
-      :client_key => clientkey,
-      :tenant_id  => azuretenantid,
+      :client_id  => client_id,
+      :client_key => client_key,
+      :tenant_id  => azure_tenant_id,
       :proxy      => proxy_uri.to_s
     )
   end
@@ -46,9 +46,9 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   def connect(options = {})
     raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(options[:auth_type])
 
-    clientid  = options[:user] || authentication_userid(options[:auth_type])
-    clientkey = options[:pass] || authentication_password(options[:auth_type])
-    self.class.raw_connect(clientid, clientkey, azure_tenant_id, options[:proxy_uri])
+    client_id  = options[:user] || authentication_userid(options[:auth_type])
+    client_key = options[:pass] || authentication_password(options[:auth_type])
+    self.class.raw_connect(client_id, client_key, azure_tenant_id, options[:proxy_uri])
   end
 
   def verify_credentials(_auth_type = nil, options = {})


### PR DESCRIPTION
Proxy connection information is set in vmdb.tmpl.yml and read by the Azure CloudManager::raw_connect method.

https://bugzilla.redhat.com/show_bug.cgi?id=1314835