### PR TITLE
No need to replace left side tree when loading copy objects form.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -297,7 +297,7 @@ class MiqAeClassController < ApplicationController
     )
     r = proc { |opts| render_to_string(opts) }
 
-    replace_trees_by_presenter(presenter, :ae => build_ae_tree) if replace_trees
+    replace_trees_by_presenter(presenter, :ae => build_ae_tree) unless replace_trees.blank?
 
     if @sb[:action] == "miq_ae_field_seq"
       if @flash_array
@@ -1770,7 +1770,7 @@ class MiqAeClassController < ApplicationController
     @sb[:domain_id] = domains.first.first
     @edit[:current] = copy_hash(@edit[:new])
     model = @edit[:selected_items].count > 1 ? :models : :model
-    @right_cell_text = _("Copy %{model}") % {model => ui_lookup(model => "typ")}
+    @right_cell_text = _("Copy %{model}") % {:model => ui_lookup(model => typ.to_s)}
     session[:edit] = @edit
   end
 

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -83,6 +83,25 @@ describe MiqAeClassController do
   end
 
   context "#copy_objects" do
+    it "do not replace left side explorer tree when copy form is loaded initially" do
+      set_user_privileges
+      d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
+      ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
+      cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+
+      node = "aec-#{cls1.id}"
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :ae_tree,
+                                       :action      => "miq_ae_class_copy",
+                                       :trees       => {:ae_tree => {:active_node => node}})
+      controller.instance_variable_set(:@_params, :button => "reset", :id => cls1.id)
+      allow(controller).to receive(:open_parent_nodes)
+      expect(controller).to_not receive(:replace_trees_by_presenter)
+      expect(controller).to receive(:render)
+      controller.send(:copy_objects)
+      expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
+
     it "copies class under specified namespace" do
       set_user_privileges
       d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")


### PR DESCRIPTION
Replacing of left side tree was causing tree to be replaced with a tree that's supposed to be displayed in Namespace popup on copy screen, causing screen to hang when reloading tree after save is pressed on copy objects form.

https://bugzilla.redhat.com/show_bug.cgi?id=1312961

@dclarizio please review

before:
![before1](https://cloud.githubusercontent.com/assets/3450808/13781866/377342c8-ea9b-11e5-9a1f-903ebb44df31.png)

![before2](https://cloud.githubusercontent.com/assets/3450808/13781870/3ba8d5ba-ea9b-11e5-838a-169ccec031bd.png)

after:
![after1](https://cloud.githubusercontent.com/assets/3450808/13781875/3e9596e6-ea9b-11e5-94dd-790f64eea203.png)

![after2](https://cloud.githubusercontent.com/assets/3450808/13781881/41c1c560-ea9b-11e5-9f51-19060864c6e7.png)

Fixed title on the right cell
![copy_class_title](https://cloud.githubusercontent.com/assets/3450808/13793734/c4fec8b4-eace-11e5-83cf-f6041e2e7952.png)
