### PR TITLE
remove EMS_CLOUD_DISCOVERY_TYPES and make it registerable

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -771,7 +771,7 @@ module ApplicationController::CiProcessing
         @discover_type = ExtManagementSystem.ems_cloud_discovery_types.invert.collect do |type|
           [discover_type(type[0]), type[1]]
         end
-        @discover_type_selected = @discover_type.first.last
+        @discover_type_selected = @discover_type.first.try!(:last)
       end
     else
       @discover_type = ExtManagementSystem.ems_infra_discovery_types
@@ -814,7 +814,7 @@ module ApplicationController::CiProcessing
       drop_breadcrumb(:name => "#{title} Discovery", :url => "/host/discover")
       @discover_type_selected = params[:discover_type_selected]
 
-      if request.parameters[:controller] == "ems_cloud" && params[:discover_type_selected] == ExtManagementSystem::EMS_CLOUD_DISCOVERY_TYPES['azure']
+      if request.parameters[:controller] == "ems_cloud" && params[:discover_type_selected] == ExtManagementSystem.ems_cloud_discovery_types['azure']
         @client_id = params[:client_id] if params[:client_id]
         @client_key = params[:client_key] if params[:client_key]
         @azure_tenant_id = params[:azure_tenant_id] if params[:azure_tenant_id]
@@ -858,7 +858,7 @@ module ApplicationController::CiProcessing
             end
             Host.discoverByIpRange(from_ip, to_ip, options)
           else
-            if params[:discover_type_selected] == ExtManagementSystem::EMS_CLOUD_DISCOVERY_TYPES['azure']
+            if params[:discover_type_selected] == ExtManagementSystem.ems_cloud_discovery_types['azure']
               ManageIQ::Providers::Azure::CloudManager.discover_queue(@client_id, @client_key, @azure_tenant_id)
             else
               ManageIQ::Providers::Amazon::CloudManager.discover_queue(@userid, @password)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -131,17 +131,6 @@ class ExtManagementSystem < ApplicationRecord
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
   alias_attribute :to_s, :name
 
-  EMS_INFRA_DISCOVERY_TYPES = {
-    'vmware'    => 'virtualcenter',
-    'microsoft' => 'scvmm',
-    'redhat'    => 'rhevm',
-  }
-
-  EMS_CLOUD_DISCOVERY_TYPES = {
-    'azure'  => 'azure',
-    'amazon' => 'ec2',
-  }
-
   def self.with_ipaddress(ipaddress)
     joins(:endpoints).where(:endpoints => {:ipaddress => ipaddress})
   end
@@ -313,11 +302,15 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.ems_infra_discovery_types
-    EMS_INFRA_DISCOVERY_TYPES.values
+    @ems_infra_discovery_types ||= %w(virtualcenter scvmm rhevm)
+  end
+
+  def self.register_cloud_discovery_type(type_hash)
+    ems_cloud_discovery_types.merge!(type_hash)
   end
 
   def self.ems_cloud_discovery_types
-    EMS_CLOUD_DISCOVERY_TYPES
+    @ems_cloud_discovery_types ||= {}
   end
 
   def disconnect_inv

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -16,6 +16,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
   has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy
 
+  ExtManagementSystem.register_cloud_discovery_type('azure' => 'azure')
+
   def self.ems_type
     @ems_type ||= "azure".freeze
   end

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -21,6 +21,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :Vm
 
   OrchestrationTemplateCfn.register_eligible_manager(self)
+  ExtManagementSystem.register_cloud_discovery_type('amazon' => 'ec2')
 
   def self.ems_type
     @ems_type ||= "ec2".freeze

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -226,7 +226,7 @@ describe ApplicationController do
       allow(controller).to receive(:drop_breadcrumb)
       controller.send(:discover)
       expect(response.status).to eq(200)
-      expect(controller.instance_variable_get(:@discover_type)).to eq([["Azure", "azure"], ["Amazon", "amazon"]])
+      expect(controller.instance_variable_get(:@discover_type)).to include(["Azure", "azure"], ["Amazon", "amazon"])
     end
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -47,8 +47,9 @@ describe ExtManagementSystem do
   end
 
   it ".ems_cloud_discovery_types" do
-    expected_types = {"azure" => "azure", "amazon" => "ec2"}
-    expect(described_class.ems_cloud_discovery_types).to eq(expected_types)
+    discovery_type = {'amazon' => 'ec2'}
+    described_class.register_cloud_discovery_type(discovery_type)
+    expect(described_class.ems_cloud_discovery_types).to include(discovery_type)
   end
 
   context "#ipaddress / #ipaddress=" do


### PR DESCRIPTION
removed the constant `EMS_CLOUD_DISCOVERY_TYPES` to a method of ExtManagementSystem
and made `Amazon::CloudManager` register that discovery type