### PR TITLE
Remove DatabaseBackup.backup_supported? method

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1116,7 +1116,6 @@ module OpsController::Settings::Common
       @zones = Zone.in_my_region
       @ldap_regions = LdapRegion.in_my_region
       @miq_schedules = MiqSchedule.where("(prod_default != 'system' or prod_default is null) and adhoc IS NULL")
-                       .select { |s| s.towhat != "DatabaseBackup" || DatabaseBackup.backup_supported? }
                        .sort_by { |s| s.name.downcase }
     end
   end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -387,12 +387,7 @@ module OpsController::Settings::Schedules
     @sortcol = session[:schedule_sortcol].nil? ? 0 : session[:schedule_sortcol].to_i
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]
 
-    # don't include db_backup records if backup not supported
-    if !DatabaseBackup.backup_supported?
-      @view, @pages = get_view(MiqSchedule, :conditions => ["towhat!=? And (prod_default!=? or prod_default IS NULL) And adhoc IS NULL", "DatabaseBackup", "system"]) # Get the records (into a view) and the paginator
-    else
-      @view, @pages = get_view(MiqSchedule, :conditions => ["prod_default!=? or prod_default IS NULL And adhoc IS NULL", "system"]) # Get the records (into a view) and the paginator
-    end
+    @view, @pages = get_view(MiqSchedule, :conditions => ["prod_default!=? or prod_default IS NULL And adhoc IS NULL", "system"]) # Get the records (into a view) and the paginator
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
     session[:schedule_sortcol] = @sortcol
@@ -553,7 +548,7 @@ module OpsController::Settings::Schedules
     if role_allows(:feature => "host_check_compliance")
       @action_type_options_for_select.push([_("Host Compliance Check"), "host_check_compliance"])
     end
-    @action_type_options_for_select.push([_("Database Backup"), "db_backup"]) if DatabaseBackup.backup_supported?
+    @action_type_options_for_select.push([_("Database Backup"), "db_backup"])
 
     @vm_options_for_select = [
       [_("All VMs"), "all"],

--- a/app/models/database_backup.rb
+++ b/app/models/database_backup.rb
@@ -4,16 +4,6 @@ class DatabaseBackup < ApplicationRecord
     'nfs' => 'Network File System'
   }.freeze
 
-  def self.backup_supported?
-    return @backup_supported unless @backup_supported.nil?
-    db_config = Rails.configuration.database_configuration[Rails.env]
-    @backup_supported = db_config["adapter"] == "postgresql"
-  end
-
-  class << self
-    alias_method :gc_supported?, :backup_supported?
-  end
-
   def self.supported_depots
     SUPPORTED_DEPOTS
   end
@@ -24,7 +14,6 @@ class DatabaseBackup < ApplicationRecord
 
   def backup(options)
     # TODO: Create a real exception out of this
-    raise "Unsupported database" unless self.class.backup_supported?
     raise "Missing or Invalid task: #{options[:task_id]}, depot id: #{options[:file_depot_id]}" unless options[:task_id].kind_of?(Integer) && options[:file_depot_id].kind_of?(Integer)
 
     task = MiqTask.find(options[:task_id])
@@ -56,7 +45,6 @@ class DatabaseBackup < ApplicationRecord
   end
 
   def self.gc(options)
-    raise "Unsupported database" unless self.gc_supported?
     raise "Missing or Invalid task: #{options[:task_id]}" unless options[:task_id].kind_of?(Integer)
 
     task = MiqTask.find(options[:task_id])

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -39,7 +39,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
       MiqSchedule.where("prod_default != 'system' or prod_default is null").to_a.sort do |a, b|
         a.name.downcase <=> b.name.downcase
       end.each do |z|
-        objects.push(z) if z.adhoc.nil? && (z.towhat != "DatabaseBackup" || DatabaseBackup.backup_supported?)
+        objects.push(z) if z.adhoc.nil?
       end
       count_only_or_objects(count_only, objects, nil)
     when "sis"

--- a/app/views/ops/_diagnostics_database_tab.html.haml
+++ b/app/views/ops/_diagnostics_database_tab.html.haml
@@ -33,69 +33,69 @@
       %p.form-control-static
         = h(@database_details["username"])
 
-  - if DatabaseBackup.backup_supported?
-    %hr/
+  %hr/
+  %h3
+    = _("Run a Database Backup Now")
+  %fieldset
+    - if @sb[:active_tab] == "diagnostics_database"
+      -# created div with different name so database validation flash message can be shown in it's own box
+      = render :partial => "layouts/flash_msg"
     %h3
-      = _("Run a Database Backup Now")
-    %fieldset
-      - if @sb[:active_tab] == "diagnostics_database"
-        -# created div with different name so database validation flash message can be shown in it's own box
-        = render :partial => "layouts/flash_msg"
-      %h3
-        = _("Backup Schedules")
-      .form-group
-        %label.col-md-2.control-label
-          = _("Fetch settings from a schedule")
-        .col-md-8
-          - if @backup_schedules.length < 1
-            %p.form-control-static
-              = _("No Backup Schedules are defined")
-          - else
-            - default_option = [_("<Choose>"), nil]
-            - schedules_ary = Array(@backup_schedules.invert)
-            - schedules_ary.sort_by! { |name, _id| name }
-            - options = options_for_select([default_option] + schedules_ary)
+      = _("Backup Schedules")
+    .form-group
+      %label.col-md-2.control-label
+        = _("Fetch settings from a schedule")
+      .col-md-8
+        - if @backup_schedules.length < 1
+          %p.form-control-static
+            = _("No Backup Schedules are defined")
+        - else
+          - default_option = [_("<Choose>"), nil]
+          - schedules_ary = Array(@backup_schedules.invert)
+          - schedules_ary.sort_by! { |name, _id| name }
+          - options = options_for_select([default_option] + schedules_ary)
 
-            = select_tag('backup_schedule_type',
-                         options,
-                         "ng-model"                    => "diagnosticsDatabaseModel.backup_schedule_type",
-                         "ng-change"                   => "backupScheduleTypeChanged()",
-                         "checkchange"                 => "",
-                         "selectpicker-for-select-tag" => "")
+          = select_tag('backup_schedule_type',
+                       options,
+                       "ng-model"                    => "diagnosticsDatabaseModel.backup_schedule_type",
+                       "ng-change"                   => "backupScheduleTypeChanged()",
+                       "checkchange"                 => "",
+                       "selectpicker-for-select-tag" => "")
 
 
-      %h3
-        = _("Database Backup Settings")
-      .form-group
-        %label.col-md-2.control-label
-          = _("Type")
-        .col-md-8
-          - default_option = [_("<No Depot>"), nil]
-          = select_tag('log_protocol', options_for_select([default_option] + @database_backup_options_for_select),
-                      "ng-model"                       => "diagnosticsDatabaseModel.log_protocol",
-                      "ng-change"                      => "logProtocolChanged(diagnosticsDatabaseModel)",
-                      "ng-required"                    => "logProtocolNotSelected(diagnosticsDatabaseModel)",
-                      "checkchange"                    => "",
-                      "selectpicker-for-select-tag"    => "")
-      = render :partial => "layouts/angular-bootstrap/edit_log_depot_settings_angular_bootstrap",
-                     :locals  => {:ng_show             => "logProtocolSelected()",
-                                  :ng_reqd_depot_name  => true,
-                                  :ng_model_depot_name => "diagnosticsDatabaseModel.depot_name",
-                                  :ng_reqd_uri         => true,
-                                  :ng_model_uri        => "diagnosticsDatabaseModel.uri",
-                                  :ng_model_uri_prefix => "diagnosticsDatabaseModel.uri_prefix",
-                                  :uri_prefix_display  =>  "{{diagnosticsDatabaseModel.uri_prefix}}://"}
-      = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
-                     :locals  => {:ng_show           => "sambaBackup()",
-                                  :ng_model          => "diagnosticsDatabaseModel",
-                                  :ng_reqd_userid    => "sambaRequired(diagnosticsDatabaseModel.log_userid)",
-                                  :ng_reqd_password  => "sambaRequired(diagnosticsDatabaseModel.log_password)",
-                                  :ng_reqd_verify    => "sambaRequired(diagnosticsDatabaseModel.log_verify)",
-                                  :validate_url      => "log_depot_validate",
-                                  :id                => nil,
-                                  :valtype           => "log",
-                                  :basic_info_needed => true}
-      %input{:type => "hidden", :value => "db_backup", :name => "action_typ"}
+    %h3
+      = _("Database Backup Settings")
+    .form-group
+      %label.col-md-2.control-label
+        = _("Type")
+      .col-md-8
+        - default_option = [_("<No Depot>"), nil]
+        = select_tag('log_protocol', options_for_select([default_option] + @database_backup_options_for_select),
+                    "ng-model"                       => "diagnosticsDatabaseModel.log_protocol",
+                    "ng-change"                      => "logProtocolChanged(diagnosticsDatabaseModel)",
+                    "ng-required"                    => "logProtocolNotSelected(diagnosticsDatabaseModel)",
+                    "checkchange"                    => "",
+                    "selectpicker-for-select-tag"    => "")
+    = render :partial => "layouts/angular-bootstrap/edit_log_depot_settings_angular_bootstrap",
+                   :locals  => {:ng_show             => "logProtocolSelected()",
+                                :ng_reqd_depot_name  => true,
+                                :ng_model_depot_name => "diagnosticsDatabaseModel.depot_name",
+                                :ng_reqd_uri         => true,
+                                :ng_model_uri        => "diagnosticsDatabaseModel.uri",
+                                :ng_model_uri_prefix => "diagnosticsDatabaseModel.uri_prefix",
+                                :uri_prefix_display  =>  "{{diagnosticsDatabaseModel.uri_prefix}}://"}
+    = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                   :locals  => {:ng_show           => "sambaBackup()",
+                                :ng_model          => "diagnosticsDatabaseModel",
+                                :ng_reqd_userid    => "sambaRequired(diagnosticsDatabaseModel.log_userid)",
+                                :ng_reqd_password  => "sambaRequired(diagnosticsDatabaseModel.log_password)",
+                                :ng_reqd_verify    => "sambaRequired(diagnosticsDatabaseModel.log_verify)",
+                                :validate_url      => "log_depot_validate",
+                                :id                => nil,
+                                :valtype           => "log",
+                                :basic_info_needed => true}
+    %input{:type => "hidden", :value => "db_backup", :name => "action_typ"}
+
     %table{:width => "100%"}
       %tr
         %td{:align => "right"}
@@ -103,26 +103,25 @@
                    :locals  => {:confirm => _("Are you sure you want to Run a Database Backup Now?")}
 
 
-    - if DatabaseBackup.gc_supported?
-      %hr/
-      %h3
-        = _("Run Database Garbage Collection Now")
-      .form-group
-        .col-md-8
-          = _("Press submit to start the Database Vacuum process")
-      %table{:width => "100%"}
-        %tr
-          %td{:align => "right"}
-            #gc_submit_on
-              - caption = _("Run Database Garbage Collection Now")
-              - submit = button_tag(_("Submit"), :class => "btn btn-primary", :alt => caption)
+    %hr/
+    %h3
+      = _("Run Database Garbage Collection Now")
+    .form-group
+      .col-md-8
+        = _("Press submit to start the Database Vacuum process")
+    %table{:width => "100%"}
+      %tr
+        %td{:align => "right"}
+          #gc_submit_on
+            - caption = _("Run Database Garbage Collection Now")
+            - submit = button_tag(_("Submit"), :class => "btn btn-primary", :alt => caption)
 
-              = link_to(submit, {:action => 'db_gc_collection'},
-                "data-miq_sparkle_on" => true,
-                :confirm              => _("Are you sure you want to Run Database Garbage Collection Now?"),
-                :remote               => true,
-                'data-method'         => :post,
-                :title                => caption)
+            = link_to(submit, {:action => 'db_gc_collection'},
+              "data-miq_sparkle_on" => true,
+              :confirm              => _("Are you sure you want to Run Database Garbage Collection Now?"),
+              :remote               => true,
+              'data-method'         => :post,
+              :title                => caption)
 
 :javascript
   miq_bootstrap('#form_div');

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -1,24 +1,4 @@
 describe DatabaseBackup do
-  context ".backup_supported?" do
-    before do
-      DatabaseBackup.instance_variable_set(:@backup_supported, nil)
-    end
-
-    it "should support backup with postgresql" do
-      allow(Rails).to receive_message_chain(
-        :configuration, :database_configuration => {"test" => {"adapter" => "postgresql"}}
-      )
-      expect(DatabaseBackup.backup_supported?).to be true
-    end
-
-    it "should not support backup with mysql" do
-      allow(Rails).to receive_message_chain(
-        :configuration, :database_configuration => {"test" => {"adapter" => "mysql"}}
-      )
-      expect(DatabaseBackup.backup_supported?).to be false
-    end
-  end
-
   context "region" do
     before(:each) do
       @region = FactoryGirl.create(:miq_region, :region => 3)


### PR DESCRIPTION
We only run on PostgreSQL and we are getting more intimate with it as
time moves forward.  We can always add this back in if necessary in the
future.

@jrafanie Please review. :scissors: 