### PR TITLE
Assign rates to tenants

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -727,21 +727,14 @@ class ChargebackController < ApplicationController
 
   def get_cis_all
     @edit[:cb_assign][:cis] = {}
-    if @edit[:new][:cbshow_typ] == "enterprise"
-      e_id = MiqEnterprise.first
-      @edit[:cb_assign][:cis]["#{e_id.id}"] = "Enterprise"
-    elsif @edit[:new][:cbshow_typ] == "storage"
-      Storage.all.each do |s|
-        @edit[:cb_assign][:cis][s.id] = s.name
+    classtype =
+      if @edit[:new][:cbshow_typ] == "enterprise"
+        MiqEnterprise
+      else
+        @edit[:new][:cbshow_typ].classify.constantize
       end
-    elsif @edit[:new][:cbshow_typ] == "ext_management_system"
-      ExtManagementSystem.all.each do |ms|
-        @edit[:cb_assign][:cis][ms.id] = ms.name
-      end
-    elsif @edit[:new][:cbshow_typ] == "ems_cluster"
-      EmsCluster.all.each do |cl|
-        @edit[:cb_assign][:cis][cl.id] = cl.name
-      end
+    classtype.all.each do |instance|
+      @edit[:cb_assign][:cis][instance.id] = instance.name
     end
   end
 

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -725,13 +725,18 @@ class ChargebackController < ApplicationController
     classification.entries.each { |e| @edit[:cb_assign][:tags][e.id.to_s] = e.description } if classification
   end
 
+  WHITELIST_INSTANCE_TYPE = %w(enterprise storage ext_management_system ems_cluster tenant).freeze
   def get_cis_all
     @edit[:cb_assign][:cis] = {}
+    klass = @edit[:new][:cbshow_typ]
+    unless WHITELIST_INSTANCE_TYPE.include?(klass)
+      raise ArgumentError, "Received: #{klass}, expected one of #{WHITELIST_INSTANCE_TYPE}"
+    end
     classtype =
-      if @edit[:new][:cbshow_typ] == "enterprise"
+      if klass == "enterprise"
         MiqEnterprise
       else
-        @edit[:new][:cbshow_typ].classify.constantize
+        klass.classify.constantize
       end
     classtype.all.each do |instance|
       @edit[:cb_assign][:cis][instance.id] = instance.name

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -462,7 +462,8 @@ module UiConstants
   ASSIGN_TOS["Storage"] = {
     "enterprise"   => _("The Enterprise"),
     "storage"      => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "storage")},
-    "storage-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "storage")}
+    "storage-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "storage")},
+    "tenant"       => _("Tenant")
   }
   ASSIGN_TOS["MiqServer"] = {
     "miq_server" => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "miq_server")},
@@ -474,7 +475,8 @@ module UiConstants
     "enterprise"            => _("The Enterprise"),
     "ext_management_system" => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ext_management_systems")},
     "ems_cluster"           => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ems_cluster")},
-    "vm-tags"               => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "vm")}
+    "vm-tags"               => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "vm")},
+    "tenant"		            => _("Tenant")
   }
 
   EXP_COUNT_TYPE = [_("Count of"), "count"].freeze  # Selection for count based filters

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -110,4 +110,30 @@ describe ChargebackController do
       expect(flash_array.first[:message]).to include("rate is assigned and cannot be deleted")
     end
   end
+
+  context "#get_cis_all" do
+    let!(:storage) { FactoryGirl.create(:storage) }
+    let!(:miq_enterprise) { FactoryGirl.create(:miq_enterprise) }
+
+    it "returns names of instances of enterprise" do
+      names_miqent = {}
+      MiqEnterprise.all.each do |instance|
+        names_miqent[instance.id] = instance.name
+      end
+      controller.instance_variable_set(:@edit, :new => {:cbshow_typ => "enterprise"}, :cb_assign => {})
+      controller.send(:get_cis_all)
+      expect(assigns(:edit)[:cb_assign][:cis]).to eq(names_miqent)
+    end
+
+    it "returns names of instances of storage" do
+      names_storage = {}
+      element = "storage"
+      element.classify.constantize.all.each do |instance|
+        names_storage[instance.id] = instance.name
+      end
+      controller.instance_variable_set(:@edit, :new => {:cbshow_typ => element}, :cb_assign => {})
+      controller.send(:get_cis_all)
+      expect(assigns(:edit)[:cb_assign][:cis]).to eq(names_storage)
+    end
+  end
 end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -135,5 +135,10 @@ describe ChargebackController do
       controller.send(:get_cis_all)
       expect(assigns(:edit)[:cb_assign][:cis]).to eq(names_storage)
     end
+
+    it "returns a ArgumentError when element not in whitelist" do
+      controller.instance_variable_set(:@edit, :new => {:cbshow_typ => "None"}, :cb_assign => {})
+      expect { controller.send(:get_cis_all) }.to raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
## Description

This pull request is simple: Assign a rate to a tenant

In this PR we add the option Tenant in the ChargeBack-->Assignments,  so now we can set a rate to a specific tenant  

## More Information 
Taiga:
https://tree.taiga.io/project/sergioocon-charging-in-manageiq/task/39