### PR TITLE
Lockdown the azure-armrest gem for now to fix tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # See miq_expression_spec Date/Time Support examples.
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
-gem "azure-armrest",                  "~>0.2.0"
+gem "azure-armrest",                  "=0.2.0"
 gem "color",                          "~>1.8"
 gem "default_value_for",              "~>3.0.1", :git => "git://github.com/matthewd/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
 gem "draper",                         "~>2.1.0", :git => "git://github.com/janraasch/draper.git", :branch => "feature/rails5-compatibility" # https://github.com/drapergem/draper/pull/712


### PR DESCRIPTION
0.2.1, released today seems to be causing the following type of error:

```
  1) ManageIQ::Providers::Azure::CloudManager::Refresher will perform a full refresh
     Failure/Error: super

     ActiveModel::UnknownAttributeError:
       unknown attribute 'namespace' for Provider.
       ./app/models/mixins/new_with_type_sti_mixin.rb:14:in `new'
       ./app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb:175:in `block in gather_data_for_this_region'
       ./app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb:174:in `collect'
       ./app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb:174:in `gather_data_for_this_region'
       ./app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb:90:in `get_stacks'
       ./app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb:46:in `ems_inv_to_hashes'
       ./app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb:10:in `ems_inv_to_hashes'
       ./app/models/manageiq/providers/azure/cloud_manager/refresher.rb:6:in `parse_inventory'
```