### PR TITLE
Remove Metric::Common#apply_time_profile_daily

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -150,27 +150,12 @@ module Metric::Common
   alias_method :v_derived_logical_cpus_used, :v_derived_cpu_total_cores_used
   Vmdb::Deprecation.deprecate_methods(self, :v_derived_logical_cpus_used => :v_derived_cpu_total_cores_used)
 
+  # Applies the given time profile to this metric record
   def apply_time_profile(profile)
-    method = "apply_time_profile_#{capture_interval_name}"
-    return send(method, profile) if self.respond_to?(method)
-  end
-
-  def apply_time_profile_hourly(profile)
     unless profile.ts_in_profile?(timestamp)
       self.inside_time_profile = false
       nil_out_values_for_apply_time_profile
       _log.debug("Hourly Timestamp: [#{timestamp}] is outside of time profile: [#{profile.description}]")
-    else
-      self.inside_time_profile = true
-    end
-    inside_time_profile
-  end
-
-  def apply_time_profile_daily(profile)
-    unless profile.ts_day_in_profile?(timestamp)
-      self.inside_time_profile = false
-      nil_out_values_for_apply_time_profile
-      _log.debug("Daily Timestamp: [#{timestamp}] is outside of time profile: [#{profile.description}]")
     else
       self.inside_time_profile = true
     end

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -645,11 +645,7 @@ module VimPerformanceAnalysis
 
   def self.get_daily_perf(obj, start_time, end_time, options)
     cond = ["resource_type = ? and resource_id = ? and (timestamp > ? and timestamp <= ?)", obj.class.base_class.name, obj.id, start_time.utc, end_time.utc]
-    results = VimPerformanceDaily.find_entries(options).where(cond).order("timestamp")
-
-    # apply time profile to returned records if one was specified
-    results.each { |rec| rec.apply_time_profile(options[:time_profile]) if rec.respond_to?(:apply_time_profile) } unless options[:time_profile].nil?
-    results
+    VimPerformanceDaily.find_entries(options).where(cond).order("timestamp")
   end
 
   def self.calc_trend_value_at_timestamp(recs, attr, timestamp)

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -51,10 +51,6 @@ class VimPerformanceDaily < MetricRollup
     klass.where(:time_profile_id => tp_ids, :capture_interval_name => 'daily')
   end
 
-  def self.find_adhoc(*_args)
-    []
-  end
-
   def self.generate_daily_for_one_day(recs, options = {})
     process_hashes(process_hourly_for_one_day(recs, options), options.merge(:save => false))
   end

--- a/spec/models/metric/common_spec.rb
+++ b/spec/models/metric/common_spec.rb
@@ -14,7 +14,7 @@ describe Metric::Common do
     end
   end
 
-  context "#apply_time_profile_hourly" do
+  context "#apply_time_profile" do
     it "with all days and hours selected it should return true" do
       profile = FactoryGirl.create(:time_profile,
                                    :description => "foo",
@@ -22,7 +22,7 @@ describe Metric::Common do
                                                     :days  => TimeProfile::ALL_DAYS,
                                                     :hours => TimeProfile::ALL_HOURS}
                                   )
-      res = @metric.apply_time_profile_hourly(profile)
+      res = @metric.apply_time_profile(profile)
       expect(res).to be_truthy
     end
 
@@ -33,31 +33,7 @@ describe Metric::Common do
                                                     :days  => [1],
                                                     :hours => [1]}
                                   )
-      res = @metric.apply_time_profile_hourly(profile)
-      expect(res).to be_falsey
-    end
-  end
-
-  context "#apply_time_profile_daily" do
-    it "with all days selected it should return true" do
-      profile = FactoryGirl.create(:time_profile,
-                                   :description => "foo",
-                                   :profile     => {:tz    => "New Delhi",
-                                                    :days  => TimeProfile::ALL_DAYS,
-                                                    :hours => [1]}
-                                  )
-      res = @metric.apply_time_profile_daily(profile)
-      expect(res).to be_truthy
-    end
-
-    it "with specific days selected it should return false" do
-      profile = FactoryGirl.create(:time_profile,
-                                   :description => "foo",
-                                   :profile     => {:tz    => "New Delhi",
-                                                    :days  => [1, 2],
-                                                    :hours => [1]}
-                                  )
-      res = @metric.apply_time_profile_daily(profile)
+      res = @metric.apply_time_profile(profile)
       expect(res).to be_falsey
     end
   end


### PR DESCRIPTION
In the past, daily records could be queried on the fly via adhoc rollups
in VimPerformanceDaily, and so this method was needed to filter those
records on the Ruby side.  Once we removed the adhoc daily rollups, and
relied solely on a TimeProfile to get daily data, this code stopped
being used.

The code for apply_time_profile is still needed for hourly records
however, since those can still be queried on the fly.

@gtanzillo Please review
cc @kbrock 