### PR TITLE
Introduce Entitlements

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -1,0 +1,4 @@
+class Entitlement < ApplicationRecord
+  belongs_to :miq_group
+  belongs_to :miq_user_role
+end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -78,7 +78,7 @@ class MiqGroup < ApplicationRecord
     # find any default tenant groups that do not have a role
     tenant_role = MiqUserRole.default_tenant_role
     if tenant_role
-      tenant_groups.where(:miq_user_role_id => nil).each do |group|
+      tenant_groups.includes(:entitlement).where(:entitlements => {:miq_user_role_id => nil}).each do |group|
         group.update_attributes(:miq_user_role => tenant_role)
       end
     else

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -4,7 +4,8 @@ class MiqGroup < ApplicationRecord
   TENANT_GROUP = "tenant"
 
   belongs_to :tenant
-  belongs_to :miq_user_role
+  has_one    :entitlement
+  has_one    :miq_user_role, :through => :entitlement
   has_and_belongs_to_many :users
   has_many   :vms,         :dependent => :nullify
   has_many   :miq_templates, :dependent => :nullify

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -3,7 +3,8 @@ class MiqUserRole < ApplicationRecord
   ADMIN_ROLE_NAME       = "EvmRole-administrator"
   DEFAULT_TENANT_ROLE_NAME = "EvmRole-tenant_administrator"
 
-  has_many                :miq_groups, :dependent => :restrict_with_exception
+  has_many                :entitlements, :dependent => :restrict_with_exception
+  has_many                :miq_groups, :through => :entitlements
   has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features
 
   virtual_column :group_count,                      :type => :integer

--- a/db/migrate/20160311155237_create_entitlements.rb
+++ b/db/migrate/20160311155237_create_entitlements.rb
@@ -1,0 +1,10 @@
+class CreateEntitlements < ActiveRecord::Migration[5.0]
+  def change
+    create_table :entitlements do |t|
+      t.bigint :miq_group_id
+      t.bigint :miq_user_role_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160317160230_move_user_roles_to_entitlements.rb
+++ b/db/migrate/20160317160230_move_user_roles_to_entitlements.rb
@@ -1,0 +1,16 @@
+class MoveUserRolesToEntitlements < ActiveRecord::Migration[5.0]
+  class MiqGroup < ActiveRecord::Base; end
+  class Entitlement < ActiveRecord::Base; end
+
+  def up
+    MiqGroup.find_each do |group|
+      Entitlement.create!(:miq_group_id => group.id, :miq_user_role_id => group.miq_user_role_id)
+    end
+  end
+
+  def down
+    MiqGroup.find_each do |group|
+      Entitlement.delete_all(:miq_group_id => group.id)
+    end
+  end
+end

--- a/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
+++ b/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
@@ -1,0 +1,5 @@
+class RemoveMiqUserRoleFromMiqGroups < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :miq_groups, :miq_user_role_id, :bigint
+  end
+end

--- a/spec/factories/entitlement.rb
+++ b/spec/factories/entitlement.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :entitlement do
+    transient do
+      features nil
+      role nil
+    end
+
+    after :build do |entitlement, e|
+      if e.role || e.features
+        entitlement.miq_user_role = FactoryGirl.create(:miq_user_role,
+                                                       :features => e.features,
+                                                       :role     => e.role)
+      end
+    end
+  end
+end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -5,17 +5,23 @@ FactoryGirl.define do
     transient do
       features nil
       role nil
+
+      # Temporary: Allows entitlements, a new table, to be invisible to current spec setup code
+      # Do NOT use these if possible.
+      miq_user_role_id nil
+      miq_user_role nil
     end
 
     sequence(:sequence)  # don't want to spend time looking these up
     description { |g| g.role ? "EvmGroup-#{g.role}" : generate(:miq_group_description) }
 
     after :build do |g, e|
-      if e.role
-        g.miq_user_role = MiqUserRole.find_by_name("EvmRole-#{e.role}") ||
-                          FactoryGirl.create(:miq_user_role, :features => e.features, :role => e.role)
-      elsif e.features.present?
-        g.miq_user_role = FactoryGirl.create(:miq_user_role, :features => e.features)
+      if e.role || e.features || e.miq_user_role_id || e.miq_user_role
+        g.entitlement = FactoryGirl.create(:entitlement,
+                                           :features => e.features,
+                                           :role => e.role,
+                                           :miq_user_role_id => e.miq_user_role_id,
+                                           :miq_user_role => e.miq_user_role)
       end
     end
 

--- a/spec/migrations/20160317160230_move_user_roles_to_entitlements_spec.rb
+++ b/spec/migrations/20160317160230_move_user_roles_to_entitlements_spec.rb
@@ -1,0 +1,20 @@
+require_migration
+
+describe MoveUserRolesToEntitlements do
+  let(:miq_group_stub) { migration_stub(:MiqGroup) }
+  let(:entitlement_stub) { migration_stub(:Entitlement) }
+  let!(:miq_group1) { miq_group_stub.create!(:miq_user_role_id => 25) }
+  let!(:miq_group2) { miq_group_stub.create!(:miq_user_role_id => 50) }
+
+  migration_context :up do
+    it "creates an entitlement for each miq_group with the miq_group_id and the group's miq_user_role" do
+      expect(entitlement_stub.count).to eq(0)
+
+      migrate
+
+      expect(entitlement_stub.exists?(:miq_group_id => miq_group1.id, :miq_user_role_id => 25)).to be_truthy
+      expect(entitlement_stub.exists?(:miq_group_id => miq_group2.id, :miq_user_role_id => 50)).to be_truthy
+      expect(entitlement_stub.count).to eq(2)
+    end
+  end
+end

--- a/spec/models/entitlement_spec.rb
+++ b/spec/models/entitlement_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Entitlement, :type => :model do
+end

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -98,12 +98,13 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       result = response_hash["results"].first
-      group_id = result["id"]
-      expect(MiqGroup.exists?(group_id)).to be_truthy
+      created_group = MiqGroup.find_by_id(result["id"])
+
+      expect(created_group).to be_present
+      expect(created_group.entitlement.miq_user_role).to eq(role3)
 
       expect_result_to_match_hash(result,
                                   "description"      => "sample_group3",
-                                  "miq_user_role_id" => role3.id,
                                   "tenant_id"        => tenant3.id)
     end
 

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -74,7 +74,7 @@ module ApiSpecHelper
 
   def define_user
     @role  = FactoryGirl.create(:miq_user_role, :name => api_config(:role_name))
-    @group = FactoryGirl.create(:miq_group, :description => api_config(:group_name), :miq_user_role_id => @role.id)
+    @group = FactoryGirl.create(:miq_group, :description => api_config(:group_name), :miq_user_role => @role)
     @user  = FactoryGirl.create(:user,
                                 :name             => api_config(:user_name),
                                 :userid           => api_config(:user),


### PR DESCRIPTION
Step 1 of latest tenancy work to allow groups of users to common permissions/features.

This PR creates an Entitlement model and table between MiqGroups and MiqUserRoles. It's intended to be completely backwards compatible with all that currently exists.

TODO:

- [x] Data migration
- [x] ~~API: Group responses no longer return an miq_user_role_id, etc. Is this a problem? Should we hide entitlements further?~~ The role in the response is unimportant, confirmed.