### PR TITLE
Convert service to use ancestry

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -239,7 +239,7 @@ class ServiceController < ApplicationController
     else      # Get list of child Catalog Items/Services of this node
       if x_node == "root"
         typ = x_active_tree == :svcs_tree ? "Service" : "ServiceTemplate"
-        process_show_list(:where_clause => "service_id is null")
+        process_show_list(:where_clause => "ancestry is null")
         @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => typ)}
       else
         show_record(from_cid(id))

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -22,7 +22,7 @@ module ServiceMixin
     if sr.nil?
       if options.kind_of?(ServiceResource)
         nh = options.attributes.dup
-        %w(id created_at updated_at service_template_id service_id).each { |key| nh.delete(key) }
+        %w(id created_at updated_at service_template_id ancestry).each { |key| nh.delete(key) }
       else
         nh = options
       end

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -28,7 +28,7 @@ module ServiceMixin
         nh = options
       end
 
-      if self.is_circular_reference?(rsc)
+      if circular_reference?(rsc)
         raise MiqException::MiqServiceCircularReferenceError,
               _("Adding resource <%{resource_name}> to Service <%{name}> will create a circular reference") %
                 {:resource_name => rsc.name, :name => name}
@@ -108,7 +108,7 @@ module ServiceMixin
     nil
   end
 
-  def is_circular_reference?(child_svc)
+  def circular_reference?(child_svc)
     return true if child_svc == self
     if child_svc.kind_of?(Service)
       ancestor_ids.include?(child_svc.id)

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -18,7 +18,8 @@ module ServiceMixin
     rsc_type = rsc.class.base_class.name.tableize
     raise _("Cannot connect service with nil ID.") if rsc.id.nil? && rsc_type == "service_templates"
 
-    # what is this?
+    # fetch the corresponding service resource
+    # may want to use a query for this
     sr = service_resources.detect { |sr| sr.resource_type == rsc.class.base_class.name && sr.resource_id == rsc.id }
     if sr.nil?
       if options.kind_of?(ServiceResource)

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -104,16 +104,6 @@ module ServiceMixin
     nil
   end
 
-  def compact_group_indexes
-    # Remove empty group
-    last_idx = last_group_index
-    return if last_idx == 0
-
-    last_idx.downto(0) do |idx|
-      each_group_resource { |r| r.group_idx -= 1 if r.group_idx >= idx } unless self.group_has_resources?(idx)
-    end
-  end
-
   def is_circular_reference?(child_svc)
     circular_reference_check(child_svc).nil? ? false : true
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -79,7 +79,7 @@ class Service < ApplicationRecord
   end
   Vmdb::Deprecation.deprecate_methods(self, :indirect_service_children)
 
-  alias descendants all_service_children
+  alias all_service_children descendants
 
   def indirect_vms
     MiqPreloader.preload_and_map(indirect_service_children, :direct_vms)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -87,7 +87,7 @@ class Service < ApplicationRecord
   Vmdb::Deprecation.deprecate_methods(self, :indirect_vms)
 
   def direct_vms
-    service_resources.where(:resource_type => 'VmOrTemplate').collect(&:resource)
+    service_resources.where(:resource_type => 'VmOrTemplate').includes(:resource).collect(&:resource)
   end
 
   def all_vms

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -52,10 +52,15 @@ class Service < ApplicationRecord
     end
     super
   end
-  alias :<< add_resource
 
   alias parent_service parent
   alias_attribute :service, :parent
+  virtual_belongs_to :service
+
+  def service_id
+    parent_id
+  end
+  virtual_attribute :service_id, :integer
 
   def has_parent?
     !root?
@@ -73,6 +78,7 @@ class Service < ApplicationRecord
   alias root_service root
   alias services children
   alias direct_service_children children
+  virtual_has_many :services
 
   def indirect_service_children
     descendants(:from_depth => 2)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -52,15 +52,15 @@ class Service < ApplicationRecord
     end
     super
   end
-  alias_method :<<, :add_resource
+  alias :<< add_resource
 
-  alias_method :parent_service, :parent
+  alias parent_service parent
   alias_attribute :service, :parent
 
   def has_parent?
     !root?
   end
-  alias_method :has_parent, :has_parent?
+  alias has_parent has_parent?
 
   def request_class
     ServiceReconfigureRequest
@@ -70,16 +70,16 @@ class Service < ApplicationRecord
     'service_reconfigure'
   end
 
-  alias_method :root_service, :root
-  alias_method :services, :children
-  alias_method :direct_service_children, :children
+  alias root_service root
+  alias services children
+  alias direct_service_children children
 
   def indirect_service_children
     descendants(:from_depth => 2)
   end
   Vmdb::Deprecation.deprecate_methods(self, :indirect_service_children)
 
-  alias_method :all_service_children, :descendants
+  alias descendants all_service_children
 
   def indirect_vms
     MiqPreloader.preload_and_map(indirect_service_children, :direct_vms)

--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -10,7 +10,7 @@ module Service::RetirementManagement
   end
 
   def before_retirement
-    services.each(&:retire_now)
+    children.each(&:retire_now)
   end
 
   def retire_service_resources

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -33,6 +33,25 @@ class ServiceTemplate < ApplicationRecord
   virtual_has_one :custom_actions, :class_name => "Hash"
   virtual_has_one :custom_action_buttons, :class_name => "Array"
 
+  # almost feels like service_templates
+  def children
+    klass = self.class
+    service_resources.flat_map do |s|
+      s.resource.kind_of?(klass) ? s.resource : []
+    end
+  end
+
+  def descendants
+    klass = self.class
+    service_resources.flat_map do |s|
+      if s.resource.kind_of?(klass)
+        s.resource.descendants + [s.resource]
+      else
+        []
+      end
+    end
+  end
+
   def custom_actions
     generic_button_group = CustomButton.buttons_for("Service").select { |button| !button.parent.nil? }
     custom_button_sets_with_generics = custom_button_sets + generic_button_group.map(&:parent).uniq.flatten

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -33,23 +33,16 @@ class ServiceTemplate < ApplicationRecord
   virtual_has_one :custom_actions, :class_name => "Hash"
   virtual_has_one :custom_action_buttons, :class_name => "Array"
 
-  # almost feels like service_templates
   def children
-    klass = self.class
-    service_resources.flat_map do |s|
-      s.resource.kind_of?(klass) ? s.resource : []
-    end
+    service_templates
   end
 
   def descendants
-    klass = self.class
-    service_resources.flat_map do |s|
-      if s.resource.kind_of?(klass)
-        s.resource.descendants + [s.resource]
-      else
-        []
-      end
-    end
+    children.flat_map { |child| [child] + child.descendants }
+  end
+
+  def subtree
+    [self] + descendants
   end
 
   def custom_actions

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -18,7 +18,7 @@ class TreeBuilderServices < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, rbac_filtered_objects(Service.where(:service_id => nil)), "name")
+    count_only_or_objects(count_only, rbac_filtered_objects(Service.where(:ancestry => nil)), "name")
   end
 
   def x_get_tree_service_kids(object, count_only)

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -18,7 +18,7 @@ class TreeBuilderServices < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, rbac_filtered_objects(Service.where(:ancestry => nil)), "name")
+    count_only_or_objects(count_only, rbac_filtered_objects(Service.roots), "name")
   end
 
   def x_get_tree_service_kids(object, count_only)

--- a/db/migrate/20160310170333_add_service_ancestry.rb
+++ b/db/migrate/20160310170333_add_service_ancestry.rb
@@ -15,9 +15,6 @@ class AddServiceAncestry < ActiveRecord::Migration[5.0]
     add_column :services, :ancestry, :string
     add_index :services, :ancestry
 
-    Service.connection.schema_cache.clear!
-    Service.reset_column_information
-
     say_with_time("Converting Services from service_id ancestry") do
       update_service_parent(nil)
     end
@@ -28,9 +25,6 @@ class AddServiceAncestry < ActiveRecord::Migration[5.0]
   def down
     add_column :services, :service_id, :bigint
     add_index :services, :service_id
-
-    Service.connection.schema_cache.clear!
-    Service.reset_column_information
 
     say_with_time("Converting Services from ancestry to service_id") do
       Service.all.each do |service|

--- a/db/migrate/20160310170333_add_service_ancestry.rb
+++ b/db/migrate/20160310170333_add_service_ancestry.rb
@@ -1,0 +1,43 @@
+class AddServiceAncestry < ActiveRecord::Migration[5.0]
+  class Service < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def update_service_parent(parent)
+    Service.where(:service_id => parent.try(:id)).each do |svc|
+      ancestry = [parent.try(:ancestry), parent.try(:id)].compact.join("/")
+      svc.update_attributes(:ancestry => ancestry) if parent
+      update_service_parent(svc)
+    end
+  end
+
+  def up
+    add_column :services, :ancestry, :string
+    add_index :services, :ancestry
+
+    Service.connection.schema_cache.clear!
+    Service.reset_column_information
+
+    say_with_time("Converting Services from service_id ancestry") do
+      update_service_parent(nil)
+    end
+
+    remove_column :services, :service_id
+  end
+
+  def down
+    add_column :services, :service_id, :bigint
+    add_index :services, :service_id
+
+    Service.connection.schema_cache.clear!
+    Service.reset_column_information
+
+    say_with_time("Converting Services from ancestry to service_id") do
+      Service.all.each do |service|
+        service.update_attributes(:service_id => service.ancestry.split("/").last.try(:to_i)) if service.ancestry
+      end
+    end
+
+    remove_column :services, :ancestry
+  end
+end

--- a/spec/migrations/20160310170333_add_service_ancestry_spec.rb
+++ b/spec/migrations/20160310170333_add_service_ancestry_spec.rb
@@ -5,6 +5,13 @@ describe AddServiceAncestry do
   let(:service_stub) { migration_stub(:Service) }
 
   migration_context :up do
+    # nodes:
+    # s1
+    #   s11
+    #     s111
+    #     s112
+    # s2
+    #   s21 (created before parent)
     it "updates tree" do
       s21  = service_stub.create!
       s1   = service_stub.create!

--- a/spec/migrations/20160310170333_add_service_ancestry_spec.rb
+++ b/spec/migrations/20160310170333_add_service_ancestry_spec.rb
@@ -6,35 +6,35 @@ describe AddServiceAncestry do
 
   migration_context :up do
     it "updates tree" do
-      s21  = service_stub.create!()
-      s1   = service_stub.create!()
-      s2   = service_stub.create!()
+      s21  = service_stub.create!
+      s1   = service_stub.create!
+      s2   = service_stub.create!
       s11  = service_stub.create!(:service_id => s1.id)
       s111 = service_stub.create!(:service_id => s11.id)
       s112 = service_stub.create!(:service_id => s11.id)
-      s21.update_attributes(:service_id => s2.id)
+      s21.update_attributes(:service_id => s2.id) # note: s21.id < s2.id
 
       migrate
 
-      expect(s1.reload.ancestry).to eq(nil)
-      expect(s2.reload.ancestry).to eq(nil)
+      expect(s1.reload.ancestry).to be_nil
+      expect(s2.reload.ancestry).to be_nil
 
-      expect(s11.reload.ancestry).to eq("#{s1.id}")
+      expect(s11.reload.ancestry).to eq(s1.id.to_s)
       expect(s111.reload.ancestry).to eq("#{s1.id}/#{s11.id}")
       expect(s112.reload.ancestry).to eq("#{s1.id}/#{s11.id}")
-      expect(s21.reload.ancestry).to eq("#{s2.id}") # has a lower id than s2
+      expect(s21.reload.ancestry).to eq(s2.id.to_s)
     end
   end
 
   migration_context :down do
     it "updates tree" do
-      s21  = service_stub.create!()
-      s1   = service_stub.create!()
-      s2   = service_stub.create!()
-      s11  = service_stub.create!(:ancestry => "#{s1.id}")
+      s21  = service_stub.create!
+      s1   = service_stub.create!
+      s2   = service_stub.create!
+      s11  = service_stub.create!(:ancestry => s1.id.to_s)
       s111 = service_stub.create!(:ancestry => "#{s1.id}/#{s11.id}")
       s112 = service_stub.create!(:ancestry => "#{s1.id}/#{s11.id}")
-      s21.update_attributes(:ancestry => "#{s2.id}") # has a lower id than s2
+      s21.update_attributes(:ancestry => s2.id.to_s) # note: s21.id < s2.id
 
       migrate
 

--- a/spec/migrations/20160310170333_add_service_ancestry_spec.rb
+++ b/spec/migrations/20160310170333_add_service_ancestry_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+require_migration
+
+describe AddServiceAncestry do
+  let(:service_stub) { migration_stub(:Service) }
+
+  migration_context :up do
+    it "updates tree" do
+      s21  = service_stub.create!()
+      s1   = service_stub.create!()
+      s2   = service_stub.create!()
+      s11  = service_stub.create!(:service_id => s1.id)
+      s111 = service_stub.create!(:service_id => s11.id)
+      s112 = service_stub.create!(:service_id => s11.id)
+      s21.update_attributes(:service_id => s2.id)
+
+      migrate
+
+      expect(s1.reload.ancestry).to eq(nil)
+      expect(s2.reload.ancestry).to eq(nil)
+
+      expect(s11.reload.ancestry).to eq("#{s1.id}")
+      expect(s111.reload.ancestry).to eq("#{s1.id}/#{s11.id}")
+      expect(s112.reload.ancestry).to eq("#{s1.id}/#{s11.id}")
+      expect(s21.reload.ancestry).to eq("#{s2.id}") # has a lower id than s2
+    end
+  end
+
+  migration_context :down do
+    it "updates tree" do
+      s21  = service_stub.create!()
+      s1   = service_stub.create!()
+      s2   = service_stub.create!()
+      s11  = service_stub.create!(:ancestry => "#{s1.id}")
+      s111 = service_stub.create!(:ancestry => "#{s1.id}/#{s11.id}")
+      s112 = service_stub.create!(:ancestry => "#{s1.id}/#{s11.id}")
+      s21.update_attributes(:ancestry => "#{s2.id}") # has a lower id than s2
+
+      migrate
+
+      expect(s1.reload.service_id).to eq(nil)
+      expect(s2.reload.service_id).to eq(nil)
+
+      expect(s11.reload.service_id).to eq(s1.id)
+      expect(s111.reload.service_id).to eq(s11.id)
+      expect(s112.reload.service_id).to eq(s11.id)
+      expect(s21.reload.service_id).to eq(s2.id)
+    end
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -263,7 +263,6 @@ describe Service do
     end
   end
 
-
   describe "#subtree" do
     it "returns sub tree" do
       create_deep_tree

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -233,23 +233,6 @@ describe Service do
         expect(@service.next_group_index(0, -1)).to be_nil
       end
 
-      it "should compact group indexes to remove empty groups" do
-        @service.compact_group_indexes
-        expect(@service.last_group_index).to equal(0)
-
-        @service.service_resources.first.group_idx = 3
-        expect(@service.last_group_index).to equal(3)
-        expect(@service.group_has_resources?(1)).to be_falsey
-
-        @service.compact_group_indexes
-        expect(@service.last_group_index).to equal(1)
-        expect(@service.group_has_resources?(1)).to be_truthy
-
-        @service.remove_all_resources
-        expect(@service.group_has_resources?(0)).to be_falsey
-        @service.compact_group_indexes
-        expect(@service.last_group_index).to equal(0)
-      end
 
       it "should not allow the same VM to be added to more than one services" do
         vm = Vm.first

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -126,7 +126,7 @@ describe ServiceTemplate do
       add_and_save_service(@svc_a, @svc_c)
       add_and_save_service(@svc_c, @svc_d)
 
-      sub_svc = @svc_a.sub_services
+      sub_svc = @svc_a.children
       expect(sub_svc).not_to include(@svc_a)
       expect(sub_svc.size).to eq(2)
       expect(sub_svc).to include(@svc_b)
@@ -140,7 +140,7 @@ describe ServiceTemplate do
       add_and_save_service(@svc_a, @svc_c)
       add_and_save_service(@svc_c, @svc_d)
 
-      sub_svc = @svc_a.sub_services({:recursive => true})
+      sub_svc = @svc_a.descendants
       expect(sub_svc.size).to eq(5)
       expect(sub_svc).not_to include(@svc_a)
       expect(sub_svc).to include(@svc_b)


### PR DESCRIPTION
This is the main version of a fix for 5.4. Instead of using recursive calls, we are using ancestry.
The original code cut down the the view services screen from **68 seconds to 10**, and number of queries from **3.2k to 860**.

This uses ancestry for the calls.

/cc @Fryguy Think this is pretty straight forward
/cc @bzwei fyi
/cc @gmcculloug think you had a bunch of insight into this one.