### PR TITLE
Fix for - undefined method `split' for 1:Fixnum

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -265,7 +265,7 @@ module OpsController::OpsRbac
     assert_privileges("rbac_user_delete")
     users = []
     unless params[:id] # showing a list
-      ids = find_checked_items.collect { |r| from_cid(r.split("-").last) }
+      ids = find_checked_items.collect { |r| from_cid(r.to_s.split("-").last) }
       users = User.where(:id => ids).compact
       if users.empty?
         add_flash(_("Default %{model} \"%{name}\" cannot be deleted") % {:model => ui_lookup(:model => "User"), :name => "Administrator"}, :error)
@@ -314,7 +314,7 @@ module OpsController::OpsRbac
     assert_privileges("rbac_role_delete")
     roles = []
     if !params[:id] # showing a role list
-      ids = find_checked_items.collect { |r| from_cid(r.split("-").last) }
+      ids = find_checked_items.collect { |r| from_cid(r.to_s.split("-").last) }
       roles = MiqUserRole.where(:id => ids)
       process_roles(roles, "destroy") unless roles.empty?
     else # showing 1 role, delete it
@@ -377,7 +377,7 @@ module OpsController::OpsRbac
     assert_privileges("rbac_group_delete")
     groups = []
     if !params[:id] # showing a list
-      ids = find_checked_items.collect { |r| from_cid(r.split("-").last) }
+      ids = find_checked_items.collect { |r| from_cid(r.to_s.split("-").last) }
       groups = MiqGroup.where(:id => ids)
       process_groups(groups, "destroy") unless groups.empty?
       self.x_node  = "xx-g"  # reset node to show list

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -351,8 +351,8 @@ module OpsController::OpsRbac
     assert_privileges("rbac_tenant_delete")
     tenants = []
     if !params[:id] # showing a tenants list
-      ids = find_checked_items.collect { |r| from_cid(r.split("-").last) }
-      tenants = Tenant.where(:id => ids)
+      ids = find_checked_items.collect { |r| from_cid(r.to_s.split("-").last) }
+      tenants = Tenant.where(:id => ids).to_a
       tenants.reject! do |t|
         t.parent.nil?
         add_flash(_("Default %{model} \"%{name}\" can not be deleted") % {:model => ui_lookup(:model => "Tenant"),

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -99,6 +99,26 @@ describe OpsController do
         expect(flash_message[:message]).to include("Error during delete")
         expect(flash_message[:level]).to be(:error)
       end
+
+      it "deletes checked tenant records successfully" do
+        allow(ApplicationHelper).to receive(:role_allows).and_return(true)
+        t = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
+        sb_hash = {
+            :trees       => {:rbac_tree => {:active_node => "tn-#{controller.to_cid(t.id)}"}},
+            :active_tree => :rbac_tree,
+            :active_tab  => "rbac_details"
+        }
+        controller.instance_variable_set(:@sb, sb_hash)
+        allow(controller).to receive(:find_checked_items).and_return([t.id])
+        expect(controller).to receive(:x_active_tree_replace_cell)
+        expect(controller).to receive(:render)
+        expect(response.status).to eq(200)
+        controller.send(:rbac_tenant_delete)
+
+        flash_message = assigns(:flash_array).first
+        expect(flash_message[:message]).to include("Delete successful")
+        expect(flash_message[:level]).to be(:success)
+      end
     end
 
     context "#rbac_tenants_list" do

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -104,14 +104,13 @@ describe OpsController do
         allow(ApplicationHelper).to receive(:role_allows).and_return(true)
         t = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
         sb_hash = {
-            :trees       => {:rbac_tree => {:active_node => "tn-#{controller.to_cid(t.id)}"}},
-            :active_tree => :rbac_tree,
-            :active_tab  => "rbac_details"
+          :trees       => {:rbac_tree => {:active_node => "tn-#{controller.to_cid(t.id)}"}},
+          :active_tree => :rbac_tree,
+          :active_tab  => "rbac_details"
         }
         controller.instance_variable_set(:@sb, sb_hash)
         allow(controller).to receive(:find_checked_items).and_return([t.id])
         expect(controller).to receive(:x_active_tree_replace_cell)
-        expect(controller).to receive(:render)
         expect(response.status).to eq(200)
         controller.send(:rbac_tenant_delete)
 


### PR DESCRIPTION
A couple of ```to_s``` conversions were applied in order to address the ```undefined method `split' for 1:Fixnum``` error, since ```.split``` was being applied to ```Fixnum``` directly.

I attribute this to rails5 because I did not see this error in rails4.

Fixes #7230

EDIT: ```to_a``` was also required for the output of ```Tenant.where(:id => ids)``` since ```.reject!``` was giving an ```undefined method``` as well (rails5 again)