### PR TITLE
Leverage ancestry for ServiceOrchestration#vms

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
@@ -19,6 +19,10 @@ class ManageIQ::Providers::CloudManager::OrchestrationStack < ::OrchestrationSta
     vms.size
   end
 
+  def indirect_vms
+    MiqPreloader.preload_and_map(children, :direct_vms)
+  end
+
   def total_security_groups
     security_groups.size
   end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -31,10 +31,7 @@ class OrchestrationStack < ApplicationRecord
   end
 
   def directs_and_indirects(direct_attrs)
-    return send(direct_attrs) if descendants.blank?
-
-    indirects = descendants.inject([]) { |arr, child| arr << child.send(direct_attrs) }
-    (indirects << send(direct_attrs)).flatten
+    MiqPreloader.preload_and_map(subtree, direct_attrs)
   end
   private :directs_and_indirects
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -98,7 +98,10 @@ class Service < ApplicationRecord
   def all_vms
     direct_vms + indirect_vms
   end
-  alias_method :vms, :all_vms
+
+  def vms
+    all_vms
+  end
 
   def start
     raise_request_start_event

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -76,7 +76,7 @@ class ServiceOrchestration < Service
   end
 
   def indirect_vms
-    all_vms - direct_vms
+    orchestration_stack.try(:indirect_vms) || []
   end
 
   def direct_vms

--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -3,4 +3,14 @@ module MiqPreloader
     preloader = ActiveRecord::Associations::Preloader.new
     preloader.preload(records, associations)
   end
+
+  # it will load records and their associations, and return the children
+  #
+  # instead of N+1:
+  #   orchestration_stack.subtree.flat_map(&:direct_vms)
+  # use instead:
+  #   preload_and_map(orchestration_stack.subtree, :direct_vms)
+  def self.preload_and_map(records, association)
+    records.to_a.tap { |recs| MiqPreloader.preload(recs, association) }.flat_map(&association)
+  end
 end

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -158,15 +158,17 @@ describe ServiceOrchestration do
 
   context '#all_vms' do
     it 'returns all vms from a deployed stack' do
-      vm1 = double
-      vm2 = double
-      allow(deployed_stack).to receive(:vms).and_return([vm1, vm2])
-      allow(deployed_stack).to receive(:direct_vms).and_return([vm1])
+      vm1 = FactoryGirl.create(:vm_amazon)
+      vm2 = FactoryGirl.create(:vm_amazon)
 
-      expect(service_with_deployed_stack.all_vms).to eq([vm1, vm2])
-      expect(service_with_deployed_stack.direct_vms).to eq([vm1])
-      expect(service_with_deployed_stack.indirect_vms).to eq([vm2])
-      expect(service_with_deployed_stack.vms).to eq([vm1, vm2])
+      child_stack = FactoryGirl.create(:orchestration_stack_amazon, :parent => deployed_stack)
+      deployed_stack.direct_vms << vm1
+      child_stack.direct_vms << vm2
+
+      expect(service_with_deployed_stack.all_vms.map(&:id)).to match_array([vm1, vm2].map(&:id))
+      expect(service_with_deployed_stack.direct_vms.map(&:id)).to match_array([vm1].map(&:id))
+      expect(service_with_deployed_stack.indirect_vms.map(&:id)).to match_array([vm2].map(&:id))
+      expect(service_with_deployed_stack.vms.map(&:id)).to match_array([vm1, vm2].map(&:id))
     end
 
     it 'returns no vm if no stack is deployed' do


### PR DESCRIPTION
Pulled out of #7114

This uses ancestry to bring back all vms and children rather than traversing the tree and then accessing each node.

/cc @matthewd @Fryguy this blocks other PR. seems to make sense pulling out
/cc @bzwei FYI