### PR TITLE
BZ1316770 - Replace text in hover text

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -286,7 +286,7 @@ module VmHelper::TextualSummary
     elsif storages.length == 1
       storage = storages.first
       h[:value] = storage.name
-      h[:title] = _("Show this %{label}") % {:label => label}
+      h[:title] = _("Show this VM's %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'storage', :action => 'show', :id => storage)
     else
       h.delete(:image) # Image will be part of each line item, instead
@@ -294,7 +294,7 @@ module VmHelper::TextualSummary
       h[:value] = storages.sort_by { |s| s.name.downcase }.collect do |s|
         {:image => "storage",
          :value => "#{s.name}#{" (main)" if s == main}",
-         :title => _("Show this %{label}") % {:label => label},
+         :title => _("Show this VM's %{label}") % {:label => label},
          :link => url_for(:controller => 'storage', :action => 'show', :id => s)}
       end
     end


### PR DESCRIPTION
 Replace 'Show this Datastores' with 'Show this VM's Datastores' on VM summary page

https://bugzilla.redhat.com/show_bug.cgi?id=1316770