### PR TITLE
Don't require modules in migrations yet due to load order issues.

### DIFF
--- a/db/migrate/20140201040548_add_update_repo_name_to_miq_database.rb
+++ b/db/migrate/20140201040548_add_update_repo_name_to_miq_database.rb
@@ -1,6 +1,5 @@
 class AddUpdateRepoNameToMiqDatabase < ActiveRecord::Migration
   class MiqDatabase < ActiveRecord::Base
-    require 'reserved_mixin'
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins
   end

--- a/db/migrate/20150206150955_migrate_miq_database_registration_organization_display_name_out_of_reserves.rb
+++ b/db/migrate/20150206150955_migrate_miq_database_registration_organization_display_name_out_of_reserves.rb
@@ -1,7 +1,5 @@
 class MigrateMiqDatabaseRegistrationOrganizationDisplayNameOutOfReserves < ActiveRecord::Migration
   class MiqDatabase < ActiveRecord::Base
-    require 'reserved_mixin'
-    require 'migration_stub_helper'
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins
   end


### PR DESCRIPTION
We'll have to come back to how make the dependencies explicit and not load
the modules via autoload so we can eventually use the good_migrations gem.

Fixes #7291

Introduced in #7220