### PR TITLE
ApplicationController#set_config - fix string+nil concatenation errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1200,11 +1200,20 @@ class ApplicationController < ActionController::Base
       # Add disks to the device array
       unless db_record.hardware.disks.nil?
         db_record.hardware.disks.each do |disk|
-          loc = disk.location.nil? ? "" : disk.location
-          dev = disk.controller_type ? disk.controller_type << " " << loc : ""  # default device is controller_type
-          desc = disk.filename                              # default description is filename
-          icon = disk.device_name                       # default icon prefix is device_name
+          # relying on to_s to force nils into ""
+          loc = disk.location.to_s
+
+          # default device is controller_type
+          dev = disk.controller_type ? "#{disk.controller_type} #{loc}" : ""
+
+          # default description is filename
+          desc = disk.filename.to_s
+
+          # default icon prefix is device_name
+          icon = disk.device_name.to_s
+
           conn = disk.start_connected ? _(", Connect at Power On = Yes") : _(", Connect at Power On = No")
+
           # Customize disk entries by type
           if disk.device_type == "cdrom-raw"
             dev = _("CD-ROM (IDE %{location})%{connection}") % {:location => loc, :connection => conn}
@@ -1272,7 +1281,7 @@ class ApplicationController < ActionController::Base
             icon = "floppy"
           end
           # uppercase the first character of the device name and description
-          dev = dev[0..0].upcase + dev[1..-1]
+          dev = dev[0..0].upcase + dev[1..-1].to_s
           desc = desc.nil? ? "" : desc[0..0].upcase + desc[1..-1].to_s
 
           @devices.push(:device      => dev,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1282,7 +1282,7 @@ class ApplicationController < ActionController::Base
           end
           # uppercase the first character of the device name and description
           dev = dev[0..0].upcase + dev[1..-1].to_s
-          desc = desc.nil? ? "" : desc[0..0].upcase + desc[1..-1].to_s
+          desc = desc[0..0].upcase + desc[1..-1].to_s
 
           @devices.push(:device      => dev,
                         :description => desc,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -158,6 +158,28 @@ describe ApplicationController do
       expect(response.status).to eq(200)
       expect(assigns(:devices)).to_not be_empty
     end
+
+    it "doesn't crash on nil filename" do
+      disk = FactoryGirl.create(:disk, :filename => nil, :controller_type => nil, :device_type => 'disk', :mode => "foo")
+      host_hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8, :disks => [disk])
+      host = FactoryGirl.create(:host, :hardware => host_hardware)
+      set_user_privileges
+
+      controller.send(:set_config, host)
+      expect(response.status).to eq(200)
+      expect(assigns(:devices)).to_not be_empty
+    end
+
+    it "doesn't crash on one letter controller_type" do
+      disk = FactoryGirl.create(:disk, :controller_type => nil)
+      host_hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8, :disks => [disk])
+      host = FactoryGirl.create(:host, :hardware => host_hardware)
+      set_user_privileges
+
+      controller.send(:set_config, host)
+      expect(response.status).to eq(200)
+      expect(assigns(:devices)).to_not be_empty
+    end
   end
 
   context "#prov_redirect" do


### PR DESCRIPTION
For some cases nil was handled but not others - forcing `loc`, `dev`, `desc` and `icon` to always be a string.
    
+ handle the case of empty or singler letter `dev` (`""[1..-1]` is nil)
    
+ 2 specs .. one is to catch `"" + nil` and the other `nil << ""`

https://bugzilla.redhat.com/show_bug.cgi?id=1312560