### PR TITLE
build ui: sorting build pods

### DIFF
--- a/app/helpers/container_build_helper/textual_summary.rb
+++ b/app/helpers/container_build_helper/textual_summary.rb
@@ -22,7 +22,8 @@ module ContainerBuildHelper::TextualSummary
       :labels                 => [_("Name"), _("Phase"),
                                   _("Message"), _("Reason"),
                                   _("Pod"), _("Output Image"),
-                                  _("Start Timestamp"), _("Completion Timestamp"),
+                                  _("Start Timestamp"),
+                                  {:value => _("Completion Timestamp"), :sortable => :desc},
                                   _("Duration"),
                                  ],
       :values                 => collect_build_pods,
@@ -30,7 +31,7 @@ module ContainerBuildHelper::TextualSummary
   end
 
   def collect_build_pods
-    @record.container_build_pods.collect do |build_pod|
+    builds = @record.container_build_pods.collect do |build_pod|
       [
         build_pod.name,
         build_pod.phase,
@@ -43,6 +44,7 @@ module ContainerBuildHelper::TextualSummary
         parse_duration(build_pod.duration),
       ]
     end
+    builds.sort! { |a, b| Time.parse(b[7] || Time.current.to_s).to_i <=> Time.parse(a[7] || Time.current.to_s).to_i }
   end
 
   #

--- a/app/views/shared/summary/_textual_multilabel.html.haml
+++ b/app/views/shared/summary/_textual_multilabel.html.haml
@@ -7,7 +7,13 @@
     - items[:labels].each do |label|
       %td
         %strong
-          = label
+          - if (label.kind_of? Hash) && label[:sortable]
+            .pull-left
+              = label[:value]
+            .pull-rigt
+              %i{:class => label[:sortable] == :asc ? "fa-sort-asc" : "fa-sort-desc"}
+          - else
+            = label
     - items[:values].each do |item|
       %tr
         - item.each do |value|


### PR DESCRIPTION
fixes #7311
before:
![sorting_builds_1](https://cloud.githubusercontent.com/assets/3123328/13846223/4278402e-ec4e-11e5-941e-ccfd1a516fd7.png)

after:
![sorting_builds_3](https://cloud.githubusercontent.com/assets/3123328/13924014/58dfd5f8-ef8b-11e5-9221-c13db6ad5530.png)

I didn't get it as chaotic as the issue picture, but I hope this is enough..
