### PR TITLE
Introduce intermediate class ManageIQ::Providers::CloudManager::OrchestrationStack

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ::OrchestrationStack
+class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
   require_dependency 'manageiq/providers/azure/cloud_manager/orchestration_stack/status'
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -6,6 +6,7 @@ module ManageIQ::Providers
     require_nested :Provision
     require_nested :ProvisionWorkflow
     require_nested :Vm
+    require_nested :OrchestrationStack
 
     class << model_name
       define_method(:route_key) { "ems_clouds" }

--- a/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
@@ -1,0 +1,55 @@
+class ManageIQ::Providers::CloudManager::OrchestrationStack < ::OrchestrationStack
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
+  belongs_to :orchestration_template
+  belongs_to :cloud_tenant
+
+  has_many   :direct_vms,             :class_name => "ManageIQ::Providers::CloudManager::Vm"
+  has_many   :direct_security_groups, :class_name => "SecurityGroup"
+  has_many   :direct_cloud_networks,  :class_name => "CloudNetwork"
+
+  virtual_has_many :vms, :class_name => "ManageIQ::Providers::CloudManager::Vm"
+  virtual_has_many :security_groups
+  virtual_has_many :cloud_networks
+
+  virtual_column :total_vms,             :type => :integer
+  virtual_column :total_security_groups, :type => :integer
+  virtual_column :total_cloud_networks,  :type => :integer
+
+  def total_vms
+    vms.size
+  end
+
+  def total_security_groups
+    security_groups.size
+  end
+
+  def total_cloud_networks
+    cloud_networks.size
+  end
+
+  def vms
+    directs_and_indirects(:direct_vms)
+  end
+
+  def security_groups
+    directs_and_indirects(:direct_security_groups)
+  end
+
+  def cloud_networks
+    directs_and_indirects(:direct_cloud_networks)
+  end
+
+  def self.create_stack(orchestration_manager, stack_name, template, options = {})
+    klass = orchestration_manager.class::OrchestrationStack
+    ems_ref = klass.raw_create_stack(orchestration_manager, stack_name, template, options)
+    tenant = CloudTenant.find_by(:name => options[:tenant_name], :ems_id => orchestration_manager.id)
+
+    klass.create(:name                   => stack_name,
+                 :ems_ref                => ems_ref,
+                 :status                 => 'CREATE_IN_PROGRESS',
+                 :resource_group         => options[:resource_group],
+                 :ext_management_system  => orchestration_manager,
+                 :cloud_tenant           => tenant,
+                 :orchestration_template => template)
+  end
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ::OrchestrationStack
+class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
   require_nested :Status
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})

--- a/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
@@ -1,5 +1,20 @@
 class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::OrchestrationStack
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::InfraManager"
+  belongs_to :orchestration_template
+  belongs_to :cloud_tenant
+
+  def self.create_stack(orchestration_manager, stack_name, template, options = {})
+    klass = orchestration_manager.class::OrchestrationStack
+    ems_ref = klass.raw_create_stack(orchestration_manager, stack_name, template, options)
+
+    klass.create(:name                   => stack_name,
+                 :ems_ref                => ems_ref,
+                 :status                 => 'CREATE_IN_PROGRESS',
+                 :resource_group         => options[:resource_group],
+                 :ext_management_system  => orchestration_manager,
+                 :cloud_tenant           => tenant,
+                 :orchestration_template => template)
+  end
 
   def raw_update_stack(template, parameters)
     ext_management_system.with_provider_connection(:service => "Orchestration") do |connection|

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -12,17 +12,7 @@ class OrchestrationStack < ApplicationRecord
 
   has_ancestry
 
-  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
-  belongs_to :orchestration_template
-  belongs_to :cloud_tenant
-
-  has_many   :direct_vms,             :class_name => "ManageIQ::Providers::CloudManager::Vm"
-  has_many   :direct_security_groups, :class_name => "SecurityGroup"
-  has_many   :direct_cloud_networks,  :class_name => "CloudNetwork"
-
-  virtual_has_many :vms, :class_name => "ManageIQ::Providers::CloudManager::Vm"
-  virtual_has_many :security_groups
-  virtual_has_many :cloud_networks
+  belongs_to :ext_management_system, :foreign_key => :ems_id
 
   has_many   :parameters, :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackParameter"
   has_many   :outputs,    :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackOutput"
@@ -32,40 +22,12 @@ class OrchestrationStack < ApplicationRecord
   alias_method :orchestration_stack_outputs,    :outputs
   alias_method :orchestration_stack_resources,  :resources
 
-  virtual_column :total_vms,             :type => :integer
-  virtual_column :total_security_groups, :type => :integer
-  virtual_column :total_cloud_networks,  :type => :integer
-
   def tenant_identity
     if ext_management_system
       ext_management_system.tenant_identity
     else
       User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
     end
-  end
-
-  def total_vms
-    vms.size
-  end
-
-  def total_security_groups
-    security_groups.size
-  end
-
-  def total_cloud_networks
-    cloud_networks.size
-  end
-
-  def vms
-    directs_and_indirects(:direct_vms)
-  end
-
-  def security_groups
-    directs_and_indirects(:direct_security_groups)
-  end
-
-  def cloud_networks
-    directs_and_indirects(:direct_cloud_networks)
   end
 
   def directs_and_indirects(direct_attrs)
@@ -77,17 +39,7 @@ class OrchestrationStack < ApplicationRecord
   private :directs_and_indirects
 
   def self.create_stack(orchestration_manager, stack_name, template, options = {})
-    klass = orchestration_manager.class::OrchestrationStack
-    ems_ref = klass.raw_create_stack(orchestration_manager, stack_name, template, options)
-    tenant = CloudTenant.find_by(:name => options[:tenant_name], :ems_id => orchestration_manager.id)
-
-    klass.create(:name                   => stack_name,
-                 :ems_ref                => ems_ref,
-                 :status                 => 'CREATE_IN_PROGRESS',
-                 :resource_group         => options[:resource_group],
-                 :ext_management_system  => orchestration_manager,
-                 :cloud_tenant           => tenant,
-                 :orchestration_template => template)
+    raw_create_stack(orchestration_manager, stack_name, template, options)
   end
 
   def self.raw_create_stack(_orchestration_manager, _stack_name, _template, _options = {})

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -49,8 +49,8 @@ class ServiceOrchestration < Service
   end
 
   def deploy_orchestration_stack
-    @orchestration_stack =
-      OrchestrationStack.create_stack(orchestration_manager, stack_name, orchestration_template, stack_options)
+    @orchestration_stack = ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(
+      orchestration_manager, stack_name, orchestration_template, stack_options)
     add_resource(@orchestration_stack)
     @orchestration_stack
   ensure

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::OrchestrationStack
+class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
   require_nested :Status
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})

--- a/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
+++ b/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
@@ -28,7 +28,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
           }
         }
         with_aws_stubbed(stubbed_responses) do
-          stack = OrchestrationStack.create_stack(ems, "mystack", template)
+          stack = ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, "mystack", template)
           expect(stack.class).to eq(described_class)
           expect(stack.name).to eq("mystack")
           expect(stack.ems_ref).to eq("stack_id")
@@ -43,7 +43,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
         }
         with_aws_stubbed(stubbed_responses) do
           expect do
-            OrchestrationStack.create_stack(ems, "mystack", template)
+            ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, "mystack", template)
           end.to raise_error(MiqException::MiqOrchestrationProvisionError)
         end
       end
@@ -153,7 +153,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
     subject      { @stack.tenant_identity }
 
     it "has tenant from provider" do
-      @stack = FactoryGirl.create(:orchestration_stack, :ems_id => ems.id)
+      @stack = FactoryGirl.create(:orchestration_stack_amazon, :ems_id => ems.id)
 
       expect(subject).to                eq(admin)
       expect(subject.current_group).to  eq(ems.tenant.default_miq_group)
@@ -161,7 +161,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
     end
 
     it "without a provider, has tenant from root tenant" do
-      @stack = FactoryGirl.create(:orchestration_stack)
+      @stack = FactoryGirl.create(:orchestration_stack_amazon)
 
       expect(subject).to                eq(admin)
       expect(subject.current_group).to  eq(Tenant.root_tenant.default_miq_group)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager-orchestration_stack.rb
@@ -1,4 +1,4 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_CloudManager_OrchestrationStack < MiqAeServiceOrchestrationStack
+  class MiqAeServiceManageIQ_Providers_Amazon_CloudManager_OrchestrationStack < MiqAeServiceManageIQ_Providers_CloudManager_OrchestrationStack
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-orchestration_stack.rb
@@ -1,4 +1,4 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Azure_CloudManager_OrchestrationStack < MiqAeServiceOrchestrationStack
+  class MiqAeServiceManageIQ_Providers_Azure_CloudManager_OrchestrationStack < MiqAeServiceManageIQ_Providers_CloudManager_OrchestrationStack
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager-orchestration_stack.rb
@@ -1,0 +1,8 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_CloudManager_OrchestrationStack < MiqAeServiceOrchestrationStack
+    expose :vms,                    :association => true
+    expose :security_groups,        :association => true
+    expose :cloud_networks,         :association => true
+    expose :orchestration_template, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-orchestration_stack.rb
@@ -1,3 +1,4 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Openstack_CloudManager_OrchestrationStack < MiqAeServiceOrchestrationStack; end
+  class MiqAeServiceManageIQ_Providers_Openstack_CloudManager_OrchestrationStack < MiqAeServiceManageIQ_Providers_CloudManager_OrchestrationStack
+  end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
@@ -6,10 +6,6 @@ module MiqAeMethodService
     expose :parameters,             :association => true
     expose :resources,              :association => true
     expose :outputs,                :association => true
-    expose :vms,                    :association => true
-    expose :security_groups,        :association => true
-    expose :cloud_networks,         :association => true
-    expose :orchestration_template, :association => true
     expose :ext_management_system,  :association => true
     expose :ems_ref
     expose :raw_delete_stack

--- a/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
@@ -8,7 +8,7 @@ describe "Orchestration retirement state machine Methods Validation" do
   end
 
   let(:stack) do
-    FactoryGirl.create(:orchestration_stack)
+    FactoryGirl.create(:orchestration_stack_cloud)
   end
 
   let(:stack_in_provider) { true }

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -9,7 +9,7 @@ describe OrchestrationStackController do
   render_views
 
   describe '#show' do
-    let(:record) { FactoryGirl.create(:orchestration_stack) }
+    let(:record) { FactoryGirl.create(:orchestration_stack_cloud) }
 
     before do
       session[:settings] = {

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -2,6 +2,9 @@ FactoryGirl.define do
   factory :orchestration_stack do
   end
 
+  factory :orchestration_stack_cloud, :parent => :orchestration_stack, :class => "ManageIQ::Providers::CloudManager::OrchestrationStack" do
+  end
+
   factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
   end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -28,7 +28,7 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
       it 'creates a stack' do
         expect(orchestration_service).to receive(:create).and_return(the_raw_stack)
 
-        stack = OrchestrationStack.create_stack(ems, 'mystack', template, {})
+        stack = ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, {})
         expect(stack.class).to   eq(described_class)
         expect(stack.name).to    eq('mystack')
         expect(stack.ems_ref).to eq(the_raw_stack.id)
@@ -37,7 +37,9 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
       it 'catches errors from provider' do
         expect(orchestration_service).to receive(:create).and_throw('bad request')
 
-        expect { OrchestrationStack.create_stack(ems, 'mystack', template, {}) }.to raise_error(MiqException::MiqOrchestrationProvisionError)
+        expect do
+          ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, {})
+        end.to raise_error(MiqException::MiqOrchestrationProvisionError)
       end
     end
 

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
@@ -1,8 +1,8 @@
-describe OrchestrationStack do
+describe ManageIQ::Providers::CloudManager::OrchestrationStack do
   describe 'direct_<resource> methods' do
     let(:root_stack) do
-      stack1 = FactoryGirl.create(:orchestration_stack)
-      stack2 = FactoryGirl.create(:orchestration_stack, :parent => stack1)
+      stack1 = FactoryGirl.create(:orchestration_stack_cloud)
+      stack2 = FactoryGirl.create(:orchestration_stack_cloud, :parent => stack1)
 
       FactoryGirl.create(:vm_cloud, :orchestration_stack => stack1)
       FactoryGirl.create(:cloud_network, :orchestration_stack => stack1)

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
@@ -39,7 +39,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
         allow(the_new_stack).to receive(:[]).with("id").and_return('new_id')
         expect(the_new_stack).to receive(:save).and_return(the_new_stack)
 
-        stack = OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
+        stack = ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
         expect(stack.class).to eq(described_class)
         expect(stack.name).to eq('mystack')
         expect(stack.ems_ref).to eq('new_id')
@@ -49,7 +49,9 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
       it 'catches errors from provider' do
         expect(the_new_stack).to receive(:save).and_throw('bad request')
 
-        expect { OrchestrationStack.create_stack(ems, 'mystack', template, stack_option) }.to raise_error(MiqException::MiqOrchestrationProvisionError)
+        expect do
+          ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
+        end.to raise_error(MiqException::MiqOrchestrationProvisionError)
       end
     end
 

--- a/spec/models/miq_expression/model_details_spec.rb
+++ b/spec/models/miq_expression/model_details_spec.rb
@@ -112,7 +112,7 @@ describe MiqExpression do
     end
 
     it "OrchestrationStack" do
-      result = described_class.build_relats("OrchestrationStack")
+      result = described_class.build_relats("ManageIQ::Providers::CloudManager::OrchestrationStack")
       expect(result.fetch_path(:reflections, :vms, :parent, :class_path).split(".").last).to eq("manageiq_providers_cloud_manager_vms")
       expect(result.fetch_path(:reflections, :vms, :parent, :assoc_path).split(".").last).to eq("vms")
     end
@@ -138,7 +138,7 @@ describe MiqExpression do
       end
 
       it "one_to_many relation" do
-        @ref = OrchestrationStack.reflections_with_virtual[:vms]
+        @ref = ManageIQ::Providers::CloudManager::OrchestrationStack.reflections_with_virtual[:vms]
         expect(subject).to eq(@ref.klass.model_name.plural)
       end
     end

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -79,7 +79,9 @@ describe OrchestrationTemplate do
 
   describe "#eligible_managers" do
     before do
-      allow(OrchestrationTemplate).to receive_messages(:eligible_manager_types => [ManageIQ::Providers::Amazon::CloudManager, ManageIQ::Providers::Openstack::CloudManager])
+      allow(OrchestrationTemplate).to receive_messages(:eligible_manager_types =>
+                                                         [ManageIQ::Providers::Amazon::CloudManager,
+                                                          ManageIQ::Providers::Openstack::CloudManager])
       @template = FactoryGirl.create(:orchestration_template)
       @aws = FactoryGirl.create(:ems_amazon)
       @openstack = FactoryGirl.create(:ems_openstack)
@@ -245,7 +247,7 @@ describe OrchestrationTemplate do
 
       context "when conflicts with existing discovered template" do
         let!(:stack) do
-          FactoryGirl.create(:orchestration_stack, :orchestration_template => existing_discovered_template)
+          FactoryGirl.create(:orchestration_stack_cloud, :orchestration_template => existing_discovered_template)
         end
 
         it "updates the stacks from the discovered template to use the working template" do


### PR DESCRIPTION
The goal is to model `AnsibleTowerJob` as a subclass of `OrchestrationStack`
The first step is to extract part of the existing `OrchestrationStack` to intermediate class `ManageIQ::Providers::CloudManager::OrchestrationStack`. The new class hierarchy is:
```
(specific cloud manager)::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
ManageIQ::Providers::CloudManager::OrchestrationStack                    < ::OrchestrationStack
ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack         < ::OrchestrationStack
ManageIQ::Providers::AnsibleTower::ConfigurationManager::AnsibleTowerJob < ::OrchestrationStack
```
The first step is ready for review.