### PR TITLE
Add specs for VmdbLogger#log_hashes for password hiding.

### DIFF
--- a/gems/pending/spec/util/vmdb-logger_spec.rb
+++ b/gems/pending/spec/util/vmdb-logger_spec.rb
@@ -1,6 +1,35 @@
 require 'util/vmdb-logger'
 
 describe VMDBLogger do
+  describe "#log_hashes" do
+    let(:buffer) { StringIO.new }
+    let(:logger) { described_class.new(buffer) }
+
+    it "filters out passwords when keys are symbols" do
+      hash = {:a => {:b => 1, :password => "pa$$w0rd"}}
+      logger.log_hashes(hash)
+
+      buffer.rewind
+      expect(buffer.read).to_not include("pa$$w0rd")
+    end
+
+    it "filters out passwords when keys are strings" do
+      hash = {"a" => {"b" => 1, "password" => "pa$$w0rd"}}
+      logger.log_hashes(hash)
+
+      buffer.rewind
+      expect(buffer.read).to_not include("pa$$w0rd")
+    end
+
+    it "with :filter option, filters out given keys and passwords" do
+      hash = {:a => {:b => 1, :extra_key => "pa$$w0rd", :password => "pa$$w0rd"}}
+      logger.log_hashes(hash, :filter => :extra_key)
+
+      buffer.rewind
+      expect(buffer.read).to_not include("pa$$w0rd")
+    end
+  end
+
   it ".contents with no log returns empty string" do
     allow(File).to receive_messages(:file? => false)
     expect(VMDBLogger.contents("mylog.log")).to eq("")

--- a/gems/pending/util/vmdb-logger.rb
+++ b/gems/pending/util/vmdb-logger.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'active_support/core_ext/object/try'
 
 class VMDBLogger < Logger
   def initialize(*args)
@@ -88,12 +89,12 @@ class VMDBLogger < Logger
 
   def self.log_hashes(logger, h, options = {})
     level  = options[:log_level] || :info
-    filter = [options[:filter]].flatten.compact << "password"
+    filter = [options[:filter]].flatten.compact.map(&:to_s) << "password"
     filter.uniq!
 
     YAML.dump(h).split("\n").each do |l|
       next if l[0...3] == '---'
-      logger.send(level, "  #{l}") unless filter.any? { |f| l.include?(f.to_s) }
+      logger.send(level, "  #{l}") unless filter.any? { |f| l.include?(f) }
     end
   end
 


### PR DESCRIPTION
Extracted from configuration_revamp branch.

There is also a minor refactoring in here to avoid calling .to_s a ton of times.  Also it turned out you couldn't run this spec alone since it required activesupport try.

@jrafanie Please review.