### PR TITLE
Gettext & ui_lookup fixes in provider_foreman_controller.rb

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1241,8 +1241,7 @@ module ApplicationController::CiProcessing
     else
       items = find_checked_items
       if items.empty?
-        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:ui_title => 'providers'),
-                                                                :task  => display_name}, :error)
+        add_flash(_("No providers were selected for %{task}") % {:task  => display_name}, :error)
       else
         process_cfgmgr(items, method) unless items.empty? && !flash_errors?
       end
@@ -1260,8 +1259,8 @@ module ApplicationController::CiProcessing
     add_flash(_("Error during '%s': ") % task << err.message, :error)
   else
     add_flash(_("%{task} initiated for %{count_model} (%{controller})") %
-                {:task        => task_name(task).gsub("Ems", "#{ui_lookup(:ui_title => 'provider')}"),
-                 :controller  => ui_lookup(:ui_title => ProviderForemanController.model_to_name(kls.to_s)),
+                {:task        => task_name(task),
+                 :controller  => ProviderForemanController.model_to_name(kls.to_s),
                  :count_model => pluralize(providers.length, _("provider"))})
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -15,9 +15,9 @@ class ProviderForemanController < ApplicationController
 
   def self.model_to_name(provmodel)
     if provmodel.include?("ManageIQ::Providers::AnsibleTower")
-      return "Ansible Tower"
+      return ui_lookup(:ui_title => 'ansible_tower')
     elsif provmodel.include?("ManageIQ::Providers::Foreman")
-      return "Foreman"
+      return ui_lookup(:ui_title => 'foreman')
     end
   end
 
@@ -158,7 +158,7 @@ class ProviderForemanController < ApplicationController
       AuditEvent.success(build_created_audit(@provider_cfgmgmt, @edit))
       @in_a_form = false
       @sb[:action] = nil
-      model = "#{ui_lookup(:ui_title => "#{model_to_name(@provider_cfgmgmt.type)}")} #{ui_lookup(:model => 'ExtManagementSystem')}"
+      model = "#{model_to_name(@provider_cfgmgmt.type)} #{ui_lookup(:model => 'ExtManagementSystem')}"
       if params[:id] == "new"
         add_flash(_("%{model} \"%{name}\" was added") % {:model => model,
                                                          :name  => @provider_cfgmgmt.name})
@@ -183,11 +183,12 @@ class ProviderForemanController < ApplicationController
   def cancel_provider_foreman
     @in_a_form = false
     @sb[:action] = nil
-    model = "#{ui_lookup(:ui_title => 'Configuration Manager')} #{ui_lookup(:model => 'ExtManagementSystem')}"
     if params[:id] == "new"
-      add_flash(_("Add of %{model} was cancelled by the user") % {:model  => model})
+      add_flash(_("Add of Configuration Manager %{provider} was cancelled by the user") %
+        {:provider  => ui_lookup(:model => 'ExtManagementSystem')})
     else
-      add_flash(_("Edit of %{model} was cancelled by the user") % {:model  => model})
+      add_flash(_("Edit of Configuration Manager %{provider} was cancelled by the user") %
+        {:provider  => ui_lookup(:model => 'ExtManagementSystem')})
     end
     replace_right_cell
   end
@@ -538,7 +539,7 @@ class ProviderForemanController < ApplicationController
     return provider_node(id, model) unless id.nil?
     if self.x_active_tree == :configuration_manager_providers_tree
       options = {:model => "#{model}"}
-      @right_cell_text = _("All %{title} Providers") % {:title => ui_lookup(:ui_title => model_to_name(model))}
+      @right_cell_text = _("All %{title} Providers") % {:title => model_to_name(model)}
       process_show_list(options)
     end
   end
@@ -580,7 +581,7 @@ class ProviderForemanController < ApplicationController
     @listicon = "configured_system"
     if self.x_active_tree == :cs_filter_tree
       options = {:model => "#{model}"}
-      @right_cell_text = _("All %{title} Configured Systems") % {:title => ui_lookup(:ui_title => model_to_name(model))}
+      @right_cell_text = _("All %{title} Configured Systems") % {:title => model_to_name(model)}
       process_show_list(options)
     end
   end
@@ -611,7 +612,7 @@ class ProviderForemanController < ApplicationController
     if self.x_active_tree == :configuration_manager_providers_tree
       options = {:model => "ManageIQ::Providers::ConfigurationManager"}
       process_show_list(options)
-      @right_cell_text = _("All %{title} Providers") % {:title => ui_lookup(:ui_title => "Configuration Management")}
+      @right_cell_text = _("All Configuration Management Providers")
     elsif self.x_active_tree == :cs_filter_tree
       options = {:model => "ConfiguredSystem"}
       process_show_list(options)
@@ -665,10 +666,9 @@ class ProviderForemanController < ApplicationController
 
   def update_title(presenter)
     if action_name == "new"
-      @right_cell_text = _("Add a new %{title} Provider") %
-                           {:title => ui_lookup(:ui_title => "Configuration Management")}
+      @right_cell_text = _("Add a new Configuration Management Provider")
     elsif action_name == "edit"
-      @right_cell_text = _("Edit %{title} Provider") % {:title => ui_lookup(:ui_title => "configuration manager")}
+      @right_cell_text = _("Edit Configuration Manager Provider")
     end
     presenter[:right_cell_text] = @right_cell_text
   end
@@ -763,10 +763,10 @@ class ProviderForemanController < ApplicationController
     elsif @in_a_form
       partial_locals = {:controller => 'provider_foreman'}
       if @sb[:action] == "provider_foreman_add_provider"
-        @right_cell_text = _("Add a new %{title} Provider") % {title => ui_lookup(:ui_title => "Configuration Manager")}
+        @right_cell_text = _("Add a new Configuration Manager Provider")
       elsif @sb[:action] == "provider_foreman_edit_provider"
         # set the title based on the configuration manager provider type
-        @right_cell_text = _("Edit %{title} Provider") % {:title => ui_lookup(:ui_title => "Configuration Manager")}
+        @right_cell_text = _("Edit Configuration Manager Provider")
       end
       partial = 'form'
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -75,7 +75,7 @@ class ProviderForemanController < ApplicationController
         provider.destroy_queue
       end
 
-      add_flash(_("%{task} initiated for %{count_model}") % {:task => "Delete", :count_model => pluralize(providers.length, "provider")})
+      add_flash(_("Delete initiated for %{count_model}") % {:count_model => pluralize(providers.length, "provider")})
     end
     replace_right_cell
   end
@@ -83,7 +83,7 @@ class ProviderForemanController < ApplicationController
   def refresh
     assert_privileges("provider_foreman_refresh_provider")
     @explorer = true
-    foreman_button_operation('refresh_ems', 'Refresh')
+    foreman_button_operation('refresh_ems', _('Refresh'))
     replace_right_cell
   end
 
@@ -159,9 +159,13 @@ class ProviderForemanController < ApplicationController
       @in_a_form = false
       @sb[:action] = nil
       model = "#{ui_lookup(:ui_title => "#{model_to_name(@provider_cfgmgmt.type)}")} #{ui_lookup(:model => 'ExtManagementSystem')}"
-      add_flash(_("%{model} \"%{name}\" was %{action}") % {:model  => model,
-                                                           :name   => @provider_cfgmgmt.name,
-                                                           :action => params[:id] == "new" ? "added" : "updated"})
+      if params[:id] == "new"
+        add_flash(_("%{model} \"%{name}\" was added") % {:model => model,
+                                                         :name  => @provider_cfgmgmt.name})
+      else
+        add_flash(_("%{model} \"%{name}\" was updated") % {:model => model,
+                                                           :name  => @provider_cfgmgmt.name})
+      end
       if params[:id] == "new"
         process_cfgmgr([@provider_cfgmgmt.configuration_manager.id], "refresh_ems")
       end
@@ -180,9 +184,11 @@ class ProviderForemanController < ApplicationController
     @in_a_form = false
     @sb[:action] = nil
     model = "#{ui_lookup(:ui_title => 'Configuration Manager')} #{ui_lookup(:model => 'ExtManagementSystem')}"
-    add_flash(_("%{action} %{model} was cancelled by the user") %
-                  {:model  => model,
-                   :action => params[:id] == "new" ? "Add of" : "Edit of"})
+    if params[:id] == "new"
+      add_flash(_("Add of %{model} was cancelled by the user") % {:model  => model})
+    else
+      add_flash(_("Edit of %{model} was cancelled by the user") % {:model  => model})
+    end
     replace_right_cell
   end
 
@@ -928,15 +934,13 @@ class ProviderForemanController < ApplicationController
     record_model = ui_lookup(:model => model ? model : TreeBuilder.get_model_for_prefix(@nodetype))
     return if @sb[:active_tab] != 'configured_systems'
     if valid_configuration_profile_record?(@configuration_profile_record)
-      @right_cell_text =
-        _("%{model} \"%{name}\"") %
-        {:name  => @configuration_profile_record.name,
-         :model => "#{ui_lookup(:tables => "configured_system")} under #{record_model}"}
+      @right_cell_text = _("%{model} under %{record_model} \"%{name}\"") %
+        {:model        => ui_lookup(:tables => "configured_system"),
+         :record_model => record_model,
+         :name         => @configuration_profile_record.name}
     else
-      name  = _("Unassigned Profiles Group")
-      @right_cell_text =
-        _("%{model}") %
-        {:model => "#{ui_lookup(:tables => "configured_system")} under \"#{name}\""}
+      @right_cell_text = _("%{model} under Unassigned Profiles Group") %
+        {:model => ui_lookup(:tables => "configured_system")}
     end
   end
 

--- a/app/helpers/application_helper/tasks.rb
+++ b/app/helpers/application_helper/tasks.rb
@@ -12,6 +12,8 @@ module ApplicationHelper
         _("Retirement")
       when "scan"
         _("Analysis")
+      when "refresh_ems"
+        _("Refresh Provider")
       else
         task.titleize
       end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -129,7 +129,7 @@ class TreeBuilder
     when :old_dialogs_tree              then [_("All Dialogs"),                  _("All Dialogs")]
     when :ot_tree                       then [_("All Orchestration Templates"),  _("All Orchestration Templates")]
     when :configuration_manager_providers_tree        then
-      title = "All #{ui_lookup(:ui_title => "configuration_manager")} Providers"
+      title = _("All Configuration Manager Providers")
       [title, title]
     when :pxe_image_types_tree          then [_("All System Image Types"),       _("All System Image Types")]
     when :pxe_servers_tree              then [_("All PXE Servers"),              _("All PXE Servers")]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -957,3 +957,4 @@ en:
 
     ui_title:
       foreman:             Foreman
+      ansible_tower:       Ansible Tower

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -85,7 +85,7 @@ module Vmdb
     end
 
     def ui_lookup_for_title(text)
-      Dictionary.gettext(text, :type => :ui_title, :notfound => :titleize)
+      Dictionary.gettext(text, :type => :ui_title)
     end
 
     # Wrap a report html table body with html table tags and headers for the columns

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -253,7 +253,7 @@ describe HostController do
       vms = [vm1.id, vm2.id, vm3.id]
       controller.send(:process_objects, vms, 'refresh_ems')
       flash_messages = assigns(:flash_array)
-      expect(flash_messages.first[:message]).to include "Refresh Ems initiated for #{vms.length} VMs"
+      expect(flash_messages.first[:message]).to include "Refresh Provider initiated for #{vms.length} VMs"
     end
   end
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -193,7 +193,7 @@ describe ProviderForemanController do
       key = ems_key_for_provider(@provider)
       controller.send(:get_node_info, "root")
       right_cell_text = controller.instance_variable_get(:@right_cell_text)
-      expect(right_cell_text).to eq("All #{ui_lookup(:ui_title => "configuration management")} Providers")
+      expect(right_cell_text).to eq("All Configuration Management Providers")
     end
 
     it "renders right cell text for ConfigurationManagerForeman node" do


### PR DESCRIPTION
Changed:
* added missing gettext
* fixed obfuscated gettext
* fixed incorrect usage of `ui_lookup(:ui_title => ...)`. Every ui_title needs to be explicitly listed in
`en.yml` and we cannot just rely on things working correctly in English by titleizing the key should
the key be missing from the yaml file.