### PR TITLE
Associations need explicit reloads; passing `true` is deprecated

### DIFF
--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -83,9 +83,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_flavors_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.flavors(true)
+    ems.flavors.reset
     deletes = if (target == ems)
-                ems.flavors.dup
+                :use_association
               else
                 []
               end
@@ -97,9 +97,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_availability_zones_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.availability_zones(true)
+    ems.availability_zones.reset
     deletes = if (target == ems)
-                ems.availability_zones.dup
+                :use_association
               else
                 []
               end
@@ -111,9 +111,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_cloud_tenants_inventory(ems, hashes, target = nil)
     target ||= ems
 
-    ems.cloud_tenants(true)
+    ems.cloud_tenants.reset
     deletes = if (target == ems)
-                ems.cloud_tenants.dup
+                :use_association
               else
                 []
               end
@@ -125,9 +125,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_cloud_resource_quotas_inventory(ems, hashes, target = nil)
     target ||= ems
 
-    ems.cloud_resource_quotas(true)
+    ems.cloud_resource_quotas.reset
     deletes = if (target == ems)
-                ems.cloud_resource_quotas.dup
+                :use_association
               else
                 []
               end
@@ -143,9 +143,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_key_pairs_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.key_pairs(true)
+    ems.key_pairs.reset
     deletes = if (target == ems)
-                ems.key_pairs.dup
+                :use_association
               else
                 []
               end
@@ -157,9 +157,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_cloud_volumes_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.cloud_volumes(true)
+    ems.cloud_volumes.reset
     deletes = if (target == ems)
-                ems.cloud_volumes.dup
+                :use_association
               else
                 []
               end
@@ -178,9 +178,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.cloud_volume_snapshots(true)
+    ems.cloud_volume_snapshots.reset
     deletes = if (target == ems)
-                ems.cloud_volume_snapshots.dup
+                :use_association
               else
                 []
               end
@@ -209,9 +209,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_cloud_object_store_containers_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.cloud_object_store_containers(true)
+    ems.cloud_object_store_containers.reset
     deletes = if (target == ems)
-                ems.cloud_object_store_containers.dup
+                :use_association
               else
                 []
               end
@@ -228,9 +228,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_cloud_object_store_objects_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.cloud_object_store_objects(true)
+    ems.cloud_object_store_objects.reset
     deletes = if (target == ems)
-                ems.cloud_object_store_objects.dup
+                :use_association
               else
                 []
               end
@@ -248,9 +248,9 @@ module EmsRefresh::SaveInventoryCloud
   def save_resource_groups_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.resource_groups(true)
+    ems.resource_groups.reset
     deletes = if (target == ems)
-                ems.resource_groups.dup
+                :use_association
               else
                 []
               end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -20,9 +20,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_projects(true)
+    ems.container_projects.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_projects.dup
+                :use_association
               else
                 []
               end
@@ -36,9 +36,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.persistent_volumes(true)
+    ems.persistent_volumes.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.persistent_volumes.dup
+                :use_association
               else
                 []
               end
@@ -51,9 +51,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hash.nil?
     target = ems if target.nil?
 
-    ems.container_quotas(true)
+    ems.container_quotas.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_quotas.dup
+                :use_association
               else
                 []
               end
@@ -68,9 +68,9 @@ module EmsRefresh::SaveInventoryContainer
 
   def save_container_quota_items_inventory(container_quota, hashes, target = nil)
     return if hashes.nil?
-    container_quota.container_quota_items(true)
+    container_quota.container_quota_items.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_quota.container_quota_items.dup
+                :use_association
               else
                 []
               end
@@ -82,9 +82,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hash.nil?
     target = ems if target.nil?
 
-    ems.container_limits(true)
+    ems.container_limits.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_limits.dup
+                :use_association
               else
                 []
               end
@@ -98,9 +98,9 @@ module EmsRefresh::SaveInventoryContainer
 
   def save_container_limit_items_inventory(container_limit, hashes, target = nil)
     return if hashes.nil?
-    container_limit.container_limit_items(true)
+    container_limit.container_limit_items.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_limit.container_limit_items.dup
+                :use_association
               else
                 []
               end
@@ -112,9 +112,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_routes(true)
+    ems.container_routes.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_routes.dup
+                :use_association
               else
                 []
               end
@@ -133,9 +133,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_nodes(true)
+    ems.container_nodes.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_nodes.dup
+                :use_association
               else
                 []
               end
@@ -153,9 +153,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_replicators(true)
+    ems.container_replicators.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_replicators.dup
+                :use_association
               else
                 []
               end
@@ -173,9 +173,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_services(true)
+    ems.container_services.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_services.dup
+                :use_association
               else
                 []
               end
@@ -197,9 +197,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_groups(true)
+    ems.container_groups.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_groups.dup
+                :use_association
               else
                 []
               end
@@ -221,9 +221,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_container_definitions_inventory(container_group, hashes, target = nil)
     return if hashes.nil?
 
-    container_group.container_definitions(true)
+    container_group.container_definitions.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_group.container_definitions.dup
+                :use_association
               else
                 []
               end
@@ -236,9 +236,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_container_port_configs_inventory(container_definition, hashes, target = nil)
     return if hashes.nil?
 
-    container_definition.container_port_configs(true)
+    container_definition.container_port_configs.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_definition.container_port_configs.dup
+                :use_association
               else
                 []
               end
@@ -250,9 +250,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_container_service_port_configs_inventory(container_service, hashes, target = nil)
     return if hashes.nil?
 
-    container_service.container_service_port_configs(true)
+    container_service.container_service_port_configs.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_service.container_service_port_configs.dup
+                :use_association
               else
                 []
               end
@@ -263,9 +263,9 @@ module EmsRefresh::SaveInventoryContainer
 
   def save_container_env_vars_inventory(container_definition, hashes, target = nil)
     return if hashes.nil?
-    container_definition.container_env_vars(true)
+    container_definition.container_env_vars.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_definition.container_env_vars.dup
+                :use_association
               else
                 []
               end
@@ -276,9 +276,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_container_images_inventory(ems, hashes, target = nil)
     return if hashes.nil?
 
-    ems.container_images(true)
+    ems.container_images.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_images.dup
+                :use_association
               else
                 []
               end
@@ -297,9 +297,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_image_registries(true)
+    ems.container_image_registries.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_image_registries.dup
+                :use_association
               else
                 []
               end
@@ -311,9 +311,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_container_component_statuses_inventory(ems, hashes, target = nil)
     return if hashes.nil?
 
-    ems.container_component_statuses(true)
+    ems.container_component_statuses.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.container_component_statuses.dup
+                :use_association
               else
                 []
               end
@@ -333,9 +333,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_container_conditions_inventory(container_entity, hashes, target = nil)
     return if hashes.nil?
 
-    container_entity.container_conditions(true)
+    container_entity.container_conditions.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_entity.container_conditions.dup
+                :use_association
               else
                 []
               end
@@ -351,9 +351,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_container_volumes_inventory(container_group, hashes, target = nil)
     return if hashes.nil?
 
-    container_group.container_volumes(true)
+    container_group.container_volumes.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                container_group.container_volumes.dup
+                :use_association
               else
                 []
               end
@@ -365,9 +365,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_labels_inventory(entity, hashes, target = nil)
     return if hashes.nil?
 
-    entity.labels(true)
+    entity.labels.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                entity.labels.dup
+                :use_association
               else
                 []
               end
@@ -379,9 +379,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_selector_parts_inventory(entity, hashes, target = nil)
     return if hashes.nil?
 
-    entity.selector_parts(true)
+    entity.selector_parts.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                entity.selector_parts.dup
+                :use_association
               else
                 []
               end
@@ -393,9 +393,9 @@ module EmsRefresh::SaveInventoryContainer
   def save_node_selector_parts_inventory(entity, hashes, target = nil)
     return if hashes.nil?
 
-    entity.node_selector_parts(true)
+    entity.node_selector_parts.reset
     deletes = if target.kind_of?(ExtManagementSystem)
-                entity.node_selector_parts.dup
+                :use_association
               else
                 []
               end
@@ -408,8 +408,8 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_builds(true)
-    deletes = target.kind_of?(ExtManagementSystem) ? ems.container_builds.dup : []
+    ems.container_builds.reset
+    deletes = target.kind_of?(ExtManagementSystem) ? :use_association : []
 
     hashes.each do |h|
       h[:container_project_id] = h.fetch_path(:project, :id)
@@ -423,8 +423,8 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     target = ems if target.nil?
 
-    ems.container_build_pods(true)
-    deletes = target.kind_of?(ExtManagementSystem) ? ems.container_build_pods.dup : []
+    ems.container_build_pods.reset
+    deletes = target.kind_of?(ExtManagementSystem) ? :use_association : []
 
     hashes.each do |h|
       h[:container_build_id] = h.fetch_path(:build_config, :id)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -34,7 +34,15 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [])
-    deletes = deletes.to_a # make sure to load the association if it's an association
+    association.reset
+
+    if deletes == :use_association
+      deletes = association
+    elsif deletes.respond_to?(:reload) && deletes.loaded?
+      deletes.reload
+    end
+    deletes = deletes.to_a
+
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys
 
@@ -139,6 +147,6 @@ module EmsRefresh::SaveInventoryHelper
     # if this association isn't the definitive source
     top_level = association.proxy_association.options[:dependent] == :destroy
 
-    top_level && (target == true || target.nil? || parent == target) ? association.to_a.dup : []
+    top_level && (target == true || target.nil? || parent == target) ? :use_association : []
   end
 end

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -107,7 +107,7 @@ module EmsRefresh::SaveInventoryInfra
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if (target == ems)
-                    target.hosts(true).to_a.dup
+                    target.hosts.reload.to_a
                   elsif target.kind_of?(Host)
                     [target.clone]
                   else
@@ -206,9 +206,9 @@ module EmsRefresh::SaveInventoryInfra
   def save_folders_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.ems_folders(true)
+    ems.ems_folders.reset
     deletes = if (target == ems)
-                ems.ems_folders.dup
+                :use_association
               else
                 []
               end
@@ -221,9 +221,9 @@ module EmsRefresh::SaveInventoryInfra
   def save_clusters_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.ems_clusters(true)
+    ems.ems_clusters.reset
     deletes = if (target == ems)
-                ems.ems_clusters.dup
+                :use_association
               else
                 []
               end
@@ -236,11 +236,11 @@ module EmsRefresh::SaveInventoryInfra
   def save_resource_pools_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.resource_pools(true)
+    ems.resource_pools.reset
     deletes = if (target == ems)
-                ems.resource_pools.dup
+                :use_association
               elsif target.kind_of?(Host)
-                target.all_resource_pools_with_default.dup
+                target.all_resource_pools_with_default
               else
                 []
               end
@@ -250,23 +250,19 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_customization_specs_inventory(ems, hashes, _target = nil)
-    deletes = ems.customization_specs(true).dup
-    save_inventory_multi(ems.customization_specs, hashes, deletes, [:name])
+    save_inventory_multi(ems.customization_specs, hashes, :use_association, [:name])
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)
-    deletes = guest_device.miq_scsi_targets(true).dup
-    save_inventory_multi(guest_device.miq_scsi_targets, hashes, deletes, [:uid_ems], :miq_scsi_luns)
+    save_inventory_multi(guest_device.miq_scsi_targets, hashes, :use_association, [:uid_ems], :miq_scsi_luns)
   end
 
   def save_miq_scsi_luns_inventory(miq_scsi_target, hashes)
-    deletes = miq_scsi_target.miq_scsi_luns(true).dup
-    save_inventory_multi(miq_scsi_target.miq_scsi_luns, hashes, deletes, [:uid_ems])
+    save_inventory_multi(miq_scsi_target.miq_scsi_luns, hashes, :use_association, [:uid_ems])
   end
 
   def save_switches_inventory(host, hashes)
-    deletes = host.switches(true).dup
-    save_inventory_multi(host.switches, hashes, deletes, [:uid_ems], :lans)
+    save_inventory_multi(host.switches, hashes, :use_association, [:uid_ems], :lans)
 
     host.save!
 
@@ -284,13 +280,11 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_lans_inventory(switch, hashes)
-    deletes = switch.lans(true).dup
-    save_inventory_multi(switch.lans, hashes, deletes, [:uid_ems])
+    save_inventory_multi(switch.lans, hashes, :use_association, [:uid_ems])
   end
 
   def save_storage_files_inventory(storage, hashes)
-    deletes = storage.storage_files(true).dup
-    save_inventory_multi(storage.storage_files, hashes, deletes, [:name])
+    save_inventory_multi(storage.storage_files, hashes, :use_association, [:name])
   end
 
   def find_host(h, ems_id)

--- a/app/models/ems_refresh/save_inventory_middleware.rb
+++ b/app/models/ems_refresh/save_inventory_middleware.rb
@@ -18,7 +18,7 @@ module EmsRefresh::SaveInventoryMiddleware
 
     ems.middleware_servers(true)
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.middleware_servers.dup
+                :use_association
               else
                 []
               end
@@ -33,7 +33,7 @@ module EmsRefresh::SaveInventoryMiddleware
 
     ems.middleware_deployments(true)
     deletes = if target.kind_of?(ExtManagementSystem)
-                ems.middleware_deployments.dup
+                :use_association
               else
                 []
               end

--- a/app/models/ems_refresh/save_inventory_networks.rb
+++ b/app/models/ems_refresh/save_inventory_networks.rb
@@ -13,9 +13,9 @@ module EmsRefresh
     def save_cloud_networks_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.cloud_networks(true)
+      ems.cloud_networks.reset
       deletes = if (target == ems)
-                  ems.cloud_networks.dup
+                  :use_association
                 else
                   []
                 end
@@ -35,8 +35,6 @@ module EmsRefresh
     end
 
     def save_cloud_subnets_inventory(cloud_network, hashes)
-      deletes = cloud_network.cloud_subnets(true).dup
-
       hashes.each do |h|
         %i(availability_zone).each do |relation|
           h[relation] = h.fetch_path(relation, :_object) if h.fetch_path(relation, :_object)
@@ -45,7 +43,7 @@ module EmsRefresh
         h[:ems_id] = cloud_network.ems_id
       end
 
-      save_inventory_multi(cloud_network.cloud_subnets, hashes, deletes, [:ems_ref], nil, [:network_router])
+      save_inventory_multi(cloud_network.cloud_subnets, hashes, :use_association, [:ems_ref], nil, [:network_router])
 
       cloud_network.save!
       store_ids_for_new_records(cloud_network.cloud_subnets, hashes, :ems_ref)
@@ -54,9 +52,9 @@ module EmsRefresh
     def save_security_groups_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.security_groups(true)
+      ems.security_groups.reset
       deletes = if (target == ems)
-                  ems.security_groups.dup
+                  :use_association
                 else
                   []
                 end
@@ -88,9 +86,9 @@ module EmsRefresh
     def save_floating_ips_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.floating_ips(true)
+      ems.floating_ips.reset
       deletes = if (target == ems)
-                  ems.floating_ips.dup
+                  :use_association
                 else
                   []
                 end
@@ -123,8 +121,7 @@ module EmsRefresh
           [:name]
         end
 
-      deletes = parent.firewall_rules(true).dup
-      save_inventory_multi(parent.firewall_rules, hashes, deletes, find_key, nil, [:source_security_group])
+      save_inventory_multi(parent.firewall_rules, hashes, :use_association, find_key, nil, [:source_security_group])
 
       parent.save!
       store_ids_for_new_records(parent.firewall_rules, hashes, find_key)
@@ -133,9 +130,9 @@ module EmsRefresh
     def save_network_routers_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.network_routers(true)
+      ems.network_routers.reset
       deletes = if (target == ems)
-                  ems.network_routers.dup
+                  :use_association
                 else
                   []
                 end
@@ -157,9 +154,9 @@ module EmsRefresh
     def save_network_ports_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.network_ports(true)
+      ems.network_ports.reset
       deletes = if (target == ems)
-                  ems.network_ports.dup
+                  :use_association
                 else
                   []
                 end

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -18,7 +18,7 @@ module EmsRefresh
     def save_orchestration_stacks_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      deletes = target == ems ? ems.orchestration_stacks(true).dup : []
+      deletes = target == ems ? :use_association : []
 
       hashes.each do |h|
         h[:orchestration_template_id] = h.fetch_path(:orchestration_template, :id)
@@ -32,7 +32,7 @@ module EmsRefresh
                                     [:parameters, :outputs, :resources],
                                     [:parent, :orchestration_template, :cloud_tenant])
 
-      store_ids_for_new_records(ems.orchestration_stacks(true), hashes, :ems_ref)
+      store_ids_for_new_records(ems.orchestration_stacks.reload, hashes, :ems_ref)
 
       save_orchestration_stack_nesting(stacks.index_by(&:id), hashes)
     end
@@ -45,29 +45,23 @@ module EmsRefresh
     end
 
     def save_parameters_inventory(orchestration_stack, hashes)
-      deletes = orchestration_stack.parameters(true).dup
-
       save_inventory_multi(orchestration_stack.parameters,
                            hashes,
-                           deletes,
+                           :use_association,
                            [:ems_ref])
     end
 
     def save_outputs_inventory(orchestration_stack, hashes)
-      deletes = orchestration_stack.outputs(true).dup
-
       save_inventory_multi(orchestration_stack.outputs,
                            hashes,
-                           deletes,
+                           :use_association,
                            [:ems_ref])
     end
 
     def save_resources_inventory(orchestration_stack, hashes)
-      deletes = orchestration_stack.resources(true).dup
-
       save_inventory_multi(orchestration_stack.resources,
                            hashes,
-                           deletes,
+                           :use_association,
                            [:ems_ref])
     end
   end

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -30,7 +30,7 @@ module Metric::Capture
   def self.perf_capture_timer(zone = nil)
     _log.info "Queueing performance capture..."
 
-    zone ||= MiqServer.my_server.zone(true)
+    zone ||= MiqServer.my_server.zone
     perf_capture_health_check(zone)
     targets = Metric::Targets.capture_targets(zone)
 

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -85,7 +85,7 @@ module Metric::Targets
   # If a Cluster is enabled, capture all of its Hosts.
   # If a Host is enabled, capture all of its Vms.
   def self.capture_targets(zone = nil, options = {})
-    zone = MiqServer.my_server.zone(true) if zone.nil?
+    zone = MiqServer.my_server.zone if zone.nil?
     zone = Zone.find(zone) if zone.kind_of?(Integer)
     capture_infra_targets(zone, options) + \
       capture_cloud_targets(zone, options) + \

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -36,10 +36,10 @@ class MiqRequestTask < ApplicationRecord
 
   def update_and_notify_parent(upd_attr)
     upd_attr[:message] = upd_attr[:message][0, 255] if upd_attr.key?(:message)
-    self.update_attributes!(upd_attr)
+    update_attributes! upd_attr
 
     # If this request has a miq_request_task parent use that, otherwise the parent is the miq_request
-    parent = miq_request_task.nil? ? miq_request(true) : miq_request_task(true)
+    parent = miq_request_task || miq_request
     parent.update_request_status
   end
 

--- a/app/models/service_template_orchestration.rb
+++ b/app/models/service_template_orchestration.rb
@@ -5,7 +5,7 @@ class ServiceTemplateOrchestration < ServiceTemplate
 
   def remove_invalid_resource
     # remove the resource from both memory and table
-    service_resources.to_a.delete_if { |r| r.destroy unless r.resource(true) }
+    service_resources.to_a.delete_if { |r| r.destroy unless r.resource }
   end
 
   def create_subtasks(_parent_service_task, _parent_service)

--- a/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
@@ -135,11 +135,11 @@ describe MiqEmsRefreshCoreWorker::Runner do
         end
 
         def should_not_have_network_changes
-          expect(@hw.nics(true).sort_by(&:address).collect { |n| [n.network.try(:ipaddress), n.network.try(:ipv6address)] }).to eq(@expected_addresses)
+          expect(@hw.nics.reload.sort_by(&:address).collect { |n| [n.network.try(:ipaddress), n.network.try(:ipv6address)] }).to eq(@expected_addresses)
         end
 
         def should_have_network_changes(expected)
-          expect(@hw.nics(true).sort_by(&:address).collect { |n| [n.network.try(:ipaddress), n.network.try(:ipv6address)] }).to eq(expected)
+          expect(@hw.nics.reload.sort_by(&:address).collect { |n| [n.network.try(:ipaddress), n.network.try(:ipv6address)] }).to eq(expected)
         end
       end
     end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -126,7 +126,7 @@ describe "MiqWorker Monitor" do
         it "on worker destroy, will no longer associate the 'ready' message with the worker" do
           @worker.destroy
           expect(MiqQueue.where(:state => 'ready').count).to eq(1)
-          expect(@worker.messages(true).size).to eq(0)
+          expect(@worker.messages.reload.size).to eq(0)
 
           m = @messages.first.reload
           expect(m.handler_type).to be_nil


### PR DESCRIPTION
Where sensible, I'm calling #reset instead of #reload. It's not really going to make a difference (because in all these cases, the load will still occur within a couple of lines), but it's a slightly clearer statement of intent.

---

I really wish we could avoid throwing away so much data so often, when the problem we're trying to protect against is that *this current process* might possibly have changed something: surely we could better track exactly which things need to be invalidated, instead of our current "just in case" approach. But that's for another time.