### PR TITLE
[api] Remove `#parse_response` spec helper

### DIFF
--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -96,7 +96,7 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
       expect_result_to_match_hash(
-        result["identity"],
+        response_hash["identity"],
         "userid"     => @user.userid,
         "name"       => @user.name,
         "user_href"  => "/api/users/#{@user.id}",
@@ -106,7 +106,7 @@ describe ApiController do
         "role_href"  => "/api/roles/#{group2.miq_user_role.id}",
         "tenant"     => @group.tenant.name
       )
-      expect(result["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
+      expect(response_hash["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
     end
 
     it "querying user's authorization" do
@@ -116,7 +116,7 @@ describe ApiController do
 
       expect_single_resource_query
       expect_result_to_have_keys(ENTRYPOINT_KEYS + %w(authorization))
-      expect_hash_to_have_keys(result["authorization"], %w(product_features))
+      expect_hash_to_have_keys(response_hash["authorization"], %w(product_features))
     end
   end
 
@@ -144,7 +144,7 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token))
 
-      auth_token = result["auth_token"]
+      auth_token = response_hash["auth_token"]
 
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
@@ -160,8 +160,8 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
 
-      auth_token = result["auth_token"]
-      token_expires_on = result["expires_on"]
+      auth_token = response_hash["auth_token"]
+      token_expires_on = response_hash["expires_on"]
 
       tm = TokenManager.new("api")
       token_info = tm.token_get_info("api", auth_token)
@@ -182,7 +182,7 @@ describe ApiController do
 
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(result["token_ttl"]).to eq(api_token_ttl)
+      expect(response_hash["token_ttl"]).to eq(api_token_ttl)
     end
 
     it "gets a token based identifier with an invalid requester_type" do
@@ -201,7 +201,7 @@ describe ApiController do
 
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(result["token_ttl"]).to eq(ui_token_ttl)
+      expect(response_hash["token_ttl"]).to eq(ui_token_ttl)
     end
 
     it "forgets the current token when asked to" do
@@ -209,7 +209,7 @@ describe ApiController do
 
       run_get auth_url
 
-      auth_token = result["auth_token"]
+      auth_token = response_hash["auth_token"]
 
       expect_any_instance_of(TokenManager).to receive(:invalidate_token).with("api", auth_token)
       run_delete auth_url, "auth_token" => auth_token

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -96,7 +96,7 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
       expect_result_to_match_hash(
-        @result["identity"],
+        result["identity"],
         "userid"     => @user.userid,
         "name"       => @user.name,
         "user_href"  => "/api/users/#{@user.id}",
@@ -106,7 +106,7 @@ describe ApiController do
         "role_href"  => "/api/roles/#{group2.miq_user_role.id}",
         "tenant"     => @group.tenant.name
       )
-      expect(@result["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
+      expect(result["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
     end
 
     it "querying user's authorization" do
@@ -116,7 +116,7 @@ describe ApiController do
 
       expect_single_resource_query
       expect_result_to_have_keys(ENTRYPOINT_KEYS + %w(authorization))
-      expect_hash_to_have_keys(@result["authorization"], %w(product_features))
+      expect_hash_to_have_keys(result["authorization"], %w(product_features))
     end
   end
 
@@ -144,7 +144,7 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token))
 
-      auth_token = @result["auth_token"]
+      auth_token = result["auth_token"]
 
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
@@ -160,8 +160,8 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
 
-      auth_token = @result["auth_token"]
-      token_expires_on = @result["expires_on"]
+      auth_token = result["auth_token"]
+      token_expires_on = result["expires_on"]
 
       tm = TokenManager.new("api")
       token_info = tm.token_get_info("api", auth_token)
@@ -182,7 +182,7 @@ describe ApiController do
 
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(@result["token_ttl"]).to eq(api_token_ttl)
+      expect(result["token_ttl"]).to eq(api_token_ttl)
     end
 
     it "gets a token based identifier with an invalid requester_type" do
@@ -201,7 +201,7 @@ describe ApiController do
 
       expect_single_resource_query
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(@result["token_ttl"]).to eq(ui_token_ttl)
+      expect(result["token_ttl"]).to eq(ui_token_ttl)
     end
 
     it "forgets the current token when asked to" do
@@ -209,7 +209,7 @@ describe ApiController do
 
       run_get auth_url
 
-      auth_token = @result["auth_token"]
+      auth_token = result["auth_token"]
 
       expect_any_instance_of(TokenManager).to receive(:invalidate_token).with("api", auth_token)
       run_delete auth_url, "auth_token" => auth_token

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -30,7 +30,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = @result["results"].first["id"]
+      task_id = result["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -43,7 +43,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = @result["results"].first["id"]
+      task_id = result["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -56,7 +56,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = @result["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = result["results"].collect { |r| r["id"] }
       expect(AutomationRequest.exists?(task_id1)).to be_truthy
       expect(AutomationRequest.exists?(task_id2)).to be_truthy
     end

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -30,7 +30,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = result["results"].first["id"]
+      task_id = response_hash["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -43,7 +43,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = result["results"].first["id"]
+      task_id = response_hash["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -56,7 +56,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = result["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = response_hash["results"].collect { |r| r["id"] }
       expect(AutomationRequest.exists?(task_id1)).to be_truthy
       expect(AutomationRequest.exists?(task_id2)).to be_truthy
     end

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "categories API" do
 
     run_get categories_url(category.id)
     expect_result_to_match_hash(
-      result,
+      response_hash,
       "description" => category.description,
       "href"        => categories_url(category.id),
       "id"          => category.id
@@ -87,7 +87,7 @@ RSpec.describe "categories API" do
       run_post categories_url, options
 
       expect_result_to_match_hash(
-        result["results"].first,
+        response_hash["results"].first,
         "read_only"    => true,
         "show"         => true,
         "single_value" => true
@@ -98,7 +98,7 @@ RSpec.describe "categories API" do
       api_basic_authorize collection_action_identifier(:categories, :create)
 
       run_post categories_url, :name => "test", :description => "Test"
-      category = Category.find(result["results"].first["id"])
+      category = Category.find(response_hash["results"].first["id"])
 
       expect(category.tag.name).to eq("/managed/test")
     end

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "categories API" do
 
     run_get categories_url(category.id)
     expect_result_to_match_hash(
-      @result,
+      result,
       "description" => category.description,
       "href"        => categories_url(category.id),
       "id"          => category.id
@@ -87,7 +87,7 @@ RSpec.describe "categories API" do
       run_post categories_url, options
 
       expect_result_to_match_hash(
-        @result["results"].first,
+        result["results"].first,
         "read_only"    => true,
         "show"         => true,
         "single_value" => true
@@ -98,7 +98,7 @@ RSpec.describe "categories API" do
       api_basic_authorize collection_action_identifier(:categories, :create)
 
       run_post categories_url, :name => "test", :description => "Test"
-      category = Category.find(@result["results"].first["id"])
+      category = Category.find(result["results"].first["id"])
 
       expect(category.tag.name).to eq("/managed/test")
     end

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "chargebacks API" do
     expect_result_resources_to_include_hrefs(
       "resources", [chargebacks_url(chargeback_rate.id)]
     )
-    expect_result_to_match_hash(result, "count" => 1)
+    expect_result_to_match_hash(response_hash, "count" => 1)
     expect_request_success
   end
 
@@ -19,7 +19,7 @@ RSpec.describe "chargebacks API" do
     run_get chargebacks_url(chargeback_rate.id)
 
     expect_result_to_match_hash(
-      result,
+      response_hash,
       "description" => chargeback_rate.description,
       "guid"        => chargeback_rate.guid,
       "id"          => chargeback_rate.id,
@@ -53,7 +53,7 @@ RSpec.describe "chargebacks API" do
     run_get "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}"
 
     expect_result_to_match_hash(
-      result,
+      response_hash,
       "chargeback_rate_id" => chargeback_rate.id,
       "href"               => "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}",
       "id"                 => chargeback_rate_detail.id,
@@ -73,7 +73,7 @@ RSpec.describe "chargebacks API" do
                  :source  => "used",
                  :enabled => true
       end.to change(ChargebackRateDetail, :count).by(1)
-      expect_result_to_match_hash(result["results"].first, "rate" => "0", "enabled" => true)
+      expect_result_to_match_hash(response_hash["results"].first, "rate" => "0", "enabled" => true)
       expect_request_success
     end
 
@@ -95,7 +95,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :edit)
       run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => "0.02")
 
-      expect(result["rate"]).to eq("0.02")
+      expect(response_hash["rate"]).to eq("0.02")
       expect_request_success
       expect(chargeback_rate_detail.reload.rate).to eq("0.02")
     end
@@ -106,7 +106,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :edit)
       run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "rate", :value => "0.02"}]
 
-      expect(result["rate"]).to eq("0.02")
+      expect(response_hash["rate"]).to eq("0.02")
       expect_request_success
       expect(chargeback_rate_detail.reload.rate).to eq("0.02")
     end

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "chargebacks API" do
     expect_result_resources_to_include_hrefs(
       "resources", [chargebacks_url(chargeback_rate.id)]
     )
-    expect_result_to_match_hash(@result, "count" => 1)
+    expect_result_to_match_hash(result, "count" => 1)
     expect_request_success
   end
 
@@ -19,7 +19,7 @@ RSpec.describe "chargebacks API" do
     run_get chargebacks_url(chargeback_rate.id)
 
     expect_result_to_match_hash(
-      @result,
+      result,
       "description" => chargeback_rate.description,
       "guid"        => chargeback_rate.guid,
       "id"          => chargeback_rate.id,
@@ -53,7 +53,7 @@ RSpec.describe "chargebacks API" do
     run_get "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}"
 
     expect_result_to_match_hash(
-      @result,
+      result,
       "chargeback_rate_id" => chargeback_rate.id,
       "href"               => "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}",
       "id"                 => chargeback_rate_detail.id,
@@ -73,7 +73,7 @@ RSpec.describe "chargebacks API" do
                  :source  => "used",
                  :enabled => true
       end.to change(ChargebackRateDetail, :count).by(1)
-      expect_result_to_match_hash(@result["results"].first, "rate" => "0", "enabled" => true)
+      expect_result_to_match_hash(result["results"].first, "rate" => "0", "enabled" => true)
       expect_request_success
     end
 
@@ -95,7 +95,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :edit)
       run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => "0.02")
 
-      expect(@result["rate"]).to eq("0.02")
+      expect(result["rate"]).to eq("0.02")
       expect_request_success
       expect(chargeback_rate_detail.reload.rate).to eq("0.02")
     end
@@ -106,7 +106,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :edit)
       run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "rate", :value => "0.02"}]
 
-      expect(@result["rate"]).to eq("0.02")
+      expect(result["rate"]).to eq("0.02")
       expect_request_success
       expect(chargeback_rate_detail.reload.rate).to eq("0.02")
     end

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -60,7 +60,7 @@ describe ApiController do
 
   def expect_result_to_have_custom_actions_hash
     expect_result_to_have_keys(%w(custom_actions))
-    custom_actions = @result["custom_actions"]
+    custom_actions = result["custom_actions"]
     expect_hash_to_have_only_keys(custom_actions, %w(buttons button_groups))
     expect(custom_actions["buttons"].size).to eq(1)
     expect(custom_actions["button_groups"].size).to eq(1)
@@ -74,7 +74,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(@result["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
+      expect(result["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
     end
   end
 
@@ -89,7 +89,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(@result["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
+      expect(result["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
     end
 
     it "supports the custom_actions attribute" do
@@ -107,7 +107,7 @@ describe ApiController do
       run_get services_url(svc1.id), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
-      expect(@result["custom_action_buttons"].size).to eq(3)
+      expect(result["custom_action_buttons"].size).to eq(3)
     end
   end
 
@@ -122,7 +122,7 @@ describe ApiController do
       run_get service_templates_url(template1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      action_specs = @result["actions"]
+      action_specs = result["actions"]
       expect(action_specs.size).to eq(1)
       expect(action_specs.first["name"]).to eq("edit")
     end
@@ -142,7 +142,7 @@ describe ApiController do
       run_get service_templates_url(template1.id), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
-      expect(@result["custom_action_buttons"].size).to eq(3)
+      expect(result["custom_action_buttons"].size).to eq(3)
     end
   end
 
@@ -183,10 +183,10 @@ describe ApiController do
       run_get services_url(svc2.id), :attributes => "custom_actions"
 
       expect_result_to_have_keys(%w(custom_actions))
-      custom_actions = @result["custom_actions"]
+      custom_actions = result["custom_actions"]
       expect_hash_to_have_only_keys(custom_actions, %w(buttons button_groups))
       expect(custom_actions["buttons"].size).to eq(1)
-      button = @result["custom_actions"]["buttons"].first
+      button = result["custom_actions"]["buttons"].first
       expect_hash_to_have_keys(button, %w(id resource_action))
       ra = button["resource_action"]
       expect_hash_to_have_keys(ra, %w(id dialog_id))

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -60,7 +60,7 @@ describe ApiController do
 
   def expect_result_to_have_custom_actions_hash
     expect_result_to_have_keys(%w(custom_actions))
-    custom_actions = result["custom_actions"]
+    custom_actions = response_hash["custom_actions"]
     expect_hash_to_have_only_keys(custom_actions, %w(buttons button_groups))
     expect(custom_actions["buttons"].size).to eq(1)
     expect(custom_actions["button_groups"].size).to eq(1)
@@ -74,7 +74,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(result["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
+      expect(response_hash["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
     end
   end
 
@@ -89,7 +89,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(result["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
+      expect(response_hash["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
     end
 
     it "supports the custom_actions attribute" do
@@ -107,7 +107,7 @@ describe ApiController do
       run_get services_url(svc1.id), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
-      expect(result["custom_action_buttons"].size).to eq(3)
+      expect(response_hash["custom_action_buttons"].size).to eq(3)
     end
   end
 
@@ -122,7 +122,7 @@ describe ApiController do
       run_get service_templates_url(template1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      action_specs = result["actions"]
+      action_specs = response_hash["actions"]
       expect(action_specs.size).to eq(1)
       expect(action_specs.first["name"]).to eq("edit")
     end
@@ -142,7 +142,7 @@ describe ApiController do
       run_get service_templates_url(template1.id), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
-      expect(result["custom_action_buttons"].size).to eq(3)
+      expect(response_hash["custom_action_buttons"].size).to eq(3)
     end
   end
 
@@ -183,10 +183,10 @@ describe ApiController do
       run_get services_url(svc2.id), :attributes => "custom_actions"
 
       expect_result_to_have_keys(%w(custom_actions))
-      custom_actions = result["custom_actions"]
+      custom_actions = response_hash["custom_actions"]
       expect_hash_to_have_only_keys(custom_actions, %w(buttons button_groups))
       expect(custom_actions["buttons"].size).to eq(1)
-      button = result["custom_actions"]["buttons"].first
+      button = response_hash["custom_actions"]["buttons"].first
       expect_hash_to_have_keys(button, %w(id resource_action))
       ra = button["resource_action"]
       expect_hash_to_have_keys(ra, %w(id dialog_id))

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "API entrypoint" do
 
     expect_single_resource_query
     expect_result_to_have_keys(%w(settings))
-    expect(result['settings']).to be_kind_of(Hash)
+    expect(response_hash['settings']).to be_kind_of(Hash)
   end
 
   it "returns a locale" do
@@ -14,6 +14,6 @@ RSpec.describe "API entrypoint" do
 
     run_get entrypoint_url
 
-    expect(%w(en en_US)).to include(result['settings']['locale'])
+    expect(%w(en en_US)).to include(response_hash['settings']['locale'])
   end
 end

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "API entrypoint" do
 
     expect_single_resource_query
     expect_result_to_have_keys(%w(settings))
-    expect(@result['settings']).to be_kind_of(Hash)
+    expect(result['settings']).to be_kind_of(Hash)
   end
 
   it "returns a locale" do
@@ -14,6 +14,6 @@ RSpec.describe "API entrypoint" do
 
     run_get entrypoint_url
 
-    expect(%w(en en_US)).to include(@result['settings']['locale'])
+    expect(%w(en en_US)).to include(result['settings']['locale'])
   end
 end

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -70,7 +70,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = @result["results"].first["id"]
+      group_id = result["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -82,7 +82,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = @result["results"].first["id"]
+      group_id = result["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -97,11 +97,11 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      result = @result["results"].first
-      group_id = result["id"]
+      res = result["results"].first
+      group_id = res["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
 
-      expect_result_to_match_hash(result,
+      expect_result_to_match_hash(res,
                                   "description"      => "sample_group3",
                                   "miq_user_role_id" => role3.id,
                                   "tenant_id"        => tenant3.id)
@@ -121,11 +121,11 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      result = @result["results"].first
-      group_id = result["id"]
+      res = result["results"].first
+      group_id = res["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
 
-      expect_result_to_match_hash(result, sample_group)
+      expect_result_to_match_hash(res, sample_group)
     end
 
     it "supports multiple group creation" do
@@ -136,7 +136,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = @result["results"]
+      results = result["results"]
       group1_id = results.first["id"]
       group2_id = results.second["id"]
       expect(MiqGroup.exists?(group1_id)).to be_truthy

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -70,7 +70,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = result["results"].first["id"]
+      group_id = response_hash["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -82,7 +82,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = result["results"].first["id"]
+      group_id = response_hash["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -97,11 +97,11 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      res = result["results"].first
-      group_id = res["id"]
+      result = response_hash["results"].first
+      group_id = result["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
 
-      expect_result_to_match_hash(res,
+      expect_result_to_match_hash(result,
                                   "description"      => "sample_group3",
                                   "miq_user_role_id" => role3.id,
                                   "tenant_id"        => tenant3.id)
@@ -121,7 +121,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      res = result["results"].first
+      res = response_hash["results"].first
       group_id = res["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
 
@@ -136,7 +136,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = result["results"]
+      results = response_hash["results"]
       group1_id = results.first["id"]
       group2_id = results.second["id"]
       expect(MiqGroup.exists?(group1_id)).to be_truthy

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -26,9 +26,9 @@ describe ApiController do
   before { api_basic_authorize }
 
   def expect_result_to_include_picture_href(source_id)
-    expect_result_to_match_hash(@result, "id" => source_id)
+    expect_result_to_match_hash(result, "id" => source_id)
     expect_result_to_have_keys(%w(id href picture))
-    expect_result_to_match_hash(@result["picture"],
+    expect_result_to_match_hash(result["picture"],
                                 "id"          => picture.id,
                                 "resource_id" => template.id,
                                 "image_href"  => /^http:.*#{picture.image_href}$/)

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -26,9 +26,9 @@ describe ApiController do
   before { api_basic_authorize }
 
   def expect_result_to_include_picture_href(source_id)
-    expect_result_to_match_hash(result, "id" => source_id)
+    expect_result_to_match_hash(response_hash, "id" => source_id)
     expect_result_to_have_keys(%w(id href picture))
-    expect_result_to_match_hash(result["picture"],
+    expect_result_to_match_hash(response_hash["picture"],
                                 "id"          => picture.id,
                                 "resource_id" => template.id,
                                 "image_href"  => /^http:.*#{picture.image_href}$/)

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -107,7 +107,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = @result["results"].first["id"]
+      provider_id = result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       endpoint = ExtManagementSystem.find(provider_id).default_endpoint
       expect_result_to_match_hash(endpoint.attributes, sample_rhevm.slice(*ENDPOINT_ATTRS))
@@ -122,7 +122,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_openshift.except(*ENDPOINT_ATTRS)])
 
-      provider_id = @result["results"].first["id"]
+      provider_id = result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       expect(ExtManagementSystem.find(provider_id).authentications.size).to eq(1)
     end
@@ -136,7 +136,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = @result["results"].first["id"]
+      provider_id = result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
     end
 
@@ -149,7 +149,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_vmware.except(*ENDPOINT_ATTRS)])
 
-      provider_id = @result["results"].first["id"]
+      provider_id = result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid).to eq(default_credentials["userid"])
@@ -165,7 +165,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = @result["results"].first["id"]
+      provider_id = result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid(:default)).to eq(default_credentials["userid"])
@@ -184,7 +184,7 @@ describe ApiController do
       expect_results_to_match_hash("results",
                                    [sample_vmware.except(*ENDPOINT_ATTRS), sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      results = @result["results"]
+      results = result["results"]
       p1_id, p2_id = results.first["id"], results.second["id"]
       expect(ExtManagementSystem.exists?(p1_id)).to be_truthy
       expect(ExtManagementSystem.exists?(p2_id)).to be_truthy

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -107,7 +107,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = result["results"].first["id"]
+      provider_id = response_hash["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       endpoint = ExtManagementSystem.find(provider_id).default_endpoint
       expect_result_to_match_hash(endpoint.attributes, sample_rhevm.slice(*ENDPOINT_ATTRS))
@@ -122,7 +122,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_openshift.except(*ENDPOINT_ATTRS)])
 
-      provider_id = result["results"].first["id"]
+      provider_id = response_hash["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       expect(ExtManagementSystem.find(provider_id).authentications.size).to eq(1)
     end
@@ -136,7 +136,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = result["results"].first["id"]
+      provider_id = response_hash["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
     end
 
@@ -149,7 +149,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_vmware.except(*ENDPOINT_ATTRS)])
 
-      provider_id = result["results"].first["id"]
+      provider_id = response_hash["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid).to eq(default_credentials["userid"])
@@ -165,7 +165,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = result["results"].first["id"]
+      provider_id = response_hash["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid(:default)).to eq(default_credentials["userid"])
@@ -184,7 +184,7 @@ describe ApiController do
       expect_results_to_match_hash("results",
                                    [sample_vmware.except(*ENDPOINT_ATTRS), sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      results = result["results"]
+      results = response_hash["results"]
       p1_id, p2_id = results.first["id"], results.second["id"]
       expect(ExtManagementSystem.exists?(p1_id)).to be_truthy
       expect(ExtManagementSystem.exists?(p2_id)).to be_truthy

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -61,7 +61,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = result["results"].first["id"]
+      task_id = response_hash["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -75,7 +75,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = result["results"].first["id"]
+      task_id = response_hash["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -89,7 +89,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = result["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = response_hash["results"].collect { |r| r["id"] }
       expect(MiqProvisionRequest.exists?(task_id1)).to be_truthy
       expect(MiqProvisionRequest.exists?(task_id2)).to be_truthy
     end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -61,7 +61,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = @result["results"].first["id"]
+      task_id = result["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -75,7 +75,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = @result["results"].first["id"]
+      task_id = result["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -89,7 +89,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = @result["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = result["results"].collect { |r| r["id"] }
       expect(MiqProvisionRequest.exists?(task_id1)).to be_truthy
       expect(MiqProvisionRequest.exists?(task_id2)).to be_truthy
     end

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -117,9 +117,9 @@ describe ApiController do
       run_get(providers_url(provider.id), :attributes => "authentications")
 
       expect_request_success
-      expect_result_to_match_hash(result, "name" => "sample")
+      expect_result_to_match_hash(response_hash, "name" => "sample")
       expect_result_to_have_keys(%w(authentications))
-      authentication = result["authentications"].first
+      authentication = response_hash["authentications"].first
       expect(authentication["userid"]).to eq("admin")
       expect(authentication.key?("password")).to be_falsey
     end
@@ -136,7 +136,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_to_have_keys(%w(configurations))
-      configuration = result["configurations"].first
+      configuration = response_hash["configurations"].first
       authentication = configuration.fetch_path("settings", "authentication")
       expect(authentication).to_not be_nil
       expect(authentication["userid"]).to eq("admin")
@@ -159,8 +159,8 @@ describe ApiController do
       run_get provision_requests_url(request.id)
 
       expect_request_success
-      expect_result_to_match_hash(result, "description" => "sample provision")
-      provision_attrs = result.fetch_path("options", "attrs")
+      expect_result_to_match_hash(response_hash, "description" => "sample provision")
+      provision_attrs = response_hash.fetch_path("options", "attrs")
       expect(provision_attrs).to_not be_nil
       expect(provision_attrs["userid"]).to eq("admin")
       expect(provision_attrs.key?(password_field)).to be_falsey

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -117,9 +117,9 @@ describe ApiController do
       run_get(providers_url(provider.id), :attributes => "authentications")
 
       expect_request_success
-      expect_result_to_match_hash(@result, "name" => "sample")
+      expect_result_to_match_hash(result, "name" => "sample")
       expect_result_to_have_keys(%w(authentications))
-      authentication = @result["authentications"].first
+      authentication = result["authentications"].first
       expect(authentication["userid"]).to eq("admin")
       expect(authentication.key?("password")).to be_falsey
     end
@@ -136,7 +136,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_to_have_keys(%w(configurations))
-      configuration = @result["configurations"].first
+      configuration = result["configurations"].first
       authentication = configuration.fetch_path("settings", "authentication")
       expect(authentication).to_not be_nil
       expect(authentication["userid"]).to eq("admin")
@@ -159,8 +159,8 @@ describe ApiController do
       run_get provision_requests_url(request.id)
 
       expect_request_success
-      expect_result_to_match_hash(@result, "description" => "sample provision")
-      provision_attrs = @result.fetch_path("options", "attrs")
+      expect_result_to_match_hash(result, "description" => "sample provision")
+      provision_attrs = result.fetch_path("options", "attrs")
       expect(provision_attrs).to_not be_nil
       expect(provision_attrs["userid"]).to eq("admin")
       expect(provision_attrs.key?(password_field)).to be_falsey

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -328,7 +328,7 @@ describe ApiController do
       run_get vms_url(vm1.id)
 
       expect_request_success
-      expect(result).to_not have_key("actions")
+      expect(response_hash).to_not have_key("actions")
     end
 
     it "returns actions if authorized" do
@@ -347,7 +347,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_to_have_keys(%w(id href name vendor actions))
-      actions = result["actions"]
+      actions = response_hash["actions"]
       expect(actions.size).to eq(1)
       expect(actions.first["name"]).to eq("suspend")
     end
@@ -360,7 +360,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_to_have_keys(%w(id href name vendor actions))
-      expect(result["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
+      expect(response_hash["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
     end
 
     it "returns actions if asked for with physical attributes" do

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -328,7 +328,7 @@ describe ApiController do
       run_get vms_url(vm1.id)
 
       expect_request_success
-      expect(@result).to_not have_key("actions")
+      expect(result).to_not have_key("actions")
     end
 
     it "returns actions if authorized" do
@@ -347,7 +347,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_to_have_keys(%w(id href name vendor actions))
-      actions = @result["actions"]
+      actions = result["actions"]
       expect(actions.size).to eq(1)
       expect(actions.first["name"]).to eq("suspend")
     end
@@ -360,7 +360,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_to_have_keys(%w(id href name vendor actions))
-      expect(@result["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
+      expect(result["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
     end
 
     it "returns actions if asked for with physical attributes" do

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "reports API" do
         reports_url(report_2.id)
       ]
     )
-    expect_result_to_match_hash(result, "count" => 2, "name" => "reports")
+    expect_result_to_match_hash(response_hash, "count" => 2, "name" => "reports")
     expect_request_success
   end
 
@@ -24,7 +24,7 @@ RSpec.describe "reports API" do
     run_get reports_url(report.id)
 
     expect_result_to_match_hash(
-      result,
+      response_hash,
       "href"  => reports_url(report.id),
       "id"    => report.id,
       "name"  => report.name,
@@ -46,7 +46,7 @@ RSpec.describe "reports API" do
         "#{reports_url(report.id)}/results/#{report_result.to_param}"
       ]
     )
-    expect(result["resources"]).not_to be_any { |resource| resource.key?("result_set") }
+    expect(response_hash["resources"]).not_to be_any { |resource| resource.key?("result_set") }
     expect_request_success
   end
 
@@ -63,7 +63,7 @@ RSpec.describe "reports API" do
     api_basic_authorize
     run_get "#{reports_url(report.id)}/results/#{report_result.to_param}"
 
-    expect_result_to_match_hash(result, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
+    expect_result_to_match_hash(response_hash, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
     expect_request_success
   end
 
@@ -96,7 +96,7 @@ RSpec.describe "reports API" do
     api_basic_authorize
     run_get results_url(report_result.id)
 
-    expect_result_to_match_hash(result, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
+    expect_result_to_match_hash(response_hash, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
     expect_request_success
   end
 
@@ -107,7 +107,7 @@ RSpec.describe "reports API" do
     api_basic_authorize
     run_get "#{reports_url(report.id)}/results/#{report_result.id}"
 
-    expect_result_to_match_hash(result, "result_set" => [])
+    expect_result_to_match_hash(response_hash, "result_set" => [])
     expect_request_success
   end
 
@@ -145,7 +145,7 @@ RSpec.describe "reports API" do
         run_post reports_url, gen_request(:import, :report => serialized_report, :options => options)
       end.to change(MiqReport, :count).by(1)
       expect_result_to_match_hash(
-        result["results"].first["result"],
+        response_hash["results"].first["result"],
         "name"      => "Test Report",
         "title"     => "Test Report",
         "rpt_group" => "Custom",
@@ -155,7 +155,7 @@ RSpec.describe "reports API" do
         "col_order" => %w(foo bar baz),
       )
       expect_result_to_match_hash(
-        result["results"].first,
+        response_hash["results"].first,
         "message" => "Imported Report: [Test Report]",
         "success" => true
       )

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "reports API" do
         reports_url(report_2.id)
       ]
     )
-    expect_result_to_match_hash(@result, "count" => 2, "name" => "reports")
+    expect_result_to_match_hash(result, "count" => 2, "name" => "reports")
     expect_request_success
   end
 
@@ -24,7 +24,7 @@ RSpec.describe "reports API" do
     run_get reports_url(report.id)
 
     expect_result_to_match_hash(
-      @result,
+      result,
       "href"  => reports_url(report.id),
       "id"    => report.id,
       "name"  => report.name,
@@ -35,7 +35,7 @@ RSpec.describe "reports API" do
 
   it "can fetch a report's results" do
     report = FactoryGirl.create(:miq_report_with_results)
-    result = report.miq_report_results.first
+    report_result = report.miq_report_results.first
 
     api_basic_authorize
     run_get "#{reports_url(report.id)}/results"
@@ -43,16 +43,16 @@ RSpec.describe "reports API" do
     expect_result_resources_to_include_hrefs(
       "resources",
       [
-        "#{reports_url(report.id)}/results/#{result.to_param}"
+        "#{reports_url(report.id)}/results/#{report_result.to_param}"
       ]
     )
-    expect(@result["resources"]).not_to be_any { |resource| resource.key?("result_set") }
+    expect(result["resources"]).not_to be_any { |resource| resource.key?("result_set") }
     expect_request_success
   end
 
   it "can fetch a report's result" do
     report = FactoryGirl.create(:miq_report_with_results)
-    result = report.miq_report_results.first
+    report_result = report.miq_report_results.first
     table = Ruport::Data::Table.new(
       :column_names => %w(foo),
       :data         => [%w(bar), %w(baz)]
@@ -61,9 +61,9 @@ RSpec.describe "reports API" do
     allow_any_instance_of(MiqReportResult).to receive(:report_results).and_return(report)
 
     api_basic_authorize
-    run_get "#{reports_url(report.id)}/results/#{result.to_param}"
+    run_get "#{reports_url(report.id)}/results/#{report_result.to_param}"
 
-    expect_result_to_match_hash(@result, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
+    expect_result_to_match_hash(result, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
     expect_request_success
   end
 
@@ -85,7 +85,7 @@ RSpec.describe "reports API" do
 
   it "can fetch a specific result as a primary collection" do
     report = FactoryGirl.create(:miq_report_with_results)
-    result = report.miq_report_results.first
+    report_result = report.miq_report_results.first
     table = Ruport::Data::Table.new(
       :column_names => %w(foo),
       :data         => [%w(bar), %w(baz)]
@@ -94,20 +94,20 @@ RSpec.describe "reports API" do
     allow_any_instance_of(MiqReportResult).to receive(:report_results).and_return(report)
 
     api_basic_authorize
-    run_get results_url(result.id)
+    run_get results_url(report_result.id)
 
-    expect_result_to_match_hash(@result, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
+    expect_result_to_match_hash(result, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
     expect_request_success
   end
 
   it "returns an empty result set if none has been run" do
     report = FactoryGirl.create(:miq_report_with_results)
-    result = report.miq_report_results.first
+    report_result = report.miq_report_results.first
 
     api_basic_authorize
-    run_get "#{reports_url(report.id)}/results/#{result.id}"
+    run_get "#{reports_url(report.id)}/results/#{report_result.id}"
 
-    expect_result_to_match_hash(@result, "result_set" => [])
+    expect_result_to_match_hash(result, "result_set" => [])
     expect_request_success
   end
 
@@ -145,7 +145,7 @@ RSpec.describe "reports API" do
         run_post reports_url, gen_request(:import, :report => serialized_report, :options => options)
       end.to change(MiqReport, :count).by(1)
       expect_result_to_match_hash(
-        @result["results"].first["result"],
+        result["results"].first["result"],
         "name"      => "Test Report",
         "title"     => "Test Report",
         "rpt_group" => "Custom",
@@ -155,7 +155,7 @@ RSpec.describe "reports API" do
         "col_order" => %w(foo bar baz),
       )
       expect_result_to_match_hash(
-        @result["results"].first,
+        result["results"].first,
         "message" => "Imported Report: [Test Report]",
         "success" => true
       )

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -65,10 +65,10 @@ describe ApiController do
     run_get role_url, :expand => "features"
     expect_request_success
 
-    expect(@result).to have_key("name")
-    expect(@result["name"]).to eq(role.name)
-    expect(@result).to have_key("features")
-    expect(@result["features"].size).to eq(fetch_value(role.miq_product_features.count))
+    expect(result).to have_key("name")
+    expect(result["name"]).to eq(role.name)
+    expect(result).to have_key("features")
+    expect(result["features"].size).to eq(fetch_value(role.miq_product_features.count))
 
     expect_result_resources_to_include_data("features", attr.to_s => klass.pluck(attr))
   end
@@ -107,7 +107,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = @result["results"].first["id"]
+      role_id = result["results"].first["id"]
 
       run_get "#{roles_url}/#{role_id}/", :expand => "features"
 
@@ -127,7 +127,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = @result["results"].first["id"]
+      role_id = result["results"].first["id"]
       expect(MiqUserRole.exists?(role_id)).to be_truthy
       role = MiqUserRole.find(role_id)
       sample_role1['features'].each do |feature|
@@ -143,7 +143,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = @result["results"]
+      results = result["results"]
       r1_id = results.first["id"]
       r2_id = results.second["id"]
       expect(MiqUserRole.exists?(r1_id)).to be_truthy

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -65,10 +65,10 @@ describe ApiController do
     run_get role_url, :expand => "features"
     expect_request_success
 
-    expect(result).to have_key("name")
-    expect(result["name"]).to eq(role.name)
-    expect(result).to have_key("features")
-    expect(result["features"].size).to eq(fetch_value(role.miq_product_features.count))
+    expect(response_hash).to have_key("name")
+    expect(response_hash["name"]).to eq(role.name)
+    expect(response_hash).to have_key("features")
+    expect(response_hash["features"].size).to eq(fetch_value(role.miq_product_features.count))
 
     expect_result_resources_to_include_data("features", attr.to_s => klass.pluck(attr))
   end
@@ -107,7 +107,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = result["results"].first["id"]
+      role_id = response_hash["results"].first["id"]
 
       run_get "#{roles_url}/#{role_id}/", :expand => "features"
 
@@ -127,7 +127,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = result["results"].first["id"]
+      role_id = response_hash["results"].first["id"]
       expect(MiqUserRole.exists?(role_id)).to be_truthy
       role = MiqUserRole.find(role_id)
       sample_role1['features'].each do |feature|
@@ -143,7 +143,7 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = result["results"]
+      results = response_hash["results"]
       r1_id = results.first["id"]
       r2_id = results.second["id"]
       expect(MiqUserRole.exists?(r1_id)).to be_truthy

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -58,7 +58,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
-      sc_id = result["results"].first["id"]
+      sc_id = response_hash["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -72,7 +72,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
-      sc_id = result["results"].first["id"]
+      sc_id = response_hash["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -86,7 +86,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sc1"}, {"name" => "sc2"}])
 
-      results = result["results"]
+      results = response_hash["results"]
       sc_id1, sc_id2 = results.first["id"], results.second["id"]
       expect(ServiceTemplateCatalog.find(sc_id1)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id2)).to be_truthy
@@ -109,7 +109,7 @@ describe ApiController do
       expect_request_success
       expect_results_to_match_hash("results", [{"name" => "sc", "description" => "sc description"}])
 
-      sc_id = result["results"].first["id"]
+      sc_id = response_hash["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id).service_templates.pluck(:id)).to match_array([st1.id, st2.id])
@@ -389,8 +389,8 @@ describe ApiController do
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
 
       expect_single_action_result(:success => true, :message => /refreshing dialog fields/i)
-      expect_hash_to_have_keys(result, %w(success href service_template_id service_template_href result))
-      expect_hash_to_have_keys(result["result"], %w(text1))
+      expect_hash_to_have_keys(response_hash, %w(success href service_template_id service_template_href result))
+      expect_hash_to_have_keys(response_hash["result"], %w(text1))
     end
   end
 end

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -58,7 +58,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
-      sc_id = @result["results"].first["id"]
+      sc_id = result["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -72,7 +72,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
-      sc_id = @result["results"].first["id"]
+      sc_id = result["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -86,7 +86,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sc1"}, {"name" => "sc2"}])
 
-      results = @result["results"]
+      results = result["results"]
       sc_id1, sc_id2 = results.first["id"], results.second["id"]
       expect(ServiceTemplateCatalog.find(sc_id1)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id2)).to be_truthy
@@ -109,7 +109,7 @@ describe ApiController do
       expect_request_success
       expect_results_to_match_hash("results", [{"name" => "sc", "description" => "sc description"}])
 
-      sc_id = @result["results"].first["id"]
+      sc_id = result["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id).service_templates.pluck(:id)).to match_array([st1.id, st2.id])
@@ -389,8 +389,8 @@ describe ApiController do
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
 
       expect_single_action_result(:success => true, :message => /refreshing dialog fields/i)
-      expect_hash_to_have_keys(@result, %w(success href service_template_id service_template_href result))
-      expect_hash_to_have_keys(@result["result"], %w(text1))
+      expect_hash_to_have_keys(result, %w(success href service_template_id service_template_href result))
+      expect_hash_to_have_keys(result["result"], %w(text1))
     end
   end
 end

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "service orders API" do
 
     run_get service_orders_url(service_order.id)
 
-    expect_result_to_match_hash(@result, "name" => service_order.name, "state" => service_order.state)
+    expect_result_to_match_hash(result, "name" => service_order.name, "state" => service_order.state)
     expect_request_success
   end
 
@@ -46,7 +46,7 @@ RSpec.describe "service orders API" do
 
     run_post service_orders_url(service_order.id), :action => "edit", :resource => {:name => "new name"}
 
-    expect_result_to_match_hash(@result, "name" => "new name")
+    expect_result_to_match_hash(result, "name" => "new name")
     expect_request_success
   end
 

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "service orders API" do
 
     run_get service_orders_url(service_order.id)
 
-    expect_result_to_match_hash(result, "name" => service_order.name, "state" => service_order.state)
+    expect_result_to_match_hash(response_hash, "name" => service_order.name, "state" => service_order.state)
     expect_request_success
   end
 
@@ -46,7 +46,7 @@ RSpec.describe "service orders API" do
 
     run_post service_orders_url(service_order.id), :action => "edit", :resource => {:name => "new name"}
 
-    expect_result_to_match_hash(result, "name" => "new name")
+    expect_result_to_match_hash(response_hash, "name" => "new name")
     expect_request_success
   end
 

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -27,7 +27,7 @@ describe ApiController do
 
   def expect_result_to_have_provision_dialog
     expect_result_to_have_keys(%w(id href provision_dialog))
-    provision_dialog = result["provision_dialog"]
+    provision_dialog = response_hash["provision_dialog"]
     expect(provision_dialog).to be_kind_of(Hash)
     expect(provision_dialog).to have_key("label")
     expect(provision_dialog).to have_key("dialog_tabs")
@@ -37,7 +37,7 @@ describe ApiController do
   def expect_result_to_have_user_email(email)
     expect_request_success
     expect_result_to_have_keys(%w(id href user))
-    expect(result["user"]["email"]).to eq(email)
+    expect(response_hash["user"]["email"]).to eq(email)
   end
 
   describe "Service Requests query" do

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -27,7 +27,7 @@ describe ApiController do
 
   def expect_result_to_have_provision_dialog
     expect_result_to_have_keys(%w(id href provision_dialog))
-    provision_dialog = @result["provision_dialog"]
+    provision_dialog = result["provision_dialog"]
     expect(provision_dialog).to be_kind_of(Hash)
     expect(provision_dialog).to have_key("label")
     expect(provision_dialog).to have_key("dialog_tabs")
@@ -37,7 +37,7 @@ describe ApiController do
   def expect_result_to_have_user_email(email)
     expect_request_success
     expect_result_to_have_keys(%w(id href user))
-    expect(@result["user"]["email"]).to eq(email)
+    expect(result["user"]["email"]).to eq(email)
   end
 
   describe "Service Requests query" do

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -44,14 +44,14 @@ describe ApiController do
       run_get service_templates_url(template.id), :attributes => "picture"
 
       expect_result_to_have_keys(%w(id href picture))
-      expect_result_to_match_hash(@result, "id" => template.id, "href" => service_templates_url(template.id))
+      expect_result_to_match_hash(result, "id" => template.id, "href" => service_templates_url(template.id))
     end
 
     it "allows queries of the related picture and image_href" do
       run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
 
       expect_result_to_have_keys(%w(id href picture))
-      expect_result_to_match_hash(@result["picture"],
+      expect_result_to_match_hash(result["picture"],
                                   "id"          => picture.id,
                                   "resource_id" => template.id,
                                   "image_href"  => /^http:.*#{picture.image_href}$/)

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -44,14 +44,14 @@ describe ApiController do
       run_get service_templates_url(template.id), :attributes => "picture"
 
       expect_result_to_have_keys(%w(id href picture))
-      expect_result_to_match_hash(result, "id" => template.id, "href" => service_templates_url(template.id))
+      expect_result_to_match_hash(response_hash, "id" => template.id, "href" => service_templates_url(template.id))
     end
 
     it "allows queries of the related picture and image_href" do
       run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
 
       expect_result_to_have_keys(%w(id href picture))
-      expect_result_to_match_hash(result["picture"],
+      expect_result_to_match_hash(response_hash["picture"],
                                   "id"          => picture.id,
                                   "resource_id" => template.id,
                                   "image_href"  => /^http:.*#{picture.image_href}$/)

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -224,7 +224,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_request_success
-      expect(@result).to declare_actions("retire")
+      expect(result).to declare_actions("retire")
     end
 
     it "returns reconfigure action for reconfigurable services" do
@@ -238,7 +238,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_request_success
-      expect(@result).to declare_actions("retire", "reconfigure")
+      expect(result).to declare_actions("retire", "reconfigure")
     end
 
     it "accepts action when service is reconfigurable" do

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -224,7 +224,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_request_success
-      expect(result).to declare_actions("retire")
+      expect(response_hash).to declare_actions("retire")
     end
 
     it "returns reconfigure action for reconfigurable services" do
@@ -238,7 +238,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_request_success
-      expect(result).to declare_actions("retire", "reconfigure")
+      expect(response_hash).to declare_actions("retire", "reconfigure")
     end
 
     it "accepts action when service is reconfigurable" do

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -47,7 +47,7 @@ describe ApiController do
 
         expect { run_post tags_url, options }.to change(Tag, :count).by(1)
 
-        tag = Tag.find(result["results"].first["id"])
+        tag = Tag.find(response_hash["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -62,7 +62,7 @@ describe ApiController do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:id => category.id}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(result["results"].first["id"])
+        tag = Tag.find(response_hash["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -77,7 +77,7 @@ describe ApiController do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:name => category.name}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(result["results"].first["id"])
+        tag = Tag.find(response_hash["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -91,7 +91,7 @@ describe ApiController do
         expect do
           run_post "#{categories_url(category.id)}/tags", :name => "test_tag", :description => "Test Tag"
         end.to change(Tag, :count).by(1)
-        tag = Tag.find(result["results"].first["id"])
+        tag = Tag.find(response_hash["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -115,7 +115,7 @@ describe ApiController do
         expect do
           run_post tags_url(tag.id), gen_request(:edit, :name => "new_name")
         end.to change { classification.reload.tag.name }.to("#{category.tag.name}/new_name")
-        expect(result["name"]).to eq("#{category.tag.name}/new_name")
+        expect(response_hash["name"]).to eq("#{category.tag.name}/new_name")
         expect_request_success
       end
 
@@ -188,7 +188,7 @@ describe ApiController do
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect_result_to_match_hash(
-          result,
+          response_hash,
           "results" => [
             {"success" => true, "message" => "tags id: #{tag1.id} deleting"},
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}
@@ -212,7 +212,7 @@ describe ApiController do
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect_result_to_match_hash(
-          result,
+          response_hash,
           "results" => [
             {"success" => true, "message" => "tags id: #{tag1.id} deleting"},
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -47,7 +47,7 @@ describe ApiController do
 
         expect { run_post tags_url, options }.to change(Tag, :count).by(1)
 
-        tag = Tag.find(@result["results"].first["id"])
+        tag = Tag.find(result["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -62,7 +62,7 @@ describe ApiController do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:id => category.id}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(@result["results"].first["id"])
+        tag = Tag.find(result["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -77,7 +77,7 @@ describe ApiController do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:name => category.name}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(@result["results"].first["id"])
+        tag = Tag.find(result["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -91,7 +91,7 @@ describe ApiController do
         expect do
           run_post "#{categories_url(category.id)}/tags", :name => "test_tag", :description => "Test Tag"
         end.to change(Tag, :count).by(1)
-        tag = Tag.find(@result["results"].first["id"])
+        tag = Tag.find(result["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -115,7 +115,7 @@ describe ApiController do
         expect do
           run_post tags_url(tag.id), gen_request(:edit, :name => "new_name")
         end.to change { classification.reload.tag.name }.to("#{category.tag.name}/new_name")
-        expect(@result["name"]).to eq("#{category.tag.name}/new_name")
+        expect(result["name"]).to eq("#{category.tag.name}/new_name")
         expect_request_success
       end
 
@@ -188,7 +188,7 @@ describe ApiController do
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect_result_to_match_hash(
-          @result,
+          result,
           "results" => [
             {"success" => true, "message" => "tags id: #{tag1.id} deleting"},
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}
@@ -212,7 +212,7 @@ describe ApiController do
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect_result_to_match_hash(
-          @result,
+          result,
           "results" => [
             {"success" => true, "message" => "tags id: #{tag1.id} deleting"},
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "tenants API" do
     run_get tenants_url(tenant.id)
 
     expect_result_to_match_hash(
-      result,
+      response_hash,
       "href"        => tenants_url(tenant.id),
       "id"          => tenant.id,
       "name"        => "Test Tenant",

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "tenants API" do
     run_get tenants_url(tenant.id)
 
     expect_result_to_match_hash(
-      @result,
+      result,
       "href"        => tenants_url(tenant.id),
       "id"          => tenant.id,
       "name"        => "Test Tenant",

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "users API" do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = result["results"].first["id"]
+      user_id = response_hash["results"].first["id"]
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -134,7 +134,7 @@ RSpec.describe "users API" do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = result["results"].first["id"]
+      user_id = response_hash["results"].first["id"]
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -146,7 +146,7 @@ RSpec.describe "users API" do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = result["results"]
+      results = response_hash["results"]
       user1_hash, user2_hash = results.first, results.second
       expect(User.exists?(user1_hash["id"])).to be_truthy
       expect(User.exists?(user2_hash["id"])).to be_truthy

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "users API" do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = @result["results"].first["id"]
+      user_id = result["results"].first["id"]
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -134,7 +134,7 @@ RSpec.describe "users API" do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = @result["results"].first["id"]
+      user_id = result["results"].first["id"]
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -146,7 +146,7 @@ RSpec.describe "users API" do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = @result["results"]
+      results = result["results"]
       user1_hash, user2_hash = results.first, results.second
       expect(User.exists?(user1_hash["id"])).to be_truthy
       expect(User.exists?(user2_hash["id"])).to be_truthy

--- a/spec/requests/api/versioning_spec.rb
+++ b/spec/requests/api/versioning_spec.rb
@@ -21,7 +21,7 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(%w(versions))
 
-      versions = @result["versions"]
+      versions = result["versions"]
 
       # Let's get the first version identifier
       expect(versions).to_not be_nil

--- a/spec/requests/api/versioning_spec.rb
+++ b/spec/requests/api/versioning_spec.rb
@@ -21,7 +21,7 @@ describe ApiController do
       expect_single_resource_query
       expect_result_to_have_keys(%w(versions))
 
-      versions = result["versions"]
+      versions = response_hash["versions"]
 
       # Let's get the first version identifier
       expect(versions).to_not be_nil

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -16,12 +16,8 @@ module ApiSpecHelper
     "Accept"       => "application/json"
   }
 
-  def result
-    case response.status
-    when Rack::Utils.status_code(:no_content)   then {}
-    when Rack::Utils.status_code(:unauthorized) then response.body
-    else JSON.parse(response.body)
-    end
+  def response_hash
+    JSON.parse(response.body)
   end
 
   def update_headers(headers)
@@ -208,8 +204,8 @@ module ApiSpecHelper
     expect(response).to have_http_status(:bad_request)
     return if error_message.blank?
 
-    expect(result).to have_key("error")
-    expect(result["error"]["message"]).to match(error_message)
+    expect(response_hash).to have_key("error")
+    expect(response_hash["error"]["message"]).to match(error_message)
   end
 
   def expect_user_unauthorized
@@ -225,28 +221,28 @@ module ApiSpecHelper
   end
 
   def expect_result_resources_to_include_data(collection, data)
-    expect(result).to have_key(collection)
+    expect(response_hash).to have_key(collection)
     fetch_value(data).each do |key, value|
       value_list = fetch_value(value)
-      expect(result[collection].size).to eq(value_list.size)
-      expect(result[collection].collect { |r| r[key] }).to match_array(value_list)
+      expect(response_hash[collection].size).to eq(value_list.size)
+      expect(response_hash[collection].collect { |r| r[key] }).to match_array(value_list)
     end
   end
 
   def expect_result_resources_to_include_hrefs(collection, hrefs)
-    expect(result).to have_key(collection)
+    expect(response_hash).to have_key(collection)
     href_list = fetch_value(hrefs)
-    expect(result[collection].size).to eq(href_list.size)
+    expect(response_hash[collection].size).to eq(href_list.size)
     href_list.each do |href|
-      expect(resources_include_suffix?(result[collection], "href", href)).to be_truthy
+      expect(resources_include_suffix?(response_hash[collection], "href", href)).to be_truthy
     end
   end
 
   def expect_result_resources_to_match_key_data(collection, key, values)
     value_list = fetch_value(values)
-    expect(result).to have_key(collection)
-    expect(result[collection].size).to eq(value_list.size)
-    value_list.zip(result[collection]) do |value, hash|
+    expect(response_hash).to have_key(collection)
+    expect(response_hash[collection].size).to eq(value_list.size)
+    value_list.zip(response_hash[collection]) do |value, hash|
       expect(hash).to have_key(key)
       expect(hash[key]).to match(value)
     end
@@ -254,12 +250,12 @@ module ApiSpecHelper
 
   def expect_result_resource_keys_to_match_pattern(collection, key, pattern)
     pattern = fetch_value(pattern)
-    expect(result).to have_key(collection)
-    expect(result[collection].all? { |result| result[key].match(pattern) }).to be_truthy
+    expect(response_hash).to have_key(collection)
+    expect(response_hash[collection].all? { |result| result[key].match(pattern) }).to be_truthy
   end
 
   def expect_result_to_have_keys(keys)
-    expect_hash_to_have_keys(result, keys)
+    expect_hash_to_have_keys(response_hash, keys)
   end
 
   def expect_hash_to_have_keys(hash, keys)
@@ -267,7 +263,7 @@ module ApiSpecHelper
   end
 
   def expect_result_to_have_only_keys(keys)
-    expect_hash_to_have_only_keys(result, keys)
+    expect_hash_to_have_only_keys(response_hash, keys)
   end
 
   def expect_hash_to_have_only_keys(hash, keys)
@@ -284,8 +280,8 @@ module ApiSpecHelper
   end
 
   def expect_results_to_match_hash(collection, result_hash)
-    expect(result).to have_key(collection)
-    fetch_value(result_hash).zip(result[collection]) do |expected, actual|
+    expect(response_hash).to have_key(collection)
+    fetch_value(result_hash).zip(response_hash[collection]) do |expected, actual|
       expect_result_to_match_hash(actual, expected)
     end
   end
@@ -295,26 +291,26 @@ module ApiSpecHelper
   end
 
   def expect_result_resource_keys_to_be_like_klass(collection, key, klass)
-    expect(result).to have_key(collection)
-    expect(result[collection].all? { |result| result[key].kind_of?(klass) }).to be_truthy
+    expect(response_hash).to have_key(collection)
+    expect(response_hash[collection].all? { |result| result[key].kind_of?(klass) }).to be_truthy
   end
 
   def expect_result_resources_to_include_keys(collection, keys)
-    expect(result).to have_key(collection)
-    results = result[collection]
+    expect(response_hash).to have_key(collection)
+    results = response_hash[collection]
     fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy, "resource missing: #{key}" }
   end
 
   def expect_result_resources_to_have_only_keys(collection, keys)
     key_list = fetch_value(keys).sort
-    expect(result).to have_key(collection)
-    expect(result[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
+    expect(response_hash).to have_key(collection)
+    expect(response_hash[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
   end
 
   def expect_results_match_key_pattern(collection, key, value)
     pattern = fetch_value(value)
-    expect(result).to have_key(collection)
-    expect(result[collection].all? { |result| result[key].match(pattern) }).to be_truthy
+    expect(response_hash).to have_key(collection)
+    expect(response_hash[collection].all? { |result| result[key].match(pattern) }).to be_truthy
   end
 
   def expect_result_to_represent_task(result)
@@ -326,33 +322,33 @@ module ApiSpecHelper
 
   def expect_empty_query_result(collection)
     expect_request_success
-    expect(result).to include("name" => collection.to_s, "resources" => [])
+    expect(response_hash).to include("name" => collection.to_s, "resources" => [])
   end
 
   def expect_query_result(collection, subcount, count = nil)
     expect_request_success
-    expect(result).to include("name" => collection.to_s, "subcount" => fetch_value(subcount))
-    expect(result["resources"].size).to eq(fetch_value(subcount))
-    expect(result["count"]).to eq(fetch_value(count)) if count.present?
+    expect(response_hash).to include("name" => collection.to_s, "subcount" => fetch_value(subcount))
+    expect(response_hash["resources"].size).to eq(fetch_value(subcount))
+    expect(response_hash["count"]).to eq(fetch_value(count)) if count.present?
   end
 
   def expect_single_resource_query(attr_hash = {})
     expect_request_success
-    expect_result_to_match_hash(result, fetch_value(attr_hash))
+    expect_result_to_match_hash(response_hash, fetch_value(attr_hash))
   end
 
   def expect_single_action_result(options = {})
     expect_request_success
-    expect(result).to include("success" => options[:success]) if options.key?(:success)
-    expect(result).to include("message" => a_string_matching(options[:message])) if options[:message]
-    expect(result).to include("href" => a_string_matching(fetch_value(options[:href]))) if options[:href]
-    expect_result_to_represent_task(result) if options[:task]
+    expect(response_hash).to include("success" => options[:success]) if options.key?(:success)
+    expect(response_hash).to include("message" => a_string_matching(options[:message])) if options[:message]
+    expect(response_hash).to include("href" => a_string_matching(fetch_value(options[:href]))) if options[:href]
+    expect_result_to_represent_task(response_hash) if options[:task]
   end
 
   def expect_multiple_action_result(count, options = {})
     expect_request_success
-    expect(result).to have_key("results")
-    results = result["results"]
+    expect(response_hash).to have_key("results")
+    results = response_hash["results"]
     expect(results.size).to eq(count)
     expect(results.all? { |r| r["success"] }).to be_truthy
 
@@ -362,8 +358,8 @@ module ApiSpecHelper
   def expect_tagging_result(tagging_results)
     expect_request_success
     tag_results = fetch_value(tagging_results)
-    expect(result).to have_key("results")
-    results = result["results"]
+    expect(response_hash).to have_key("results")
+    results = response_hash["results"]
     expect(results.size).to eq(tag_results.size)
     tag_results.zip(results) do |tag_result, result|
       expect(result).to include(

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -16,19 +16,12 @@ module ApiSpecHelper
     "Accept"       => "application/json"
   }
 
-  API_STATUS = Rack::Utils::HTTP_STATUS_CODES.merge(0 => "Network Connection Error")
-
-  def parse_response
-    @code    = response.status
-    @result  = case @code
-               when Rack::Utils.status_code(:no_content)   then {}
-               when Rack::Utils.status_code(:unauthorized) then response.body
-               else JSON.parse(response.body)
-               end
-    @success = response.success?
-    @status  = API_STATUS[@code] || (@success ? Rack::Utils.status_code(:ok) : Rack::Utils.status_code(:bad_request))
-    @message = @result.kind_of?(Hash) ? @result.fetch_path("error", "message").to_s : @result
-    @success
+  def result
+    case response.status
+    when Rack::Utils.status_code(:no_content)   then {}
+    when Rack::Utils.status_code(:unauthorized) then response.body
+    else JSON.parse(response.body)
+    end
   end
 
   def update_headers(headers)
@@ -45,27 +38,22 @@ module ApiSpecHelper
   def run_get(url, options = {})
     headers = options.delete(:headers) || {}
     get url, :params => options.stringify_keys, :headers => update_headers(headers)
-    parse_response
   end
 
   def run_post(url, body = {}, headers = {})
     post url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
-    parse_response
   end
 
   def run_put(url, body = {}, headers = {})
     put url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
-    parse_response
   end
 
   def run_patch(url, body = {}, headers = {})
     patch url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
-    parse_response
   end
 
   def run_delete(url, headers = {})
     delete url, :headers => update_headers(headers)
-    parse_response
   end
 
   def resources_include_suffix?(resources, key, suffix)
@@ -209,56 +197,56 @@ module ApiSpecHelper
   # Rest API Expects
 
   def expect_request_success
-    expect(@code).to eq(Rack::Utils.status_code(:ok))           # 200
+    expect(response).to have_http_status(:ok)
   end
 
   def expect_request_success_with_no_content
-    expect(@code).to eq(Rack::Utils.status_code(:no_content))   # 204
+    expect(response).to have_http_status(:no_content)
   end
 
   def expect_bad_request(error_message = nil)
-    expect(@code).to eq(Rack::Utils.status_code(:bad_request))  # 400
+    expect(response).to have_http_status(:bad_request)
     return if error_message.blank?
 
-    expect(@result).to have_key("error")
-    expect(@result["error"]["message"]).to match(error_message)
+    expect(result).to have_key("error")
+    expect(result["error"]["message"]).to match(error_message)
   end
 
   def expect_user_unauthorized
-    expect(@code).to eq(Rack::Utils.status_code(:unauthorized)) # 401
+    expect(response).to have_http_status(:unauthorized)
   end
 
   def expect_request_forbidden
-    expect(@code).to eq(Rack::Utils.status_code(:forbidden))    # 403
+    expect(response).to have_http_status(:forbidden)
   end
 
   def expect_resource_not_found
-    expect(@code).to eq(Rack::Utils.status_code(:not_found))    # 404
+    expect(response).to have_http_status(:not_found)
   end
 
   def expect_result_resources_to_include_data(collection, data)
-    expect(@result).to have_key(collection)
+    expect(result).to have_key(collection)
     fetch_value(data).each do |key, value|
       value_list = fetch_value(value)
-      expect(@result[collection].size).to eq(value_list.size)
-      expect(@result[collection].collect { |r| r[key] }).to match_array(value_list)
+      expect(result[collection].size).to eq(value_list.size)
+      expect(result[collection].collect { |r| r[key] }).to match_array(value_list)
     end
   end
 
   def expect_result_resources_to_include_hrefs(collection, hrefs)
-    expect(@result).to have_key(collection)
+    expect(result).to have_key(collection)
     href_list = fetch_value(hrefs)
-    expect(@result[collection].size).to eq(href_list.size)
+    expect(result[collection].size).to eq(href_list.size)
     href_list.each do |href|
-      expect(resources_include_suffix?(@result[collection], "href", href)).to be_truthy
+      expect(resources_include_suffix?(result[collection], "href", href)).to be_truthy
     end
   end
 
   def expect_result_resources_to_match_key_data(collection, key, values)
     value_list = fetch_value(values)
-    expect(@result).to have_key(collection)
-    expect(@result[collection].size).to eq(value_list.size)
-    value_list.zip(@result[collection]) do |value, hash|
+    expect(result).to have_key(collection)
+    expect(result[collection].size).to eq(value_list.size)
+    value_list.zip(result[collection]) do |value, hash|
       expect(hash).to have_key(key)
       expect(hash[key]).to match(value)
     end
@@ -266,12 +254,12 @@ module ApiSpecHelper
 
   def expect_result_resource_keys_to_match_pattern(collection, key, pattern)
     pattern = fetch_value(pattern)
-    expect(@result).to have_key(collection)
-    expect(@result[collection].all? { |result| result[key].match(pattern) }).to be_truthy
+    expect(result).to have_key(collection)
+    expect(result[collection].all? { |result| result[key].match(pattern) }).to be_truthy
   end
 
   def expect_result_to_have_keys(keys)
-    expect_hash_to_have_keys(@result, keys)
+    expect_hash_to_have_keys(result, keys)
   end
 
   def expect_hash_to_have_keys(hash, keys)
@@ -279,7 +267,7 @@ module ApiSpecHelper
   end
 
   def expect_result_to_have_only_keys(keys)
-    expect_hash_to_have_only_keys(@result, keys)
+    expect_hash_to_have_only_keys(result, keys)
   end
 
   def expect_hash_to_have_only_keys(hash, keys)
@@ -296,8 +284,8 @@ module ApiSpecHelper
   end
 
   def expect_results_to_match_hash(collection, result_hash)
-    expect(@result).to have_key(collection)
-    fetch_value(result_hash).zip(@result[collection]) do |expected, actual|
+    expect(result).to have_key(collection)
+    fetch_value(result_hash).zip(result[collection]) do |expected, actual|
       expect_result_to_match_hash(actual, expected)
     end
   end
@@ -307,26 +295,26 @@ module ApiSpecHelper
   end
 
   def expect_result_resource_keys_to_be_like_klass(collection, key, klass)
-    expect(@result).to have_key(collection)
-    expect(@result[collection].all? { |result| result[key].kind_of?(klass) }).to be_truthy
+    expect(result).to have_key(collection)
+    expect(result[collection].all? { |result| result[key].kind_of?(klass) }).to be_truthy
   end
 
   def expect_result_resources_to_include_keys(collection, keys)
-    expect(@result).to have_key(collection)
-    results = @result[collection]
+    expect(result).to have_key(collection)
+    results = result[collection]
     fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy, "resource missing: #{key}" }
   end
 
   def expect_result_resources_to_have_only_keys(collection, keys)
     key_list = fetch_value(keys).sort
-    expect(@result).to have_key(collection)
-    expect(@result[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
+    expect(result).to have_key(collection)
+    expect(result[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
   end
 
   def expect_results_match_key_pattern(collection, key, value)
     pattern = fetch_value(value)
-    expect(@result).to have_key(collection)
-    expect(@result[collection].all? { |result| result[key].match(pattern) }).to be_truthy
+    expect(result).to have_key(collection)
+    expect(result[collection].all? { |result| result[key].match(pattern) }).to be_truthy
   end
 
   def expect_result_to_represent_task(result)
@@ -338,33 +326,33 @@ module ApiSpecHelper
 
   def expect_empty_query_result(collection)
     expect_request_success
-    expect(@result).to include("name" => collection.to_s, "resources" => [])
+    expect(result).to include("name" => collection.to_s, "resources" => [])
   end
 
   def expect_query_result(collection, subcount, count = nil)
     expect_request_success
-    expect(@result).to include("name" => collection.to_s, "subcount" => fetch_value(subcount))
-    expect(@result["resources"].size).to eq(fetch_value(subcount))
-    expect(@result["count"]).to eq(fetch_value(count)) if count.present?
+    expect(result).to include("name" => collection.to_s, "subcount" => fetch_value(subcount))
+    expect(result["resources"].size).to eq(fetch_value(subcount))
+    expect(result["count"]).to eq(fetch_value(count)) if count.present?
   end
 
   def expect_single_resource_query(attr_hash = {})
     expect_request_success
-    expect_result_to_match_hash(@result, fetch_value(attr_hash))
+    expect_result_to_match_hash(result, fetch_value(attr_hash))
   end
 
   def expect_single_action_result(options = {})
     expect_request_success
-    expect(@result).to include("success" => options[:success]) if options.key?(:success)
-    expect(@result).to include("message" => a_string_matching(options[:message])) if options[:message]
-    expect(@result).to include("href" => a_string_matching(fetch_value(options[:href]))) if options[:href]
-    expect_result_to_represent_task(@result) if options[:task]
+    expect(result).to include("success" => options[:success]) if options.key?(:success)
+    expect(result).to include("message" => a_string_matching(options[:message])) if options[:message]
+    expect(result).to include("href" => a_string_matching(fetch_value(options[:href]))) if options[:href]
+    expect_result_to_represent_task(result) if options[:task]
   end
 
   def expect_multiple_action_result(count, options = {})
     expect_request_success
-    expect(@result).to have_key("results")
-    results = @result["results"]
+    expect(result).to have_key("results")
+    results = result["results"]
     expect(results.size).to eq(count)
     expect(results.all? { |r| r["success"] }).to be_truthy
 
@@ -374,8 +362,8 @@ module ApiSpecHelper
   def expect_tagging_result(tagging_results)
     expect_request_success
     tag_results = fetch_value(tagging_results)
-    expect(@result).to have_key("results")
-    results = @result["results"]
+    expect(result).to have_key("results")
+    results = result["results"]
     expect(results.size).to eq(tag_results.size)
     tag_results.zip(results) do |tag_result, result|
       expect(result).to include(


### PR DESCRIPTION
Each request method was calling `#parse_response` after the request was
submitted. This method was doing some things that were either unused, or
could be easily replaced by a method built into the request spec
framework.

In particular:

* References to `@code` could be replaced with `response.status`, or use
  the built-in http status matcher
* `@success` was not used externally
* `@status` was not used
* `@message` was not used
* `@result` was used quite extensively, so was replaced with a method

The net result is that the state has been reduced, as has the work done
on each request.

/cc @jrafanie :scissors: :fire: etc..
/cc @abellotti @gtanzillo 
@miq-bot add-label test, refactoring, api