### PR TITLE
Ensure the record is not stale when trying to destroy

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -378,7 +378,7 @@ class MiqQueue < ApplicationRecord
   rescue => err
     _log.error("#{MiqQueue.format_short_log_msg(self)}, #{err.message}")
   ensure
-    destroy
+    destroy_potentially_stale_record
   end
 
   def delivered_on
@@ -516,5 +516,11 @@ class MiqQueue < ApplicationRecord
       options[key] = [nil, options[key]].uniq if options.key?(key)
     end
     options
+  end
+
+  def destroy_potentially_stale_record
+    destroy
+  rescue ActiveRecord::StaleObjectError
+    reload.destroy
   end
 end # Class MiqQueue

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -595,4 +595,15 @@ describe MiqQueue do
                                   :expanded     => [nil, "exp"]
                                 )
   end
+
+  context "#delivered" do
+    it "destroys a stale object" do
+      q = MiqQueue.create!(:state => 'ready')
+      MiqQueue.find(q.id).tap { |q2| q2.state = 'dequeue' }.save # update_attributes doesn't expose the issue
+
+      q.delivered('warn', nil, nil)
+
+      expect(MiqQueue.where(:id => q.id).count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
I ran into the following at the end of an EMS refresh:

```
   (0.1ms)  BEGIN
  SQL (0.2ms)  DELETE FROM "miq_queue" WHERE "miq_queue"."id" = $1 AND "miq_queue"."lock_version" = $2  [["id", 1984], ["lock_version", 0]]
   (0.1ms)  ROLLBACK
ActiveRecord::StaleObjectError: Attempted to destroy a stale object: MiqQueue.
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/locking/optimistic.rb:118:in `destroy_row'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/persistence.rb:184:in `destroy'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/callbacks.rb:283:in `block in destroy'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activesupport/lib/active_support/callbacks.rb:750:in `_run_destroy_callbacks'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/callbacks.rb:283:in `destroy'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/transactions.rb:314:in `block in destroy'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `block in transaction'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `transaction'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/transactions.rb:211:in `transaction'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/activerecord/lib/active_record/transactions.rb:314:in `destroy'
	from /home/bdunne/projects/redhat/manageiq/app/models/miq_queue.rb:381:in `delivered'
	from /home/bdunne/projects/redhat/manageiq/lib/vmdb/console_methods.rb:22:in `block in simulate_queue_worker'
	from /home/bdunne/projects/redhat/manageiq/lib/vmdb/console_methods.rb:18:in `loop'
	from /home/bdunne/projects/redhat/manageiq/lib/vmdb/console_methods.rb:18:in `simulate_queue_worker'
	from (irb):1
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/railties/lib/rails/commands/console.rb:65:in `start'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/railties/lib/rails/commands/console_helper.rb:9:in `start'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/railties/lib/rails/commands/commands_tasks.rb:78:in `console'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/railties/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /home/bdunne/.gem/ruby/2.2.4/bundler/gems/rails-4232f7ee427a/railties/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```