### PR TITLE
[api] Remove superfluous expectations on status

### DIFF
--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe "categories API" do
 
     expect_query_result(:categories, 1, 2)
     expect_result_resources_to_include_hrefs("resources", [categories_url(category_1.id)])
-    expect_request_success
   end
 
   it "will return a bad request error if the filter name is invalid" do

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe "chargebacks API" do
       "resources",
       ["#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}"]
     )
-    expect_request_success
   end
 
   it "can fetch an individual chargeback rate detail" do

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Instances API" do
 
       expect_query_result(:instances, 1, 1)
       expect_result_resources_to_include_hrefs("resources", [instances_url(instance.id)])
-      expect_request_success
     end
   end
 

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -124,7 +124,6 @@ RSpec.describe "reports API" do
         :success => true,
         :message => "running report #{report.id}"
       )
-      expect_request_success
     end
 
     it "can import a report" do


### PR DESCRIPTION
Several helpers call `expect_request_success`. Adding it again after one
of these helpers is called is not needed.

***

It might be better if these spec helpers (e.g. `expect_query_result`) didn't call other spec helpers, but this is an easy win and the alternative is not, so going with this for now.

/cc @abellotti @gtanzillo @chrisarcand 
@miq-bot add-label api, test