### PR TITLE
Added basic template for root-password via cloud-init customization

### DIFF
--- a/db/fixtures/customization_templates.yml
+++ b/db/fixtures/customization_templates.yml
@@ -274,3 +274,9 @@
     />\n</unattend>"
   :type: CustomizationTemplateSysprep
   :system: true
+
+- :name: Basic root pass template
+  :description: This template takes use of rootpassword defined in the UI
+  :script: "#cloud-config\nchpasswd:\n  list: |\n    root:<%= MiqPassword.decrypt(evm[:root_password]) %>\n  expire: False"
+  :type: CustomizationTemplateCloudInit
+  :system: true


### PR DESCRIPTION
Added this template for the following reasons:
* Its not trivial for user to understand that when you insert root password from the UI that you need a script in order for it to take effect, by having the basic one its clearer.
* The template implements a very basic and required cloud-init task
* Needed for the OpenShift deployment via automation, using this script to set rootpass on all vm.

Didn't understand why it has to be connected to pxe_image_type_id, if anyone has an idea please explain (I have added one that is also made in the db seed so for sure it will exist).