### PR TITLE
Changed to skip the iscsi disk lun during scanning in RHEV

### DIFF
--- a/gems/pending/MiqVm/MiqRhevmVm.rb
+++ b/gems/pending/MiqVm/MiqRhevmVm.rb
@@ -43,6 +43,10 @@ class MiqRhevmVm < MiqVm
     @rhevmVm.disks.each_with_index do |disk, idx|
       $log.debug "MiqRhevmVm#getCfg: disk = #{disk.inspect}"
       storage_domain = disk[:storage_domains].first
+      if storage_domain.nil?
+        $log.warn "Disk <#{disk[:name]}> is skipped due to unassigned storage domain"
+        next
+      end
       storage_id     = storage_domain && storage_domain[:id]
       storage_obj    = storage_domains_by_id[storage_id]
 

--- a/gems/pending/MiqVm/MiqRhevmVm.rb
+++ b/gems/pending/MiqVm/MiqRhevmVm.rb
@@ -44,7 +44,7 @@ class MiqRhevmVm < MiqVm
       $log.debug "MiqRhevmVm#getCfg: disk = #{disk.inspect}"
       storage_domain = disk[:storage_domains].first
       if storage_domain.nil?
-        $log.warn "Disk <#{disk[:name]}> is skipped due to unassigned storage domain"
+        $log.info "Disk <#{disk[:name]}> is skipped due to unassigned storage domain"
         next
       end
       storage_id     = storage_domain && storage_domain[:id]


### PR DESCRIPTION
Skip the iscsi disk lun in smart state analysis.

https://bugzilla.redhat.com/show_bug.cgi?id=1309431