### PR TITLE
Show VMs devices collected during SSA

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -255,6 +255,9 @@ module VmCommon
     elsif @display == "snapshot_info"
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
+    elsif @display == "devices"
+      drop_breadcrumb(:name => @record.name + _(" (Devices)"),
+                      :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
       build_snapshot_tree
       @button_group = "snapshot"
     elsif @display == "vmtree_info"

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -6,7 +6,7 @@ module VmHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name region server description hostname ipaddress custom_1 container host_platform tools_status osinfo cpu_affinity snapshots advanced_settings resources guid)
+    %i(name region server description hostname ipaddress custom_1 container host_platform tools_status osinfo devices cpu_affinity snapshots advanced_settings resources guid)
   end
 
   def textual_group_lifecycle
@@ -821,6 +821,18 @@ module VmHelper::TextualSummary
       value = @record.send("max_mem_usage_absolute_average_#{key}_over_time_period")
       h[:value] << {:label => label,
                     :value => (value.nil? ? _("Not Available") : number_to_percentage(value, :precision => 2))}
+    end
+    h
+  end
+
+  def textual_devices
+    h = {:label    => _("Devices"),
+         :image    => "devices",
+         :explorer => true,
+         :value    => (@devices.nil? || @devices.empty? ? _("None") : @devices.length)}
+    if @devices.length > 0
+      h[:title] = _("Show VMs devices")
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'devices')
     end
     h
   end

--- a/app/views/vm_common/_config.html.haml
+++ b/app/views/vm_common/_config.html.haml
@@ -1,5 +1,19 @@
 = render :partial => "layouts/flash_msg"
 - case @display
+- when "devices"
+  - unless @devices.empty?
+    %table.table.table-bordered.table-striped
+      %thead
+        %tr
+          %th{:colspan => "2"}= _('Devices')
+      %tbody
+        - @devices.each do |item|
+          %tr
+            %td.label
+              = h(item[:device])
+            %td
+              %img{:src => image_path("100/hardware-#{item[:icon].downcase}.png")}
+              = h(item[:description])
 - when "os_info"
   - if @osinfo
     %table.table.table-bordered.table-striped


### PR DESCRIPTION
Implemented:
* 'Devices' link in VMs summary page
* New screen showing VMs devices discovered during smart state analysis
![vm](https://cloud.githubusercontent.com/assets/6648365/13822665/d821c7b0-eba6-11e5-8ed4-3f8726f6e627.jpg)
![devices](https://cloud.githubusercontent.com/assets/6648365/13822672/dcec63ea-eba6-11e5-9770-b03932ff22e1.jpg)

