### PR TITLE
[auth] Added external authentication options menu to appliance console

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -58,6 +58,7 @@ require 'appliance_console/database_configuration'
 require 'appliance_console/internal_database_configuration'
 require 'appliance_console/external_database_configuration'
 require 'appliance_console/external_httpd_authentication'
+require 'appliance_console/external_auth_options'
 require 'appliance_console/temp_storage_configuration'
 require 'appliance_console/key_configuration'
 require 'appliance_console/scap'
@@ -272,6 +273,18 @@ Static Network Configuration
           press_any_key
           raise MiqSignalError
         end
+
+      when I18n.t("advanced_settings.extauth_opts")
+        say("#{selection}\n\n")
+
+        extauth_options = ExternalAuthOptions.new
+        if extauth_options.ask_questions && extauth_options.any_updates?
+          extauth_options.update_configuration
+          say("\nExternal Authentication Options updated successfully.\n")
+        else
+          say("\nExternal Authentication Options not updated.\n")
+        end
+        press_any_key
 
       when I18n.t("advanced_settings.ca")
         say("#{selection}\n\n")

--- a/gems/pending/appliance_console/external_auth_options.rb
+++ b/gems/pending/appliance_console/external_auth_options.rb
@@ -1,0 +1,159 @@
+require 'pathname'
+require 'fileutils'
+require 'appliance_console/errors'
+require 'appliance_console/utilities'
+require 'appliance_console/logging'
+
+RAILS_ROOT ||= Pathname.new(__dir__).join("../../..")
+
+module ApplianceConsole
+  class ExternalAuthOptions
+    # VMDB_YML      = RAILS_ROOT.join("config/vmdb.yml.db")
+    # VMDB_YML_TMPL = RAILS_ROOT.join("config/vmdb.tmpl.yml")
+
+    AUTH_PATH = "/authentication".freeze
+
+    EXT_AUTH_OPTIONS = {
+      "#{AUTH_PATH}/sso_enabled"          => {:label => "Single Sign-On", :logic => true},
+      "#{AUTH_PATH}/saml_enabled"         => {:label => "SAML",           :logic => true},
+      "#{AUTH_PATH}/local_login_disabled" => {:label => "Local Login",    :logic => false}
+    }.freeze
+
+    include ApplianceConsole::Logging
+
+    def initialize
+      @updates = {}
+      @current_config = {}
+    end
+
+    def ask_questions
+      @current_config = load_current
+      apply = EXT_AUTH_OPTIONS.keys.count + 1
+      skip = apply + 1
+      selection = 0
+      while selection < apply
+        say("\nChoose External Authentication Options to update:")
+        cnt = 1
+        EXT_AUTH_OPTIONS.keys.each do |key|
+          current_state = selected_value(key)
+          say("#{cnt}) #{selected_verb(key, !current_state)} #{EXT_AUTH_OPTIONS[key][:label]}")
+          cnt += 1
+        end
+        say("#{apply}) Apply updates")
+        say("#{skip}) Skip updates")
+        show_updates
+        selection = ask_for_integer("Choose option 1-#{skip}", 1..skip)
+        if selection < apply
+          key = EXT_AUTH_OPTIONS.keys[selection - 1]
+          @updates[key] = !selected_value(key)
+        end
+      end
+      @updates = {} if selection == skip
+      true
+    end
+
+    def show_updates
+      updates_todo = ""
+      EXT_AUTH_OPTIONS.keys.each do |key|
+        next unless @updates.key?(key)
+        updates_todo << ", " if updates_todo.present?
+        updates_todo << " #{selected_verb(key, @updates[key])} #{EXT_AUTH_OPTIONS[key][:label]}"
+      end
+      updates_to_apply = updates_todo.present? ? "Updates to apply: #{updates_todo}" : ""
+      say("\n#{updates_to_apply}")
+    end
+
+    def selected_value(key)
+      return @updates[key] if @updates.key?(key)
+      return @current_config[key] if @current_config.key?(key)
+      false
+    end
+
+    def selected_verb(key, flag)
+      if EXT_AUTH_OPTIONS[key][:logic]
+        flag ? "Enable" : "Disable"
+      else
+        flag ? "Disable" : "Enable"
+      end
+    end
+
+    def any_updates?
+      @updates.present?
+    end
+
+    def update_configuration(update_hash = nil)
+      update_hash ||= @updates
+      if update_hash.present?
+        say("\nUpdating external authentication options on appliance ...")
+        params = update_hash.collect { |key, value| "#{key}=#{value}" }
+        result = ApplianceConsole::Utilities.rake_run("evm:settings:set", params)
+        raise parse_errors(result).join(', ') if result.failure?
+      end
+    end
+
+    # extauth_opts option parser: syntax is key=value,key=value
+    #   key is one of the EXT_AUTH_OPTIONS keys.
+    #   value is one of 1, true, 0 or false.
+    #
+    def parse(options)
+      parsed_updates = {}
+      options.split(",").each do |keyval|
+        key, val = keyval.split('=')
+        key, val = normalize_key(key.to_s.strip), val.to_s.strip
+        unless EXT_AUTH_OPTIONS.key?(key)
+          message = "Unknown external authentication option #{key} specified"
+          message << ", supported options are #{EXT_AUTH_OPTIONS.keys.join(', ')}"
+          raise message
+        end
+
+        value = option_value(val)
+        raise("Invalid #{key} option value #{val} specified, must be true or false") if value.nil?
+        parsed_updates[key] = value
+      end
+      parsed_updates
+    end
+
+    def self.configured?
+      # DB Up and running
+      true
+    end
+
+    private
+
+    def load_current
+      say("\nFetching external authentication options from appliance ...")
+      result = ApplianceConsole::Utilities.rake_run("evm:settings:get", EXT_AUTH_OPTIONS.keys)
+
+      if result.success?
+        return parse_response(result)
+      else
+        raise parse_errors(result).join(', ')
+      end
+    end
+
+    def parse_errors(result)
+      result.error.split("\n").collect { |line| line if line =~ /^error: /i }.compact
+    end
+
+    def normalize_key(key)
+      key.include?('/') ? key : "#{AUTH_PATH}/#{key}"
+    end
+
+    def parse_response(result)
+      result.output.split("\n").each_with_object({}) do |line, hash|
+        key, val = line.split("=")
+        hash[key] = parse_value(val)
+      end
+    end
+
+    def option_value(value)
+      return true  if value == '1' || value =~ /true/i
+      return false if value == '0' || value =~ /false/i
+      nil
+    end
+
+    def parse_value(value)
+      value.present? ? option_value(value) : false
+    end
+  end
+end

--- a/gems/pending/appliance_console/locales/en.yml
+++ b/gems/pending/appliance_console/locales/en.yml
@@ -13,6 +13,7 @@ en:
     - dbrestore
     - db_config
     - httpdauth
+    - extauth_opts
     - key_gen
     - evmstop
     - evmstart
@@ -29,6 +30,7 @@ en:
     dbrestore: Restore Database From Backup
     db_config: Configure Database
     httpdauth: Configure External Authentication (httpd)
+    extauth_opts: Update External Authentication Options
     evmstop: Stop EVM Server Processes
     key_gen: Generate Custom Encryption Key
     evmstart: Start EVM Server Processes

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -7,9 +7,13 @@ require "appliance_console/logging"
 module ApplianceConsole
   module Utilities
     def self.rake(task, params)
+      rake_run(task, params).success?
+    end
+
+    def self.rake_run(task, params)
       result = AwesomeSpawn.run("rake #{task}", :chdir => RAILS_ROOT, :params => params)
       ApplianceConsole::Logging.logger.error(result.error) if result.failure?
-      result.success?
+      result
     end
 
     def self.db_connections

--- a/gems/pending/spec/appliance_console/cli_spec.rb
+++ b/gems/pending/spec/appliance_console/cli_spec.rb
@@ -387,6 +387,37 @@ describe ApplianceConsole::Cli do
     end
   end
 
+  context "#extauth_opts" do
+    it "should handle setting external auth options with partial key" do
+      extauth_opts = double
+      expect(ApplianceConsole::ExternalAuthOptions).to receive(:new).and_return(extauth_opts)
+      expect(extauth_opts).to receive(:parse)
+        .with("sso_enabled=true")
+        .and_return("/authentication/sso_enabled" => true)
+      expect(extauth_opts).to receive(:update_configuration).with("/authentication/sso_enabled" => true)
+      subject.parse(%w(--extauth-opts sso_enabled=true)).run
+    end
+
+    it "should handle setting external auth options with fully qualified key" do
+      extauth_opts = double
+      expect(ApplianceConsole::ExternalAuthOptions).to receive(:new).and_return(extauth_opts)
+      expect(extauth_opts).to receive(:parse)
+        .with("/authentication/local_login_disabled=false")
+        .and_return("/authentication/local_login_disabled" => false)
+      expect(extauth_opts).to receive(:update_configuration).with("/authentication/local_login_disabled" => false)
+      subject.parse(%w(--extauth-opts /authentication/local_login_disabled=false)).run
+    end
+
+    it "should fail with invalid external auth options" do
+      extauth_opts = double
+      expect(ApplianceConsole::ExternalAuthOptions).to receive(:new).and_return(extauth_opts)
+      expect(extauth_opts).to receive(:parse).with("invalid_auth_option=true").and_return({})
+      expect do
+        subject.parse(%w(--extauth-opts invalid_auth_option=true)).run
+      end.to raise_error(/Must specify at least one/)
+    end
+  end
+
   private
 
   def expect_v2_key(exists = true)

--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -1,0 +1,102 @@
+module EvmSettings
+  ALLOWED_KEYS = [
+    "/authentication/sso_enabled",
+    "/authentication/saml_enabled",
+    "/authentication/local_login_disabled"
+  ].freeze
+
+  INFO, WARN, ERROR = %w(info warn error)
+
+  def self.get_keys(keylist = nil)
+    keylist = ALLOWED_KEYS unless keylist.present?
+    settings_hash = Settings.to_hash
+    keylist.each do |key|
+      validate_key(key)
+      value = settings_hash.fetch_path(*key_parts(key))
+      puts "#{key}=#{value_to_str(value)}"
+    end
+  end
+
+  def self.put_keys(keyval_list = nil)
+    import_hash = {}
+    Array(keyval_list).each do |keyval|
+      key, value = keyval.split("=")
+      validate_key(key)
+      keyval_hash = keyval_to_hash(key, value)
+      import_hash.deep_merge!(keyval_hash) if keyval_hash.present?
+      log(INFO, "Setting key #{key} to #{value}")
+      puts "#{key}=#{value}"
+    end
+    config_import(import_hash)
+  end
+
+  def self.config_import(import_hash)
+    if import_hash.present?
+      full_config_hash = MiqServer.my_server.get_config.config
+      MiqServer.my_server.set_config(full_config_hash.deep_merge(import_hash))
+    end
+  end
+  private_class_method :config_import
+
+  def self.log(level, msg)
+    $log.send(level, "EVM:Settings Task: #{msg}")
+    STDERR.puts "#{level}: #{msg}" if level != INFO
+  end
+  private_class_method :log
+
+  def self.supported_key?(key)
+    ALLOWED_KEYS.include?(key)
+  end
+  private_class_method :supported_key?
+
+  def self.validate_key(key)
+    unless supported_key?(key)
+      log(ERROR, "Unsupported key #{key} specified")
+      exit(1)
+    end
+  end
+  private_class_method :validate_key
+
+  def self.key_parts(key)
+    key.split("/")[1..-1].collect(&:to_sym)
+  end
+  private_class_method :key_parts
+
+  def self.keyval_to_hash(key, value)
+    hash = nil
+    key_parts(key).reverse_each do |path|
+      hash = {path => (hash.nil? ? str_to_value(value) : hash)}
+    end
+    hash
+  end
+  private_class_method :keyval_to_hash
+
+  def self.str_to_value(value)
+    return true  if value =~ /true/i
+    return false if value =~ /false/i
+    return nil   if value =~ /nil/
+    value
+  end
+  private_class_method :str_to_value
+
+  def self.value_to_str(value)
+    return "true"  if value  || value =~ /true/i
+    return "false" if !value || value =~ /false/i
+    value
+  end
+  private_class_method :value_to_str
+end
+
+namespace :evm do
+  namespace :settings do
+    task :get => :environment do
+      EvmSettings.get_keys $ARGV[1..-1]
+      exit(0)
+    end
+
+    task :set => :environment do
+      EvmSettings.put_keys $ARGV[1..-1]
+      exit(0)
+    end
+  end
+end


### PR DESCRIPTION
- Added rake evm:settings: tasks :get and :set
- Added External Authentication Options menu
- Also supporting appliance_console_cli --extauth-opts key=value,key=value,...

Options used with PR# https://github.com/ManageIQ/manageiq/pull/6603
