### PR TITLE
Show <choose> in Virtual Private Cloud select by default.

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
@@ -159,7 +159,6 @@
             :method: :allowed_cloud_networks
           :description: Virtual Private Cloud
           :auto_select_single: false
-          :default: nil
           :required: false
           :display: :edit
           :data_type: :integer

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -155,7 +155,6 @@
             :method: :allowed_cloud_networks
           :description: Virtual Private Cloud
           :auto_select_single: false
-          :default: nil
           :required: true
           :display: :edit
           :data_type: :integer


### PR DESCRIPTION
Removed default: nil from dialog, so VPC pull down displays <Choose> as default selected option to get other pull downs on the screen populated appropriately based upon Virtual Private Cloud pull down selection.

https://bugzilla.redhat.com/show_bug.cgi?id=1315945
Issue #6501 

@bronaghs @dclarizio please review.

before:
![before](https://cloud.githubusercontent.com/assets/3450808/13674633/4303b53e-e6ac-11e5-8903-33487f3e5b7c.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/13674638/4a0fc070-e6ac-11e5-8654-e409bf0daf97.png)
