### PR TITLE
Change status classes to lowercase in topology css

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -73,19 +73,19 @@ ManageIQ.angular.app.service('topologyService', function() {
       case "Running":
       case "Succeeded":
       case "Valid":
-        return "Success";
+        return "success";
       case "NotReady":
       case "Failed":
       case "Error":
       case "Unreachable":
-        return "Error";
+        return "error";
       case 'Warning':
       case 'Waiting':
       case 'Pending':
-        return "Warning";
+        return "warning";
       case 'Unknown':
       case 'Terminated':
-        return "Unknown";
+        return "unknown";
     }
   };
 

--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -53,19 +53,19 @@ kubernetes-topology-icon svg {
   stroke-width: 2px;
 }
 
-.kube-topology g circle.Success {
+.kube-topology g circle.success {
     stroke: #3F9C35;
 }
 
-.kube-topology g circle.Error {
+.kube-topology g circle.error {
     stroke: #CC0000;
 }
 
-.kube-topology g circle.Warning {
+.kube-topology g circle.warning {
     stroke: #EC7A08;
 }
 
-.kube-topology g circle.Unknown {
+.kube-topology g circle.unknown {
     stroke: #bbb;
 }
 


### PR DESCRIPTION
@miq-bot add_label ui, providers/containers

@himdel this is per your comment yesterday. Please review. I kept the statuses themselves with uppercase because they look better like that in the tooltips that users see. but the css class can definitely be lowercase.