### PR TITLE
Ensure developers running rubocop have the same version as the miq_bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ gem "sshkey",                         "~>1.8.0",   :require => false
 #
 unless ENV['APPLIANCE']
   group :development do
+    gem "rubocop",          "~>0.37.2", :require => false
     gem "ruby-graphviz",                :require => false  # Used by state_machine:draw Rake Task
   end
 


### PR DESCRIPTION
Running other versions of rubocop can be problematic with the current `.rubocop.yml`.