### PR TITLE
Fix typo in method ExplorerPresenter#show_miq_buttons

### DIFF
--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -80,7 +80,7 @@ class ExplorerPresenter
   end
 
   def show_miq_buttons(show = true)
-    @options[show_miq_buttons] = show
+    @options[:show_miq_buttons] = show
   end
 
   def set_visibility(value, *elements)


### PR DESCRIPTION
Issue was introduced in https://github.com/ManageIQ/manageiq/pull/7223