### PR TITLE
Vim performance scope

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -223,10 +223,6 @@ module MiqReport::Generator
     elsif !db_options.blank? && db_options[:interval] == 'daily' && klass <= MetricRollup
       # Ad-hoc daily performance reports
       #   Daily for: Performance - Clusters...
-      associations = includes.kind_of?(Hash) ? includes.keys : Array(includes)
-
-      results = []
-
       unless conditions.nil?
         conditions.preprocess_options = {:vim_performance_daily_adhoc => (time_profile && time_profile.rollup_daily_metrics)}
         exp_sql, exp_includes = conditions.to_sql
@@ -236,7 +232,7 @@ module MiqReport::Generator
 
       start_time, end_time = Metric::Helper.get_time_range_from_offset(db_options[:start_offset], db_options[:end_offset], :tz => tz)
       results = VimPerformanceDaily
-                .find_entries(ext_options.merge(:reflections => associations, :class => klass))
+                .find_entries(ext_options.merge(:class => klass))
                 .where(where_clause)
                 .where(:timestamp => start_time..end_time)
                 .includes(includes)

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -28,8 +28,6 @@ module MiqReport::Generator::Trend
       results = []
 
       includes = include.blank? ? [] : include.keys
-      associations = includes.kind_of?(Hash) ? includes.keys : Array(includes)
-      only_cols = [db_options[:limit_col], db_options[:trend_col]].compact
 
       start_time, end_time = Metric::Helper.get_time_range_from_offset(db_options[:start_offset], db_options[:end_offset], :tz => tz)
       trend_klass = db_options[:trend_db].kind_of?(Class) ? db_options[:trend_db] : Object.const_get(db_options[:trend_db])

--- a/app/models/miq_report/generator/utilization.rb
+++ b/app/models/miq_report/generator/utilization.rb
@@ -18,12 +18,12 @@ module MiqReport::Generator::Utilization
     if db_options[:tag]
       tag_klass, cat, tag = db_options[:tag].split("/")
       cond = ["resource_type = ? and tag_names like ?", tag_klass, "%#{cat}/#{tag}%"]
-      results = VimPerformanceAnalysis.find_child_perf_for_time_period(resource, db_options[:interval], db_options.merge(:conditions => cond, :ext_options => {:only_cols => cols, :tz => tz, :time_profile => time_profile}))
+      results = VimPerformanceAnalysis.find_child_perf_for_time_period(resource, db_options[:interval], db_options.merge(:conditions => cond, :ext_options => {:tz => tz, :time_profile => time_profile}))
 
       # Roll up results by timestamp
       results = VimPerformanceAnalysis.group_perf_by_timestamp(resource, results, cols)
     else
-      results = VimPerformanceAnalysis.find_perf_for_time_period(resource, db_options[:interval], db_options.merge(:ext_options => {:only_cols => cols, :tz => tz, :time_profile => time_profile}))
+      results = VimPerformanceAnalysis.find_perf_for_time_period(resource, db_options[:interval], db_options.merge(:ext_options => {:tz => tz, :time_profile => time_profile}))
     end
 
     # Return rpt object:

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -508,9 +508,9 @@ module VimPerformanceAnalysis
     rel        = rel.where(options[:conditions]) if options[:conditions]
 
     if obj.kind_of?(MiqEnterprise) || obj.kind_of?(MiqRegion)
-      cond1 = klass.send(:sanitize_sql_for_conditions, :resource_type => "Storage",             :resource_id => obj.storage_ids)
-      cond2 = klass.send(:sanitize_sql_for_conditions, :resource_type => "ExtManagementSystem", :resource_id => obj.ext_management_system_ids)
-      rel   = rel.where("((#{cond1}) OR (#{cond2}))")
+      cond1 = rel.where(:resource_type => "Storage",             :resource_id => obj.storage_ids)
+      cond2 = rel.where(:resource_type => "ExtManagementSystem", :resource_id => obj.ext_management_system_ids)
+      rel = cond1.or(cond2)
     else
       parent_col = case obj
                    when Host then                :parent_host_id

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -512,8 +512,8 @@ module VimPerformanceAnalysis
     rel        = rel.where(options[:conditions]) if options[:conditions]
 
     if obj.kind_of?(MiqEnterprise) || obj.kind_of?(MiqRegion)
-      cond1 = rel.where(:resource_type => "Storage",             :resource_id => obj.storage_ids)
-      cond2 = rel.where(:resource_type => "ExtManagementSystem", :resource_id => obj.ext_management_system_ids)
+      cond1 = rel.where(:resource => obj.storages)
+      cond2 = rel.where(:resource => obj.ext_management_systems)
       rel = cond1.or(cond2)
     else
       parent_col = case obj

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -230,11 +230,9 @@ class ContainerDashboardService
 
   def daily_provider_metrics
     if @daily_metrics.blank?
-      resource_ids = @ems.try(:id) || ManageIQ::Providers::ContainerManager.select(:id)
       @daily_metrics = VimPerformanceDaily.find_entries(:tz => @controller.current_user.get_timezone)
-                         .where(:resource_type => 'ExtManagementSystem', :resource_id => resource_ids)
-                         .where('timestamp > :min_time', :min_time => 30.days.ago)
-                         .order("timestamp")
+                                          .where(:resource => (@ems || ManageIQ::Providers::ContainerManager.all))
+                                          .where('timestamp > ?', 30.days.ago.utc).order("timestamp")
     end
     @daily_metrics
   end

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -230,12 +230,11 @@ class ContainerDashboardService
 
   def daily_provider_metrics
     if @daily_metrics.blank?
-      resource_ids = @ems.present? ? [@ems.id] : ManageIQ::Providers::ContainerManager.select(:id)
+      resource_ids = @ems.try(:id) || ManageIQ::Providers::ContainerManager.select(:id)
       @daily_metrics = VimPerformanceDaily.find_entries(:tz => @controller.current_user.get_timezone)
-      @daily_metrics =
-        @daily_metrics.where('resource_type = :type and resource_id in (:resource_ids) and timestamp > :min_time',
-                             :type => 'ExtManagementSystem', :resource_ids => resource_ids, :min_time => 30.days.ago)
-      @daily_metrics = @daily_metrics.order("timestamp")
+                         .where(:resource_type => 'ExtManagementSystem', :resource_id => resource_ids)
+                         .where('timestamp > :min_time', :min_time => 30.days.ago)
+                         .order("timestamp")
     end
     @daily_metrics
   end

--- a/spec/factories/metric_rollup.rb
+++ b/spec/factories/metric_rollup.rb
@@ -1,6 +1,16 @@
 FactoryGirl.define do
   factory :metric_rollup do
     timestamp { Time.now.utc }
+    trait :with_data do
+      cpu_usagemhz_rate_average         50.0
+      derived_vm_numvcpus               1.0
+      derived_memory_available          1000.0
+      derived_memory_used               100.0
+      disk_usage_rate_average           100.0
+      net_usage_rate_average            25.0
+      derived_vm_used_disk_storage      1.0.gigabytes
+      derived_vm_allocated_disk_storage 4.0.gigabytes
+    end
   end
 
   factory :metric_rollup_vm_hr, :parent => :metric_rollup, :class => :MetricRollup do

--- a/spec/models/vim_performance_analysis_spec.rb
+++ b/spec/models/vim_performance_analysis_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe VimPerformanceAnalysis do
+  let(:tag_text) { "operations/good" }
+  let(:tag_good) { FactoryGirl.create(:tag, :name => "/managed/#{tag_text}") }
+  let(:tag_bad)  { FactoryGirl.create(:tag, :name => "/managed/operations/bad") }
+  let(:time_profile) { FactoryGirl.create(:time_profile_with_rollup, :profile => {:tz => "UTC"}) }
+
+  let(:user) { FactoryGirl.create(:user_admin) }
+
+  let(:ems) { FactoryGirl.create(:ems_vmware) }
+
+  let(:good_day) { DateTime.current - 2.day }
+  let(:bad_day)  { DateTime.current - 4.months }
+  let(:vm1) do
+    FactoryGirl.create(:vm_vmware, :name => "test_vm", :tags => [tag_good], :ext_management_system => ems).tap do |vm|
+      [7, 8, 9, 10].each do |hour|
+        add_rollup(vm, (good_day + hour.hours).to_s, tag_text)
+        add_rollup(vm, (bad_day + hour.hours).to_s, tag_text)
+      end
+      vm.save!
+    end
+  end
+
+  let(:storage) { FactoryGirl.create(:storage_target_vmware) }
+  let(:host1) do
+    FactoryGirl.create(:host,
+                       :hardware => FactoryGirl.create(:hardware,
+                                                       :memory_mb       => 8124,
+                                                       :cpu_total_cores => 1,
+                                                       :cpu_speed       => 9576),
+                       :vms      => [vm1],
+                       :storages => [storage])
+  end
+
+  let(:ems_cluster) do
+    FactoryGirl.create(:ems_cluster, :ext_management_system => ems, :hosts => [host1])
+  end
+
+  before do
+    MiqRegion.seed
+    EvmSpecHelper.local_miq_server
+  end
+
+  describe ".find_child_perf_for_time_period" do
+    it "returns only tagged nodes" do
+      ems_cluster
+      expect(MetricRollup.count).to be > 0
+
+      cols = %i(id name project provider_id)
+      # :conditions => ["resource_type = ? and tag_names like ?", tag_klass, "%#{cat}/#{tag}%"]
+      options = {:end_date => DateTime.current, :days => 30, :ext_options => {:time_profile => time_profile}}
+
+      # currently, only vms have data, but only host data is returned
+      results = VimPerformanceAnalysis.find_child_perf_for_time_period(ems, "daily", options)
+      # expect(results).not_to be_empty
+      VimPerformanceAnalysis.group_perf_by_timestamp(ems, results, cols)
+
+      # for now, we're just content that it did not blow up
+    end
+  end
+
+  # describe ".child_tags_over_time_period" do
+  #   it "returns only tagged nodes" do
+  #     good_vm = FactoryGirl.create(:vm_vmware, :tags => [tag_good])
+  #     bad_vm  = FactoryGirl.create(:vm_vmware, :tags => [tag_bad])
+  #   end
+  # end
+
+  private
+
+  def add_rollup(vm, timestamp, tag = tag_text)
+    vm.metric_rollups << FactoryGirl.create(:metric_rollup_vm_daily, :with_data,
+                                            :timestamp          => timestamp,
+                                            :tag_names          => tag,
+                                            :parent_host        => vm.host,
+                                            :parent_ems_cluster => vm.ems_cluster,
+                                            :parent_ems         => vm.ext_management_system,
+                                            :parent_storage     => vm.storage,
+                                            :resource_name      => vm.name,
+                                            :time_profile       => time_profile,
+                                           )
+  end
+end


### PR DESCRIPTION
This is focused on `VimPerformanceDaily.find_entries`

The goal is to remove allow scopes to be used instead. Rbac will be able to convert `VimPerformanceDaily` into a scope and much of the specialized logic around `scope` and `klass` can be removed. 

After this, think we can pull `klass` lookup out of `find_entries`
Let me know the best way to code the `OR` if you think I should convert that too.

/cc @matthewd This is a follow up to our conversation.