### PR TITLE
Add a dsn to hash parser to the ar_dba extension

### DIFF
--- a/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -874,4 +874,37 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
   def vacuum_full_analyze_table(table)
     execute("VACUUM FULL ANALYZE #{quote_table_name(table)}")
   end
+
+  def self.parse_dsn(dsn)
+    scanner = StringScanner.new(dsn)
+
+    dsn_hash = {}
+
+    until scanner.eos?
+      # get the key by matching up to and including the (optionally) white space bordered '='
+      key = scanner.scan_until(/\s?=\s?/)
+      key = key[0...-scanner.matched_size]
+
+      dsn_hash[key.to_sym] = get_dsn_value(scanner)
+    end
+
+    dsn_hash
+  end
+
+  def self.get_dsn_value(scanner)
+    value =
+      if scanner.peek(1) == "'"
+        # if we are a quoted value get the first quote and the
+        # string that ends with a quote not preceded by a backslash
+        scanner.getch + scanner.scan_until(/(?<!\\)'\s*/).strip
+      else
+        scanner.scan_until(/\s+|$/).strip
+      end
+
+    value = value[1..-2] if value.start_with?("'") && value.end_with?("'")
+
+    # un-escape any single quotes in the remaining value
+    value.gsub(/\\'/, "'")
+  end
+  private_class_method :get_dsn_value
 end

--- a/spec/lib/extensions/ar_dba_spec.rb
+++ b/spec/lib/extensions/ar_dba_spec.rb
@@ -16,4 +16,101 @@ describe "ar_dba extension" do
       expect(connection.primary_key?("storages_vms_and_templates")).to be true
     end
   end
+
+  describe "#parse_dsn" do
+    it "no spaces, no quotes" do
+      s = "host=localhost"
+      expect(connection.class.parse_dsn(s)).to eq(:host => "localhost")
+    end
+
+    it "spaces, no quotes" do
+      s = "host = localhost"
+      expect(connection.class.parse_dsn(s)).to eq(:host => "localhost")
+    end
+
+    it "no spaces, quotes" do
+      s = "host='localhost'"
+      expect(connection.class.parse_dsn(s)).to eq(:host => "localhost")
+    end
+
+    it "spaces, quotes" do
+      s = "host = 'localhost'"
+      expect(connection.class.parse_dsn(s)).to eq(:host => "localhost")
+    end
+
+    it "spaces, quotes, space in value" do
+      s = "host = 'local host'"
+      expect(connection.class.parse_dsn(s)).to eq(:host => "local host")
+    end
+
+    it "spaces, quotes, quote in value" do
+      s = "host = 'local\\'shost\\''"
+      expect(connection.class.parse_dsn(s)).to eq(:host => "local'shost'")
+    end
+
+    it "full dsn quoted" do
+      s = "dbname = 'vmdb\\'s_test' host='example.com' user = 'root' port='' password='p=as\\' s\\''"
+      expected = {
+        :dbname   => "vmdb's_test",
+        :host     => "example.com",
+        :user     => "root",
+        :port     => "",
+        :password => "p=as' s'"
+      }
+      expect(connection.class.parse_dsn(s)).to eq(expected)
+    end
+
+    it "full dsn unquoted" do
+      s = "dbname = vmdb\\'s_test host=example.com user = root password=p=as\\'s\\'"
+      expected = {
+        :dbname   => "vmdb's_test",
+        :host     => "example.com",
+        :user     => "root",
+        :password => "p=as's'"
+      }
+      expect(connection.class.parse_dsn(s)).to eq(expected)
+    end
+
+    it "mixed quoted and unquoted" do
+      s = "dbname = vmdb\\'s_test host=example.com user = 'root' port='' password='p=as\\' s\\''"
+      expected = {
+        :dbname   => "vmdb's_test",
+        :host     => "example.com",
+        :user     => "root",
+        :port     => "",
+        :password => "p=as' s'"
+      }
+      expect(connection.class.parse_dsn(s)).to eq(expected)
+    end
+
+    it "= with spaces" do
+      s = "dbname=vmdb_test host=example.com password='pass = word'"
+      expected = {
+        :dbname   => "vmdb_test",
+        :host     => "example.com",
+        :password => "pass = word"
+      }
+      expect(connection.class.parse_dsn(s)).to eq(expected)
+    end
+
+    it "leading single quote" do
+      s = "dbname=vmdb_test host=example.com password='\\'password'"
+      expected = {
+        :dbname   => "vmdb_test",
+        :host     => "example.com",
+        :password => "'password"
+      }
+      expect(connection.class.parse_dsn(s)).to eq(expected)
+    end
+
+    it "single quote after =" do
+      s = "dbname=vmdb_test host=example.com password='pass =\\' word'"
+      expected = {
+        :dbname   => "vmdb_test",
+        :host     => "example.com",
+        :password => "pass =' word"
+      }
+      expect(connection.class.parse_dsn(s)).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
There is not currently a good way to get a connection params hash from a postgres dsn string without creating a new connection using those values.

This provides us with one initially to be used when reading connection strings from the database while dealing with pglogical.

@Fryguy 