### PR TITLE
Use white list when requeueing

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -30,7 +30,7 @@ class MiqQueue < ApplicationRecord
 
   PRIORITY_WHICH  = [:max, :high, :normal, :low, :min]
   PRIORITY_DIR    = [:higher, :lower]
-  WHITE_LIST      = MiqQueue.column_names.map(&:to_sym) - [:id]
+  COLUMNS_FOR_REQUEUE = MiqQueue.column_names.map(&:to_sym) - [:id]
 
   def self.priority(which, dir = nil, by = 0)
     raise ArgumentError, "which must be an Integer or one of #{PRIORITY_WHICH.join(", ")}" unless which.kind_of?(Integer) || PRIORITY_WHICH.include?(which)
@@ -416,9 +416,8 @@ class MiqQueue < ApplicationRecord
   end
 
   def requeue(options = {})
-    options.reverse_merge!(attributes.symbolize_keys.slice(*WHITE_LIST))
-    options.delete(:id)
-    MiqQueue.put(options)
+    options.reverse_merge!(attributes.symbolize_keys)
+    MiqQueue.put(options.slice(*COLUMNS_FOR_REQUEUE))
   end
 
   def check_for_timeout(log_prefix = "MIQ(MiqQueue.check_for_timeout)", grace = 10.seconds, timeout = msg_timeout.seconds)

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -30,6 +30,7 @@ class MiqQueue < ApplicationRecord
 
   PRIORITY_WHICH  = [:max, :high, :normal, :low, :min]
   PRIORITY_DIR    = [:higher, :lower]
+  WHITE_LIST      = MiqQueue.column_names.map(&:to_sym) - [:id]
 
   def self.priority(which, dir = nil, by = 0)
     raise ArgumentError, "which must be an Integer or one of #{PRIORITY_WHICH.join(", ")}" unless which.kind_of?(Integer) || PRIORITY_WHICH.include?(which)
@@ -415,7 +416,7 @@ class MiqQueue < ApplicationRecord
   end
 
   def requeue(options = {})
-    options.reverse_merge!(attributes.symbolize_keys)
+    options.reverse_merge!(attributes.symbolize_keys.slice(*WHITE_LIST))
     options.delete(:id)
     MiqQueue.put(options)
   end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -275,6 +275,7 @@ describe MiqQueue do
       @new_msg = @msg.requeue(options)
       @new_msg_id = @new_msg.id
 
+      expect(@new_msg.attributes.keys.exclude?('no_such_key')).to be_truthy
       expect(@msg.id).not_to eq(@msg.requeue(options).id)
     end
 

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -268,6 +268,7 @@ describe MiqQueue do
         :msg_timeout => 60.minutes
       }
 
+      @msg.update_attributes!(:state => 'error')
       @old_msg_id = @msg.id
 
       @new_msg = @msg.requeue(options)

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -265,7 +265,8 @@ describe MiqQueue do
         :args        => ['rq_message', 1, ["A", "B", "C"], 'AUTOMATION', 'gp', 'warn', 'automate message', 'ae_fsm_started', 'ae_state_started', 'ae_state_retries'],
         :zone        => @zone.name,
         :role        => 'automate',
-        :msg_timeout => 60.minutes
+        :msg_timeout => 60.minutes,
+        :no_such_key => 'Does not exist'
       }
 
       @msg.update_attributes!(:state => 'error')


### PR DESCRIPTION
Fixes #6943

The attributes function includes the custom attributes like
region_number and region_description. Use a white list to only
include the column names for MiqQueue and skip over the custom
attributes.