### PR TITLE
Avoid deadlock due to our Dalli autoload "enhancement"

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -32,6 +32,23 @@ else
       :expire_after => 24.hours,
       :key          => "_vmdb_session",
     )
+
+    require 'rack/session/dalli'
+    Rack::Session::Dalli.prepend Module.new {
+      # As we monkey-patch marshal to support autoloading, Dalli can
+      # cause a load to occur. Consequently, we need to manage things
+      # carefully to prevent a deadlock between the Rails Interlock and
+      # Dalli's own exclusive lock.
+      def with_lock(*args)
+        ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+          super(*args) do
+            ActiveSupport::Dependencies.interlock.running do
+              yield
+            end
+          end
+        end
+      end
+    }
   end
 
   Vmdb::Application.config.session_store rails_store, session_options


### PR DESCRIPTION
As we monkey-patch marshal to support autoloading, Dalli can
cause a load to occur. Consequently, we need to manage things
carefully to prevent a deadlock between the Rails Interlock and
Dalli's own exclusive lock.

This PR avoids the deadlock
[edited by @kbrock]