### PR TITLE
Provide a button to trigger a reload operation of middleware servers.

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -7,6 +7,17 @@ class MiddlewareServerController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  OPERATIONS = {
+    :middleware_server_reload => {:op   => :reload_middleware_server,
+                                  :hawk => N_('Not reloading Hawkular server'),
+                                  :msg  => N_('Reload initiated for selected server(s)')
+    },
+    :middleware_server_stop   => {:op   => :stop_middleware_server,
+                                  :hawk => N_('Not stopping Hawkular server'),
+                                  :msg  => N_('Stop initiated for selected server(s)')
+    }
+  }.freeze
+
   def show_list
     process_show_list
   end
@@ -28,9 +39,62 @@ class MiddlewareServerController < ApplicationController
     "svg/#{icon}.svg"
   end
 
+  def button
+    selected_operation = params[:pressed].to_sym
+
+    if OPERATIONS.key?(selected_operation)
+      selected_servers = identify_selected_servers
+
+      run_server_operation(OPERATIONS.fetch(selected_operation), selected_servers)
+
+      render :update do |page|
+        page << javascript_prologue
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      end
+    else
+      super
+    end
+  end
+
   private ############################
 
   def display_name
     _('Middleware Servers')
+  end
+
+  # Identify the selected servers. When we got the call from the
+  # single server page, we need to look at :id, otherwise from
+  # the list of servers we need to query :miq_grid_checks
+  def identify_selected_servers
+    items = params[:miq_grid_checks]
+    return items unless items.nil? || items.empty?
+
+    params[:id]
+  end
+
+  def run_server_operation(operation_info, items)
+    if items.nil?
+      add_flash(_("No servers selected"))
+      return
+    end
+
+    operation_triggered = false
+    items.split(/,/).each do |item|
+      mw_server = identify_record item
+      if mw_server.product == 'Hawkular'
+        add_flash(operation_info.fetch(:hawk))
+      else
+        trigger_mw_operation operation_info.fetch(:op), mw_server
+        operation_triggered = true
+      end
+    end
+    add_flash(operation_info.fetch(:msg)) if operation_triggered
+  end
+
+  def trigger_mw_operation(operation, mw_server)
+    mw_manager = mw_server.ext_management_system
+
+    op = mw_manager.public_method operation
+    op.call mw_server.ems_ref
   end
 end

--- a/app/helpers/application_helper/toolbar/middleware_server_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_server_center.rb
@@ -1,3 +1,4 @@
+# noinspection RubyArgCount
 class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::Toolbar::Basic
   button_group('middleware_server_vmdb', [
     select(
@@ -34,6 +35,29 @@ class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::To
           'pficon pficon-edit fa-lg',
           N_('Edit Tags for this #{ui_lookup(:table=>"middleware_server")}'),
           N_('Edit Tags')),
+      ]
+    ),
+  ])
+  button_group('middleware_server_operations', [
+    select(
+      :middleware_server_power_choice,
+      'fa fa-power-off fa-lg',
+      t = N_('Power'),
+      t,
+      :items => [
+        button(
+          :middleware_server_reload,
+          'pficon pficon-restart fa-lg',
+          N_('Reload this #{ui_lookup(:table=>"middleware_server")}'),
+          N_('Reload Server'),
+          :confirm => N_("Do you want to trigger a reload of this server?")),
+        button(
+          :middleware_server_stop,
+          nil,
+          N_('Stop this #{ui_lookup(:table=>"middleware_server")}'),
+          N_('Stop Server'),
+          :image   => "guest_shutdown",
+          :confirm => N_("Do you want to stop this server?")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/middleware_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_servers_center.rb
@@ -1,3 +1,4 @@
+# noinspection ALL
 class ApplicationHelper::Toolbar::MiddlewareServersCenter < ApplicationHelper::Toolbar::Basic
   button_group('middleware_server_vmdb', [
     select(
@@ -45,6 +46,37 @@ class ApplicationHelper::Toolbar::MiddlewareServersCenter < ApplicationHelper::T
           N_('Edit Tags for this #{ui_lookup(:table=>"middleware_servers")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+  button_group('middleware_server_operations', [
+    select(
+      :middleware_server_power_choice,
+      'fa fa-power-off fa-lg',
+      t = N_('Power'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :middleware_server_reload,
+          'pficon pficon-restart fa-lg',
+          N_('Reload these #{ui_lookup(:table=>"middleware_server")}'),
+          N_('Reload Server'),
+          :url_parms => "main_div",
+          :confirm   => N_("Do you want to reload selected servers?"),
+          :enabled   => false,
+          :onwhen    => "1+"),
+        button(
+          :middleware_server_stop,
+          nil,
+          N_('Stop this #{ui_lookup(:table=>"middleware_server")}'),
+          N_('Stop Server'),
+          :url_parms => "main_div",
+          :image     => "guest_shutdown",
+          :confirm   => N_("Do you want to stop selected servers?"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -448,7 +448,7 @@ class ApplicationHelper::ToolbarChooser
               ems_container ems_middleware container_project container_route container_replicator container_image
               ems_network security_group floating_ip cloud_subnet network_router
               container_image_registry ems_infra flavor host container_build
-              ontap_file_share ontap_logical_disk container_topology middleware_topology
+              ontap_file_share ontap_logical_disk container_topology middleware_topology middleware_server
               ontap_storage_system orchestration_stack resource_pool storage storage_manager
               timeline usage).include?(@layout)
           if ["show_list"].include?(@lastaction)

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3256,6 +3256,14 @@
         :description: Edit Tags of Middleware Servers
         :feature_type: control
         :identifier: middleware_server_tag
+      - :name: Reload middleware server
+        :description: Trigger reload operation for Middleware Server
+        :feature_type: admin
+        :identifier: middleware_server_reload
+      - :name: Stop middleware server
+        :description: Stop Middleware Server
+        :feature_type: admin
+        :identifier: middleware_server_stop
 
   # MiddlewareDeployment
   - :name: MiddlewareDeployment

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 990 }
+  let(:expected_feature_count) { 992 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
Add a new menubar button to trigger a call for an operation on the Hawkular server to reload or stop (one of the) connected WildFly/EAP kind of servers.
Hawkular servers (=the providers) are not reloaded.

@miq-bot add_label wip
@miq-bot add_label providers/hawkular
@miq-bot add_label enhancement
cc @lucasponce @jiri-kremser @jshaughn