### PR TITLE
[api] Limit filtering associations

### DIFF
--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -43,6 +43,9 @@ class ApiController
         parsed_filter = parse_filter(filter, operators)
         parts = parsed_filter[:attr].split(".")
         attr = parts.pop
+        if parts.size > 1
+          raise BadRequestError, "Filtering of attributes with more than one association away is not supported"
+        end
         unless virtual_or_physical_attribute?(target_class(klass, parts), attr)
           raise BadRequestError, "attribute #{attr} does not exist"
         end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -260,6 +260,12 @@ describe ApiController do
       expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid}])
     end
 
+    it "does not support filtering by attributes of associations' associations" do
+      run_get vms_url, :expand => "resources", :filter => ["host.hardware.memory_mb>1024"]
+
+      expect_bad_request(/Filtering of attributes with more than one association away is not supported/)
+    end
+
     it "supports filtering by virtual string attributes" do
       host_a = FactoryGirl.create(:host, :name => "aa")
       host_b = FactoryGirl.create(:host, :name => "bb")


### PR DESCRIPTION
MiqExpressions don't support all use cases for fields with more than one
reflection, so it's better to intercept it in the API and return a
better failure message

***

@abellotti @gtanzillo please review, thanks!
@miq-bot add-label api, bug