### PR TITLE
Fix 'Add a currency column' bug

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -184,7 +184,7 @@ class ChargebackController < ApplicationController
         @sb[:rate] = ChargebackRate.new
         @sb[:rate].description = _("Copy of %{description}") % {:description => rate.description}
         @sb[:rate].rate_type = rate.rate_type
-        rate_details = rate.includes(:chargeback_rate_details => :detail_currency)
+        rate_details = rate.chargeback_rate_details
         # Create new rate detail records for copied rate record
         rate_details.each do |r|
           detail = ChargebackRateDetail.new
@@ -197,7 +197,6 @@ class ChargebackController < ApplicationController
           detail.metric = r[:metric]
           detail.chargeback_rate_detail_measure_id = r[:chargeback_rate_detail_measure_id]
           detail.chargeback_rate_detail_currency_id = r[:chargeback_rate_detail_currency_id]
-          @sb[:rate_details][:currency] = r.detail_currency.code
           @sb[:rate_details].push(detail) unless @sb[:rate_details].include?(detail)
         end
       else

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -38,6 +38,7 @@
         %th= _('Per Unit')
         %th= _('Currency')
     %tbody
+      - code_currency = @sb[:rate_details][0].detail_currency.code
       - @sb[:rate_details].each_with_index do |r, i|
         - @cur_group = r[:group] if @cur_group.nil?
         - if @cur_group != r[:group]
@@ -67,4 +68,4 @@
                 = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
           /Show the code of the currency selected by the user
           %td{:id => "column_currency_#{i}"}
-            = r[:currency]
+            = code_currency


### PR DESCRIPTION
I fix bugs created at 'Add a currency column' PR:
- The first time you access to edit view, the currency column isn't showing anything.
- We can't copy a rate.

Fixes https://github.com/ManageIQ/manageiq/issues/7217