### PR TITLE
Remove the first of two [] methods, since the second version is in use.

### DIFF
--- a/gems/pending/fs/ntfs/data_run.rb
+++ b/gems/pending/fs/ntfs/data_run.rb
@@ -94,20 +94,6 @@ module NTFS
       @length += r.length
     end
 
-    def [](what)
-      if what.class == Range
-        offset = what.begin
-        len    = what.end - what.begin + 1
-        return self.[](offset, len)
-      end
-
-      if what.instance_of?(Integer)
-        return self.[](what, 1)
-      end
-
-      raise "MIQ(NTFS::DataRun.[]) Invalid Class (#{what.class})"
-    end
-
     def [](offset, len)
       seek(offset)
       read(len)


### PR DESCRIPTION
Both were originally added in 9c7cf839e62911 in 2008, but it seems as though the
first method was never used since ruby would never call one over the other based
on arity.

cc @chessbyte @roliveri 