### PR TITLE
Replace deprecated WaitForUpdates calls with WaitForUpdatesEx

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
@@ -6,7 +6,8 @@ class ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner < ManageIQ
       @ems.authentication_userid,
       @ems.authentication_password,
       nil,
-      worker_settings[:ems_event_page_size])
+      worker_settings[:ems_event_page_size],
+      worker_settings[:ems_event_max_wait])
   end
 
   def reset_event_monitor_handle

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -300,6 +300,7 @@ workers:
         :poll: 15.seconds
       :event_catcher_vmware:
         :poll: 1.seconds
+        :ems_event_max_wait: 60
       :event_catcher_openstack:
         :poll: 15.seconds
         :topics:

--- a/gems/pending/VMwareWebService/DMiqVim.rb
+++ b/gems/pending/VMwareWebService/DMiqVim.rb
@@ -25,7 +25,7 @@ class DMiqVim < MiqVim
 
   attr_reader :updateThread
 
-  def initialize(server, username, password, broker, preLoad = false, debugUpdates = false, notifyMethod = nil, cacheScope = nil)
+  def initialize(server, username, password, broker, preLoad = false, debugUpdates = false, notifyMethod = nil, cacheScope = nil, maxWait = 60)
     super(server, username, password, cacheScope)
 
     log_prefix        = "DMiqVim.initialize (#{@connId})"
@@ -36,6 +36,7 @@ class DMiqVim < MiqVim
     @connectionShuttingDown = false
     @connectionRemoved    = false
     @debugUpdates     = debugUpdates
+    @maxWait          = maxWait
 
     checkForOrphanedMonitors
     $vim_log.info "#{log_prefix}: starting update monitor thread" if $vim_log

--- a/gems/pending/VMwareWebService/MiqVimUpdate.rb
+++ b/gems/pending/VMwareWebService/MiqVimUpdate.rb
@@ -28,7 +28,7 @@ module MiqVimUpdate
     retries = @@max_retries
     begin
       $vim_log.info "#{log_prefix}: call to waitForUpdates...Starting" if $vim_log
-      updateSet = waitForUpdates(@umPropCol)
+      updateSet = waitForUpdatesEx(@umPropCol)
       $vim_log.info "#{log_prefix}: call to waitForUpdates...Complete" if $vim_log
       version = updateSet.version
 
@@ -60,8 +60,10 @@ module MiqVimUpdate
     log_prefix = "MiqVimUpdate.monitorUpdatesSince (#{@connId})"
     begin
       $vim_log.info "#{log_prefix}: call to waitForUpdates...Starting (version = #{version})" if $vim_log
-      updateSet = waitForUpdates(@umPropCol, version)
+      updateSet = waitForUpdatesEx(@umPropCol, version, :max_wait => @maxWait)
       $vim_log.info "#{log_prefix}: call to waitForUpdates...Complete (version = #{version})" if $vim_log
+      return version if updateSet.nil?
+
       version = updateSet.version
 
       return if updateSet.filterSet.nil? || updateSet.filterSet.empty?

--- a/gems/pending/VMwareWebService/VimService.rb
+++ b/gems/pending/VMwareWebService/VimService.rb
@@ -1122,6 +1122,29 @@ class VimService < Handsoap::Service
     (parse_response(response, 'WaitForUpdatesResponse')['returnval'])
   end
 
+  def waitForUpdatesEx(propCol, version = nil, options = {})
+    max_wait    = options[:max_wait]
+    max_objects = options[:max_objects]
+
+    options = VimHash.new("WaitOptions") do |opts|
+      opts.maxObjectUpdates = max_objects.to_s if max_objects
+      opts.maxWaitSeconds   = max_wait.to_s    if max_wait
+    end
+
+    response = invoke("n1:WaitForUpdatesEx") do |message|
+      message.add "n1:_this", propCol do |i|
+        i.set_attr "type", propCol.vimType
+      end
+
+      message.add "n1:version", version if version
+      message.add "n1:options" do |i|
+        i.set_attr "type", options.vimType
+        marshalObj(i, options)
+      end
+    end
+    (parse_response(response, 'WaitForUpdatesExResponse')['returnval'])
+  end
+
   def xmlToCustomizationSpecItem(csmMor, specItemXml)
     response = invoke("n1:XmlToCustomizationSpecItem") do |message|
       message.add "n1:_this", csmMor do |i|


### PR DESCRIPTION
WaitForUpdates was deprecated in vSphere 4.1 and all callers should be moved to the new WaitForUpdatesEx.

https://www.vmware.com/support/developer/vc-sdk/wssdk_4_1_releasenotes.html#deprecations