### PR TITLE
find_filtered: remove 'count' argument

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2464,7 +2464,7 @@ class ApplicationController < ActionController::Base
       raise("User '#{current_userid}' is not authorized to access '#{ui_lookup(:model => db.to_s)}' record id '#{id}'")
   end
 
-  def find_filtered(db, count, options = {})
+  def find_filtered(db, options = {})
     user     = current_user
     mfilters = user ? user.get_managed_filters : []
     bfilters = user ? user.get_belongsto_filters : []
@@ -2472,7 +2472,7 @@ class ApplicationController < ActionController::Base
     if db.respond_to?(:find_filtered) && !mfilters.empty?
       result = db.find_tags_by_grouping(mfilters, :conditions => options[:conditions], :ns => "*")
     else
-      result = db.find(count, options)
+      result = db.all
     end
 
     result = MiqFilter.apply_belongsto_filters(result, bfilters) if db.respond_to?(:find_filtered) && result

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -161,7 +161,7 @@ class MiqCapacityController < ApplicationController
       @sb[:planning][:options][:filter_value] = nil
       if params[:filter_typ] == "all"
         @sb[:planning][:vms] = {}
-        find_filtered(Vm, :all).sort_by { |v| v.name.downcase }.each { |e| @sb[:planning][:vms][e.id.to_s] = e.name }
+        find_filtered(Vm).sort_by { |v| v.name.downcase }.each { |e| @sb[:planning][:vms][e.id.to_s] = e.name }
       end
     end
     if params[:filter_value]
@@ -546,13 +546,13 @@ class MiqCapacityController < ApplicationController
     @sb[:planning][:options][:display_vms] ||= 100
 
     @sb[:planning][:emss] = {}
-    find_filtered(ExtManagementSystem, :all).each { |e| @sb[:planning][:emss][e.id.to_s] = e.name }
+    find_filtered(ExtManagementSystem).each { |e| @sb[:planning][:emss][e.id.to_s] = e.name }
     @sb[:planning][:clusters] = {}
-    find_filtered(EmsCluster, :all).each { |e| @sb[:planning][:clusters][e.id.to_s] = e.name }
+    find_filtered(EmsCluster).each { |e| @sb[:planning][:clusters][e.id.to_s] = e.name }
     @sb[:planning][:hosts] = {}
-    find_filtered(Host, :all).each { |e| @sb[:planning][:hosts][e.id.to_s] = e.name }
+    find_filtered(Host).each { |e| @sb[:planning][:hosts][e.id.to_s] = e.name }
     @sb[:planning][:datastores] = {}
-    find_filtered(Storage, :all).each { |e| @sb[:planning][:datastores][e.id.to_s] = e.name }
+    find_filtered(Storage).each { |e| @sb[:planning][:datastores][e.id.to_s] = e.name }
     @sb[:planning][:vm_filters] = MiqSearch.where(:db => "Vm").descriptions
     @right_cell_text = "Planning Summary"
     if params[:button] == "reset"

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -53,11 +53,11 @@ module MiqPolicyController::Rsop
       @accords = [{:name => "rsop", :title => "Options", :container => "rsop_options_div"}]
       session[:changed] = false
       @sb[:rsop] ||= {}   # Leave exising values
-      rsop_put_objects_in_sb(find_filtered(ExtManagementSystem, :all), :emss)
-      rsop_put_objects_in_sb(find_filtered(EmsCluster, :all), :clusters)
-      rsop_put_objects_in_sb(find_filtered(Host, :all), :hosts)
-      rsop_put_objects_in_sb(find_filtered(Vm, :all), :vms)
-      rsop_put_objects_in_sb(find_filtered(Storage, :all), :datastores)
+      rsop_put_objects_in_sb(find_filtered(ExtManagementSystem), :emss)
+      rsop_put_objects_in_sb(find_filtered(EmsCluster), :clusters)
+      rsop_put_objects_in_sb(find_filtered(Host), :hosts)
+      rsop_put_objects_in_sb(find_filtered(Vm), :vms)
+      rsop_put_objects_in_sb(find_filtered(Storage), :datastores)
       @rsop_events = MiqEventDefinitionSet.all.collect { |e| [e.description, e.id.to_s] }.sort
       @rsop_event_sets = MiqEventDefinitionSet.find(@sb[:rsop][:event]).miq_event_definitions.collect { |e| [e.description, e.id.to_s] }.sort unless @sb[:rsop][:event].nil?
       render :layout => "application"

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -306,16 +306,16 @@ module OpsController::Settings::Schedules
   def build_filtered_item_list(filter_type)
     case filter_type
     when "vm"
-      filtered_item_list = find_filtered(Vm, :all).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
+      filtered_item_list = find_filtered(Vm).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
     when "miq_template"
       filtered_item_list =
-        find_filtered(MiqTemplate, :all).sort_by { |miq_template| miq_template.name.downcase }.collect(&:name).uniq
+        find_filtered(MiqTemplate).sort_by { |miq_template| miq_template.name.downcase }.collect(&:name).uniq
     when "host"
-      filtered_item_list = find_filtered(Host, :all).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
+      filtered_item_list = find_filtered(Host).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
     when "ems"
-      filtered_item_list = find_filtered(ExtManagementSystem, :all).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
+      filtered_item_list = find_filtered(ExtManagementSystem).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
     when "cluster"
-      filtered_item_list = find_filtered(EmsCluster, :all).collect do |cluster|
+      filtered_item_list = find_filtered(EmsCluster).collect do |cluster|
         [cluster.name + "__" + cluster.v_parent_datacenter, cluster.v_qualified_desc]
       end.sort_by { |cluster| cluster.first.downcase }.uniq
     when "global"


### PR DESCRIPTION
We don't need the `count` argument, because:
1. `db.find(:all)` no longer works with ActiveRecord 5
2. the semantics of `find_filtered()` is:
   * apply `managed` and `belongsto` filters if applicable and return results
   * return all results otherwise (we use `find_filtered(db, :all)` everywhere anyway)