### PR TITLE
When copying an alert record dont copy id of the record.

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -214,8 +214,8 @@ module MiqPolicyController::Alerts
     @edit[:current] = {}
 
     if params[:copy]  # If copying, create a new alert based on the original
-      a = MiqAlert.find(params[:id])
-      @alert = MiqAlert.new(a.attributes)
+      # skip record id when copying attributes
+      @alert = MiqAlert.find(params[:id]).dup
     else
       @alert = params[:id] ? MiqAlert.find(params[:id]) : MiqAlert.new  # Get existing or new record
       @alert.enabled = true unless @alert.id            # Default enabled to true if new record

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -1,0 +1,29 @@
+describe MiqPolicyController do
+  context "::Alerts" do
+    before do
+      login_as FactoryGirl.create(:user, :features => "alert_admin")
+    end
+
+    context "#alert_build_edit_screen" do
+      before :each do
+        @miq_alert = FactoryGirl.create(:miq_alert)
+        controller.instance_variable_set(:@sb,
+                                         :trees       => {:alert_tree => {:active_node => "al-#{@miq_alert.id}"}},
+                                         :active_tree => :alert_tree
+        )
+      end
+
+      it "it should skip id when copying all attributes of an existing alert" do
+        controller.instance_variable_set(:@_params, :id => @miq_alert.id, :copy => "copy")
+        controller.send(:alert_build_edit_screen)
+        expect(assigns(:alert).id).to eq(nil)
+      end
+
+      it "it should select correct record when editing an existing alert" do
+        controller.instance_variable_set(:@_params, :id => @miq_alert.id)
+        controller.send(:alert_build_edit_screen)
+        expect(assigns(:alert).id).to eq(@miq_alert.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Presence of id in @alert was causing UI to think that existing record is being edited instead a new copied record being added. Due to this incorrect cell title and form buttons were displayed on screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1315377

before:
![alert_copy_before](https://cloud.githubusercontent.com/assets/3450808/13607634/0b39486e-e51f-11e5-8e6b-6fc8b961b1ca.png)

![alert_copy_saved](https://cloud.githubusercontent.com/assets/3450808/13607636/0d42c2c0-e51f-11e5-8c59-90ddb12237d8.png)

after:
![alert_copy_after](https://cloud.githubusercontent.com/assets/3450808/13607639/13170256-e51f-11e5-8654-a82829a51798.png)

![alert_added](https://cloud.githubusercontent.com/assets/3450808/13607644/1b8e54de-e51f-11e5-9141-e3c3458089ac.png)
