### PR TITLE
Check for the existence of event prior to checking if a policy exists for the event

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -388,7 +388,7 @@ class MiqPolicy < ApplicationRecord
   end
 
   def self.policy_for_event?(policy, event)
-    event.name == 'rsop' || policy.events.include?(event)
+    event && event.name == 'rsop' || policy.events.include?(event)
   end
   private_class_method :policy_for_event?
 


### PR DESCRIPTION
```
[----] F, [2016-03-14T14:46:20.907287 #73283:3fc8de96e380] FATAL -- : Error caught: [NoMethodError] undefined method `name' for nil:NilClass
/Users/aparnakarve/rh/master/manageiq/app/models/miq_policy.rb:391:in `policy_for_event?'
/Users/aparnakarve/rh/master/manageiq/app/models/miq_policy.rb:382:in `block in get_policies_for_target'
/Users/aparnakarve/rh/master/manageiq/app/models/miq_policy.rb:379:in `keep_if'
/Users/aparnakarve/rh/master/manageiq/app/models/miq_policy.rb:379:in `get_policies_for_target'
/Users/aparnakarve/rh/master/manageiq/app/models/vm_or_template.rb:1370:in `has_compliance_policies?'
```

Encountered the above error while navigating to a VM from this url - ```http://localhost:3000/ems_infra/show/10000000000002?display=vms```

@bzwei Does this simple fix look OK, or is there something more to it ?