### PR TITLE
Decouple migration from Vmdb::ConfigurationEncoder.

### DIFF
--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -8,7 +8,7 @@ class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
   end
 
   class Configuration < ActiveRecord::Base
-    serialize :settings, Vmdb::ConfigurationEncoder
+    serialize :settings, Hash
     self.inheritance_column = :_type_disabled
   end
 


### PR DESCRIPTION
Extracted from my configuration_revamp branch.

The migration doesn't actually need to decrypt passwords, so no need to couple it here.  Decoupling makes the refactoring later easier.

@jrafanie Please review.