### PR TITLE
Fix worker settings for testing

### DIFF
--- a/app/models/miq_replication_worker/runner.rb
+++ b/app/models/miq_replication_worker/runner.rb
@@ -174,13 +174,9 @@ class MiqReplicationWorker::Runner < MiqWorker::Runner
   end
 
   def child_process_heartbeat_settings
-    @default_settings ||= VMDB::Config.new("vmdb").retrieve_config(:tmpl)
-                          .fetch_path(:workers, :worker_base, :replication_worker, :replication)
-    worker_settings ||= @default_settings
     {
       :file      => MiqRubyrep.heartbeat_file,
-      :threshold => worker_settings.fetch_path(:options, :heartbeat_threshold).to_i ||
-        @default_settings.fetch_path(:options, :heartbeat_threshold).to_i
+      :threshold => (worker_settings.fetch_path(:replication, :options, :heartbeat_threshold) || 300).to_i_with_method
     }
   end
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -7,7 +7,8 @@ class MiqWorker::Runner
 
   include Vmdb::Logging
   attr_accessor :last_hb, :worker, :worker_settings
-  attr_reader   :vmdb_config, :active_roles, :server
+  attr_reader   :active_roles, :server
+  attr_writer   :vmdb_config
 
   INTERRUPT_SIGNALS = ["SIGINT", "SIGTERM"]
 
@@ -19,6 +20,10 @@ class MiqWorker::Runner
 
   def self.start_worker(*args)
     new(*args).start
+  end
+
+  def vmdb_config
+    @vmdb_config ||= VMDB::Config.new("vmdb")
   end
 
   def poll_method
@@ -274,7 +279,7 @@ class MiqWorker::Runner
   end
 
   def sync_config(config = nil)
-    @vmdb_config = config || VMDB::Config.new("vmdb")
+    self.vmdb_config = config
     @my_zone ||= MiqServer.my_zone
     sync_log_level
     sync_worker_settings
@@ -288,11 +293,11 @@ class MiqWorker::Runner
   end
 
   def sync_log_level
-    Vmdb::Loggers.apply_config(@vmdb_config.config[:log])
+    Vmdb::Loggers.apply_config(vmdb_config.config[:log])
   end
 
   def sync_worker_settings
-    @worker_settings = self.class.corresponding_model.worker_settings(:config => @vmdb_config)
+    @worker_settings = self.class.corresponding_model.worker_settings(:config => vmdb_config)
     @poll = @worker_settings[:poll]
     poll_method
   end

--- a/spec/models/miq_replication_worker/runner_spec.rb
+++ b/spec/models/miq_replication_worker/runner_spec.rb
@@ -1,7 +1,8 @@
 describe MiqReplicationWorker::Runner do
   before do
+    EvmSpecHelper.create_guid_miq_server_zone
     allow_any_instance_of(MiqReplicationWorker::Runner).to receive(:worker_initialization)
-    @worker = MiqReplicationWorker::Runner.new
+    @worker = MiqReplicationWorker::Runner.new.tap { |w| w.sync_worker_settings }
   end
 
   context "testing rubyrep_alive?" do


### PR DESCRIPTION
Extracted from my configuration_revamp branch.

This was doing some strange juggling of configurations just to handle tests where the `@vmdb_config` was not available because `worker_initialization` was stubbed, and thus `worker_initialization` could not call `sync_worker_settings`.

@jrafanie Please review