### PR TITLE
Use powered_on_in_provider? during pxe provisions

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -53,7 +53,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
     update_and_notify_parent(:message => "Waiting for provider PowerOn of #{for_destination}")
     raise MiqException::MiqProvisionError, "VM Failed to start" if phase_context[:power_on_wait_count].to_i > 120
 
-    if destination.with_provider_object(&:status)[:state] == "up"
+    if powered_on_in_provider?
       signal :poll_destination_powered_off_in_provider
     else
       phase_context[:power_on_wait_count] ||= 0
@@ -87,5 +87,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
 
   def powered_off_in_provider?
     destination.with_provider_object(&:status)[:state] == "down"
+  end
+
+  def powered_on_in_provider?
+    destination.with_provider_object(&:status)[:state] == "up"
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -49,16 +49,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
     signal :poll_destination_powered_off_in_provider
   end
 
-  def poll_destination_powered_off_in_provider
-    update_and_notify_parent(:message => "Waiting for provider PowerOff of #{for_destination}")
-
-    if powered_off_in_provider?
-      signal :poll_destination_powered_off_in_vmdb
-    else
-      requeue_phase
-    end
-  end
-
   def autostart_destination
     if get_option(:vm_auto_start)
       message = "Starting"

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -49,19 +49,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
     signal :poll_destination_powered_off_in_provider
   end
 
-  def poll_destination_powered_on_in_provider
-    update_and_notify_parent(:message => "Waiting for provider PowerOn of #{for_destination}")
-    raise MiqException::MiqProvisionError, "VM Failed to start" if phase_context[:power_on_wait_count].to_i > 120
-
-    if powered_on_in_provider?
-      signal :poll_destination_powered_off_in_provider
-    else
-      phase_context[:power_on_wait_count] ||= 0
-      phase_context[:power_on_wait_count] += 1
-      requeue_phase
-    end
-  end
-
   def poll_destination_powered_off_in_provider
     update_and_notify_parent(:message => "Waiting for provider PowerOff of #{for_destination}")
 

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -83,6 +83,10 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
     destination.start
   end
 
+  def powered_off_in_provider?
+    destination.with_provider_object(&:poweredOff?)
+  end
+
   def powered_on_in_provider?
     destination.with_provider_object(&:poweredOn?)
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -82,4 +82,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
     destination.ext_management_system.reset_vim_cache
     destination.start
   end
+
+  def powered_on_in_provider?
+    destination.with_provider_object(&:poweredOn?)
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_via_pxe/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_via_pxe/state_machine.rb
@@ -30,10 +30,7 @@ module ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe::StateMachine
       _log.info("#{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else
-      # Temporarily set the database raw_power_state in case the refresh has not come along yet.
-      destination.update_attributes(:raw_power_state => "wait_for_launch")
-
-      signal :poll_destination_powered_off_in_vmdb
+      signal :poll_destination_powered_on_in_provider
     end
   end
 

--- a/app/models/miq_provision/state_machine.rb
+++ b/app/models/miq_provision/state_machine.rb
@@ -17,6 +17,19 @@ module MiqProvision::StateMachine
     signal :start_clone_task
   end
 
+  def poll_destination_powered_on_in_provider
+    update_and_notify_parent(:message => "Waiting for provider PowerOn of #{for_destination}")
+    raise MiqException::MiqProvisionError, "VM Failed to start" if phase_context[:power_on_wait_count].to_i > 120
+
+    if powered_on_in_provider?
+      signal :poll_destination_powered_off_in_provider
+    else
+      phase_context[:power_on_wait_count] ||= 0
+      phase_context[:power_on_wait_count] += 1
+      requeue_phase
+    end
+  end
+
   def poll_destination_in_vmdb
     update_and_notify_parent(:message => "Validating New #{destination_type}")
 

--- a/app/models/miq_provision/state_machine.rb
+++ b/app/models/miq_provision/state_machine.rb
@@ -17,6 +17,16 @@ module MiqProvision::StateMachine
     signal :start_clone_task
   end
 
+  def poll_destination_powered_off_in_provider
+    update_and_notify_parent(:message => "Waiting for provider PowerOff of #{for_destination}")
+
+    if powered_off_in_provider?
+      signal :poll_destination_powered_off_in_vmdb
+    else
+      requeue_phase
+    end
+  end
+
   def poll_destination_powered_on_in_provider
     update_and_notify_parent(:message => "Waiting for provider PowerOn of #{for_destination}")
     raise MiqException::MiqProvisionError, "VM Failed to start" if phase_context[:power_on_wait_count].to_i > 120

--- a/spec/factories/miq_provision_vmware.rb
+++ b/spec/factories/miq_provision_vmware.rb
@@ -1,4 +1,9 @@
 FactoryGirl.define do
   factory :miq_provision_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::Provision" do
+    trait :clone_to_vm do
+      request_type "clone_to_vm"
+    end
   end
+
+  factory :miq_provision_vmware_via_pxe, :parent => :miq_provision_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe"
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision/state_machine_spec.rb
@@ -1,0 +1,16 @@
+describe ManageIQ::Providers::Vmware::InfraManager::Provision do
+  context "::StateMachine" do
+    before do
+      ems      = FactoryGirl.create(:ems_vmware_with_authentication)
+      template = FactoryGirl.create(:template_vmware, :ext_management_system => ems)
+      vm       = FactoryGirl.create(:vm_vmware)
+      options  = {:src_vm_id => template.id}
+
+      @task = FactoryGirl.create(:miq_provision_vmware, :clone_to_vm, :source => template, :destination => vm, :state => 'pending', :status => 'Ok', :options => options)
+      allow(@task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
+      allow(@task).to receive_messages(:dest_cluster => FactoryGirl.create(:ems_cluster, :ext_management_system => ems))
+    end
+
+    include_examples "polling destination power status in provider"
+  end
+end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_via_pxe/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_via_pxe/state_machine_spec.rb
@@ -1,0 +1,16 @@
+describe ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe do
+  context "::StateMachine" do
+    before do
+      ems      = FactoryGirl.create(:ems_vmware_with_authentication)
+      template = FactoryGirl.create(:template_vmware, :ext_management_system => ems)
+      vm       = FactoryGirl.create(:vm_vmware)
+      options  = {:src_vm_id => template.id}
+
+      @task = FactoryGirl.create(:miq_provision_vmware_via_pxe, :clone_to_vm, :source => template, :destination => vm, :state => 'pending', :status => 'Ok', :options => options)
+      allow(@task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
+      allow(@task).to receive_messages(:dest_cluster => FactoryGirl.create(:ems_cluster, :ext_management_system => ems))
+    end
+
+    include_examples "polling destination power status in provider"
+  end
+end

--- a/spec/support/examples_group/shared_examples_for_provisioning_state_machine.rb
+++ b/spec/support/examples_group/shared_examples_for_provisioning_state_machine.rb
@@ -9,3 +9,38 @@ shared_examples_for "common rhev state machine methods" do
     @task.customize_destination
   end
 end
+
+shared_examples_for "polling destination power status in provider" do
+  it "#poll_destination_powered_off_in_provider" do
+    expect(@task).to receive(:powered_off_in_provider?).and_return(true)
+    expect(@task).to receive(:requeue_phase)
+
+    @task.poll_destination_powered_off_in_provider
+  end
+
+  context "#poll_destination_powered_on_in_provider" do
+    it "requeues if the VM didn't start" do
+      expect(@task).to receive(:powered_on_in_provider?).and_return(false)
+      expect(@task).to receive(:requeue_phase)
+
+      @task.poll_destination_powered_on_in_provider
+
+      expect(@task.phase_context[:power_on_wait_count]).to eq(1)
+    end
+
+    it "moves on if the vm started" do
+      expect(@task).to receive(:powered_on_in_provider?).and_return(true)
+      expect(@task).to receive(:poll_destination_powered_off_in_provider)
+
+      @task.poll_destination_powered_on_in_provider
+
+      expect(@task.phase_context[:power_on_wait_count]).to be_nil
+    end
+
+    it "raises if the vm failed to start" do
+      @task.phase_context[:power_on_wait_count] = 121
+
+      expect { @task.poll_destination_powered_on_in_provider }.to raise_error(MiqException::MiqProvisionError)
+    end
+  end
+end


### PR DESCRIPTION
During a PXE provision, using the power state in the VMDB to drive provisioning operations is too slow and unreliable.

Too often we find that we call the raw VM power on, update the VM record power state, then refresh the provider (which can take a while) and ask for the power status and it's off (this can all happen before the VM is even powered on in a slow provider).  Since the VM is now off, we consider the PXE install completed and delete the PXE files from the server.

It is much more reliable to call the raw VM power on, then sit in a loop waiting for it to power on in the provider before moving to the next state (polling for the power off, our indication that the install has completed).

https://bugzilla.redhat.com/show_bug.cgi?id=1318019