### PR TITLE
Fix save_hosts_inventory handling of 10+ duplicate hostnames

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -161,7 +161,7 @@ module EmsRefresh::SaveInventoryInfra
           found.save!
         rescue ActiveRecord::RecordInvalid
           raise if found.errors[:name].blank?
-          old_name = Host.where("name LIKE ?", "#{found.name.sub(/ - \d+$/, "")}%").order("name DESC").first.name
+          old_name = Host.where("name LIKE ?", "#{found.name.sub(/ - \d+$/, "")}%").order("LENGTH(name) DESC").order("name DESC").first.name
           found.name = old_name =~ / - \d+$/ ? old_name.succ : "#{old_name} - 2"
           retry
         end

--- a/spec/models/ems_refresh/save_inventory_infra_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_infra_spec.rb
@@ -110,4 +110,26 @@ describe EmsRefresh::SaveInventoryInfra do
       expect(refresher.look_up_host(host_duplicate_hostname.hostname, host_duplicate_hostname.ipaddress, :ems_ref => host_duplicate_hostname.ems_ref, :ems_id => 0)).to be_nil
     end
   end
+
+  context ".save_hosts_inventory" do
+    before(:each) do
+      @zone   = FactoryGirl.create(:zone)
+      @ems    = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    end
+
+    it "should handle >10 hosts with duplicate hostnames" do
+      data = Array.new(11) do |i|
+        {
+          :name     => 'localhost',
+          :hostname => 'localhost',
+          :ems_ref  => "host-#{i}"
+        }
+      end
+
+      EmsRefresh.save_hosts_inventory(@ems, data)
+
+      hosts = Host.all
+      expect(hosts.length).to eq(data.length)
+    end
+  end
 end


### PR DESCRIPTION
When there are more than 10 duplicate hostnames, the default order will be "localhost - 9", "localhost - 8", ..., "localhost - 2", "localhost - 10", "localhost" which puts save_host_inventory into an infinite loop trying to save localhost - 10, never incrementing to localhost - 11.

This will do a natural sort so that "localhost - 10" will always be returned before "localhost - 9"

Fixes https://github.com/ManageIQ/manageiq/issues/7082