### PR TITLE
[api] Enhancement to support refresh_dialog_fields action on /api/service_dialogs

### DIFF
--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -137,9 +137,6 @@ class ApiController
       refresh_fields.each do |field|
         dynamic_field = dialog.field(field)
         return action_result(false, "Unknown dialog field #{field} specified") unless dynamic_field
-        unless dynamic_field.respond_to?(:update_and_serialize_values)
-          return action_result(false, "Dialog field #{field} specified cannot be refreshed")
-        end
         result[field] = dynamic_field.update_and_serialize_values
       end
       action_result(true, "Refreshing dialog fields for #{resource_ident}", :result => result)

--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -132,6 +132,19 @@ class ApiController
       end
     end
 
+    def refresh_dialog_fields_action(dialog, refresh_fields, resource_ident)
+      result = {}
+      refresh_fields.each do |field|
+        dynamic_field = dialog.field(field)
+        return action_result(false, "Unknown dialog field #{field} specified") unless dynamic_field
+        unless dynamic_field.respond_to?(:update_and_serialize_values)
+          return action_result(false, "Dialog field #{field} specified cannot be refreshed")
+        end
+        result[field] = dynamic_field.update_and_serialize_values
+      end
+      action_result(true, "Refreshing dialog fields for #{resource_ident}", :result => result)
+    end
+
     private
 
     def add_subcollection_data_to_resource(resource, type, subcollection_data)

--- a/app/controllers/api_controller/service_dialogs.rb
+++ b/app/controllers/api_controller/service_dialogs.rb
@@ -14,5 +14,44 @@ class ApiController
       end
       show_generic(:service_dialogs)
     end
+
+    def refresh_dialog_fields_resource_service_dialogs(type, id = nil, data = nil)
+      raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        service_dialog = resource_search(id, type, klass)
+        api_log_info("Refreshing Dialog Fields for #{service_dialog_ident(service_dialog)}")
+
+        refresh_dialog_fields_service_dialog(service_dialog, data)
+      end
+    end
+
+    private
+
+    def service_dialog_ident(service_dialog)
+      "Service Dialog id:#{service_dialog.id} label:'#{service_dialog.label}'"
+    end
+
+    def refresh_dialog_fields_service_dialog(service_dialog, data)
+      data ||= {}
+      dialog_fields = Hash(data["dialog_fields"])
+      refresh_fields = data["fields"]
+      return action_result(false, "Must specify fields to refresh") if refresh_fields.blank?
+
+      define_service_dialog_fields(service_dialog, dialog_fields)
+
+      refresh_dialog_fields_action(service_dialog, refresh_fields, service_dialog_ident(service_dialog))
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def define_service_dialog_fields(service_dialog, dialog_fields)
+      ident = service_dialog_ident(service_dialog)
+      dialog_fields.each do |key, value|
+        dialog_field = service_dialog.field(key)
+        raise BadRequestError, "Dialog field #{key} specified does not exist in #{ident}" if dialog_field.nil?
+        dialog_field.value = value
+      end
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -727,8 +727,16 @@
     :options:
     - :collection
     - :subcollection
-    :methods: *70174834086080
+    :methods: *70174834085860
     :klass: Dialog
+    :collection_actions:
+      :post:
+      - :name: refresh_dialog_fields
+        :identifier: svc_catalog_provision
+    :resource_actions:
+      :post:
+      - :name: refresh_dialog_fields
+        :identifier: svc_catalog_provision
   :service_orders:
     :description: Service Orders
     :identifier: svc_catalog_provision

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -1,6 +1,8 @@
 #
 # REST API Request Tests - Service Dialogs specs
 #
+# - Refresh dialog fields       /api/service_dialogs/:id "refresh_dialog_fields"
+#
 describe ApiController do
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -70,6 +72,58 @@ describe ApiController do
       dialogs = service.dialogs
       expect_query_result(:service_dialogs, dialogs.count, dialogs.count)
       expect_result_resources_to_include_data("resources", "label" => dialogs.pluck(:label))
+    end
+  end
+
+  describe "Service Dialogs refresh dialog fields" do
+    let(:dialog1) { FactoryGirl.create(:dialog, :label => "Dialog1") }
+    let(:tab1)    { FactoryGirl.create(:dialog_tab, :label => "Tab1") }
+    let(:group1)  { FactoryGirl.create(:dialog_group, :label => "Group1") }
+    let(:text1)   { FactoryGirl.create(:dialog_field_text_box, :label => "TextBox1", :name => "text1") }
+
+    def init_dialog
+      dialog1.dialog_tabs << tab1
+      tab1.dialog_groups << group1
+      group1.dialog_fields << text1
+    end
+
+    it "rejects refresh dialog fields requests without appropriate role" do
+      api_basic_authorize
+
+      run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(test1)))
+
+      expect_request_forbidden
+    end
+
+    it "rejects refresh dialog fields with unspecified fields" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields))
+
+      expect_single_action_result(:success => false, :message => /must specify fields/i)
+    end
+
+    it "rejects refresh dialog fields of invalid fields" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(bad_field)))
+
+      expect_single_action_result(:success => false, :message => /unknown dialog field bad_field/i)
+    end
+
+    it "supports refresh dialog fields of valid fields" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
+
+      expect_single_action_result(:success => true,
+                                  :message => /refreshing dialog fields/i,
+                                  :href    => service_dialogs_url(dialog1.id))
+      expect_hash_to_have_keys(response_hash, %w(result))
+      expect_hash_to_have_keys(response_hash["result"], %w(text1))
     end
   end
 end

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -119,11 +119,12 @@ describe ApiController do
 
       run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
 
-      expect_single_action_result(:success => true,
-                                  :message => /refreshing dialog fields/i,
-                                  :href    => service_dialogs_url(dialog1.id))
-      expect_hash_to_have_keys(response_hash, %w(result))
-      expect_hash_to_have_keys(response_hash["result"], %w(text1))
+      expect(response_hash).to include(
+        "success" => true,
+        "message" => a_string_matching(/refreshing dialog fields/i),
+        "href"    => a_string_matching(service_dialogs_url(dialog1.id)),
+        "result"  => hash_including("text1")
+      )
     end
   end
 end


### PR DESCRIPTION
* Enhancement to support the refresh_dialog_fields action on service_dialogs resources /api/service_dialogs/:id
* Same post contents as the refresh_dialog_fields action on service_templates which include "dialog_fields" as currently filled in field, value hash and "fields"  the array of fields to refresh.
* Adding rspecs