### PR TITLE
Allow host network interfaces without IP data

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -143,7 +143,7 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
 
     inv[:host_nics].to_miq_a.each do |nic|
       ip_data = nic[:ip]
-      if !ip_data[:gateway].blank? && !ip_data[:address].blank?
+      if !ip_data.nil? && !ip_data[:gateway].blank? && !ip_data[:address].blank?
         ipaddress = ip_data[:address]
         break
       end
@@ -303,7 +303,7 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       guest_device = guest_device_uids.fetch_path(:pnic, uid)
 
       # Get the ip section
-      ip = vnic[:ip]
+      ip = vnic[:ip].presence || {}
 
       new_result = {
         :description => vnic[:name],

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -40,15 +40,15 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(CustomAttribute.count).to eq(0) # TODO: 3.0 spec has values for this
     expect(CustomizationSpec.count).to eq(0)
     expect(Disk.count).to eq(66)
-    expect(GuestDevice.count).to eq(29)
+    expect(GuestDevice.count).to eq(30)
     expect(Hardware.count).to eq(40)
-    expect(Lan.count).to eq(3)
+    expect(Lan.count).to eq(4)
     expect(MiqScsiLun.count).to eq(0)
     expect(MiqScsiTarget.count).to eq(0)
-    expect(Network.count).to eq(5)
+    expect(Network.count).to eq(6)
     expect(OperatingSystem.count).to eq(40)
     expect(Snapshot.count).to eq(32)
-    expect(Switch.count).to eq(3)
+    expect(Switch.count).to eq(4)
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(81)
@@ -175,7 +175,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
     expect(@host.system_services.size).to eq(0)
 
-    expect(@host.switches.size).to eq(2)
+    expect(@host.switches.size).to eq(3)
     switch = @host.switches.find_by_name("rhevm")
     expect(switch).to have_attributes(
       :uid_ems           => "00000000-0000-0000-0000-000000000009",
@@ -218,7 +218,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_usage         => nil
     )
 
-    expect(@host.hardware.networks.size).to eq(2)
+    expect(@host.hardware.networks.size).to eq(3)
     network = @host.hardware.networks.find_by_description("em1")
     expect(network).to have_attributes(
       :description  => "em1",
@@ -227,10 +227,18 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :subnet_mask  => "255.255.254.0"
     )
 
-    # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
-    expect(@host.hardware.guest_devices.size).to eq(2)
+    nic_without_ip = @host.hardware.networks.find_by_description("em3")
+    expect(nic_without_ip).to have_attributes(
+      :description  => "em3",
+      :dhcp_enabled => nil,
+      :ipaddress    => nil,
+      :subnet_mask  => nil
+    )
 
-    expect(@host.hardware.nics.size).to eq(2)
+    # TODO: Verify this host should have 3 nics, 2 cdroms, 1 floppy, any storage adapters?
+    expect(@host.hardware.guest_devices.size).to eq(3)
+
+    expect(@host.hardware.nics.size).to eq(3)
     nic = @host.hardware.nics.find_by_device_name("em1")
     expect(nic).to have_attributes(
       :uid_ems         => "1e783be8-fe80-456e-9a19-42329b03f28c",

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
@@ -268,6 +268,10 @@ http_interactions:
         id=\"5fdbd265-0ead-4038-ba68-39ef4deafcd6\">\n        <name>iSCSI</name>\n
         \       <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
         id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n        <stp>false</stp>\n
+        \       <mtu>0</mtu>\n        <usages/>\n    </network>\n    <network href=\"/api/networks/249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\"
+        id=\"249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\">\n        <name>vmnet</name>\n
+        \       <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
+        id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n        <stp>false</stp>\n
         \       <mtu>0</mtu>\n        <usages/>\n    </network>\n    <network href=\"/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
         id=\"bf717cad-b3fd-4dea-a7d5-c56778dc70fa\">\n        <name>rhevm</name>\n
         \       <description>Management Network</description>\n        <data_center
@@ -2310,6 +2314,18 @@ http_interactions:
         id=\"5fdbd265-0ead-4038-ba68-39ef4deafcd6\"/>\n        <mac address=\"00:24:e8:69:f0:b6\"/>\n
         \       <ip address=\"\" netmask=\"\"/>\n        <boot_protocol>static</boot_protocol>\n
         \       <speed>1000000000</speed>\n        <status>\n            <state>up</state>\n
+        \       </status>\n        <mtu>1500</mtu>\n        <bridged>false</bridged>\n
+        \       <custom_configuration>false</custom_configuration>\n    </host_nic>\n
+        <host_nic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92\"
+        id=\"f2585809-3563-483a-8b62-e9976c7d1d92\">\n        <actions>\n        <link
+        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/attach\"
+        rel=\"attach\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/detach\"
+        rel=\"detach\"/>\n        </actions>\n        <name>em3</name>\n        <link
+        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/statistics\"
+        rel=\"statistics\"/>\n        <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\"
+        id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n        <network href=\"/api/networks/249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\"
+        id=\"b167e5b4-1c68-429c-8c82-14fe668739af\"/>\n        <mac address=\"00:24:e8:69:f0:cc\"/>\n
+        \       <speed>1000000000</speed>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <mtu>1500</mtu>\n        <bridged>false</bridged>\n
         \       <custom_configuration>false</custom_configuration>\n    </host_nic>\n</host_nics>\n"
     http_version: 


### PR DESCRIPTION
Not all of host nics require IP configuration, i.e. network
interfaces which are designed only for L2 connectivity.