### PR TITLE
Optionally allow for Automate state fields to contain methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_state_machine.rb
@@ -1,5 +1,7 @@
 module MiqAeEngine
   module MiqAeStateMachine
+
+    STATE_METHOD_REGEX = Regexp.new(/^METHOD::(.*$)/i)
     def state_runnable?(f)
       return false unless (@workspace.root['ae_state'] == f['name'])
       return false unless (@workspace.root['ae_result'] == 'ok')
@@ -106,8 +108,13 @@ module MiqAeEngine
         $miq_ae_logger.info "Processing State=[#{f['name']}]"
         @workspace.root['ae_state_step'] = 'main'
         enforce_state_maxima(f)
-        process_relationship_raw(relationship, message, args, f['name'], f['collect'])
-        raise MiqAeException::MiqAeDatastoreError, "empty relationship" unless @rels[f['name']]
+        match_data = STATE_METHOD_REGEX.match(relationship)
+        if match_data
+          process_method_raw(match_data[1])
+        else
+          process_relationship_raw(relationship, message, args, f['name'], f['collect'])
+          raise MiqAeException::MiqAeDatastoreError, "empty relationship" unless @rels[f['name']]
+        end
         $miq_ae_logger.info "Processed  State=[#{f['name']}] with Result=[#{@workspace.root['ae_result']}]"
       end
     end

--- a/spec/lib/miq_automation_engine/miq_ae_state_machine_new_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_state_machine_new_spec.rb
@@ -7,6 +7,10 @@ describe "MiqAeStateMachine" do
       def initialize(workspace)
         @workspace = workspace
       end
+
+      def get_value(_f, type)
+        @workspace.root[type]
+      end
     end
   end
 
@@ -76,6 +80,29 @@ describe "MiqAeStateMachine" do
             expect { obj.enforce_max_time('max_time' => '6.seconds') }.to_not raise_error
           end
         end
+      end
+    end
+  end
+
+  describe "#process_state_relationship" do
+    context "method" do
+      let(:options) { {:aetype_relationship => "Method::my_method"} }
+      it "check it calls method" do
+        obj = test_class
+        expect(obj).to receive(:process_method_raw).with('my_method').once.and_return({})
+        expect(obj).to receive(:enforce_state_maxima).with(any_args).once.and_return({})
+        obj.process_state_relationship({'name' => 'a'}, "abc", nil)
+      end
+    end
+
+    context "relationship" do
+      let(:options) { {:aetype_relationship => "my_relations"} }
+      it "check it calls relationship" do
+        obj = test_class
+        obj.instance_variable_set(:@rels, 'a' => "test")
+        expect(obj).to receive(:process_relationship_raw).with('my_relations', 'abc', nil, 'a', nil).once.and_return({})
+        expect(obj).to receive(:enforce_state_maxima).with(any_args).once.and_return({})
+        obj.process_state_relationship({'name' => 'a'}, "abc", nil)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/iDPInXVU

An automate state field only contains relationships to instances and cannot contain methods. Users had to use the 'on_entry' slot to reference a method in the current class. This enhancement allows a user to use an Automate method in the current class using the keyword METHOD:: in a state field.


e.g.

field1                 METHOD::my_method_name

or

field1                /ManageIQ/Infrastructure/SomeClass/SomeInstance