### PR TITLE
Include 'Service' CustomButtons in the custom_actions method for ServiceTemplates

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -39,7 +39,7 @@ class CustomButton < ApplicationRecord
   end
 
   def expanded_serializable_hash
-    button_hash = serializable_hash(:except => [:created_on, :updated_on])
+    button_hash = serializable_hash
     if resource_action
       button_hash[:resource_action] = resource_action.serializable_hash
     end

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -39,7 +39,7 @@ class CustomButton < ApplicationRecord
   end
 
   def expanded_serializable_hash
-    button_hash = serializable_hash
+    button_hash = serializable_hash(:except => [:created_on, :updated_on])
     if resource_action
       button_hash[:resource_action] = resource_action.serializable_hash
     end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -34,9 +34,11 @@ class ServiceTemplate < ApplicationRecord
   virtual_has_one :custom_action_buttons, :class_name => "Array"
 
   def custom_actions
+    generic_button_group = CustomButton.buttons_for("Service").select { |button| !button.parent.nil? }
+    custom_button_sets_with_generics = custom_button_sets + generic_button_group.map(&:parent).uniq.flatten
     {
       :buttons       => custom_buttons.collect(&:expanded_serializable_hash),
-      :button_groups => custom_button_sets.collect do |button_set|
+      :button_groups => custom_button_sets_with_generics.collect do |button_set|
         button_set.serializable_hash.merge(:buttons => button_set.children.collect(&:expanded_serializable_hash))
       end
     }
@@ -47,7 +49,8 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def custom_buttons
-    CustomButton.buttons_for(self).select { |b| b.parent.nil? }
+    service_buttons = CustomButton.buttons_for("Service").select { |button| button.parent.nil? }
+    service_buttons + CustomButton.buttons_for(self).select { |b| b.parent.nil? }
   end
 
   def vms_and_templates

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -30,12 +30,33 @@ describe ServiceTemplate do
     end
 
     it "returns the custom actions in a hash grouped by buttons and button groups" do
-      expect(service_template.custom_actions).to eq(
+      assigned_group_buttons = assigned_group.expanded_serializable_hash.reject do |key, _|
+        %w(created_on updated_on).include?(key)
+      end
+      expected_assigned_group_set = assigned_group_set.serializable_hash.reject { |key, _|
+        %w(created_on updated_on).include?(key)
+      }.merge(:buttons => [assigned_group_buttons])
+
+      generic_group_buttons = generic_group.expanded_serializable_hash.reject do |key, _|
+        %w(created_on updated_on).include?(key)
+      end
+      expected_generic_group_set = generic_group_set.serializable_hash.reject { |key, _|
+        %w(created_on updated_on).include?(key)
+      }.merge(:buttons => [generic_group_buttons])
+
+      expected_hash_without_created_or_updated = service_template.custom_actions
+      expected_hash_without_created_or_updated[:button_groups].each do |button_group|
+        button_group.reject! do |key, _|
+          %w(created_on updated_on).include?(key)
+        end
+        button_group[:buttons].each do |button|
+          button.reject! { |key, _| %w(created_on updated_on).include?(key) }
+        end
+      end
+
+      expect(expected_hash_without_created_or_updated).to eq(
         :buttons       => %w(generic_no_group assigned_no_group),
-        :button_groups => [
-          assigned_group_set.serializable_hash.merge(:buttons => [assigned_group.expanded_serializable_hash]),
-          generic_group_set.serializable_hash.merge(:buttons => [generic_group.expanded_serializable_hash])
-        ]
+        :button_groups => [expected_assigned_group_set, expected_generic_group_set]
       )
     end
   end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1,4 +1,45 @@
 describe ServiceTemplate do
+  describe "#custom_actions" do
+    let(:service_template) do
+      described_class.create(:name => "test", :description => "test", :custom_button_sets => [assigned_group_set])
+    end
+    let(:generic_no_group) { FactoryGirl.create(:custom_button, :applies_to_class => "Service") }
+    let(:assigned_no_group) { FactoryGirl.create(:custom_button, :applies_to_class => "ServiceTemplate") }
+    let(:generic_group) { FactoryGirl.create(:custom_button, :applies_to_class => "Service") }
+    let(:assigned_group) { FactoryGirl.create(:custom_button, :applies_to_class => "ServiceTemplate") }
+    let(:assigned_group_set) do
+      FactoryGirl.create(:custom_button_set, :name => "assigned_group", :description => "assigned_group")
+    end
+    let(:generic_group_set) do
+      FactoryGirl.create(:custom_button_set, :name => "generic_group", :description => "generic_group")
+    end
+
+    before do
+      allow(generic_no_group).to receive(:expanded_serializable_hash).and_return("generic_no_group")
+      allow(assigned_no_group).to receive(:expanded_serializable_hash).and_return("assigned_no_group")
+
+      generic_group_set.add_member(generic_group)
+      assigned_group_set.add_member(assigned_group)
+
+      allow(CustomButton).to receive(:buttons_for).with("Service").and_return(
+        [generic_no_group, generic_group]
+      )
+      allow(CustomButton).to receive(:buttons_for).with(service_template).and_return(
+        [assigned_no_group, assigned_group]
+      )
+    end
+
+    it "returns the custom actions in a hash grouped by buttons and button groups" do
+      expect(service_template.custom_actions).to eq(
+        :buttons       => %w(generic_no_group assigned_no_group),
+        :button_groups => [
+          assigned_group_set.serializable_hash.merge(:buttons => [assigned_group.expanded_serializable_hash]),
+          generic_group_set.serializable_hash.merge(:buttons => [generic_group.expanded_serializable_hash])
+        ]
+      )
+    end
+  end
+
   context "#type_display" do
     before(:each) do
       @st1 = FactoryGirl.create(:service_template, :name => 'Service Template 1')


### PR DESCRIPTION
This makes it so that the custom buttons that you assign to a service from the "Automate/Customization" side of things will show up in the SSUI. Previously it was only buttons directly assigned to the service.