### PR TITLE
Remove all uses of VMDB::Config.new("database")

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -70,9 +70,9 @@ class MiqRegionRemote < ApplicationRecord
 
   def self.prepare_default_fields(database, adapter)
     if database.nil? || adapter.nil?
-      db_conf = VMDB::Config.new("database").config[Rails.env.to_sym]
-      database ||= db_conf[:database]
-      adapter ||= db_conf[:adapter]
+      db_conf = Rails.configuration.database_configuration[Rails.env]
+      database ||= db_conf["database"]
+      adapter  ||= db_conf["adapter"]
     end
     return database, adapter
   end
@@ -89,7 +89,7 @@ class MiqRegionRemote < ApplicationRecord
     host = host.to_s.strip
     raise ArgumentError, "host cannot be blank" if host.blank?
     if [nil, "", "localhost", "localhost.localdomain", "127.0.0.1", "0.0.0.0"].include?(host)
-      local_database = VMDB::Config.new("database").config.fetch_path(Rails.env.to_sym, :database).to_s.strip
+      local_database = Rails.configuration.database_configuration.fetch_path(Rails.env, "database").to_s.strip
       raise ArgumentError, "host cannot be set to localhost if database matches the local database" if database == local_database
     end
 

--- a/lib/miq_rubyrep.rb
+++ b/lib/miq_rubyrep.rb
@@ -12,9 +12,9 @@ class MiqRubyrep
   end
 
   def self.prepare_configuration(config)
-    db_conf  = VMDB::Config.new("database").config[Rails.env.to_sym]
+    db_conf = Rails.configuration.database_configuration[Rails.env].symbolize_keys
 
-    rp_conf  = MiqReplicationWorker.worker_settings[:replication]
+    rp_conf = MiqReplicationWorker.worker_settings[:replication]
     raise "Replication configuration missing" if rp_conf.blank?
     if db_conf.slice(:host, :port, :database) == rp_conf.slice(:host, :port, :database)
       raise "Replication configuration source must not point to destination"

--- a/lib/tasks/evm_dbsync.rake
+++ b/lib/tasks/evm_dbsync.rake
@@ -152,8 +152,8 @@ namespace :evm do
       puts "Exporting tables for bulk sync..."
       t = Time.now
 
-      db_conf = VMDB::Config.new("database").config[Rails.env.to_sym]
-      adapter, database, username, password, host, port = db_conf.values_at(:adapter, :database, :username, :password, :host, :port)
+      db_conf = Rails.configuration.database_configuration[Rails.env]
+      adapter, database, username, password, host, port = db_conf.values_at("adapter", "database", "username", "password", "host", "port")
 
       tables = sync_tables
       puts "Exporting #{tables.join(", ")}..."

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -41,8 +41,7 @@ module Vmdb
       fh.info "---"
 
       fh.info "DATABASE settings:"
-      db_config = VMDB::Config.new("database").config[Rails.env.to_sym]
-      VMDBLogger.log_hashes(fh, db_config)
+      VMDBLogger.log_hashes(fh, Rails.configuration.database_configuration[Rails.env])
       fh.info "DATABASE settings END"
       fh.info "---"
     end


### PR DESCRIPTION
Extracted from my configuration_revamp branch.

Avoiding using VMDB::Config for accessing database.yml removes a ton of code paths and makes the refactoring a lot easier.

@jrafanie Please review