### PR TITLE
Update azure-armrest gem to 0.2.2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # See miq_expression_spec Date/Time Support examples.
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
-gem "azure-armrest",                  "=0.2.0"
+gem "azure-armrest",                  "~>0.2.2"
 gem "color",                          "~>1.8"
 gem "default_value_for",              "~>3.0.1", :git => "git://github.com/matthewd/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
 gem "draper",                         "~>2.1.0", :git => "git://github.com/janraasch/draper.git", :branch => "feature/rails5-compatibility" # https://github.com/drapergem/draper/pull/712


### PR DESCRIPTION
This bumps the azure-armrest gem to the latest version, which fixes the issue that caused the name collision problems in 0.2.1.