### PR TITLE
Remove unused MiqReport::Formatting methods

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -159,34 +159,6 @@ module MiqReport::Formatting
     apply_prefix_and_suffix(val, options)
   end
 
-  def format_elapsed_time_human(val, _options)
-    val = val.to_i
-
-    names = %w(day hour minute second)
-    arr = []
-
-    days    = (val / 86400)
-    hours   = (val / 3600) - (days * 24)
-    minutes = (val / 60) - (hours * 60) - (days * 1440)
-    seconds = (val % 60)
-
-    arr = [days, hours, minutes, seconds]
-    return if arr.all? { |a| a == 0 }
-
-    sidx = arr.index { |a| a > 0 }
-    values = arr[sidx..(sidx + 1)]
-    result = ''
-    sep    = ''
-    values.each_index do |i|
-      sfx = names[sidx + i]
-      sfx += "s" if values[i] > 1 || values[i] == 0
-      result = result + sep + "#{values[i]} #{sfx}"
-      sep = ", "
-    end
-
-    result
-  end
-
   def format_string_truncate(val, options = {})
     result = val.to_s
     result.length > options[:length] ? result[0..(options[:length] - 1)] + "..." : val

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -167,15 +167,6 @@ module MiqReport::Formatting
     val.strftime(options[:format])
   end
 
-  def format_datetime_ordinal(val, options)
-    val = format_datetime(val, options)
-    format_number_ordinal(val, options)
-  end
-
-  def format_number_ordinal(val, _options)
-    val.to_i.ordinalize
-  end
-
   def format_elapsed_time_human(val, _options)
     val = val.to_i
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -159,11 +159,6 @@ module MiqReport::Formatting
     apply_prefix_and_suffix(val, options)
   end
 
-  def format_string_truncate(val, options = {})
-    result = val.to_s
-    result.length > options[:length] ? result[0..(options[:length] - 1)] + "..." : val
-  end
-
   def format_large_number_to_exponential_form(val, _options = {})
     return val if val.to_f < 1.0e+15
     val.to_f.to_s

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -159,14 +159,6 @@ module MiqReport::Formatting
     apply_prefix_and_suffix(val, options)
   end
 
-  def format_datetime(val, options)
-    return val unless val.kind_of?(Time) || val.kind_of?(Date)
-
-    val = val.in_time_zone(options[:tz]) if val.kind_of?(Time) && options[:tz]
-    return val if options[:format].nil?
-    val.strftime(options[:format])
-  end
-
   def format_elapsed_time_human(val, _options)
     val = val.to_i
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -167,28 +167,6 @@ module MiqReport::Formatting
     val.strftime(options[:format])
   end
 
-  def format_datetime_range(val, options)
-    return val if options[:format].nil?
-    return val unless val.kind_of?(Time) || stime.kind_of?(Date)
-
-    col = options[:column]
-    col, sfx = col.to_s.split("__") # The suffix (month, quarter, year) defines the range
-
-    val = val.in_time_zone(get_time_zone("UTC"))
-    if val.respond_to?("beginning_of_#{sfx}")
-      stime = val.send("beginning_of_#{sfx}")
-      etime = val.send("end_of_#{sfx}")
-    else
-      stime = etime = val
-    end
-
-    if options[:description].to_s.include?("Start")
-      return stime.strftime(options[:format])
-    else
-      return "(#{stime.strftime(options[:format])} - #{etime.strftime(options[:format])})"
-    end
-  end
-
   def format_set(val, options)
     return val unless val.kind_of?(Array)
     options[:delimiter] ||= ", "

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -167,12 +167,6 @@ module MiqReport::Formatting
     val.strftime(options[:format])
   end
 
-  def format_set(val, options)
-    return val unless val.kind_of?(Array)
-    options[:delimiter] ||= ", "
-    val.join(options[:delimiter])
-  end
-
   def format_datetime_ordinal(val, options)
     val = format_datetime(val, options)
     format_number_ordinal(val, options)

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -159,24 +159,6 @@ module MiqReport::Formatting
     apply_prefix_and_suffix(val, options)
   end
 
-  def format_boolean(val, options = {})
-    return val.to_s.titleize if options.blank?
-    return val.to_s.titleize unless val.kind_of?(TrueClass) || val.kind_of?(FalseClass)
-
-    case options[:format]
-    when "yes_no"
-      return val == true ? "Yes" : "No"
-    when "y_n"
-      return val == true ? "Y" : "N"
-    when "t_f"
-      return val == true ? "T" : "F"
-    when "pass_fail"
-      return val == true ? "Pass" : "Fail"
-    else
-      return val.to_s.titleize
-    end
-  end
-
   def format_datetime(val, options)
     return val unless val.kind_of?(Time) || val.kind_of?(Date)
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -158,9 +158,4 @@ module MiqReport::Formatting
     val = ActionView::Base.new.mhz_to_human_size(val, options[:precision])
     apply_prefix_and_suffix(val, options)
   end
-
-  def format_large_number_to_exponential_form(val, _options = {})
-    return val if val.to_f < 1.0e+15
-    val.to_f.to_s
-  end
 end


### PR DESCRIPTION
All of these methods aren't being used. Confirmed spelunking through history passed the vmdb reroot and moving these into their own module.