### PR TITLE
Gemfile: bumping kubeclient to 0.8.1

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -24,7 +24,7 @@ gem "fog",                     "~>1.37.0",          :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "image-inspector-client",  "~>1.0.0",           :require => false
-gem "kubeclient",              "=0.8.0",            :require => false
+gem "kubeclient",              "=0.8.1",            :require => false
 gem "hawkular-client",         "~>0.2.0",           :require => false
 gem "linux_admin",             "~>0.16.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false


### PR DESCRIPTION
This solves the problem of SmartState Analysis being Broken on OpenShift 3.2