### PR TITLE
Don't translate rails log name

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -117,7 +117,7 @@ class OpsController < ApplicationController
     @breadcrumbs = []
     build_accordions_and_trees
 
-    @sb[:rails_log] = $rails_log.filename.to_s.include?("production.log") ? _("Production") : _("Development")
+    @sb[:rails_log] = $rails_log.filename.to_s.include?("production.log") ? "Production" : "Development"
 
     if !params[:no_refresh]
       @sb[:good] = nil


### PR DESCRIPTION
The variable is later used to construct a log file name.