### PR TITLE
Handle an empty consoleVnic array for a VMware host

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -483,7 +483,7 @@ module ManageIQ::Providers
         result = []
         return result if inv.nil?
 
-        vnics = inv['consoleVnic'] || inv['vnic']
+        vnics = inv['consoleVnic'].to_miq_a + inv['vnic'].to_miq_a
         vnics.to_miq_a.each do |vnic|
           # Find the pnic to which this service console is connected
           port_key = vnic['port']

--- a/spec/tools/vim_data/miq_vim_inventory/hostSystemsByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/hostSystemsByMor.yml
@@ -149,6 +149,9 @@
       __iv__@vimType: 
       __iv__@xsiType: :HostServiceInfo
     network: !map:VimHash 
+      consoleVnic: !map:VimArray
+        __iv__@vimType:
+        __iv__@xsiType: :ArrayOfHostVirtualNic
       dnsConfig: !map:VimHash 
         domainName: !str:VimString 
           str: manageiq.com
@@ -940,6 +943,9 @@
       __iv__@vimType: 
       __iv__@xsiType: :HostServiceInfo
     network: !map:VimHash 
+      consoleVnic: !map:VimArray
+        __iv__@vimType:
+        __iv__@xsiType: :ArrayOfHostVirtualNic
       dnsConfig: !map:VimHash 
         domainName: !str:VimString 
           str: manageiq.com
@@ -1765,6 +1771,9 @@
       __iv__@vimType: 
       __iv__@xsiType: :HostServiceInfo
     network: !map:VimHash 
+      consoleVnic: !map:VimArray
+        __iv__@vimType:
+        __iv__@xsiType: :ArrayOfHostVirtualNic
       dnsConfig: !map:VimHash 
         domainName: !str:VimString 
           str: ""


### PR DESCRIPTION
Handle `inv['consoleVnic']` being an empty array as well as nil.  This was preventing hosts from having their vnic networks being inventoried leading to fewer entries in Networks than there should have been.

The spec tests were passing because `inv['consoleVnic']` was always nil since there wasn't an config.network.consoleVnic property in hostSystemsByMor.yml but this wasn't the case for inventory returned from a live system.

Added an empty consoleVnic array to 3 out of 4 hosts in hostSystemsByMor.yml to exercise both cases.