### PR TITLE
Remove unused refresh_state since refreshes use the ems. :fire:

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -320,13 +320,6 @@ class VmOrTemplate < ApplicationRecord
     save
   end
 
-  # Ask host to update all locally registered vm state data
-  def refresh_state
-    run_command_via_parent("SendVMState")
-  rescue => err
-    _log.log_backtrace(err)
-  end
-
   def run_command_via_parent(verb, options = {})
     raise "VM/Template <#{name}> with Id: <#{id}> is not associated with a provider." unless ext_management_system
     raise "VM/Template <#{name}> with Id: <#{id}>: Provider authentication failed." unless ext_management_system.authentication_status_ok?


### PR DESCRIPTION
This was added back in early 2008 in acf394cfc704 when we must have sent the
request through the smart proxy residing on the host.  I think ???

Unless my git fu is off, this method became unused in b78174781baa back in
February 2008, when we moved to using the ems to refresh the states.

@gmcculloug Please review (noticed while untangling Verbs deletion)