### PR TITLE
Don't load container models from app folder in migration

### DIFF
--- a/db/migrate/20160119125950_add_created_on_for_container_entities.rb
+++ b/db/migrate/20160119125950_add_created_on_for_container_entities.rb
@@ -1,15 +1,43 @@
 class AddCreatedOnForContainerEntities < ActiveRecord::Migration
-  CONTAINER_TABLES = [:container_nodes, :container_projects, :container_services, :container_routes, :container_groups,
-                      :container_replicators, :container_quotas, :container_builds, :container_build_pods,
-                      :container_limits, :container_volumes]
+  class ContainerNode < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class ContainerProject < ActiveRecord::Base; end
+
+  class ContainerService < ActiveRecord::Base; end
+
+  class ContainerRoute < ActiveRecord::Base; end
+
+  class ContainerGroup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class ContainerReplicator < ActiveRecord::Base; end
+
+  class ContainerQuota < ActiveRecord::Base; end
+
+  class ContainerBuild < ActiveRecord::Base; end
+
+  class ContainerBuildPod < ActiveRecord::Base; end
+
+  class ContainerLimit < ActiveRecord::Base; end
+
+  class ContainerVolume < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  CONTAINER_MODELS = [ContainerNode, ContainerProject, ContainerService, ContainerRoute, ContainerGroup,
+                      ContainerReplicator, ContainerQuota, ContainerBuild, ContainerBuildPod, ContainerLimit,
+                      ContainerVolume].freeze
 
   def change
-    CONTAINER_TABLES.each do |t|
-      add_column t, :created_on, :datetime
-      rename_column t, :creation_timestamp, :ems_created_on
+    CONTAINER_MODELS.each do |model|
+      add_column model.table_name, :created_on, :datetime
+      rename_column model.table_name, :creation_timestamp, :ems_created_on
 
-      say_with_time("adding created_on datetime to all existing #{t.to_s.tr("_", " ")}") do
-        t.to_s.classify.constantize.update_all("created_on=ems_created_on")
+      say_with_time("adding created_on datetime to all existing #{model}") do
+        model.update_all("created_on=ems_created_on")
       end
     end
   end

--- a/spec/migrations/20160119125950_add_created_on_for_container_entities_spec.rb
+++ b/spec/migrations/20160119125950_add_created_on_for_container_entities_spec.rb
@@ -1,0 +1,43 @@
+require_migration
+
+describe AddCreatedOnForContainerEntities do
+  CONTAINER_TABLES = described_class::CONTAINER_MODELS.collect { |m| m.table_name.to_sym }
+
+  CONTAINER_TABLES.each { |table| let("#{table}_stub") { migration_stub(table.to_s.classify.to_sym) } }
+
+  let(:mock_timestamp) { Time.zone.parse('2016-03-09 12:00:38.711120') }
+  let(:mock_name)      { "Name_1" }
+
+  migration_context :up do
+    it "populates new column created_on and ems_created_on with value from creation_timestamp" do
+      records = {}
+
+      CONTAINER_TABLES.each do |table|
+        records[table] = send("#{table}_stub").create!(:name => mock_name, :creation_timestamp => mock_timestamp)
+      end
+
+      migrate
+
+      CONTAINER_TABLES.each do |table|
+        expect(records[table].reload.created_on).to eq(mock_timestamp)
+        expect(records[table].reload.ems_created_on).to eq(mock_timestamp)
+      end
+    end
+  end
+
+  migration_context :down do
+    it "renames ems_created_on back to creation_timestamp and it has same value as ems_created_on" do
+      records = {}
+
+      CONTAINER_TABLES.each do |table|
+        records[table] = send("#{table}_stub").create!(:name => mock_name, :ems_created_on => mock_timestamp)
+      end
+
+      migrate
+
+      CONTAINER_TABLES.each do |table|
+        expect(records[table].reload.creation_timestamp).to eq(mock_timestamp)
+      end
+    end
+  end
+end


### PR DESCRIPTION
for possibility to use good_migration gem

related https://github.com/ManageIQ/manageiq/issues/6739

change from `CONTAINER_TABLES to `CONTAINER_MODELS` was needed because this command
`t.to_s.classify.constantize.update_all` is loading it from app/ folder even if we are defining these models in the migration

this changes have been made by this script
```
CONTAINER_TABLES = [:container_nodes, :container_projects, :container_services, :container_routes, :container_groups,
                    :container_replicators, :container_quotas, :container_builds, :container_build_pods,
                    :container_limits, :container_volumes]

type_column_exists = lambda { |t| ActiveRecord::Base.connection.column_exists?(t, :type) }
tables = CONTAINER_TABLES.map { |e| [e.to_s.classify.constantize, type_column_exists.call(e)] }
puts tables

tables.each do |t|
  print "\n"
  print "class #{t.first.to_s} < ActiveRecord::Base"
  if t.second
    print "\n"
    print "  self.inheritance_column = :_type_disabled # disable STI\n"
    print "end\n"
  else
    print "; end\n"
  end
end

print "CONTAINER_TABLES =["
CONTAINER_TABLES.each do |t|
  print "#{t.to_s.classify}, "
end

```

cc @jrafanie @Fryguy 
