### PR TITLE
Lock apipie-bindings gem to version 0.0.15

### DIFF
--- a/gems/manageiq_foreman/manageiq_foreman.gemspec
+++ b/gems/manageiq_foreman/manageiq_foreman.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "apipie-bindings", "~> 0.0.15"
+  spec.add_runtime_dependency "apipie-bindings", "= 0.0.15"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
v0.0.16 is not compliant with rest-client v2.0.0.rc1
```
  1) ManageIQ::Providers::Foreman::ConfigurationManager::Refresher loads data with locations and organizations
     Failure/Error: raw_ems_data = connection.inventory.refresh_provisioning(targets)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 0)
     # /Users/gmccullough/.gem/ruby/2.3.0/gems/rest-client-2.0.0.rc1/lib/restclient/abstract_response.rb:71:in `return!'
     # /Users/gmccullough/.gem/ruby/2.3.0/gems/apipie-bindings-0.0.16/lib/apipie_bindings/api.rb:308:in `block in rest_client_call_block'
```