### PR TITLE
Remove :_type_disabled for models in migrations, where type column doesn't exist

### DIFF
--- a/db/migrate/20131107000917_expand_dialog_field_default_value_size.rb
+++ b/db/migrate/20131107000917_expand_dialog_field_default_value_size.rb
@@ -1,5 +1,7 @@
 class ExpandDialogFieldDefaultValueSize < ActiveRecord::Migration
   class DialogField < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins
   end

--- a/db/migrate/20131118232818_encrypt_miq_database_registration_http_proxy_password_field.rb
+++ b/db/migrate/20131118232818_encrypt_miq_database_registration_http_proxy_password_field.rb
@@ -1,7 +1,5 @@
 class EncryptMiqDatabaseRegistrationHttpProxyPasswordField < ActiveRecord::Migration
-  class MiqDatabase < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqDatabase < ActiveRecord::Base; end
 
   def up
     say_with_time("Encrypt miq_database registration_http_proxy_password field") do

--- a/db/migrate/20131121211455_change_options_in_miq_alert.rb
+++ b/db/migrate/20131121211455_change_options_in_miq_alert.rb
@@ -1,7 +1,6 @@
 class ChangeOptionsInMiqAlert < ActiveRecord::Migration
   class MiqAlert < ActiveRecord::Base
     serialize :options
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   def up

--- a/db/migrate/20131125153220_import_provision_dialogs.rb
+++ b/db/migrate/20131125153220_import_provision_dialogs.rb
@@ -1,6 +1,5 @@
 class ImportProvisionDialogs < ActiveRecord::Migration
   class MiqDialog < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled    # disable STI
     serialize :content
   end
 

--- a/db/migrate/20131210202928_update_log_collection_path_in_configurations_settings.rb
+++ b/db/migrate/20131210202928_update_log_collection_path_in_configurations_settings.rb
@@ -1,7 +1,6 @@
 class UpdateLogCollectionPathInConfigurationsSettings < ActiveRecord::Migration
   class Configuration < ActiveRecord::Base
     serialize :settings
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   NEW_PG_CONF_PATH = "/opt/rh/postgresql92/root/var/lib/pgsql/data/*.conf"

--- a/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
+++ b/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
@@ -4,7 +4,6 @@ class FixReplicationOnUpgradeFromVersionFour < ActiveRecord::Migration
 
   class Configuration < ActiveRecord::Base
     serialize :settings
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   V5_DEFAULT_EXCLUDE_TABLES = %w(

--- a/db/migrate/20140121213913_split_widget_set_name_to_three_columns.rb
+++ b/db/migrate/20140121213913_split_widget_set_name_to_three_columns.rb
@@ -1,7 +1,5 @@
 class SplitWidgetSetNameToThreeColumns < ActiveRecord::Migration
-  class MiqSet < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqSet < ActiveRecord::Base; end
 
   def up
     add_column :miq_sets, :userid,  :string

--- a/db/migrate/20140218232357_add_group_and_user_columns_to_miq_widget_contents.rb
+++ b/db/migrate/20140218232357_add_group_and_user_columns_to_miq_widget_contents.rb
@@ -1,7 +1,5 @@
 class AddGroupAndUserColumnsToMiqWidgetContents < ActiveRecord::Migration
-  class MiqWidgetContent < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqWidgetContent < ActiveRecord::Base; end
 
   def up
     add_column    :miq_widget_contents, :miq_group_id, :bigint

--- a/db/migrate/20140301034340_leverage_authentications_for_registration_http_proxy_credentials.rb
+++ b/db/migrate/20140301034340_leverage_authentications_for_registration_http_proxy_credentials.rb
@@ -1,7 +1,5 @@
 class LeverageAuthenticationsForRegistrationHttpProxyCredentials < ActiveRecord::Migration
-  class MiqDatabase < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqDatabase < ActiveRecord::Base; end
 
   class Authentication < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI

--- a/db/migrate/20140402134329_change_utc_time_profile_type_to_global.rb
+++ b/db/migrate/20140402134329_change_utc_time_profile_type_to_global.rb
@@ -1,7 +1,5 @@
 class ChangeUtcTimeProfileTypeToGlobal < ActiveRecord::Migration
-  class TimeProfile < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class TimeProfile < ActiveRecord::Base; end
 
   def up
     say_with_time("Change Default UTC Time Profile to Type Global") do

--- a/db/migrate/20140409134713_move_log_collection_depot_settings_to_file_depot.rb
+++ b/db/migrate/20140409134713_move_log_collection_depot_settings_to_file_depot.rb
@@ -5,20 +5,14 @@ class MoveLogCollectionDepotSettingsToFileDepot < ActiveRecord::Migration
 
   class Configuration < ActiveRecord::Base
     serialize :settings, Hash
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class FileDepot < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class FileDepot < ActiveRecord::Base; end
 
-  class MiqServer < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqServer < ActiveRecord::Base; end
 
   class Zone < ActiveRecord::Base
     serialize :settings, Hash
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   def up

--- a/db/migrate/20140421150958_create_miq_groups_users_join_table.rb
+++ b/db/migrate/20140421150958_create_miq_groups_users_join_table.rb
@@ -1,11 +1,9 @@
 class CreateMiqGroupsUsersJoinTable < ActiveRecord::Migration
   class MiqGroupsUsers < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     self.primary_key = nil
   end
 
   class User < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins
   end

--- a/db/migrate/20140424173120_migrate_automate_to_customer_domain.rb
+++ b/db/migrate/20140424173120_migrate_automate_to_customer_domain.rb
@@ -1,7 +1,5 @@
 class MigrateAutomateToCustomerDomain < ActiveRecord::Migration
   class MiqAeNamespace < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-
     def self.root_instances
       where(:parent_id => nil).where(arel_table[:name].not_eq("$"))
     end

--- a/db/migrate/20140519211930_add_user_current_group_to_miq_groups.rb
+++ b/db/migrate/20140519211930_add_user_current_group_to_miq_groups.rb
@@ -1,14 +1,10 @@
 class AddUserCurrentGroupToMiqGroups < ActiveRecord::Migration
   class User < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-
     belongs_to :current_group, :class_name => "AddUserCurrentGroupToMiqGroups::MiqGroup"
     has_and_belongs_to_many :miq_groups, :class_name => "AddUserCurrentGroupToMiqGroups::MiqGroup"
   end
 
-  class MiqGroup < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqGroup < ActiveRecord::Base; end
 
   def up
     say_with_time("Migrating current_group into user's miq_groups") do

--- a/db/migrate/20140611194007_change_options_in_miq_alert_for_email_to.rb
+++ b/db/migrate/20140611194007_change_options_in_miq_alert_for_email_to.rb
@@ -1,7 +1,6 @@
 class ChangeOptionsInMiqAlertForEmailTo < ActiveRecord::Migration
   class MiqAlert < ActiveRecord::Base
     serialize :options
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   def up

--- a/db/migrate/20140715200621_set_default_for_pxe_server_customization_directory.rb
+++ b/db/migrate/20140715200621_set_default_for_pxe_server_customization_directory.rb
@@ -1,7 +1,5 @@
 class SetDefaultForPxeServerCustomizationDirectory < ActiveRecord::Migration
-  class PxeServer < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class PxeServer < ActiveRecord::Base; end
 
   def up
     say_with_time("Seting default value for PxeServer #customization_directory") do

--- a/db/migrate/20140905020643_update_default_registration_channel_names.rb
+++ b/db/migrate/20140905020643_update_default_registration_channel_names.rb
@@ -1,7 +1,5 @@
 class UpdateDefaultRegistrationChannelNames < ActiveRecord::Migration
-  class MiqDatabase < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqDatabase < ActiveRecord::Base; end
 
   def up
     say_with_time("Updating Default Registration Channel Names for v5.3") do

--- a/db/migrate/20141015170920_remove_vdi_tab_from_miq_dialogs.rb
+++ b/db/migrate/20141015170920_remove_vdi_tab_from_miq_dialogs.rb
@@ -1,7 +1,6 @@
 class RemoveVdiTabFromMiqDialogs < ActiveRecord::Migration
   class MiqDialog < ActiveRecord::Base
     serialize :content, Hash
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   def up

--- a/db/migrate/20141021103820_remove_miq_search_vdi_instances.rb
+++ b/db/migrate/20141021103820_remove_miq_search_vdi_instances.rb
@@ -1,7 +1,5 @@
 class RemoveMiqSearchVdiInstances < ActiveRecord::Migration
-  class MiqSearch < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqSearch < ActiveRecord::Base; end
 
   def up
     say_with_time("Removing VDI User references from MiqSearch") do

--- a/db/migrate/20141121200153_migrate_ems_attributes_to_endpoints.rb
+++ b/db/migrate/20141121200153_migrate_ems_attributes_to_endpoints.rb
@@ -3,9 +3,7 @@ class MigrateEmsAttributesToEndpoints < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class Endpoint < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Endpoint < ActiveRecord::Base; end
 
   def up
     say_with_time("Migrating EMS attributes to endpoints") do

--- a/db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration.rb
+++ b/db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration.rb
@@ -1,6 +1,5 @@
 class AddLoopbackToMemcacheServerOptsInConfiguration < ActiveRecord::Migration
   class Configuration < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     serialize :settings, Hash
   end
 

--- a/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
+++ b/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
@@ -8,9 +8,7 @@ class MigrateProvisioningManagerToEms < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled
   end
 
-  class OperatingSystemFlavor < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class OperatingSystemFlavor < ActiveRecord::Base; end
 
   class CustomizationScript < ActiveRecord::Base
     self.inheritance_column = :_type_disabled

--- a/db/migrate/20150316175916_update_miq_database_default_update_repo_name.rb
+++ b/db/migrate/20150316175916_update_miq_database_default_update_repo_name.rb
@@ -1,7 +1,5 @@
 class UpdateMiqDatabaseDefaultUpdateRepoName < ActiveRecord::Migration
-  class MiqDatabase < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class MiqDatabase < ActiveRecord::Base; end
 
   REPO_NAME_HASH = {
     "rhel-x86_64-server-6-cf-me-3"                                => "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1",

--- a/db/migrate/20150330214408_add_file_depot_id_to_miq_schedule.rb
+++ b/db/migrate/20150330214408_add_file_depot_id_to_miq_schedule.rb
@@ -1,7 +1,5 @@
 class AddFileDepotIdToMiqSchedule < ActiveRecord::Migration
   class MiqSchedule < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-
     def file_depot
       return @file_depot if defined?(@file_depot)
       @file_depot = FileDepot.where(:id => file_depot_id).first

--- a/db/migrate/20150405141637_remove_port_config_from_container_service.rb
+++ b/db/migrate/20150405141637_remove_port_config_from_container_service.rb
@@ -1,12 +1,10 @@
 class RemovePortConfigFromContainerService < ActiveRecord::Migration
   class ContainerService < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     has_many :container_service_port_configs,
              :class_name => "RemovePortConfigFromContainerService::ContainerServicePortConfig"
   end
 
   class ContainerServicePortConfig < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     belongs_to :container_service,
                :class_name => "RemovePortConfigFromContainerService::ContainerService"
   end

--- a/db/migrate/20150407144345_add_kerberos_to_ext_management_system.rb
+++ b/db/migrate/20150407144345_add_kerberos_to_ext_management_system.rb
@@ -1,5 +1,7 @@
 class AddKerberosToExtManagementSystem < ActiveRecord::Migration
   class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins
   end

--- a/db/migrate/20150604154825_rename_container_node_conditions_to_container_conditions.rb
+++ b/db/migrate/20150604154825_rename_container_node_conditions_to_container_conditions.rb
@@ -1,7 +1,5 @@
 class RenameContainerNodeConditionsToContainerConditions < ActiveRecord::Migration
-  class ContainerCondition < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class ContainerCondition < ActiveRecord::Base; end
 
   def up
     rename_table :container_node_conditions, :container_conditions

--- a/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
+++ b/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
@@ -44,8 +44,6 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
   end
 
   class MiqReportResult < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-
     include Serializer
   end
 
@@ -82,7 +80,6 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
   end
 
   class BinaryBlob < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
     has_many :binary_blob_parts, -> { order(:id) }, :class_name => 'FixSerializedReportsForRailsFour::BinaryBlobPart'
     belongs_to :resource, :class_name => 'FixSerializedReportsForRailsFour::MiqReportResult'
 

--- a/db/migrate/20150714143821_remove_ui_tasks_and_ui_task_sets.rb
+++ b/db/migrate/20150714143821_remove_ui_tasks_and_ui_task_sets.rb
@@ -1,11 +1,7 @@
 class RemoveUiTasksAndUiTaskSets < ActiveRecord::Migration
-  class MiqSet < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqSet < ActiveRecord::Base; end
 
-  class Relationship < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Relationship < ActiveRecord::Base; end
 
   def up
     remove_index :ui_tasks, [:area, :typ, :task]

--- a/db/migrate/20150806190149_rename_miq_event_table_to_miq_event_definition.rb
+++ b/db/migrate/20150806190149_rename_miq_event_table_to_miq_event_definition.rb
@@ -2,18 +2,13 @@ class RenameMiqEventTableToMiqEventDefinition < ActiveRecord::Migration
   include MigrationHelper
   include MigrationHelper::SharedStubs
 
-  class MiqSet < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
-  class Relationship < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
-  class MiqEvent < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
-  class MiqEventDefinition < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqSet < ActiveRecord::Base; end
+
+  class Relationship < ActiveRecord::Base; end
+
+  class MiqEvent < ActiveRecord::Base; end
+
+  class MiqEventDefinition < ActiveRecord::Base; end
 
   def up
     rename_table  :miq_events, :miq_event_definitions

--- a/db/migrate/20150806194147_migrate_filtered_events_to_blacklisted_events.rb
+++ b/db/migrate/20150806194147_migrate_filtered_events_to_blacklisted_events.rb
@@ -1,12 +1,9 @@
 class MigrateFilteredEventsToBlacklistedEvents < ActiveRecord::Migration
   class Configuration < ActiveRecord::Base
     serialize :settings
-    self.inheritance_column = :_type_disabled
   end
 
-  class BlacklistedEvent < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class BlacklistedEvent < ActiveRecord::Base; end
 
   def up
     say_with_time('Migrating filtered events from Configuration to BlacklistedEvent') do

--- a/db/migrate/20150806211453_rename_ems_event_table_to_event_stream.rb
+++ b/db/migrate/20150806211453_rename_ems_event_table_to_event_stream.rb
@@ -3,12 +3,10 @@ class RenameEmsEventTableToEventStream < ActiveRecord::Migration
   include MigrationHelper::SharedStubs
 
   class EventStream < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
+    self.inheritance_column = :_type_disabled
   end
 
-  class EmsEvent < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class EmsEvent < ActiveRecord::Base; end
 
   def up
     rename_table :ems_events, :event_streams

--- a/db/migrate/20150817213409_clear_tenant_seed.rb
+++ b/db/migrate/20150817213409_clear_tenant_seed.rb
@@ -1,7 +1,5 @@
 class ClearTenantSeed < ActiveRecord::Migration
-  class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Tenant < ActiveRecord::Base; end
 
   def up
     say_with_time("Setting root tenant to default to settings") do

--- a/db/migrate/20150818181427_update_tenant_divisible_on_existing_rows.rb
+++ b/db/migrate/20150818181427_update_tenant_divisible_on_existing_rows.rb
@@ -1,7 +1,5 @@
 class UpdateTenantDivisibleOnExistingRows < ActiveRecord::Migration
-  class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Tenant < ActiveRecord::Base; end
 
   def up
     say_with_time("marking root tenant divisible") do

--- a/db/migrate/20150824130000_update_tenant_override_settings.rb
+++ b/db/migrate/20150824130000_update_tenant_override_settings.rb
@@ -1,9 +1,7 @@
 class UpdateTenantOverrideSettings < ActiveRecord::Migration
   include MigrationHelper
 
-  class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Tenant < ActiveRecord::Base; end
 
   def up
     return if previously_migrated_as?("20151435234634")

--- a/db/migrate/20150903162623_assign_tenant.rb
+++ b/db/migrate/20150903162623_assign_tenant.rb
@@ -1,7 +1,5 @@
 class AssignTenant < ActiveRecord::Migration
   class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-
     # seed and return the current root_tenant
     def self.root_tenant
       create_with(
@@ -17,21 +15,15 @@ class AssignTenant < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class MiqAeNamespace < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqAeNamespace < ActiveRecord::Base; end
 
-  class MiqGroup < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqGroup < ActiveRecord::Base; end
 
   class Provider < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class TenantQuota < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class TenantQuota < ActiveRecord::Base; end
 
   class Vm < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI

--- a/db/migrate/20150904181202_miq_groups_add_ldap_role.rb
+++ b/db/migrate/20150904181202_miq_groups_add_ldap_role.rb
@@ -1,11 +1,7 @@
 class MiqGroupsAddLdapRole < ActiveRecord::Migration
-  class MiqUserRole < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqUserRole < ActiveRecord::Base; end
 
-  class MiqGroup < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqGroup < ActiveRecord::Base; end
 
   def up
     say_with_time "migrating old ldap groups" do

--- a/db/migrate/20150907095639_add_container_image_digest.rb
+++ b/db/migrate/20150907095639_add_container_image_digest.rb
@@ -2,9 +2,7 @@ class AddContainerImageDigest < ActiveRecord::Migration
   # https://github.com/docker/distribution/blob/v2.1.1/digest/digester.go#L15-L17
   SUPPORTED_DIGESTS = 'sha256', 'sha384', 'sha512'
 
-  class ContainerImage < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class ContainerImage < ActiveRecord::Base; end
 
   def up
     add_column :container_images, :digest, :string

--- a/db/migrate/20150914202922_correct_user_created_role_feature_sets.rb
+++ b/db/migrate/20150914202922_correct_user_created_role_feature_sets.rb
@@ -1,12 +1,9 @@
 class CorrectUserCreatedRoleFeatureSets < ActiveRecord::Migration
   class MiqUserRole < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features, :class_name => "CorrectUserCreatedRoleFeatureSets::MiqProductFeature"
   end
 
-  class MiqProductFeature < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqProductFeature < ActiveRecord::Base; end
 
   def up
     say_with_time "Correcting user created role feature sets" do

--- a/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
+++ b/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
@@ -1,7 +1,5 @@
 class AssignTenantToMiqRequest < ActiveRecord::Migration
   class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-
     # seed and return the current root_tenant
     def self.root_tenant
       create_with(
@@ -13,13 +11,9 @@ class AssignTenantToMiqRequest < ActiveRecord::Migration
     end
   end
 
-  class MiqAeNamespace < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqAeNamespace < ActiveRecord::Base; end
 
-  class MiqGroup < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqGroup < ActiveRecord::Base; end
 
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
@@ -49,9 +43,7 @@ class AssignTenantToMiqRequest < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class ServiceTemplateCatalog < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class ServiceTemplateCatalog < ActiveRecord::Base; end
 
   def up
     models = [ExtManagementSystem, MiqAeNamespace, MiqGroup, Provider, Vm,

--- a/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
+++ b/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
@@ -1,7 +1,5 @@
 class AddVmwareRoDatastoresToHostsStorages < ActiveRecord::Migration
-  class HostsStorage < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class HostsStorage < ActiveRecord::Base; end
 
   def up
     rename_table :hosts_storages, :host_storages

--- a/db/migrate/20151019194111_tenant_cfg_not_nil.rb
+++ b/db/migrate/20151019194111_tenant_cfg_not_nil.rb
@@ -1,7 +1,5 @@
 class TenantCfgNotNil < ActiveRecord::Migration
-  class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Tenant < ActiveRecord::Base; end
 
   def up
     say_with_time "Set default for use_config_for_attributes on Tenants" do

--- a/db/migrate/20151021174140_assign_tenant_default_group.rb
+++ b/db/migrate/20151021174140_assign_tenant_default_group.rb
@@ -1,7 +1,5 @@
 class AssignTenantDefaultGroup < ActiveRecord::Migration
   class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-
     def add_default_miq_group
       tenant_group = ::AssignTenantDefaultGroup::MiqGroup.create_tenant_group(self)
       update_attributes!(:default_miq_group_id => tenant_group.id)
@@ -14,7 +12,6 @@ class AssignTenantDefaultGroup < ActiveRecord::Migration
 
   class MiqUserRole < ActiveRecord::Base
     DEFAULT_TENANT_ROLE_NAME = "EvmRole-tenant_administrator"
-    self.inheritance_column = :_type_disabled # disable STI
 
     # if there is no role, that is ok
     # MiqGroup.seed will populate
@@ -26,7 +23,6 @@ class AssignTenantDefaultGroup < ActiveRecord::Migration
 
   class MiqGroup < ActiveRecord::Base
     TENANT_GROUP = "tenant"
-    self.inheritance_column = :_type_disabled # disable STI
 
     def self.create_tenant_group(tenant)
       role = ::AssignTenantDefaultGroup::MiqUserRole.default_tenant_role

--- a/db/migrate/20151026170631_set_miq_groups_group_type.rb
+++ b/db/migrate/20151026170631_set_miq_groups_group_type.rb
@@ -1,7 +1,6 @@
 class SetMiqGroupsGroupType < ActiveRecord::Migration
   class MiqGroup < ActiveRecord::Base
     USER_GROUP = "user"
-    self.inheritance_column = :_type_disabled # disable STI
   end
 
   def up

--- a/db/migrate/20151026220722_assign_vm_group.rb
+++ b/db/migrate/20151026220722_assign_vm_group.rb
@@ -1,7 +1,5 @@
 class AssignVmGroup < ActiveRecord::Migration
   class Tenant < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-
     def self.root_tenant
       where(:ancestry => nil).first
     end

--- a/db/migrate/20151030201919_fix_miq_group_sequences.rb
+++ b/db/migrate/20151030201919_fix_miq_group_sequences.rb
@@ -1,7 +1,5 @@
 class FixMiqGroupSequences < ActiveRecord::Migration
-  class MiqGroup < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqGroup < ActiveRecord::Base; end
 
   def up
     say_with_time("Update MiqGroup missing sequences") do

--- a/db/migrate/20151111165020_rename_miq_search_db.rb
+++ b/db/migrate/20151111165020_rename_miq_search_db.rb
@@ -1,7 +1,5 @@
 class RenameMiqSearchDb < ActiveRecord::Migration
-  class MiqSearch < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class MiqSearch < ActiveRecord::Base; end
 
   NAME_HASH = Hash[*%w(
     TemplateInfra ManageIQ::Providers::InfraManager::Template

--- a/db/migrate/20151119202643_update_default_update_repo_names.rb
+++ b/db/migrate/20151119202643_update_default_update_repo_names.rb
@@ -1,7 +1,5 @@
 class UpdateDefaultUpdateRepoNames < ActiveRecord::Migration
-  class MiqDatabase < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class MiqDatabase < ActiveRecord::Base; end
 
   REPO_NAME_HASH = {
     "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1" => "",

--- a/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
+++ b/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
@@ -2,13 +2,10 @@ class FixHostStorageReplicationOnUpgrade < ActiveRecord::Migration
   include MigrationHelper
   include MigrationHelper::SharedStubs
 
-  class MiqRegion < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class MiqRegion < ActiveRecord::Base; end
 
   class HostsStorage < ActiveRecord::Base
     self.table_name = "host_storages"
-    self.inheritance_column = :_type_disabled
   end
 
   def up

--- a/db/migrate/20151221134925_remove_sat5_repo_config.rb
+++ b/db/migrate/20151221134925_remove_sat5_repo_config.rb
@@ -1,7 +1,5 @@
 class RemoveSat5RepoConfig < ActiveRecord::Migration
-  class MiqDatabase < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class MiqDatabase < ActiveRecord::Base; end
 
   class Authentication < ActiveRecord::Base
     self.inheritance_column = :_type_disabled

--- a/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
+++ b/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
@@ -3,9 +3,7 @@ class MigrateProviderAttributesToEndpoints < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class Endpoint < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Endpoint < ActiveRecord::Base; end
 
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI

--- a/db/migrate/20151222152212_remove_vm_discover_row_from_miq_event_definitions.rb
+++ b/db/migrate/20151222152212_remove_vm_discover_row_from_miq_event_definitions.rb
@@ -1,11 +1,7 @@
 class RemoveVmDiscoverRowFromMiqEventDefinitions < ActiveRecord::Migration
-  class Relationship < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class Relationship < ActiveRecord::Base; end
 
-  class MiqEventDefinition < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class MiqEventDefinition < ActiveRecord::Base; end
 
   def up
     say_with_time("Remove event definition vm_discover") do

--- a/db/migrate/20160115111829_chargeback_rate_detail_currency_not_nil.rb
+++ b/db/migrate/20160115111829_chargeback_rate_detail_currency_not_nil.rb
@@ -1,12 +1,8 @@
 class ChargebackRateDetailCurrencyNotNil < ActiveRecord::Migration
   # Migration in order to put a currency by default in rates that were added by a user before the addition of currencies
-  class ChargebackRateDetail < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class ChargebackRateDetail < ActiveRecord::Base; end
 
-  class ChargebackRateDetailCurrency < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class ChargebackRateDetailCurrency < ActiveRecord::Base; end
 
   def up
     chargeback_rate_details = ChargebackRateDetail.where(:chargeback_rate_detail_currency_id => nil)

--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -1,15 +1,10 @@
 class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
-  class MiqEventDefinition < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class MiqEventDefinition < ActiveRecord::Base; end
 
-  class ScanItem < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-  end
+  class ScanItem < ActiveRecord::Base; end
 
   class Configuration < ActiveRecord::Base
     serialize :settings, Hash
-    self.inheritance_column = :_type_disabled
   end
 
   def up

--- a/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
+++ b/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
@@ -3,9 +3,7 @@ class MigrateUrlFromProviderToEndpoints < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  class Endpoint < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Endpoint < ActiveRecord::Base; end
 
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI

--- a/db/migrate/20160127210622_migrate_old_configuration_settings.rb
+++ b/db/migrate/20160127210622_migrate_old_configuration_settings.rb
@@ -1,6 +1,5 @@
 class MigrateOldConfigurationSettings < ActiveRecord::Migration
   class Configuration < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     serialize :settings, Hash
   end
 

--- a/db/migrate/20160127210624_convert_configurations_to_settings_changes.rb
+++ b/db/migrate/20160127210624_convert_configurations_to_settings_changes.rb
@@ -1,6 +1,5 @@
 class ConvertConfigurationsToSettingsChanges < ActiveRecord::Migration
   class Configuration < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     serialize :settings
   end
 

--- a/db/migrate/20160203101130_add_orderable_to_orchestration_templates.rb
+++ b/db/migrate/20160203101130_add_orderable_to_orchestration_templates.rb
@@ -1,5 +1,7 @@
 class AddOrderableToOrchestrationTemplates < ActiveRecord::Migration
-  class OrchestrationTemplate < ActiveRecord::Base; end
+  class OrchestrationTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
 
   def self.up
     add_column :orchestration_templates, :orderable, :boolean

--- a/db/migrate/20160214115800_inline_ems_id.rb
+++ b/db/migrate/20160214115800_inline_ems_id.rb
@@ -1,7 +1,5 @@
 class InlineEmsId < ActiveRecord::Migration
-  class ContainerDefinition < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class ContainerDefinition < ActiveRecord::Base; end
 
   class ContainerGroup < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
@@ -15,8 +13,6 @@ class InlineEmsId < ActiveRecord::Migration
   end
 
   class ContainerDefinition < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-
     belongs_to :container_group, :class_name => "InlineEmsId::ContainerGroup"
   end
 

--- a/lib/migration_stub_helper.rb
+++ b/lib/migration_stub_helper.rb
@@ -11,8 +11,5 @@ module MigrationStubHelper
     def self.name
       super.split("::")[1..-1].join("::")
     end
-
-    # Disable STI, so we don't have to define every subclass
-    self.inheritance_column = :_type_disabled
   end
 end


### PR DESCRIPTION
related https://github.com/ManageIQ/manageiq/issues/6739
based on comments:
https://github.com/ManageIQ/manageiq/pull/5554#discussion_r45544458 or https://github.com/ManageIQ/manageiq/issues/6739#issuecomment-185972452

this script helpded me:
```ruby
# prepare
#system("mkdir db/migrate_temp")
#Dir.glob("db/migrate/*").each do |f|
#  next if File.directory?(f)
#  next if f.include?("20130923182042_collapsed_initial_migration.rb")
#  f_with_new_path = f.gsub('migrate', 'migrate_temp')
#  system("mv #{f} #{f_with_new_path}")
#end
# system("rake db:migrate")

Dir.glob("db/migrate_temp/*").each do |f|
  next if File.directory?(f)
  f_with_new_path = f.gsub('migrate_temp', 'migrate')
  system("cp #{f} #{f_with_new_path}")
  system("rake db:migrate &>/dev/null")
  migration_info = get_migration_info(f_with_new_path)
  if migration_info.present?
    migration_info.map! do |klass_stub|
      klass_stub[:suggestion] = klass_stub[:sti_should_be_disabled] ? "ADD it -> " : "REMOVE it -> "
      klass_stub[:where] = "#{klass_stub[:f]} for #{klass_stub[:klass_stub]}"
      puts klass_stub[:suggestion] + klass_stub[:where]
    end
  end
end

def get_migration_info(f)
  type_column_exists = lambda { |t| ActiveRecord::Base.connection.column_exists?(t, :type) }
  table_exist = lambda { |t| ActiveRecord::Base.connection.data_source_exists?(t) }
  sti_disabled_in_stub = lambda do |content|
    content.include?("self.inheritance_column = :_type_disabled") ||
        content.include?("MigrationStubHelper")
  end
  matches = File.read(f).scan(/\s+class (.*) < ActiveRecord::Base([\s\S]*?)end/)
  if matches.present?
    out_array = []
    matches.each do |match|
      klass_stub, klass_content = match
      tbl_exist                 = table_exist.call(klass_stub.tableize.to_sym)
      sti_dis_in_stub           = sti_disabled_in_stub.call(klass_content)
      sti_should_be_disabled    = tbl_exist ? type_column_exists.call(klass_stub.tableize.to_sym) : false

      unless sti_should_be_disabled == sti_dis_in_stub
        out_array.push({:f => f, :klass_stub    => klass_stub,
                       :table_exist            => tbl_exist,
                       :sti_disabled_stub      => sti_dis_in_stub,
                       :sti_should_be_disabled => sti_should_be_disabled})
      end
    end
    out_array
  else
    []
  end
end
```

cc @Fryguy @jrafanie 