### PR TITLE
Rbac scope klass 2

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -267,8 +267,8 @@ module Rbac
     end
   end
 
-  def self.find_options_for_tenant(klass, user_or_group, find_options = {})
-    tenant_id_clause = klass.tenant_id_clause(user_or_group)
+  def self.find_options_for_tenant(scope, user_or_group, find_options = {})
+    tenant_id_clause = scope.klass.tenant_id_clause(user_or_group)
 
     find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], tenant_id_clause) if tenant_id_clause
     find_options
@@ -279,7 +279,7 @@ module Rbac
   end
 
   def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options = {}, user_or_group = nil)
-    find_options = find_options_for_tenant(klass, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
+    find_options = find_options_for_tenant(scope, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
 
     return find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)
     return find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user_or_group)   if apply_rbac_to_associated_class?(klass)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -176,7 +176,7 @@ module Rbac
     parent_class = rbac_class(klass)
     filtered_ids, _ = calc_filtered_ids(parent_class, rbac_filters, user_or_group)
 
-    find_targets_filtered_by_parent_ids(parent_class, klass, scope, find_options, filtered_ids)
+    find_targets_filtered_by_parent_ids(parent_class, scope, find_options, filtered_ids)
   end
 
   def self.total_scope(scope, extra_target_ids, conditions, includes)
@@ -198,14 +198,14 @@ module Rbac
   # @option find_options :conditions [String|Hash|Array] active record where conditions for primary records (e.g. { "vms.archived" => true} )
   # @param filtered_ids [nil|Array<Integer>] ids for the parent class (e.g. [1,2,3] for host)
   # @return [Array<Array<Object>,Integer,Integer] targets, total count, authorized count
-  def self.find_targets_filtered_by_parent_ids(parent_class, klass, scope, find_options, filtered_ids)
+  def self.find_targets_filtered_by_parent_ids(parent_class, scope, find_options, filtered_ids)
     total_count = scope.where(find_options[:conditions]).includes(find_options[:include]).references(find_options[:include]).count
     if filtered_ids
-      reflection = klass.reflections[parent_class.name.underscore]
+      reflection = scope.reflections[parent_class.name.underscore]
       if reflection
-        ids_clause = ["#{klass.table_name}.#{reflection.foreign_key} IN (?)", filtered_ids]
+        ids_clause = ["#{scope.table_name}.#{reflection.foreign_key} IN (?)", filtered_ids]
       else
-        ids_clause = ["#{klass.table_name}.resource_type = ? AND #{klass.table_name}.resource_id IN (?)", parent_class.name, filtered_ids]
+        ids_clause = ["#{scope.table_name}.resource_type = ? AND #{scope.table_name}.resource_id IN (?)", parent_class.name, filtered_ids]
       end
 
       find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], ids_clause)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -129,7 +129,7 @@ module Rbac
     klass = scope.respond_to?(:klass) ? scope.klass : scope
     u_filtered_ids = get_self_service_object_ids(user_or_group, klass)
     b_filtered_ids = get_belongsto_filter_object_ids(klass, user_filters['belongsto'])
-    m_filtered_ids = get_managed_filter_object_ids(klass, scope, user_filters['managed'])
+    m_filtered_ids = get_managed_filter_object_ids(scope, user_filters['managed'])
     d_filtered_ids = user_filters['ids_via_descendants']
 
     filtered_ids = combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids)
@@ -235,8 +235,8 @@ module Rbac
     get_belongsto_matches(filter, rbac_class(klass)).collect(&:id)
   end
 
-  def self.get_managed_filter_object_ids(klass, scope, filter)
-    return nil if !TAGGABLE_FILTER_CLASSES.include?(safe_base_class(klass).name) || filter.blank?
+  def self.get_managed_filter_object_ids(scope, filter)
+    return nil if !TAGGABLE_FILTER_CLASSES.include?(safe_base_class(scope.klass).name) || filter.blank?
     scope.find_tags_by_grouping(filter, :ns => '*', :select => minimum_columns_for(klass)).reorder(nil).collect(&:id)
   end
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -263,7 +263,7 @@ module Rbac
 
       [targets, targets.length, targets.length]
     else
-      find_targets_without_rbac(klass, scope, find_options)
+      find_targets_without_rbac(scope, find_options)
     end
   end
 
@@ -284,10 +284,10 @@ module Rbac
     return find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)
     return find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user_or_group)   if apply_rbac_to_associated_class?(klass)
     return find_targets_with_user_group_rbac(klass, scope, rbac_filters, find_options, user_or_group) if apply_user_group_rbac_to_class?(klass)
-    find_targets_without_rbac(klass, scope, find_options)
+    find_targets_without_rbac(scope, find_options)
   end
 
-  def self.find_targets_without_rbac(_klass, scope, find_options = {})
+  def self.find_targets_without_rbac(scope, find_options = {})
     targets     = method_with_scope(scope, find_options)
     total_count = find_options[:limit] ? scope.where(find_options[:conditions]).includes(find_options[:include]).references(find_options[:include]).count : targets.length
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -172,8 +172,8 @@ module Rbac
     filtered_ids
   end
 
-  def self.find_targets_with_indirect_rbac(klass, scope, rbac_filters, find_options = {}, user_or_group = nil)
-    parent_class = rbac_class(klass)
+  def self.find_targets_with_indirect_rbac(scope, rbac_filters, find_options = {}, user_or_group = nil)
+    parent_class = rbac_class(scope.klass)
     filtered_ids, _ = calc_filtered_ids(parent_class, rbac_filters, user_or_group)
 
     find_targets_filtered_by_parent_ids(parent_class, scope, find_options, filtered_ids)
@@ -282,7 +282,7 @@ module Rbac
     find_options = find_options_for_tenant(klass, user_or_group, find_options) if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
 
     return find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)
-    return find_targets_with_indirect_rbac(klass, scope, rbac_filters, find_options, user_or_group)   if apply_rbac_to_associated_class?(klass)
+    return find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user_or_group)   if apply_rbac_to_associated_class?(klass)
     return find_targets_with_user_group_rbac(klass, scope, rbac_filters, find_options, user_or_group) if apply_user_group_rbac_to_class?(klass)
     find_targets_without_rbac(klass, scope, find_options)
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -245,11 +245,11 @@ module Rbac
     find_targets_filtered_by_ids(scope, find_options, u_filtered_ids, filtered_ids)
   end
 
-  def self.find_targets_with_user_group_rbac(klass, scope, _rbac_filters, find_options = {}, user_or_group = nil)
+  def self.find_targets_with_user_group_rbac(scope, _rbac_filters, find_options = {}, user_or_group = nil)
     if user_or_group && user_or_group.self_service?
-      if klass == User && user_or_group.kind_of?(User)
+      if scope.klass == User && user_or_group.kind_of?(User)
         cond = ["id = ?", user_or_group.id]
-      elsif klass == MiqGroup
+      elsif scope.klass == MiqGroup
         group_id = user_or_group.id if user_or_group.kind_of?(MiqGroup)
         group_id ||= user_or_group.current_group_id if user_or_group.kind_of?(User) && user_or_group.current_group
         cond = ["id = ?", group_id] if group_id
@@ -258,7 +258,7 @@ module Rbac
       end
 
       cond, incl = MiqExpression.merge_where_clauses_and_includes([find_options[:condition], cond].compact, [find_options[:include]].compact)
-      targets = klass.where(cond).includes(incl).references(incl).group(find_options[:group])
+      targets = scope.klass.where(cond).includes(incl).references(incl).group(find_options[:group])
                      .order(find_options[:order]).offset(find_options[:offset]).limit(find_options[:limit]).to_a
 
       [targets, targets.length, targets.length]
@@ -283,7 +283,7 @@ module Rbac
 
     return find_targets_with_direct_rbac(scope, rbac_filters, find_options, user_or_group)     if apply_rbac_to_class?(klass)
     return find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user_or_group)   if apply_rbac_to_associated_class?(klass)
-    return find_targets_with_user_group_rbac(klass, scope, rbac_filters, find_options, user_or_group) if apply_user_group_rbac_to_class?(klass)
+    return find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user_or_group) if apply_user_group_rbac_to_class?(klass)
     find_targets_without_rbac(scope, find_options)
   end
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -95,8 +95,8 @@ module Rbac
     klass < MetricRollup || klass < Metric
   end
 
-  def self.rbac_class(klass)
-    klass = klass.respond_to?(:klass) ? klass.klass : klass
+  def self.rbac_class(scope)
+    klass = scope.respond_to?(:klass) ? scope.klass : scope
     return klass if apply_rbac_to_class?(klass)
     if apply_rbac_to_associated_class?(klass)
       return klass.name[0..-12].constantize.base_class # e.g. VmPerformance => VmOrTemplate


### PR DESCRIPTION
removing `klass` from rbac

This is based upon the scope work, where rbac will just take in 1 parameter instead of taking `targets`, `klass`, `scope` and others.

/cc @matthewd :grapes: thnx