### PR TITLE
containers dashboard: ignore metrics with missing fields in heatmaps

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
@@ -54,17 +54,23 @@ angular.module('miq.util').factory('chartsMixin', function() {
 
   var processHeatmapData = function(heatmapsStruct, data) {
     if (data) {
-      heatmapsStruct.data = _.sortBy(data, 'percent').map(function(d) {
-        var percent = d.percent * 100;
-        var tooltip = "Node: " + d.node + "<br> Provider: " + d.provider + "<br> Usage: " + percent + "% in use of " +
-          d.total + " total";
+      var heatmapsStructData = data.map(function(d) {
+        var percent = -1;
+        var tooltip = __("Node: ") + d.node + "<br>" + __("Provider: ") + d.provider
+        if (d.percent === null || d.total === null) {
+          tooltip += "<br> " + __("Usage: Unknown");
+        } else {
+          percent = d.percent
+          tooltip += "<br>" + __("Usage: ") + sprintf(__("%d%% in use of %d total"), (percent * 100).toFixed(0), d.total);
+        }
 
         return {
           "id": d.id,
           "tooltip": tooltip,
-          "value": d.percent
+          "value": percent
         };
-      }).reverse()
+      })
+      heatmapsStruct.data = _.sortBy(heatmapsStructData, 'value').reverse()
     } else  {
       heatmapsStruct.dataAvailable = false
     }

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -131,16 +131,16 @@ class ContainerDashboardService
         :id       => m.resource.id,
         :node     => m.resource.name,
         :provider => provider_name,
-        :total    => m.derived_vm_numvcpus.round,
-        :percent  => (m.cpu_usage_rate_average / 100.0).round(CPU_USAGE_PRECISION) # pf accepts fractions 90% = 0.90
+        :total    => m.derived_vm_numvcpus.present? ? m.derived_vm_numvcpus.round : nil,
+        :percent  => m.cpu_usage_rate_average.present? ? (m.cpu_usage_rate_average / 100.0).round(CPU_USAGE_PRECISION) : nil # pf accepts fractions 90% = 0.90
       }
 
       node_memory_usage << {
         :id       => m.resource.id,
         :node     => m.resource.name,
         :provider => m.resource.ext_management_system.name,
-        :total    => m.derived_memory_available.round,
-        :percent  => (m.mem_usage_absolute_average / 100.0).round(CPU_USAGE_PRECISION) # pf accepts fractions 90% = 0.90
+        :total    => m.derived_memory_available.present? ? m.derived_memory_available.round : nil,
+        :percent  => m.mem_usage_absolute_average.present? ? (m.mem_usage_absolute_average / 100.0).round(CPU_USAGE_PRECISION) : nil # pf accepts fractions 90% = 0.90
       }
     end
 

--- a/spec/javascripts/fixtures/json/container_dashboard_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_response.json
@@ -46,23 +46,19 @@
       "nodeCpuUsage": [
         {
           "id": 1,
-          "info": {
-            "node": "oshift01.eng.lab.tlv.redhat.com",
-            "provider": "Molecule",
-            "total": 2
-          },
-          "value": 0.18
+          "node": "oshift01.eng.lab.tlv.redhat.com",
+          "provider": "Molecule",
+          "total": 2,
+          "percent": 0.18
         }
       ],
       "nodeMemoryUsage":[
         {
           "id":1,
-          "info":{
-            "node":"oshift01.eng.lab.tlv.redhat.com",
-            "provider":"Molecule",
-            "total": 7822
-          },
-          "value": 0.82
+          "node":"oshift01.eng.lab.tlv.redhat.com",
+          "provider":"Molecule",
+          "total": 7822,
+          "percent": 0.82
         }
       ]
     },


### PR DESCRIPTION
Sometimes the metrics dont have all fields filled out so we have to ignore those in heatmaps
![no_hole_heatmap2](https://cloud.githubusercontent.com/assets/11256940/13971075/de5f1634-f095-11e5-950f-09adffbdfaac.png)
