### PR TITLE
[auth] Adding support for 6.x based IPA servers

### DIFF
--- a/gems/pending/appliance_console/principal.rb
+++ b/gems/pending/appliance_console/principal.rb
@@ -32,13 +32,13 @@ module ApplianceConsole
     private
 
     def exist?
-      AwesomeSpawn.run("/usr/bin/ipa", :params => ["service-find", "--principal", name]).success?
+      AwesomeSpawn.run("/usr/bin/ipa", :params => ["-e", "skip_version_check=1", "service-find", "--principal", name]).success?
     end
 
     def request
       # using --force because these services tend not to be in dns
       # this is like VERIFY_NONE
-      AwesomeSpawn.run!("/usr/bin/ipa", :params => ["service-add", "--force", name])
+      AwesomeSpawn.run!("/usr/bin/ipa", :params => ["-e", "skip_version_check=1", "service-add", "--force", name])
     end
   end
 end

--- a/gems/pending/spec/appliance_console/principal_spec.rb
+++ b/gems/pending/spec/appliance_console/principal_spec.rb
@@ -18,14 +18,14 @@ describe ApplianceConsole::Principal do
   it { expect(subject).to be_ipa }
 
   it "should register if not yet registered" do
-    expect_run(/ipa/, ["service-find", "--principal", principal_name], response(1))
-    expect_run(/ipa/, ["service-add", "--force", principal_name], response)
+    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-find", "--principal", principal_name], response(1))
+    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-add", "--force", principal_name], response)
 
     subject.register
   end
 
   it "should not register if already registered" do
-    expect_run(/ipa/, ["service-find", "--principal", principal_name], response)
+    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-find", "--principal", principal_name], response)
 
     subject.register
   end


### PR DESCRIPTION
With the 7.2 IPA client we need to skip the version check to we can seamlessly work with 6.x based IPA servers.

Trello: https://trello.com/c/XVfwkvGF
