### PR TITLE
Remove extra_js from ExplorerPresenter

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1926,17 +1926,11 @@ class CatalogController < ApplicationController
     presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
 
     presenter[:record_id] = determine_record_id_for_presenter
-
     presenter[:lock_unlock_trees][x_active_tree] = @edit && @edit[:current]
-
     presenter[:osf_node] = x_node
+    presenter.reset_changes
+    presenter.reset_one_trans
 
-    # unset variable that was set in form_field_changed to prompt for changes when leaving the screen
-    presenter[:extra_js] << "ManageIQ.changes = null;"
-    # resetting ManageIQ.oneTransition.oneTrans when tab loads
-    presenter[:extra_js] << "ManageIQ.oneTransition.oneTrans = 0;"
-
-    # Render the JS responses to update the explorer screen
     render :js => presenter.to_html
   end
 

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -371,10 +371,8 @@ class MiqAeClassController < ApplicationController
     end
 
     presenter[:record_id] = determine_record_id_for_presenter
-
     presenter[:osf_node] = x_node
-
-    presenter[:extra_js] << "miqButtons('#{@changed ? 'show' : 'hide'}');"
+    presenter.show_miq_buttons if @changed
 
     # Render the JS responses to update the explorer screen
     render :js => presenter.to_html

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -452,10 +452,8 @@ class MiqAeCustomizationController < ApplicationController
 
     presenter[:build_calendar] = true
     # resetting ManageIQ.oneTransition.oneTrans when tab loads
-    presenter[:extra_js] << 'ManageIQ.oneTransition.oneTrans = 0;'
-    if %w(save reset).include?(params[:button]) && is_browser_ie?
-      presenter[:extra_js] << "ManageIQ.oneTransition.IEButtonPressed = true"
-    end
+    presenter.reset_one_trans
+    presenter.one_trans_ie if %w(save reset).include?(params[:button]) && is_browser_ie?
     presenter.hide(:custom_left_cell).show(:default_left_cell)
   end
 
@@ -481,8 +479,8 @@ class MiqAeCustomizationController < ApplicationController
         @right_cell_text = _("Editing %{model} \"%{name}\"") % {:name => @dialog.description.gsub(/'/, "\\'"), :model => "#{title} #{ui_lookup(:model => "MiqDialog")}"}
       end
 
-      presenter[:extra_js] << 'ManageIQ.oneTransition.oneTrans = 0;' # resetting ManageIQ.oneTransition.oneTrans when tab loads
-      presenter[:extra_js] << "ManageIQ.oneTransition.IEButtonPressed = true" if %w(save reset).include?(params[:button]) && is_browser_ie?
+      presenter.reset_one_trans
+      presenter.one_trans_ie if %w(save reset).include?(params[:button]) && is_browser_ie?
     end
   end
 

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -509,9 +509,6 @@ class MiqCapacityController < ApplicationController
       :skip_days => @sb[:util][:options][:skip_days],
     }
 
-    # FIXME: where is curTab declared?
-    presenter[:extra_js] << "curTab = $('#utilization_tabs.ui-tabs-panel:not(.ui-tabs-hide)');"
-    presenter[:extra_js] << "tab = curTab.prop('id');"
     # FIXME: handle or verify the IE/non-IE branch for the flash charts
     presenter[:extra_js] << Charting.js_load_statement(true)
 
@@ -619,9 +616,6 @@ class MiqCapacityController < ApplicationController
                                     else
                                       _("Best Fit Clusters")
                                     end
-
-    presenter[:extra_js] << "curTab = $('#planning_tabs.ui-tabs-panel:not(.ui-tabs-hide)');"
-    presenter[:extra_js] << "tab = curTab.prop('id');"
     presenter[:extra_js] << Charting.js_load_statement(true)
 
     render :js => presenter.to_html
@@ -635,9 +629,6 @@ class MiqCapacityController < ApplicationController
     presenter.update(:main_div, r[:partial => 'bottlenecks_tabs'])
     presenter[:build_calendar] = true
     presenter[:right_cell_text] = @right_cell_text
-
-    presenter[:extra_js] << "curTab = $('#bottlenecks_tabs.ui-tabs-panel:not(.ui-tabs-hide)');"
-    presenter[:extra_js] << "tab = curTab.prop('id');"
 
     render :js => presenter.to_html
   end

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -493,7 +493,7 @@ class MiqCapacityController < ApplicationController
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
     r = proc { |opts| render_to_string(opts) }
 
-    presenter[:extra_js] << 'ManageIQ.charts.chartData = ' + @sb[:util][:chart_data].to_json + ';'
+    presenter.load_chart(@sb[:util][:chart_data])
 
     # clearing out any selection in tree if active node has been reset to "" upon returning to screen or when first time in
     presenter[:clear_selection] = x_node == ''
@@ -508,9 +508,6 @@ class MiqCapacityController < ApplicationController
       :date_to   => @sb[:util][:options][:edate],
       :skip_days => @sb[:util][:options][:skip_days],
     }
-
-    # FIXME: handle or verify the IE/non-IE branch for the flash charts
-    presenter[:extra_js] << Charting.js_load_statement(true)
 
     render :js => presenter.to_html
   end
@@ -605,7 +602,7 @@ class MiqCapacityController < ApplicationController
     presenter = ExplorerPresenter.new(:active_tree => @sb[:active_tree])
     r = proc { |opts| render_to_string(opts) }
 
-    presenter[:extra_js] << 'ManageIQ.charts.chartData = ' + @sb[:planning][:chart_data].to_json + ';'
+    presenter.load_chart(@sb[:planning][:chart_data])
 
     presenter.reload_toolbars(:view => v_tb)
     presenter.set_visibility(@sb[:active_tab] == 'report', :toolbar)
@@ -616,7 +613,6 @@ class MiqCapacityController < ApplicationController
                                     else
                                       _("Best Fit Clusters")
                                     end
-    presenter[:extra_js] << Charting.js_load_statement(true)
 
     render :js => presenter.to_html
   end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -643,9 +643,7 @@ class OpsController < ApplicationController
       if x_node.split("-").first == "svr" && my_server_id == active_id.to_i
         # show all the tabs if on current server node
         @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
-        if %w(save reset).include?(params[:button]) && is_browser_ie?
-          presenter[:extra_js] << "ManageIQ.oneTransition.IEButtonPressed = true;"
-        end
+        presenter.one_trans_ie if %w(save reset).include?(params[:button]) && is_browser_ie?
       elsif x_node.split("-").first == "svr" && my_server_id != active_id.to_i
         # show only 4 tabs if not on current server node
         @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
@@ -719,8 +717,8 @@ class OpsController < ApplicationController
   def extra_js_commands(presenter)
     presenter[:right_cell_text] = @right_cell_text
     presenter[:osf_node] = x_node
-    presenter[:extra_js] << "ManageIQ.oneTransition.oneTrans = 0;" # resetting miqOneTrans when tab loads
-    presenter[:extra_js] << "if ($('#server_company').length) $('#server_company').focus();"
+    presenter.reset_one_trans
+    presenter.focus('server_company')
     presenter[:ajax_action] = {
       :controller => controller_name,
       :action     => @ajax_action,

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -655,8 +655,6 @@ class OpsController < ApplicationController
 
   def rbac_replace_right_cell(nodetype, presenter, r)
     @sb[:tab_label] = @tagging ? _("Tagging") : rbac_set_tab_label
-    # Make sure the double_click var is there
-    presenter[:extra_js] << "var miq_double_click = false;"
     if %w(accordion_select change_tab tree_select).include?(params[:action])
       presenter.replace(:ops_tabs, r[:partial => "all_tabs"])
     elsif nodetype == "group_seq"

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -186,10 +186,8 @@ class PxeController < ApplicationController
                     _("%{model} \"%{name}\"") % {:name  => @ct.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "PxeCustomizationTemplate")}
           end
         # resetting ManageIQ.oneTransition.oneTrans when tab loads
-        presenter[:extra_js] << 'ManageIQ.oneTransition.oneTrans = 0;'
-        if %w(save reset).include?(params[:button]) && is_browser_ie?
-          presenter[:extra_js] << 'ManageIQ.oneTransition.IEButtonPressed = true'
-        end
+        presenter.reset_one_trans
+        presenter.one_trans_ie if %w(save reset).include?(params[:button]) && is_browser_ie?
       end
     when :iso_datastores_tree
       presenter.update(:main_div, r[:partial => "iso_datastore_list"])

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -369,7 +369,7 @@ class ServiceController < ApplicationController
     presenter[:lock_unlock_trees][x_active_tree] = @edit && @edit[:current]
     presenter[:osf_node] = x_node
     # unset variable that was set in form_field_changed to prompt for changes when leaving the screen
-    presenter[:extra_js] << "ManageIQ.changes = null;"
+    presenter.reset_changes
 
     # Render the JS responses to update the explorer screen
     render :js => presenter.to_html

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -55,8 +55,13 @@ class ExplorerPresenter
       :extra_js             => [],
       :object_tree_json     => '',
       :exp                  => {},
-      :osf_node             => ''
+      :osf_node             => '',
+      :show_miq_buttons     => false,
     ).update(options)
+  end
+
+  def show_miq_buttons(show = true)
+    @options[show_miq_buttons] = show
   end
 
   def set_visibility(value, *elements)
@@ -115,7 +120,7 @@ class ExplorerPresenter
     end
 
     # Turn off form buttons when replacing explorer right cell
-    @out << javascript_for_miq_button_visibility(false).html_safe
+    @out << javascript_for_miq_button_visibility(@options[:show_miq_buttons]).html_safe
 
     @out << "miqDeleteDynatreeCookies('#{@options[:clear_tree_cookies]}')" if @options[:clear_tree_cookies]
 

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -28,7 +28,6 @@ class ExplorerPresenter
   #   ManageIQ.widget.dashboardUrl     -- set dashboard widget drag drop url
   #   osf_node                         -- node to open, select and focus
   #   open_accord                      -- accordion to open
-  #   extra_js                         -- array of extra javascript chunks to be written out
   #
   #   object_tree_json            --
   #   exp                         --
@@ -52,13 +51,28 @@ class ExplorerPresenter
       :element_updates      => {},
       :replace_partials     => {},
       :reload_toolbars      => {},
-      :extra_js             => [],
       :object_tree_json     => '',
       :exp                  => {},
       :osf_node             => '',
       :show_miq_buttons     => false,
       :load_chart           => nil
     ).update(options)
+  end
+
+  def reset_changes
+    @options[:reset_changes] = true
+  end
+
+  def reset_one_trans
+    @options[:reset_one_trans] = true
+  end
+
+  def one_trans_ie
+    @options[:one_trans_ie] = true
+  end
+
+  def focus(element_id)
+    @options[:focus] = element_id
   end
 
   def load_chart(chart_data)
@@ -206,11 +220,17 @@ class ExplorerPresenter
 
     @options[:lock_unlock_trees].each { |tree, lock| @out << tree_lock(tree, lock) }
 
-    @out << @options[:extra_js].join("\n")
-
     if @options[:load_chart]
       @out << 'ManageIQ.charts.chartData = ' + @options[:load_chart].to_json + ';'
       @out << Charting.js_load_statement(true)
+    end
+
+    @out << 'ManageIQ.changes = null;'                       if @options[:reset_changes]
+    @out << 'ManageIQ.oneTransition.oneTrans = 0;'           if @options[:reset_one_trans]
+    @out << 'ManageIQ.oneTransition.IEButtonPressed = true;' if @options[:one_trans_ie]
+
+    if @options[:focus]
+      @out << "if ($('##{@options[:focus]}').length) $('##{@options[:focus]}').focus();"
     end
 
     @out << "$('#clear_search').#{@options[:clear_search_show_or_hide]}();" if @options[:clear_search_show_or_hide]

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -57,7 +57,12 @@ class ExplorerPresenter
       :exp                  => {},
       :osf_node             => '',
       :show_miq_buttons     => false,
+      :load_chart           => nil
     ).update(options)
+  end
+
+  def load_chart(chart_data)
+    @options[:load_chart] = chart_data
   end
 
   def show_miq_buttons(show = true)
@@ -202,6 +207,11 @@ class ExplorerPresenter
     @options[:lock_unlock_trees].each { |tree, lock| @out << tree_lock(tree, lock) }
 
     @out << @options[:extra_js].join("\n")
+
+    if @options[:load_chart]
+      @out << 'ManageIQ.charts.chartData = ' + @options[:load_chart].to_json + ';'
+      @out << Charting.js_load_statement(true)
+    end
 
     @out << "$('#clear_search').#{@options[:clear_search_show_or_hide]}();" if @options[:clear_search_show_or_hide]
     # always replace content partial to adjust height of content div


### PR DESCRIPTION
Remove `extra_js` from ExplorerPresenter.

After this is merged, we can switch from generating JavaScript to generating JSON, move the bits of logic to client-side removing this huge use or the `eval`.