### PR TITLE
Fix deletion of multiple tenants at once

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -351,12 +351,10 @@ module OpsController::OpsRbac
     assert_privileges("rbac_tenant_delete")
     tenants = []
     if !params[:id] # showing a tenants list
-      ids = find_checked_items.collect { |r| from_cid(r.to_s.split("-").last) }
-      tenants = Tenant.where(:id => ids).to_a
-      tenants.reject! do |t|
-        t.parent.nil?
+      tenants = Tenant.where(:id => find_checked_items).reject do |t|
         add_flash(_("Default %{model} \"%{name}\" can not be deleted") % {:model => ui_lookup(:model => "Tenant"),
                                                                           :name  => t.name}, :error) if t.parent.nil?
+        t.parent.nil?
       end
     else # showing 1 tenant, delete it
       if params[:id].nil? || Tenant.find_by_id(params[:id]).nil?


### PR DESCRIPTION
It seems that the 'miq_grid_checks' post parameter is already being sent
as an array of integers, so there no need to split the 'tn-' out of its
items. That would lead to an error:

```
INFO -- : Started POST "/ops/x_button?pressed=rbac_tenant_delete" for 127.0.0.1 at 2016-03-17 13:35:43 +0100
INFO -- : Processing by OpsController#x_button as JS
INFO -- :   Parameters: {"miq_grid_checks"=>"11,12", "pressed"=>"rbac_tenant_delete"}
FATAL -- : Error caught: [NoMethodError] undefined method `split' for 11:Fixnum
app/controllers/ops_controller/ops_rbac.rb:354:in `block in rbac_tenant_delete'
app/controllers/ops_controller/ops_rbac.rb:354:in `collect'
app/controllers/ops_controller/ops_rbac.rb:354:in `rbac_tenant_delete'
app/controllers/ops_controller.rb:100:in `x_button'
```

Also, reject! does not work with Active Record Relation.