### PR TITLE
Don't translate model names in audit messages

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -1,13 +1,19 @@
 class Dictionary
   def self.gettext(text, opts = {})
     opts[:type] ||= :column
-    opts[:plural] ||= false
+    opts[:plural] = false if opts[:plural].nil?
+    opts[:translate] = true if opts[:translate].nil?
 
     key, suffix = text.split("__")  # HACK: Sometimes we need to add a suffix to report columns, this should probably be moved into the presenter.
 
     i18n_result = i18n_lookup(opts[:type], key)
     i18n_result ||= i18n_lookup(opts[:type], key.split(".").last)
-    result = _(opts[:plural] ? i18n_result.pluralize : i18n_result) if i18n_result
+    i18n_result = i18n_result.pluralize if i18n_result && opts[:plural]
+
+    result = if i18n_result
+               opts[:translate] ? _(i18n_result) : i18n_result
+             end
+
     result << " (#{suffix.titleize})" if result && suffix  # HACK: continued.  i.e. Adding (Min) or (Max) to a column name.
 
     return result if result

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -175,8 +175,17 @@ class ExtManagementSystem < ApplicationRecord
       )
 
       _log.info "#{ui_lookup(:table => "ext_management_systems")} #{ems.name} created"
-      AuditEvent.success(:event => "ems_created", :target_id => ems.id, :target_class => "ExtManagementSystem",
-                         :message => "#{ui_lookup(:table => "ext_management_systems")} #{ems.name} created")
+      AuditEvent.success(
+        :event        => "ems_created",
+        :target_id    => ems.id,
+        :target_class => "ExtManagementSystem",
+        :message      => "%{provider_type} %{provider_name} created" % {
+          :provider_type => Dictionary.gettext("ext_management_systems",
+                                               :type      => :table,
+                                               :notfound  => :titleize,
+                                               :plural    => false,
+                                               :translate => false),
+          :provider_name => ems.name})
     end
   end
 

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -62,7 +62,14 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
   end
 
   def self.create_audit_event(options)
-    msg = "'#{options[:task]}' initiated for #{options[:ids].length} #{ui_lookup(:table => 'providers').pluralize}"
+    msg = "'%{task}' initiated for %{amount} %{providers}" % {
+      :task      => options[:task],
+      :amount    => options[:ids].length,
+      :providers => Dictionary.gettext('providers',
+                                       :type      => :table,
+                                       :notfound  => :titleize,
+                                       :plural    => options[:ids].length > 1,
+                                       :translate => false)}
     AuditEvent.success(:event        => options[:task],
                        :target_class => base_class.name,
                        :userid       => options[:userid],

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -84,7 +84,14 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
   end
 
   def self.create_audit_event(options)
-    msg = "'#{options[:task]}' initiated for #{options[:ids].length} #{ui_lookup(:table => 'providers').pluralize}"
+    msg = "'%{task}' initiated for %{amount} %{providers}" % {
+      :task      => options[:task],
+      :amount    => options[:ids].length,
+      :providers => Dictionary.gettext('providers',
+                                       :type      => :table,
+                                       :notfound  => :titleize,
+                                       :plural    => options[:ids].length > 1,
+                                       :translate => false)}
     AuditEvent.success(:event        => options[:task],
                        :target_class => base_class.name,
                        :userid       => options[:userid],


### PR DESCRIPTION
Since these will be put into a log file, the model names have to be in english.