### PR TITLE
Added service_order processing for service requests.

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -18,6 +18,7 @@ class MiqRequest < ApplicationRecord
   default_value_for :request_state, 'pending'
   default_value_for(:request_type)  { |r| r.request_types.first }
   default_value_for :status,        'Ok'
+  default_value_for :process,       true
 
   validates_inclusion_of :approval_state, :in => %w(pending_approval approved denied), :message => "should be 'pending_approval', 'approved' or 'denied'"
   validates_inclusion_of :status,         :in => %w(Ok Warn Error Timeout Denied)
@@ -478,6 +479,10 @@ class MiqRequest < ApplicationRecord
 
   def event_name(mode)
     "#{self.class.name.underscore}_#{mode}"
+  end
+
+  def process_on_create?
+    true
   end
 
   def request_pending_approval?

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -95,9 +95,13 @@ class MiqRequestWorkflow
 
     request.log_request_success(@requester, :created)
 
-    request.call_automate_event_queue("request_created")
-    request.approve(@requester, "Auto-Approved") if auto_approve == true
-    request.reload if auto_approve
+    if request.process_on_create?
+      # TODO: address auto-approve potential issue
+      request.call_automate_event_queue("request_created")
+      request.approve(@requester, "Auto-Approved") if auto_approve == true
+      request.reload if auto_approve
+    end
+
     request
   end
 

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -32,12 +32,21 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     values[:src_id] = @target.id
 
     if create_request?(values)
-      create_request(values)
+      request = create_request(values)
+      create_service_order_and_checkout(request) if request
     else
       ra = load_resource_action(values)
       ra.deliver_to_automate_from_dialog(values, @target, @requester)
     end
     result
+  end
+
+  def create_service_order_and_checkout(request)
+    service_order = ServiceOrder.create(:state        => 'ordered',
+                                        :user         => @requester,
+                                        :miq_requests => [request],
+                                        :tenant       => request.tenant)
+    service_order.checkout
   end
 
   def request_class

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -4,12 +4,29 @@ class ServiceOrder < ActiveRecord::Base
   has_many :miq_requests, :dependent => :nullify
 
   validates :state, :inclusion => {:in => %w(wish cart ordered)}
-  validates :name, :presence => true
   validates :state, :presence => true
+  validates :name, :presence => true, :on => :update
 
-  before_create :assign_user_name
+  before_create :assign_user
+  after_create  :create_order_name
 
-  def assign_user_name
+  def assign_user
+    self.user      ||= User.current_user
+    self.tenant    ||= user.try(:current_tenant)
     self.user_name = user.try(:name)
+  end
+
+  def create_order_name
+    update_attributes(:name => "Order # #{id}") if name.blank?
+  end
+
+  def checkout
+    _log.info("Service Order checkout for service: #{name}")
+
+    miq_requests.each do |request|
+      request.update_attributes(:process => true)
+      request.call_automate_event_queue("request_created")
+    end
+    update_attributes(:state => 'ordered')
   end
 end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -13,6 +13,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
   default_value_for :source_type,  SOURCE_CLASS_NAME
+  default_value_for :process,      false
 
   def user
     get_user
@@ -50,5 +51,9 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   def my_records
     "#{self.class::SOURCE_CLASS_NAME}:#{get_option(:src_id)}"
+  end
+
+  def process_on_create?
+    false
   end
 end

--- a/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_created.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_created.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: 
   fields:
+  - guard:
+      value: "${/#miq_request.process}"
   - rel5:
       value: "/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#user.normalized_ldap_group}#get_auto_approval_state_machine"
   - rel6:

--- a/db/migrate/20160309223941_add_process_to_miq_requests.rb
+++ b/db/migrate/20160309223941_add_process_to_miq_requests.rb
@@ -1,0 +1,16 @@
+class AddProcessToMiqRequests < ActiveRecord::Migration[5.0]
+  class MiqRequest < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    add_column :miq_requests, :process, :boolean
+    say_with_time("Update process attribute") do
+      MiqRequest.update_all(:process => true)
+    end
+  end
+
+  def down
+    remove_column :miq_requests, :process
+  end
+end

--- a/spec/migrations/20160309223941_add_process_to_miq_requests_spec.rb
+++ b/spec/migrations/20160309223941_add_process_to_miq_requests_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe AddProcessToMiqRequests do
+  migration_context :up do
+    let(:miq_request_stub) { migration_stub(:MiqRequest) }
+
+    it "updates existing records" do
+      miq_request = miq_request_stub.create!
+
+      migrate
+
+      expect(miq_request.reload.process).to be true
+    end
+  end
+end

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -1,0 +1,66 @@
+describe ServiceOrder do
+  let(:admin)         { FactoryGirl.create(:user_admin) }
+  let(:service_order) { FactoryGirl.create(:service_order, :state => 'cart') }
+  let(:user_obj)      { FactoryGirl.create(:user) }
+  let(:ems)           { FactoryGirl.create(:ems_vmware) }
+  let(:vm)            { FactoryGirl.create(:vm_vmware, :name => "vm1", :location => "abc/def.vmx") }
+  let(:vm_template)   { FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems) }
+  let(:request) do
+    FactoryGirl.create(:service_template_provision_request,
+                       :description => 'Service Request',
+                       :requester   => admin,
+                       :options     => {:service_order_id => service_order.id})
+  end
+  let(:request2) do
+    FactoryGirl.create(:service_template_provision_request,
+                       :description => 'Service Request',
+                       :requester   => admin,
+                       :options     => {:service_order_id => service_order.id})
+  end
+  let(:request3) do
+    FactoryGirl.create(:service_template_provision_request,
+                       :description => 'Service Request',
+                       :requester   => admin,
+                       :options     => {:service_order_id => service_order.id})
+  end
+
+  it "should add an miq_request properly" do
+    request
+
+    expect request.service_order == service_order.id
+    expect request.process == false
+    expect(ServiceOrder.first).to have_attributes(
+      :name  => 'service order',
+      :state => 'cart'
+    )
+  end
+
+  it "should add multiple miq_requests properly" do
+    [request, request2, request3].each do |r|
+      expect r.service_order == service_order.id
+      expect r.process == false
+    end
+    service_order = ServiceOrder.first
+    expect(service_order).to have_attributes(
+      :name  => 'service order',
+      :state => 'cart'
+    )
+    expect service_order.miq_requests.count == MiqRequest.count
+  end
+
+  it "should checkout properly" do
+    r1 = request
+    r2 = request2
+    r3 = request3
+    service_order.checkout
+    [r1, r2, r3].each do |r|
+      r.reload
+      expect r.service_order == service_order.id
+      expect r.process == true
+    end
+    expect(ServiceOrder.first).to have_attributes(
+      :name  => 'service order',
+      :state => 'ordered'
+    )
+  end
+end


### PR DESCRIPTION
Initially, create_service_order when service miq_request is created, and checkout immediately following. New miq_request column "process" set to false for request and checkout changes it to true.
Add tests and migration.
Added assertion in the automate model to stop an miq_request from processing while it is still in a
process=false state(cart).