### PR TITLE
Don't apply .pluralize on a string returned by Dictionary.gettext

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -31,7 +31,8 @@ module ApplicationController::CiProcessing
       recs = [params[:id].to_i]
     end
     if recs.length < 1
-      add_flash(_("One or more %{model} must be selected to %{task}") % {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize).pluralize, :task => "Set Ownership"}, :error)
+      add_flash(_("One or more %{model} must be selected to Set Ownership") % {
+        :model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize, :plural => true)}, :error)
       @refresh_div = "flash_msg_div"
       @refresh_partial = "layouts/flash_msg"
       return
@@ -1077,7 +1078,7 @@ module ApplicationController::CiProcessing
     end
     if recs.length < 1
       add_flash(_("One or more %{model} must be selected to Reconfigure") %
-        {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize).pluralize}, :error)
+        {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize, :plural => true)}, :error)
       render_flash_and_scroll
       return
     else

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -167,7 +167,8 @@ module ApplicationController::PolicySupport
       recs = [params[:id]]
     end
     if recs.length < 1
-      add_flash(_("One or more %{model} must be selected to %{task}") % {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize).pluralize, :task => "Policy assignment"}, :error)
+      add_flash(_("One or more %{model} must be selected to Policy assignment") % {
+        :model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize, :plural => true)}, :error)
       @refresh_div = "flash_msg_div"
       @refresh_partial = "layouts/flash_msg"
       return

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -121,7 +121,7 @@ module ApplicationController::Tags
     end
     if recs.length < 1
       add_flash(_("One or more %{model} must be selected to Smart Tagging") %
-        {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize).pluralize}, :error)
+        {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize, :plural => true)}, :error)
       @refresh_div = "flash_msg_div"
       @refresh_partial = "layouts/flash_msg"
       return

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1130,7 +1130,7 @@ module OpsController::Settings::Common
     {
       :key      => "#{server.id}__#{node_type}",
       :icon     => ActionController::Base.helpers.image_path("100/#{node_type}.png"),
-      :title    => Dictionary.gettext(node_type.camelcase, :type => :model, :notfound => :titleize).pluralize,
+      :title    => Dictionary.gettext(node_type.camelcase, :type => :model, :notfound => :titleize, :plural => true),
       :children => zone.send(node_type.pluralize).sort_by(&:name).collect do |node|
         {
           :key    => "#{server.id}__#{node_type}_#{node.id}",

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1604,7 +1604,7 @@ module ReportController::Reports::Editor
     unless @edit[:models] # Only create once
       @edit[:models] = []
       MiqReport.reportable_models.each do |m|
-        @edit[:models].push([Dictionary.gettext(m, :type => :model, :notfound => :titleize).pluralize, m])
+        @edit[:models].push([Dictionary.gettext(m, :type => :model, :notfound => :titleize, :plural => true), m])
       end
     end
 

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -327,7 +327,7 @@ module VmCloudHelper::TextualSummary
     return nil if os == "unknown"
     num = @record.number_of(:guest_applications)
     label = (os =~ /linux/) ? n_("Package", "Packages", num) : n_("Application", "Applications", num)
-    h = {:label => label.pluralize, :image => "guest_application", :value => num}
+    h = {:label => label, :image => "guest_application", :value => num}
     if num > 0
       h[:title] = ("Show the %{label} installed on this VM") % {:label => label}
       h[:explorer] = true

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -440,7 +440,7 @@ module VmHelper::TextualSummary
     num = @record.number_of(:guest_applications)
     label = (os =~ /linux/) ? n_("Package", "Packages", num) : n_("Application", "Applications", num)
 
-    h = {:label => label.pluralize, :image => "guest_application", :value => num}
+    h = {:label => label, :image => "guest_application", :value => num}
     if num > 0
       h[:title] = _("Show the %{label} installed on this VM") % {:label => label}
       h[:explorer] = true

--- a/app/helpers/vm_infra_helper/textual_summary.rb
+++ b/app/helpers/vm_infra_helper/textual_summary.rb
@@ -341,7 +341,7 @@ module VmCloudHelper::TextualSummary
     return nil if os == "unknown"
     num = @record.number_of(:guest_applications)
     label = (os =~ /linux/) ? n_("Package", "Packages", num) : n_("Application", "Applications", num)
-    h = {:label => label.pluralize, :image => "guest_application", :value => num}
+    h = {:label => label, :image => "guest_application", :value => num}
     if num > 0
       h[:title] = _("Show the %{label} installed on this VM") % {:label => label}
       h[:explorer] = true


### PR DESCRIPTION
We don't want to apply .pluralize to a string returned by `Dictionary.gettext`,
we should better use `:plural => true` argument when invoking `Dictionary.gettext`.