### PR TITLE
[WIP] Get all resources for all subscriptions for Azure refresh parser

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -14,7 +14,7 @@ gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails
 
 # Not locally modified and not required
 gem "awesome_spawn",           "~> 1.3",            :require => false
-gem "azure-armrest",           "~> 0.2.4"
+gem "azure-armrest",           "~> 0.2.5"
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - b8d3c068-ce0b-431b-a568-dc397ab76f00
+      - 9ffee653-7156-4891-90a3-0b9dd01c6267
       Client-Request-Id:
-      - 0e71247a-bfa5-4c24-972f-a08eaaef99f2
+      - f9d6804a-b750-4196-99ed-3f21be3d1b0f
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_396
+      - ESTSFE_IN_153
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -47,18 +47,18 @@ http_interactions:
       Set-Cookie:
       - flight-uxoptin=true; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 06 Apr 2016 20:50:10 GMT
+      - Mon, 11 Apr 2016 23:31:37 GMT
       Content-Length:
       - '1247'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1459979410","not_before":"1459975510","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ"}'
+      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1460421097","not_before":"1460417197","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA"}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:11 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -75,7 +75,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -96,21 +96,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 18e84a27-3b11-433a-9aa2-4c48b6cfe145
+      - 562ed3c0-4a12-4ec0-af91-4344d34c180e
       X-Ms-Correlation-Request-Id:
-      - 18e84a27-3b11-433a-9aa2-4c48b6cfe145
+      - 562ed3c0-4a12-4ec0-af91-4344d34c180e
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205011Z:18e84a27-3b11-433a-9aa2-4c48b6cfe145
+      - NORTHCENTRALUS:20160411T233139Z:562ed3c0-4a12-4ec0-af91-4344d34c180e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:11 GMT
+      - Mon, 11 Apr 2016 23:31:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01"}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:11 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -148,15 +148,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 812dd643-8399-47fa-9eff-3f09eb6915b3
+      - baf61f3a-3f95-4d94-83fd-5e9754290971
       X-Ms-Correlation-Request-Id:
-      - 812dd643-8399-47fa-9eff-3f09eb6915b3
+      - baf61f3a-3f95-4d94-83fd-5e9754290971
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205011Z:812dd643-8399-47fa-9eff-3f09eb6915b3
+      - NORTHCENTRALUS:20160411T233139Z:baf61f3a-3f95-4d94-83fd-5e9754290971
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:11 GMT
+      - Mon, 11 Apr 2016 23:31:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
@@ -211,19 +211,19 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        India","Canada Central","Canada East","South India"],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        India","South India","Canada Central","Canada East"],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
-        India"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Central
+        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
         South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Central
@@ -386,11 +386,11 @@ http_interactions:
         Central US","West Europe","North Europe","East US"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}]},{"namespace":"Microsoft.CortanaAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["West
         US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","Japan
-        East","East Asia"],"apiVersions":["2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2015-07-01-preview"]},{"resourceType":"operations","locations":["West
-        Europe"],"apiVersions":["2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        East","East Asia"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","Japan
-        East","East Asia"],"apiVersions":["2015-07-01-preview"]}]},{"namespace":"Microsoft.DataConnect","resourceTypes":[{"resourceType":"connectionManagers","locations":["West
+        East","East Asia"],"apiVersions":["2016-03-30","2015-07-01-preview"]}]},{"namespace":"Microsoft.DataConnect","resourceTypes":[{"resourceType":"connectionManagers","locations":["West
         US"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":["West
         US"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
         US"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
@@ -484,10 +484,12 @@ http_interactions:
         South","South India","Central India","West India"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]}]},{"namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
-        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India"],"apiVersions":["2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
-        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01","2014-12-19-preview"]}]},{"namespace":"Microsoft.Logic","resourceTypes":[{"resourceType":"workflows","locations":["North
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01","2014-12-19-preview"]}]},{"namespace":"Microsoft.Logic","resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
@@ -587,7 +589,7 @@ http_interactions:
         US","East Asia","Southeast Asia","East US","East US 2","West US","North Central
         US","South Central US","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","West India","South India","Central
-        India"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        India"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -606,28 +608,30 @@ http_interactions:
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
         India"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}]},{"namespace":"Microsoft.Security","resourceTypes":[{"resourceType":"securityStatus","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        India","West India"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"policies","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
-        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-12-01-alpha","2015-07-01-alpha","2015-06-01-preview"]}]},{"namespace":"Microsoft.ServerManagement","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","West India"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US"],"apiVersions":["2016-01-15-alpha","2016-01-03-alpha","2016-01-02-alpha","2016-01-01-alpha","2015-06-01-preview"]}]},{"namespace":"Microsoft.ServerManagement","resourceTypes":[{"resourceType":"operations","locations":["Central
         US","East US","North Europe","West Europe"],"apiVersions":["2015-07-01-preview"]},{"resourceType":"gateways","locations":["Central
         US","East US","North Europe","West Europe"],"apiVersions":["2015-07-01-preview"]},{"resourceType":"nodes","locations":["Central
         US","East US","North Europe","West Europe"],"apiVersions":["2015-07-01-preview"]}]},{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
@@ -1096,7 +1100,59 @@ http_interactions:
         US","Australia Southeast","Australia East","South Central US"],"apiVersions":["2014-04-01"]}]},{"namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["West
         US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:12 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 9d4522d6-33d2-4c78-860f-773b1854026b
+      X-Ms-Correlation-Request-Id:
+      - 9d4522d6-33d2-4c78-860f-773b1854026b
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160411T233140Z:9d4522d6-33d2-4c78-860f-773b1854026b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 11 Apr 2016 23:31:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01"}}]}'
+    http_version: 
+  recorded_at: Mon, 11 Apr 2016 23:31:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
@@ -1113,7 +1169,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -1130,25 +1186,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 64459e50-e60c-47cd-a424-3d2693103b1e
+      - f9d7940e-5fcf-4359-adc2-057952793f4b
       X-Ms-Correlation-Request-Id:
-      - 64459e50-e60c-47cd-a424-3d2693103b1e
+      - f9d7940e-5fcf-4359-adc2-057952793f4b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205012Z:64459e50-e60c-47cd-a424-3d2693103b1e
+      - NORTHCENTRALUS:20160411T233141Z:f9d7940e-5fcf-4359-adc2-057952793f4b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:12 GMT
+      - Mon, 11 Apr 2016 23:31:41 GMT
       Content-Length:
       - '566'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:12 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1162,7 +1218,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -1172,8 +1228,6 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -1181,206 +1235,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ce0adda5-c3d3-4463-9411-1d6546ca1c21
+      - 0a45b7b3-ff2d-42e6-8933-c0a512ef9bc9
+      X-Ms-Correlation-Request-Id:
+      - 0a45b7b3-ff2d-42e6-8933-c0a512ef9bc9
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160411T233143Z:0a45b7b3-ff2d-42e6-8933-c0a512ef9bc9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - 42aa7f49-8eab-46af-a56d-8a3e4edb33bb
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205013Z:42aa7f49-8eab-46af-a56d-8a3e4edb33bb
       Date:
-      - Wed, 06 Apr 2016 20:50:13 GMT
+      - Mon, 11 Apr 2016 23:31:42 GMT
+      Content-Length:
+      - '20440'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1390\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \     \"etag\": \"W/\\\"be9db298-404b-48b5-8e0c-63380d9804e5\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"be9db298-404b-48b5-8e0c-63380d9804e5\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-13-FA-EC\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1989\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\",\r\n
-        \     \"etag\": \"W/\\\"6d12eaea-c831-4bc1-aeb0-731bb624193f\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"134a6669-ac4a-4d08-a0db-387bc4c49537\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"6d12eaea-c831-4bc1-aeb0-731bb624193f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.17.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"fgekpbyth0luvg2bjbwzhttehb.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-12-7B-2C\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12610\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\",\r\n
-        \     \"etag\": \"W/\\\"e9af206a-fc17-489c-b479-6a6168907ff6\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"5c2eef2c-0b36-4277-a940-957ed4d13be0\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"e9af206a-fc17-489c-b479-6a6168907ff6\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.18.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"odsypf5qp3jedifl1jx0cc3eng.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-10-02-DD\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg241\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\",\r\n
-        \     \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.7\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg724\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724\",\r\n
-        \     \"etag\": \"W/\\\"890c589e-07f2-4c8e-8524-268e24646fef\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"bef7b677-30b7-460b-a6e3-3004f093da99\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"890c589e-07f2-4c8e-8524-268e24646fef\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.6\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1611\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \     \"etag\": \"W/\\\"995abf1f-cef0-4b19-bddd-9203f157cffd\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"995abf1f-cef0-4b19-bddd-9203f157cffd\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.5\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic0\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \     \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.0.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n
-        \                 \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \               }\r\n              ],\r\n              \"loadBalancerInboundNatRules\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n
-        \       \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\":
-        [],\r\n          \"internalDomainNameSuffix\": \"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"virtualMachine\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
-        \     \"etag\": \"W/\\\"92bde856-e663-4de1-8ca7-068103585381\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"92bde856-e663-4de1-8ca7-068103585381\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.0.0.5\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n
-        \                 \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \               }\r\n              ],\r\n              \"loadBalancerInboundNatRules\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n
-        \       \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\":
-        [],\r\n          \"internalDomainNameSuffix\": \"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"virtualMachine\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
+      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"f26b349c-27ab-4d7b-9c82-1e0e7497e8b1\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"f26b349c-27ab-4d7b-9c82-1e0e7497e8b1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"}}},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"be9db298-404b-48b5-8e0c-63380d9804e5\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"be9db298-404b-48b5-8e0c-63380d9804e5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-13-FA-EC","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"}}},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"e62526a2-eb18-405d-9669-402845eaa82b\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"e62526a2-eb18-405d-9669-402845eaa82b\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"fgekpbyth0luvg2bjbwzhttehb.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-DE-D7","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"}}},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"e9af206a-fc17-489c-b479-6a6168907ff6\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"e9af206a-fc17-489c-b479-6a6168907ff6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"odsypf5qp3jedifl1jx0cc3eng.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-02-DD","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"}}},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"}}},{"name":"miq-test-winimg724","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"bef7b677-30b7-460b-a6e3-3004f093da99","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg"}}},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"995abf1f-cef0-4b19-bddd-9203f157cffd\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"995abf1f-cef0-4b19-bddd-9203f157cffd\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"}}},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"}}},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"}}},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"35899d1f-e10c-471c-93f4-5ef78cee4ec8\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"35899d1f-e10c-471c-93f4-5ef78cee4ec8\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-91-58-E8","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"}}},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"c95b4a3c-ea6f-4ff6-bde2-a5c3e9397eb3\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"c95b4a3c-ea6f-4ff6-bde2-a5c3e9397eb3\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-91-5F-F0","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"}}},{"name":"miqazure-sharednic1-dyn","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e1344ec7-08bf-487b-84d5-51b9c70e7ddc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"}}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:13 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1394,7 +1267,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -1404,8 +1277,6 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -1413,485 +1284,70 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5a4869ce-9655-4547-8554-1b4065d32ad5
+      - 65660e50-8f63-4aed-ad6f-686f9fb7cea0
+      X-Ms-Correlation-Request-Id:
+      - 65660e50-8f63-4aed-ad6f-686f9fb7cea0
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160411T233144Z:65660e50-8f63-4aed-ad6f-686f9fb7cea0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - ba328434-909b-4a88-8732-0a56b489547b
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205014Z:ba328434-909b-4a88-8732-0a56b489547b
       Date:
-      - Wed, 06 Apr 2016 20:50:13 GMT
+      - Mon, 11 Apr 2016 23:31:44 GMT
+      Content-Length:
+      - '37872'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
-        \     \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n
-        \       \"securityRules\": [\r\n          {\r\n            \"name\": \"default-allow-ssh\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"rhel1-inbound1\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"80\",\r\n              \"destinationPortRange\": \"80\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 100,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"rhel1-inbound2\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"443\",\r\n              \"destinationPortRange\": \"443\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 200,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miq-test-ubuntu1\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\",\r\n
-        \     \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"71d7bf65-e381-4a93-947e-d9d3d1e8184f\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-ssh\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/securityRules/default-allow-ssh\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miq-test-win12\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\",\r\n
-        \     \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"b0ec472f-5934-4415-9bfe-e3d3fb679e66\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-rdp\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/securityRules/default-allow-rdp\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"3389\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miq-test-winimg\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg\",\r\n
-        \     \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"2946a0a6-cb60-42b0-9083-bfff52256da6\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-rdp\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/securityRules/default-allow-rdp\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"3389\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miqazure-centos1\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
-        \     \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-ssh\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miqtestwinimg3696\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696\",\r\n
-        \     \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"e3c9f688-d2e9-4fba-9f3a-4cac2e9dcdb7\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-rdp\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/securityRules/default-allow-rdp\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"3389\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"1b43094e-d28d-46b6-af3a-f2701904f448","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/securityRules/default-allow-ssh","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/DenyAllInBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235"}]}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}},{"name":"rhel1-inbound1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"80","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}},{"name":"rhel1-inbound2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"443","destinationPortRange":"443","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":200,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"}]}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"71d7bf65-e381-4a93-947e-d9d3d1e8184f","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/securityRules/default-allow-ssh","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllInBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"}]}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b0ec472f-5934-4415-9bfe-e3d3fb679e66","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/securityRules/default-allow-rdp","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetInBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllInBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllOutBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610"}]}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"2946a0a6-cb60-42b0-9083-bfff52256da6","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/securityRules/default-allow-rdp","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetInBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllInBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllOutBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724"}]}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"9ca49a93-6f7d-464c-b23d-e61e847ce2d6","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"}]}},{"name":"miqtestwinimg3696","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e3c9f688-d2e9-4fba-9f3a-4cac2e9dcdb7","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/securityRules/default-allow-rdp","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetInBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllInBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllOutBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241"}]}},{"name":"miqazure-sharednsg1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","type":"Microsoft.Network/networkSecurityGroups","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f6baaa43-dacf-4e3f-8643-f4445a3f8209","securityRules":[{"name":"miqazure-inbound1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/securityRules/miqazure-inbound1","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","protocol":"*","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993"}]}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:14 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:45 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2016-03-30
@@ -1908,7 +1364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -1929,20 +1385,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - ccd7b166-80b3-4dec-ae1d-f0b1dad5cfeb
+      - 62064750-c608-472d-85f8-edc19cff96dd
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 297f477d-06c9-4387-b3e0-28bc36a2b518
+      - d706acf1-074d-4de8-b8a0-a1d9e26d9b30
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205014Z:297f477d-06c9-4387-b3e0-28bc36a2b518
+      - NORTHCENTRALUS:20160411T233145Z:d706acf1-074d-4de8-b8a0-a1d9e26d9b30
       Date:
-      - Wed, 06 Apr 2016 20:50:14 GMT
+      - Mon, 11 Apr 2016 23:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n
@@ -2076,7 +1532,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 16\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:15 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:45 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -2093,7 +1549,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -2110,17 +1566,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14993'
       X-Ms-Request-Id:
-      - 6b77ce77-1843-4272-9229-8f7fa9c63bb6
+      - 7eaa1641-df9c-4683-9e01-a29dc5aabead
       X-Ms-Correlation-Request-Id:
-      - 6b77ce77-1843-4272-9229-8f7fa9c63bb6
+      - 7eaa1641-df9c-4683-9e01-a29dc5aabead
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205016Z:6b77ce77-1843-4272-9229-8f7fa9c63bb6
+      - NORTHCENTRALUS:20160411T233146Z:7eaa1641-df9c-4683-9e01-a29dc5aabead
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:15 GMT
+      - Mon, 11 Apr 2016 23:31:46 GMT
       Content-Length:
       - '40155'
     body:
@@ -2128,7 +1584,7 @@ http_interactions:
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010","name":"Microsoft.WindowsServer2012R2Datacenter-20160222104010","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A1"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg241"},"networkSecurityGroupName":{"type":"String","value":"miqtestwinimg3696"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqtestwinimg6202"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.5830069Z","duration":"PT10M55.2480986S","correlationId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg241"},{"id":"Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},{"id":"Microsoft.Network/publicIpAddresses/miqtestwinimg6202"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646","name":"Microsoft.WindowsServer2012R2Datacenter-20160222101646","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg724"},"networkSecurityGroupName":{"type":"String","value":"miq-test-winimg"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miq-test-winimg"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.8666296Z","duration":"PT10M47.5658692S","correlationId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg724"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-winimg"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-winimg"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019","name":"Microsoft.WindowsServer2012R2Datacenter-20160218113019","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-win12"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miqazuretest19881"},"networkInterfaceName":{"type":"String","value":"miq-test-win12610"},"networkSecurityGroupName":{"type":"String","value":"miq-test-win12"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest14047"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.18.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.18.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-win12"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.8337856Z","duration":"PT11M9.8080785S","correlationId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-win12"},{"id":"Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-win12610"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-win12"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-win12"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest19881"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest14047"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651","name":"Canonical.UbuntuServer1510-20160218112651","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-ubuntu1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest16487"},"virtualNetworkName":{"type":"String","value":"miqazuretest18687"},"networkInterfaceName":{"type":"String","value":"miq-test-ubuntu1989"},"networkSecurityGroupName":{"type":"String","value":"miq-test-ubuntu1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest16487"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.17.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.17.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-ubuntu1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.2528115Z","duration":"PT4M10.3614981S","correlationId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-ubuntu1"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest18687"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest16487"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:16 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
@@ -2145,7 +1601,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -2162,24 +1618,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14989'
       X-Ms-Request-Id:
-      - 2beb15af-4da6-47e0-b6e5-129dde8871c1
+      - 96fdcb22-e8b0-43a4-98d8-58884277e93e
       X-Ms-Correlation-Request-Id:
-      - 2beb15af-4da6-47e0-b6e5-129dde8871c1
+      - 96fdcb22-e8b0-43a4-98d8-58884277e93e
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205016Z:2beb15af-4da6-47e0-b6e5-129dde8871c1
+      - NORTHCENTRALUS:20160411T233147Z:96fdcb22-e8b0-43a4-98d8-58884277e93e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:16 GMT
+      - Mon, 11 Apr 2016 23:31:47 GMT
       Content-Length:
       - '5777'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:17 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:48 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json
@@ -2215,19 +1671,19 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2822:5B24:ABB4B2:57057688
+      - 17EB2C22:4DBC:7C8DD97:570C33E2
       Content-Length:
       - '10366'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 06 Apr 2016 20:50:17 GMT
+      - Mon, 11 Apr 2016 23:31:49 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-ord1742-ORD
+      - cache-dfw1845-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -2237,9 +1693,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - b628f37dfe5e04b51ccdb94ec593b375f17f07da
+      - 228f965cb33c4c5f05d203f6c643d8b3e68a5b89
       Expires:
-      - Wed, 06 Apr 2016 20:55:17 GMT
+      - Mon, 11 Apr 2016 23:36:49 GMT
       Source-Age:
       - '0'
     body:
@@ -2589,7 +2045,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:17 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2014-04-01-preview
@@ -2606,7 +2062,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -2625,22 +2081,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14986'
       X-Ms-Request-Id:
-      - 45f60b29-3f60-4e5e-9c2c-564e15449a2c
+      - cd7aac7d-9631-4a1c-a710-82f7103155c4
       X-Ms-Correlation-Request-Id:
-      - 45f60b29-3f60-4e5e-9c2c-564e15449a2c
+      - cd7aac7d-9631-4a1c-a710-82f7103155c4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205018Z:45f60b29-3f60-4e5e-9c2c-564e15449a2c
+      - NORTHCENTRALUS:20160411T233149Z:cd7aac7d-9631-4a1c-a710-82f7103155c4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:17 GMT
+      - Mon, 11 Apr 2016 23:31:48 GMT
       Content-Length:
       - '680'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:18 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:49 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json
@@ -2676,19 +2132,19 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB281F:5B26:2206BD4:57057689
+      - 17EB2C1F:4DBF:1002EF2C:570C33E5
       Content-Length:
       - '3830'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 06 Apr 2016 20:50:18 GMT
+      - Mon, 11 Apr 2016 23:31:50 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-ord1728-ORD
+      - cache-dfw1829-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -2698,9 +2154,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 7764b9a2d320a2af0237ac645de4e922306f78b0
+      - 2453b15f153408c60d4ca36e198cea62328907e4
       Expires:
-      - Wed, 06 Apr 2016 20:55:18 GMT
+      - Mon, 11 Apr 2016 23:36:50 GMT
       Source-Age:
       - '0'
     body:
@@ -2841,7 +2297,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:18 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations?api-version=2014-04-01-preview
@@ -2858,7 +2314,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -2875,24 +2331,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14985'
       X-Ms-Request-Id:
-      - 35fa5ba6-0dc6-4fc7-a58c-b3b5204399fd
+      - 69110be6-a775-4d75-b963-567b7774b6e3
       X-Ms-Correlation-Request-Id:
-      - 35fa5ba6-0dc6-4fc7-a58c-b3b5204399fd
+      - 69110be6-a775-4d75-b963-567b7774b6e3
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205019Z:35fa5ba6-0dc6-4fc7-a58c-b3b5204399fd
+      - NORTHCENTRALUS:20160411T233150Z:69110be6-a775-4d75-b963-567b7774b6e3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:18 GMT
+      - Mon, 11 Apr 2016 23:31:50 GMT
       Content-Length:
       - '5298'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:06.7915034Z","duration":"PT3M1.4329712S","trackingId":"b747ec27-f04a-4dc5-a097-03b78d06b4f3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:48:05.2174686Z","duration":"PT7M35.1627165S","trackingId":"dc765fff-be2e-485c-b812-26cbaf08492c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/3FD73BA3A618D357","operationId":"3FD73BA3A618D357","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:29.9601151Z","duration":"PT2.604551S","trackingId":"280b442e-2010-45a6-b9b2-ac761d5dee7d","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:18.3026417Z","duration":"PT4.8364985S","trackingId":"7d2f970a-57fc-40b4-9152-2c3c883d58c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/6CCA0B3A82197571","operationId":"6CCA0B3A82197571","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.0300385Z","duration":"PT13.4143548S","trackingId":"0830ff7f-fb77-44f0-a393-6003873380e8","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/291C0AC5D4F88BDB","operationId":"291C0AC5D4F88BDB","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.2645854Z","duration":"PT13.7950357S","trackingId":"bfd21915-f13e-4ece-a48c-19a5a9a58fcd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:14.3483638Z","duration":"PT0.8769498S","trackingId":"54ee2082-f487-4f98-b5da-08f4fb8450ac","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/08587429420731427531","operationId":"08587429420731427531","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.53375Z","duration":"PT0.5447355S","trackingId":"d4fae0de-498c-4177-8239-46a0f58e2ebf","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:19 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations?api-version=2014-04-01-preview
@@ -2909,7 +2365,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -2926,24 +2382,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14916'
       X-Ms-Request-Id:
-      - 8d17ab02-a3dc-4682-a3d6-c5374ce90e9b
+      - 09ef27b4-7055-4568-b888-a316a56eb6e7
       X-Ms-Correlation-Request-Id:
-      - 8d17ab02-a3dc-4682-a3d6-c5374ce90e9b
+      - 09ef27b4-7055-4568-b888-a316a56eb6e7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205019Z:8d17ab02-a3dc-4682-a3d6-c5374ce90e9b
+      - NORTHCENTRALUS:20160411T233151Z:09ef27b4-7055-4568-b888-a316a56eb6e7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:19 GMT
+      - Mon, 11 Apr 2016 23:31:51 GMT
       Content-Length:
       - '5293'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.1806556Z","duration":"PT3M14.7317782S","trackingId":"2e8bc5df-290e-4427-9d7e-b07dc8b56157","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:24:20.3730557Z","duration":"PT7M15.3472227S","trackingId":"b15735ed-1f9c-4235-8554-0359a94d8021","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/FAC43E00E60F40D6","operationId":"FAC43E00E60F40D6","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:04.9686575Z","duration":"PT1.7424043S","trackingId":"9cd93d46-01d3-4fcb-9d33-32d362efad6b","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/4A34D86BCACDE87A","operationId":"4A34D86BCACDE87A","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.172193Z","duration":"PT13.1694927S","trackingId":"f1189e74-dc7c-4a8e-9f87-f125c87fac6e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/857E6EBF700A64F8","operationId":"857E6EBF700A64F8","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.1483554Z","duration":"PT13.0919048S","trackingId":"ca1bda1a-fda1-4270-8442-a3145bfbe1f2","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:51.1217903Z","duration":"PT1.1217779S","trackingId":"76e77bc0-53a4-4df3-a941-4c5e007b6a66","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:50.9535836Z","duration":"PT0.9351894S","trackingId":"de79265b-c4a2-457b-807a-9e98060a82f6","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/08587429434771769170","operationId":"08587429434771769170","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.7888649Z","duration":"PT0.5055897S","trackingId":"d03c7b95-d9d8-48bb-a526-41e9651ad971","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:19 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2014-04-01-preview
@@ -2960,7 +2416,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -2977,24 +2433,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14988'
       X-Ms-Request-Id:
-      - fe2d2a09-eee4-45e6-810c-2aa24b9bf221
+      - 0fac8ad5-6c39-4bb6-b3fd-f30a50169ecf
       X-Ms-Correlation-Request-Id:
-      - fe2d2a09-eee4-45e6-810c-2aa24b9bf221
+      - 0fac8ad5-6c39-4bb6-b3fd-f30a50169ecf
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205020Z:fe2d2a09-eee4-45e6-810c-2aa24b9bf221
+      - NORTHCENTRALUS:20160411T233152Z:0fac8ad5-6c39-4bb6-b3fd-f30a50169ecf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:20 GMT
+      - Mon, 11 Apr 2016 23:31:51 GMT
       Content-Length:
       - '5829'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:20 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations?api-version=2014-04-01-preview
@@ -3011,7 +2467,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3028,24 +2484,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14991'
       X-Ms-Request-Id:
-      - 6dd3b8c0-2bd1-4645-9e04-66fdbcbf3aa6
+      - 20086377-330b-45cf-83c1-3c7c69312402
       X-Ms-Correlation-Request-Id:
-      - 6dd3b8c0-2bd1-4645-9e04-66fdbcbf3aa6
+      - 20086377-330b-45cf-83c1-3c7c69312402
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205021Z:6dd3b8c0-2bd1-4645-9e04-66fdbcbf3aa6
+      - NORTHCENTRALUS:20160411T233153Z:20086377-330b-45cf-83c1-3c7c69312402
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:20 GMT
+      - Mon, 11 Apr 2016 23:31:53 GMT
       Content-Length:
       - '6608'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/15838BCFE46760A1","operationId":"15838BCFE46760A1","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:28.6222483Z","duration":"PT3M20.660116S","trackingId":"a6653508-59b3-4e4a-b796-f1cf431a9162","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/DDBEEC376EA09F7E","operationId":"DDBEEC376EA09F7E","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:38:07.8075094Z","duration":"PT7M9.35647S","trackingId":"943dac3c-a98b-465d-b759-06506e599546","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.5055633Z","duration":"PT0.6114738S","trackingId":"1b754371-18ec-4517-bd38-46c9d2ef975d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.3710882Z","duration":"PT0.4790524S","trackingId":"9dfcf1d7-6e4a-4a73-b17e-13b2afdf9d6b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/7F5153152761DD05","operationId":"7F5153152761DD05","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:38.3445066Z","duration":"PT1.6145978S","trackingId":"861a701b-3964-4754-954c-cb21d5e93db8","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/F97EC162743B5FF4","operationId":"F97EC162743B5FF4","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:57.7800754Z","duration":"PT34.9812759S","trackingId":"92865cda-40cb-41c9-9317-d864b2b3c309","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/EA21060B6C976C52","operationId":"EA21060B6C976C52","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.6308058Z","duration":"PT13.8442357S","trackingId":"e950697d-0ec6-40f5-8d14-7bfae0ecabf5","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/61B1466BCE99F9D3","operationId":"61B1466BCE99F9D3","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.4233646Z","duration":"PT13.6985797S","trackingId":"fd76215f-8c01-4e2a-8068-636237270be4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/58705CE1AC7417FE","operationId":"58705CE1AC7417FE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.5145163Z","duration":"PT13.7848628S","trackingId":"31027583-c7fb-4302-9bbe-9d1f79502a4c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/08587432846644519702","operationId":"08587432846644519702","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.7434262Z","duration":"PT2.0330234S","trackingId":"1bf25585-8cf8-4c99-9078-aa6f5c036128","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:21 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations?api-version=2014-04-01-preview
@@ -3062,7 +2518,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3079,24 +2535,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14983'
       X-Ms-Request-Id:
-      - 0ff93992-1373-47cb-8ca8-a1aa0da8eae5
+      - 86edcc89-6be2-4705-bb01-d2362ce18bcc
       X-Ms-Correlation-Request-Id:
-      - 0ff93992-1373-47cb-8ca8-a1aa0da8eae5
+      - 86edcc89-6be2-4705-bb01-d2362ce18bcc
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205022Z:0ff93992-1373-47cb-8ca8-a1aa0da8eae5
+      - NORTHCENTRALUS:20160411T233154Z:86edcc89-6be2-4705-bb01-d2362ce18bcc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:22 GMT
+      - Mon, 11 Apr 2016 23:31:53 GMT
       Content-Length:
       - '6499'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/056F4B33F11A3099","operationId":"056F4B33F11A3099","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:01.4236054Z","duration":"PT1M23.6187466S","trackingId":"70c620a7-2c3c-4743-ae6f-e3836270f2f1","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/62E621EEEC5E62EE","operationId":"62E621EEEC5E62EE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:29:37.7414996Z","duration":"PT2M9.3834226S","trackingId":"48044c61-7a07-4aff-be71-aeacc2471e7b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.2125225Z","duration":"PT0.642269S","trackingId":"51ea1626-1a59-4e23-8590-445c4ca176d0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/34A4347ECF2A45BE","operationId":"34A4347ECF2A45BE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.1112967Z","duration":"PT0.5497549S","trackingId":"ce1e6b19-7951-4c73-9005-20fe16d36036","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8F3051FDE964A700","operationId":"8F3051FDE964A700","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:09.9030716Z","duration":"PT2.0210551S","trackingId":"ed583a8c-7b18-4b99-a285-f09a67c14a3b","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/9D251C6DB1BEEA3B","operationId":"9D251C6DB1BEEA3B","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:27.4794736Z","duration":"PT33.3813549S","trackingId":"f9366eee-29f7-42e3-b0fe-1f577c8ae55c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/7CE1E6C413F108AC","operationId":"7CE1E6C413F108AC","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.7755462Z","duration":"PT13.6793163S","trackingId":"ca83e042-a8c6-4ffb-9f2c-2e4a9f1bbd7c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/76F60549C9B601F7","operationId":"76F60549C9B601F7","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.0295771Z","duration":"PT12.9355177S","trackingId":"7fb0a493-ee8a-4d59-86f3-f435a2e1deba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/E142660DAD24486A","operationId":"E142660DAD24486A","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.101236Z","duration":"PT12.9593617S","trackingId":"68e1b6fa-040c-450f-bd16-0426d5af0f9f","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/08587432848725863745","operationId":"08587432848725863745","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.1079152Z","duration":"PT1.6252469S","trackingId":"229c4e55-24ce-4126-b6ff-de2aba268ff3","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:22 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2014-04-01-preview
@@ -3113,7 +2569,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3130,27 +2586,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14824'
+      - '14983'
       X-Ms-Request-Id:
-      - 145dc7b0-b6b5-4f09-af5b-f86fab078c1f
+      - 5e5c3850-880e-4137-a15d-b7be30575dda
       X-Ms-Correlation-Request-Id:
-      - 145dc7b0-b6b5-4f09-af5b-f86fab078c1f
+      - 5e5c3850-880e-4137-a15d-b7be30575dda
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205023Z:145dc7b0-b6b5-4f09-af5b-f86fab078c1f
+      - NORTHCENTRALUS:20160411T233155Z:5e5c3850-880e-4137-a15d-b7be30575dda
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:22 GMT
+      - Mon, 11 Apr 2016 23:31:54 GMT
       Content-Length:
       - '6514'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:23 GMT
+  recorded_at: Mon, 11 Apr 2016 23:31:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3164,7 +2620,105 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 47850c8f-51fb-4969-bfea-0b11b44ddb38
+      X-Ms-Correlation-Request-Id:
+      - 47850c8f-51fb-4969-bfea-0b11b44ddb38
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160411T233157Z:47850c8f-51fb-4969-bfea-0b11b44ddb38
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 11 Apr 2016 23:31:56 GMT
+      Content-Length:
+      - '7011'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"name":"miq-azure-test3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","type":"Microsoft.Network/virtualNetworks","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8b01d08a-ea11-45f6-85b2-b7a200de06dd","addressSpace":{"addressPrefixes":["10.20.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.20.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}]}}]}},{"name":"miq-azure-test1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","etag":"W/\"34df1975-22c8-4c87-9071-13a8f5c66279\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915","addressSpace":{"addressPrefixes":["10.16.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default","etag":"W/\"34df1975-22c8-4c87-9071-13a8f5c66279\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.16.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}]}}]}},{"name":"miqazuretest18687","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","etag":"W/\"d65f4b2f-ac55-40d4-822a-8560c917e038\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"87a78829-3e13-4a97-9b81-486d93ce6439","addressSpace":{"addressPrefixes":["10.17.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default","etag":"W/\"d65f4b2f-ac55-40d4-822a-8560c917e038\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.17.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}]}}]}},{"name":"miqazuretest19881","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","etag":"W/\"8c36ba7f-8079-4319-804e-81cd4b183b02\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"9787e570-7ff0-4152-a0ab-da6fa10ba46e","addressSpace":{"addressPrefixes":["10.18.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default","etag":"W/\"8c36ba7f-8079-4319-804e-81cd4b183b02\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.18.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}]}}]}},{"name":"spec0deply1vnet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"0bb1f005-1af2-4d4b-966a-89aaf6daefca","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"Subnet-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1"}]}}]}},{"name":"miqazure-sharedvn1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1","etag":"W/\"6465c041-41a4-428f-b599-0a8419015092\"","type":"Microsoft.Network/virtualNetworks","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f83aa7be-47d0-485b-a614-0c1432fbe518","addressSpace":{"addressPrefixes":["10.19.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default","etag":"W/\"6465c041-41a4-428f-b599-0a8419015092\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.19.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}]}}]}}]}'
+    http_version: 
+  recorded_at: Mon, 11 Apr 2016 23:31:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 123b091f-226c-4153-a155-009c207fb8b6
+      X-Ms-Correlation-Request-Id:
+      - 123b091f-226c-4153-a155-009c207fb8b6
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160411T233159Z:123b091f-226c-4153-a155-009c207fb8b6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 11 Apr 2016 23:31:58 GMT
+      Content-Length:
+      - '14042'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"properties":{"vmId":"796c5bcc-338a-448d-b61c-165279a7fb3e","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"OpenLogic","offer":"CentOS","sku":"7.1","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-centos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-centos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"03e8467b-baab-4867-9cc4-157336b7e2e4","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-rhel1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-rhel1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest18686.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"c4d577ae-4be8-41c1-84f8-642320910a5e","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"15.10","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-ubuntu1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest16487.blob.core.windows.net/vhds/miq-test-ubuntu12016218112647.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-ubuntu1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest16487.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"6e555b88-3fd4-4b72-a404-4bba5d11de93","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-win12","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-win122016218113014.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-win12","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"e17a95b0-f4fb-4196-93c5-0c8be7d5c536","hardwareProfile":{"vmSize":"Basic_A1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-winimg","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg201622210407.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-winimg","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"d7022008-f6b1-4f4c-8be8-e2d677ef3261","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm0","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"4d1502d5-351a-42f4-8569-22284f906d68","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm1","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"440f18d3-d4a7-4660-a7fa-ec955e248c9c","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET1"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"CoreOS","offer":"CoreOS","sku":"Alpha","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-coreos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest32946.blob.core.windows.net/vhds/miqazure-coreos12016218151822.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-coreos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235"}]},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus"},{"properties":{"vmId":"26b70d9d-1022-41b0-aa94-75c2dd526e4a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux1","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux1201621814595.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus"},{"properties":{"vmId":"4ed26e6d-edf8-4868-a174-4daf1ec8713a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux2","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux2201621815529.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux2","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus"}]}'
+    http_version: 
+  recorded_at: Mon, 11 Apr 2016 23:31:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3180,91 +2734,40 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"ff9a2555-ac36-4f02-91aa-312bebc5e381"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6e75beb3-7d8f-4054-af30-86c83a210ebd
+      - 53d8986a-1720-4632-940b-ee0d719e6a9b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - e59f403f-362c-401f-9196-be030969d618
+      - 0f7a815e-2029-4b77-8378-0485bf49d0d0
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205023Z:e59f403f-362c-401f-9196-be030969d618
+      - NORTHCENTRALUS:20160411T233159Z:0f7a815e-2029-4b77-8378-0485bf49d0d0
       Date:
-      - Wed, 06 Apr 2016 20:50:23 GMT
+      - Mon, 11 Apr 2016 23:31:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-azure-test1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \     \"etag\": \"W/\\\"34df1975-22c8-4c87-9071-13a8f5c66279\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.16.0.0/16\"\r\n
-        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"34df1975-22c8-4c87-9071-13a8f5c66279\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.16.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    },\r\n    {\r\n      \"name\": \"miqazuretest18687\",\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687\",\r\n
-        \     \"etag\": \"W/\\\"b8b416e1-eb47-45d4-808a-b2291f03d495\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"87a78829-3e13-4a97-9b81-486d93ce6439\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.17.0.0/16\"\r\n
-        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"b8b416e1-eb47-45d4-808a-b2291f03d495\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.17.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    },\r\n    {\r\n      \"name\": \"miqazuretest19881\",\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881\",\r\n
-        \     \"etag\": \"W/\\\"8c36ba7f-8079-4319-804e-81cd4b183b02\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"9787e570-7ff0-4152-a0ab-da6fa10ba46e\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.18.0.0/16\"\r\n
-        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"8c36ba7f-8079-4319-804e-81cd4b183b02\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.18.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1vnet\",\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
-        \     \"etag\": \"W/\\\"faeb44c8-b1d7-4efb-9551-a713405cde5a\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"0bb1f005-1af2-4d4b-966a-89aaf6daefca\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n          ]\r\n
-        \       },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"Subnet-1\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\",\r\n
-        \           \"etag\": \"W/\\\"faeb44c8-b1d7-4efb-9551-a713405cde5a\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    }\r\n  ]\r\n}"
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"ff9a2555-ac36-4f02-91aa-312bebc5e381\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:24 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3278,7 +2781,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3299,172 +2802,42 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - 4c3181c9-fb02-4ae0-82e5-c6847dde3275
+      - 663418c7-c863-46c9-8af5-99ede2570e1a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 5b50e6ce-3894-40f6-b62b-e0c14be6ff35
+      - 79ecf0e2-d857-4d71-ad1b-1992e6cb6a44
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205024Z:5b50e6ce-3894-40f6-b62b-e0c14be6ff35
+      - NORTHCENTRALUS:20160411T233200Z:79ecf0e2-d857-4d71-ad1b-1992e6cb6a44
       Date:
-      - Wed, 06 Apr 2016 20:50:23 GMT
+      - Mon, 11 Apr 2016 23:32:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\":
-        \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A0\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"RedHat\",\r\n
-        \           \"offer\": \"RHEL\",\r\n            \"sku\": \"7.2\",\r\n            \"version\":
-        \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\":
-        \"Linux\",\r\n            \"name\": \"miq-test-rhel1\",\r\n            \"createOption\":
-        \"FromImage\",\r\n            \"vhd\": {\r\n              \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-rhel1\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
-        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
-        \     \"name\": \"miq-test-rhel1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"c4d577ae-4be8-41c1-84f8-642320910a5e\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A0\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n
-        \           \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"15.10\",\r\n
-        \           \"version\": \"latest\"\r\n          },\r\n          \"osDisk\":
-        {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"miq-test-ubuntu1\",\r\n
-        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
-        \             \"uri\": \"https://miqazuretest16487.blob.core.windows.net/vhds/miq-test-ubuntu12016218112647.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-ubuntu1\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
-        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\",\r\n
-        \     \"name\": \"miq-test-ubuntu1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"6e555b88-3fd4-4b72-a404-4bba5d11de93\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A0\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n
-        \           \"offer\": \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n
-        \           \"version\": \"latest\"\r\n          },\r\n          \"osDisk\":
-        {\r\n            \"osType\": \"Windows\",\r\n            \"name\": \"miq-test-win12\",\r\n
-        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
-        \             \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-win122016218113014.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-win12\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\",\r\n
-        \     \"name\": \"miq-test-win12\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"e17a95b0-f4fb-4196-93c5-0c8be7d5c536\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A1\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n
-        \           \"offer\": \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n
-        \           \"version\": \"latest\"\r\n          },\r\n          \"osDisk\":
-        {\r\n            \"osType\": \"Windows\",\r\n            \"name\": \"miq-test-winimg\",\r\n
-        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
-        \             \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg201622210407.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-winimg\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg\",\r\n
-        \     \"name\": \"miq-test-winimg\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n        \"availabilitySet\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
-        \       },\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Basic_A0\"\r\n
-        \       },\r\n        \"storageProfile\": {\r\n          \"imageReference\":
-        {\r\n            \"publisher\": \"OpenLogic\",\r\n            \"offer\": \"CentOS\",\r\n
-        \           \"sku\": \"7.1\",\r\n            \"version\": \"latest\"\r\n          },\r\n
-        \         \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\":
-        \"miqazure-centos1\",\r\n            \"createOption\": \"FromImage\",\r\n
-        \           \"vhd\": {\r\n              \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miqazure-centos1\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
-        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
-        \     \"name\": \"miqazure-centos1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n        \"availabilitySet\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \       },\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_D1\"\r\n
-        \       },\r\n        \"storageProfile\": {\r\n          \"imageReference\":
-        {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n            \"offer\":
-        \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n            \"version\":
-        \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\":
-        \"Windows\",\r\n            \"name\": \"osdisk\",\r\n            \"createOption\":
-        \"FromImage\",\r\n            \"vhd\": {\r\n              \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"spec0deply1vm0\",\r\n          \"adminUsername\":
-        \"deploy1admin\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
-        \     \"name\": \"spec0deply1vm0\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n        \"availabilitySet\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \       },\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_D1\"\r\n
-        \       },\r\n        \"storageProfile\": {\r\n          \"imageReference\":
-        {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n            \"offer\":
-        \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n            \"version\":
-        \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\":
-        \"Windows\",\r\n            \"name\": \"osdisk\",\r\n            \"createOption\":
-        \"FromImage\",\r\n            \"vhd\": {\r\n              \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"spec0deply1vm1\",\r\n          \"adminUsername\":
-        \"deploy1admin\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
-        \     \"name\": \"spec0deply1vm1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    }\r\n  ]\r\n}"
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-11T23:32:01+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-03-21T17:07:24.107916+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-03-21T17:07:24.1547266+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:24 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:01 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2016-03-30
@@ -3481,7 +2854,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3502,20 +2875,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 66e25cde-73db-4438-b686-1c5a2d875e13
+      - 2fd45e87-8504-4666-82f3-fcc6ec952115
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14963'
       X-Ms-Correlation-Request-Id:
-      - 9c08dd45-7918-42c6-bb43-7abcfca67414
+      - 53db3143-07a0-4503-9f56-bd2068f9cc32
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205025Z:9c08dd45-7918-42c6-bb43-7abcfca67414
+      - NORTHCENTRALUS:20160411T233201Z:53db3143-07a0-4503-9f56-bd2068f9cc32
       Date:
-      - Wed, 06 Apr 2016 20:50:24 GMT
+      - Mon, 11 Apr 2016 23:32:01 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
@@ -3528,10 +2901,10 @@ http_interactions:
         {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:25 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3545,7 +2918,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3566,27 +2939,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - 2cfdf3ba-24a2-4977-b7ea-002564fcf6cf
+      - 47dec4ad-5bf8-4dda-ada7-315956dd8b77
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 220fad4a-2b04-4766-8e98-62bc654e4ecb
+      - 7e2dc93d-693f-4333-8915-ae97d43104e7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205025Z:220fad4a-2b04-4766-8e98-62bc654e4ecb
+      - NORTHCENTRALUS:20160411T233202Z:7e2dc93d-693f-4333-8915-ae97d43104e7
       Date:
-      - Wed, 06 Apr 2016 20:50:25 GMT
+      - Mon, 11 Apr 2016 23:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
         \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2016-04-06T20:50:13+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        \       \"time\": \"2016-04-11T23:31:48+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
         [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
         \       \"typeHandlerVersion\": \"2.3.5\",\r\n        \"status\": {\r\n          \"code\":
         \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
@@ -3600,18 +2973,16 @@ http_interactions:
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
         \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
-        \"2.3.5\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/failed/1\",\r\n
-        \         \"level\": \"Error\",\r\n          \"displayStatus\": \"Provisioning
-        failed\",\r\n          \"message\": \"mdsd stopped:MDSD crash:/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/mdsd:
-        error while loading shared libraries: libglibmm-2.4.so.1: cannot open shared
-        object file: No such file or directory\\n\"\r\n        }\r\n      ]\r\n    }\r\n
-        \ ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-03-18T17:28:50.4032706+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+        \"2.3.5\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
+        \     ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2016-03-18T17:28:50.4032706+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:26 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:02 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1?api-version=2016-03-30
@@ -3628,7 +2999,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3645,40 +3016,40 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"d470b043-afd0-4849-9dfb-f7e134bf802f"
+      - W/"87100693-01bd-4a10-b5c6-0b94e93538b5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b638f5e5-096c-443a-a9ef-5d6fc17df436
+      - e69c4706-5b3d-49d0-80b0-3fc8a97d7122
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - faa65b3f-5f0d-4401-9614-a93ad966f547
+      - 2001a067-ce39-4eae-bc65-e812de394268
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205026Z:faa65b3f-5f0d-4401-9614-a93ad966f547
+      - NORTHCENTRALUS:20160411T233203Z:2001a067-ce39-4eae-bc65-e812de394268
       Date:
-      - Wed, 06 Apr 2016 20:50:26 GMT
+      - Mon, 11 Apr 2016 23:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-ubuntu1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\",\r\n
-        \ \"etag\": \"W/\\\"d470b043-afd0-4849-9dfb-f7e134bf802f\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"87100693-01bd-4a10-b5c6-0b94e93538b5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n    \"ipAddress\": \"13.92.188.25\",\r\n
+        \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n    \"ipAddress\": \"191.237.46.18\",\r\n
         \   \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
         \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
         {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:26 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3692,7 +3063,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3713,26 +3084,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - 63bd571b-5758-4aa9-b93d-b8532bd28e8f
+      - 0249fe69-d116-4059-bf2a-0a652a14fba2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 740fab32-2b12-475b-b92a-99a53e8b038b
+      - 1ff9adcc-a0cf-488c-a5c5-97c28e41435b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205027Z:740fab32-2b12-475b-b92a-99a53e8b038b
+      - NORTHCENTRALUS:20160411T233203Z:1ff9adcc-a0cf-488c-a5c5-97c28e41435b
       Date:
-      - Wed, 06 Apr 2016 20:50:26 GMT
+      - Mon, 11 Apr 2016 23:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.1.2\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2016-04-06T20:50:14+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2016-04-11T23:31:50+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n        \"typeHandlerVersion\":
         \"2.3.5\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
@@ -3740,7 +3111,7 @@ http_interactions:
         \       }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\":
         \"miq-test-ubuntu1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
         \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
-        \"Provisioning succeeded\",\r\n          \"time\": \"2016-03-18T17:29:39.2002487+00:00\"\r\n
+        \"Provisioning succeeded\",\r\n          \"time\": \"2016-04-11T14:43:32.2143678+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e/miq-test-ubuntu1.c4d577ae-4be8-41c1-84f8-642320910a5e.screenshot.bmp\",\r\n
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e/miq-test-ubuntu1.c4d577ae-4be8-41c1-84f8-642320910a5e.serialconsole.log\"\r\n
@@ -3748,17 +3119,17 @@ http_interactions:
         \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
         \"2.3.5\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"message\": \"message in /var/log/mdsd.err:2016-04-04
-        12:07:31:S6_9_Task_ptrIT_E5_TypeERKNS0_IT0_EEEUlS4_E_St17integral_constantIbLb1EENS6_20_TypeSelectorNoAsyncEED0Ev+0x2e)[0x7f932cc0e77e]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvPFvPvENS3_5list1INS3_5valueIS5_EEEEEEE11do_completeEPNS1_15task_io_serviceEPNS1_25task_io_service_operationERKNS_6system10error_codeEm+0x51)[0x7f932d2c1e81]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN5boost4asio6detail15task_io_service3runERNS_6system10error_codeE+0x45f)[0x7f932d20ba2f]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN9crossplat10threadpool12thread_startEPv+0x26)[0x7f932d27fd86]\\n/lib/x86_64-linux-gnu/libpthread.so.0(+0x76aa)[0x7f932b2476aa]\\n/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d)[0x7f932af7ce9d]\\n2016-03-31T05:11:07.2569700Z:
+        succeeded\",\r\n          \"message\": \"message in /var/log/mdsd.err:2016-04-11
+        16:51:10:S6_9_Task_ptrIT_E5_TypeERKNS0_IT0_EEEUlS4_E_St17integral_constantIbLb1EENS6_20_TypeSelectorNoAsyncEED0Ev+0x2e)[0x7f932cc0e77e]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvPFvPvENS3_5list1INS3_5valueIS5_EEEEEEE11do_completeEPNS1_15task_io_serviceEPNS1_25task_io_service_operationERKNS_6system10error_codeEm+0x51)[0x7f932d2c1e81]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN5boost4asio6detail15task_io_service3runERNS_6system10error_codeE+0x45f)[0x7f932d20ba2f]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN9crossplat10threadpool12thread_startEPv+0x26)[0x7f932d27fd86]\\n/lib/x86_64-linux-gnu/libpthread.so.0(+0x76aa)[0x7f932b2476aa]\\n/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d)[0x7f932af7ce9d]\\n2016-03-31T05:11:07.2569700Z:
         ===========\\n2016-04-04T12:07:31.5466830Z: XTR::DoContinuation(): Caught
         exception: Retrieving message chunk header\\n\"\r\n        }\r\n      ]\r\n
         \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-03-18T17:30:51.7158734+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2016-04-11T16:49:17.2053422+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:27 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:04 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12?api-version=2016-03-30
@@ -3775,7 +3146,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3796,20 +3167,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9a9c3574-dd39-4b71-a5c0-7dce83c9eeb0
+      - 59df8940-1982-4a41-9a9c-4f01c325b29d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 3afa7c5c-d3f2-456b-80e1-4278f4e5efde
+      - 16266534-5d78-45b5-b9e6-6e6a50aad64a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205028Z:3afa7c5c-d3f2-456b-80e1-4278f4e5efde
+      - NORTHCENTRALUS:20160411T233204Z:16266534-5d78-45b5-b9e6-6e6a50aad64a
       Date:
-      - Wed, 06 Apr 2016 20:50:28 GMT
+      - Mon, 11 Apr 2016 23:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-win12\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\",\r\n
@@ -3822,10 +3193,10 @@ http_interactions:
         {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:28 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3839,7 +3210,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3860,27 +3231,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - 3d34733e-8bca-4cc5-8ef6-12023e0ccef5
+      - d867d7dc-2da0-4b65-98f5-ac0a1b6c2acc
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - ca343459-3815-45db-9ba4-f8f96d8cb8db
+      - 6bc88163-5614-477c-af35-8c8d237d0949
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205029Z:ca343459-3815-45db-9ba4-f8f96d8cb8db
+      - NORTHCENTRALUS:20160411T233205Z:6bc88163-5614-477c-af35-8c8d237d0949
       Date:
-      - Wed, 06 Apr 2016 20:50:28 GMT
+      - Mon, 11 Apr 2016 23:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.7.1198.735\",\r\n
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
         \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2016-04-06T20:50:22+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        \       \"time\": \"2016-04-11T23:31:53+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
         [\r\n      {\r\n        \"type\": \"Microsoft.Azure.Diagnostics.IaaSDiagnostics\",\r\n
         \       \"typeHandlerVersion\": \"1.5.9.0\",\r\n        \"status\": {\r\n
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
@@ -3907,7 +3278,7 @@ http_interactions:
         \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:29 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:05 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202?api-version=2016-03-30
@@ -3924,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -3945,20 +3316,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ca1e05c6-c1ee-4ef8-93a9-d252c43d4944
+      - 47493bea-1f56-4e37-a06b-38874be7cb59
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - e507abc6-232b-4ff0-87f0-66bc8bfcda4d
+      - fd91c92d-db93-457c-a51e-bae4f511e6d3
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205030Z:e507abc6-232b-4ff0-87f0-66bc8bfcda4d
+      - NORTHCENTRALUS:20160411T233205Z:fd91c92d-db93-457c-a51e-bae4f511e6d3
       Date:
-      - Wed, 06 Apr 2016 20:50:29 GMT
+      - Mon, 11 Apr 2016 23:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miqtestwinimg6202\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\",\r\n
@@ -3970,10 +3341,10 @@ http_interactions:
         4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:30 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3987,7 +3358,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -4008,26 +3379,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - baf2a205-fc3c-4ff1-b757-06367a248900
+      - 4e77c377-0bfb-42e4-9892-0a0eac5df562
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - fc4eec50-5e61-4f32-91f8-7c0c90559e8e
+      - e26d5403-00f7-408c-8a2d-c9a1a0a59af7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205030Z:fc4eec50-5e61-4f32-91f8-7c0c90559e8e
+      - NORTHCENTRALUS:20160411T233206Z:e26d5403-00f7-408c-8a2d-c9a1a0a59af7
       Date:
-      - Wed, 06 Apr 2016 20:50:30 GMT
+      - Mon, 11 Apr 2016 23:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-06T20:50:30+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-11T23:32:06+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -4043,10 +3414,10 @@ http_interactions:
         \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:30 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -4060,70 +3431,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ff9a2555-ac36-4f02-91aa-312bebc5e381"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 432481a7-6041-4441-882a-71bcaccfd91d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 8cabc56a-4410-4fb9-8b6a-9cb9e589b306
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205031Z:8cabc56a-4410-4fb9-8b6a-9cb9e589b306
-      Date:
-      - Wed, 06 Apr 2016 20:50:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \ \"etag\": \"W/\\\"ff9a2555-ac36-4f02-91aa-312bebc5e381\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -4144,100 +3452,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - 5de9c13b-e601-421c-abc1-48b5f8811585
+      - 80004db0-970b-449a-a943-10054ddc36ff
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - cf883ea8-5808-43a7-a3c0-db37586b15fb
+      - 6cd4ad26-7331-414b-992f-388fb1b045e9
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205032Z:cf883ea8-5808-43a7-a3c0-db37586b15fb
+      - NORTHCENTRALUS:20160411T233207Z:6cd4ad26-7331-414b-992f-388fb1b045e9
       Date:
-      - Wed, 06 Apr 2016 20:50:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-06T20:50:31+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-03-21T17:07:24.107916+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-03-21T17:07:24.1547266+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
-      X-Ms-Request-Id:
-      - 914c5426-715f-4661-bb95-d4bc2fbc2d85
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - a44a162d-96bb-449f-a1dd-403d2be4af3a
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205032Z:a44a162d-96bb-449f-a1dd-403d2be4af3a
-      Date:
-      - Wed, 06 Apr 2016 20:50:32 GMT
+      - Mon, 11 Apr 2016 23:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-06T20:50:32+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-11T23:32:07+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -4250,10 +3485,10 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:33 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -4267,7 +3502,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -4288,27 +3523,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131020171355715444
       X-Ms-Request-Id:
-      - c4aea931-0bd1-4949-9030-9b3d715a96e1
+      - 4a043019-d801-4182-88c5-0139e19324a9
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 6e4bab6d-1231-42bc-8c72-a1ee0656046e
+      - e7c870eb-16e6-446e-bb5e-b5fcb8451307
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205033Z:6e4bab6d-1231-42bc-8c72-a1ee0656046e
+      - NORTHCENTRALUS:20160411T233207Z:e7c870eb-16e6-446e-bb5e-b5fcb8451307
       Date:
-      - Wed, 06 Apr 2016 20:50:33 GMT
+      - Mon, 11 Apr 2016 23:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-06T20:50:33+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-11T23:32:08+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -4321,7 +3556,7 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:33 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -4338,7 +3573,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
   response:
     status:
       code: 200
@@ -4357,19 +3592,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 671881e3-c1d3-4292-96a1-8294253544ab
+      - 92691505-97d6-447c-8323-f1d016f67fd8
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 671881e3-c1d3-4292-96a1-8294253544ab
+      - 92691505-97d6-447c-8323-f1d016f67fd8
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205033Z:671881e3-c1d3-4292-96a1-8294253544ab
+      - NORTHCENTRALUS:20160411T233208Z:92691505-97d6-447c-8323-f1d016f67fd8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:33 GMT
+      - Mon, 11 Apr 2016 23:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"nextLink":"","value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","location":"East
@@ -4384,7 +3619,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:34 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:08 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2015-05-01-preview
@@ -4401,7 +3636,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
       Content-Length:
       - '0'
   response:
@@ -4422,26 +3657,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 965211f1-be72-4ed4-b471-02eefe924ce6
+      - 4c2b645c-af8d-463a-b45c-11df0cee18e3
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1198'
       X-Ms-Correlation-Request-Id:
-      - 965211f1-be72-4ed4-b471-02eefe924ce6
+      - 4c2b645c-af8d-463a-b45c-11df0cee18e3
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205034Z:965211f1-be72-4ed4-b471-02eefe924ce6
+      - NORTHCENTRALUS:20160411T233208Z:4c2b645c-af8d-463a-b45c-11df0cee18e3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:33 GMT
+      - Mon, 11 Apr 2016 23:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"key1":"FR27zlayw/BE6MkbBhzEI42zZWHZpXIowho9C0byefqW2AXiRHDn3rsUJSJEJ9UAy7bc5RN8NbhOyegpg5VP6Q==","key2":"cXASUkLCkGJbZ6urDq8U2Je11KT+Y9ihyatlZsX1bIPVGehwenUJrokY6AO+rFChPXYnEFJpYHbRqTMTkAnu/w=="}
 
 '
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:34 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:09 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
@@ -4458,11 +3693,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:34 GMT
+      - Mon, 11 Apr 2016 23:32:09 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:0W8rpU1bO2JBZAITIChSHF4AtKplSfuRCcagLn3XvAs=
+      - SharedKey miqazuretest14047:4RLF7r64rh5pCp9g57WtpARmngYLvYu7xg27i5K5mQg=
   response:
     status:
       code: 200
@@ -4475,11 +3710,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b61ce06d-0001-00a4-5e45-901c9b000000
+      - 396e4a1c-0001-00ab-304a-94f16d000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:35 GMT
+      - Mon, 11 Apr 2016 23:32:09 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4525,7 +3760,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:35 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:09 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e?comp=list&restype=container
@@ -4542,11 +3777,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:35 GMT
+      - Mon, 11 Apr 2016 23:32:09 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:yjKNVhEZdReHNtB/+KmmaV3HqVwwyiExVtD1ymm/j2g=
+      - SharedKey miqazuretest14047:iHnRIYfuKGBHSz7ThuYuTRUQIvk8IYf860nhrLTVr2E=
   response:
     status:
       code: 200
@@ -4559,11 +3794,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 83825f4d-0001-0081-5745-908428000000
+      - ca7fde5b-0001-00af-0a4a-9404ef000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:37 GMT
+      - Mon, 11 Apr 2016 23:32:09 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4598,7 +3833,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:35 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:10 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-6e555b88-3fd4-4b72-a404-4bba5d11de93?comp=list&restype=container
@@ -4615,11 +3850,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:35 GMT
+      - Mon, 11 Apr 2016 23:32:10 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:oR3eXcA6QXTqITnb7ipi70kU5rtKPRz4N0QZBHKGDOY=
+      - SharedKey miqazuretest14047:KuvNtcMUr5GeF884OU7S1aLLUE+TtVblNn4UNem55YU=
   response:
     status:
       code: 200
@@ -4632,11 +3867,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 939e1539-0001-0071-7645-905446000000
+      - 363952be-0001-00da-5f4a-948354000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:35 GMT
+      - Mon, 11 Apr 2016 23:32:10 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4647,8 +3882,8 @@ http_interactions:
         ZDQtNGI3Mi1hNDA0LTRiYmE1ZDExZGU5MyI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXdpbjEyLjZlNTU1Yjg4LTNmZDQtNGI3Mi1hNDA0LTRiYmE1
         ZDExZGU5My5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5XZWQsIDA2IEFwciAyMDE2IDIwOjUwOjA3IEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzVFNUQwOTk1NkVDOTwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5Nb24sIDExIEFwciAyMDE2IDIzOjMyOjA5IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzYyNjE4MEIyMUY1QzwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -4659,7 +3894,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:36 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:10 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-b97ff488-e114-40ed-8d7a-f4500d73eec0?comp=list&restype=container
@@ -4676,11 +3911,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:36 GMT
+      - Mon, 11 Apr 2016 23:32:10 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:/T6rdbJVSuD9dqbfNRtFN8FSZZruPdpoeYyw+9WjRcQ=
+      - SharedKey miqazuretest14047:8Twc6WDNEEdZhi0oC1uyojSaesNUgEzyDFi19FT3vZE=
   response:
     status:
       code: 200
@@ -4693,11 +3928,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3e7fe0f0-0001-00ed-6145-902ffb000000
+      - ba0e8e15-0001-012e-464a-94e0ed000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:36 GMT
+      - Mon, 11 Apr 2016 23:32:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4720,7 +3955,7 @@ http_interactions:
         c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:36 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:11 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-e17a95b0-f4fb-4196-93c5-0c8be7d5c536?comp=list&restype=container
@@ -4737,11 +3972,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:36 GMT
+      - Mon, 11 Apr 2016 23:32:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:D8e3VPIkOlEXFjRuz2DV2KySldK1P1GwAHy0QFFPE20=
+      - SharedKey miqazuretest14047:XQrgsF6CFcTnydrZhnhQBNp7FQN7wfM72IPRpNhSQcM=
   response:
     status:
       code: 200
@@ -4754,11 +3989,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9c4cda8b-0001-0119-7c45-904c42000000
+      - 83146a71-0001-0019-294a-940a17000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:37 GMT
+      - Mon, 11 Apr 2016 23:32:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4769,7 +4004,7 @@ http_interactions:
         ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNiI+PEJsb2JzIC8+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:36 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:11 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
@@ -4786,11 +4021,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:36 GMT
+      - Mon, 11 Apr 2016 23:32:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:ICCw3IDM1uL/PSWcL8A3ufpn4OsfZBoS9c9PcwjPlwQ=
+      - SharedKey miqazuretest14047:3rS6ws2p8eQyJYqZqaao0xwVIKRr0ud/IkY6yzTi10s=
   response:
     status:
       code: 200
@@ -4803,11 +4038,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 108377e8-0001-010a-0d45-9079a3000000
+      - f394c1e2-0001-010d-554a-948f26000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:37 GMT
+      - Mon, 11 Apr 2016 23:32:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4844,7 +4079,7 @@ http_interactions:
         L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1
         bHRzPg==
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:37 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:11 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4861,11 +4096,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:37 GMT
+      - Mon, 11 Apr 2016 23:32:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:hjBt05wazshwLdnbwa/EunE6RSFEhEhH3VTyK26fGlo=
+      - SharedKey miqazuretest14047:Qs3uG21+FyqGcRBA+yocmXXCmqtK42otHjbhfoyFrjM=
   response:
     status:
       code: 200
@@ -4878,11 +4113,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 85e2f6f7-0001-0096-0e45-90444b000000
+      - 35698c7f-0001-00d5-2f4a-946ea2000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:37 GMT
+      - Mon, 11 Apr 2016 23:32:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4891,26 +4126,26 @@ http_interactions:
         enVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2lu
         MTIuNmU1NTViODgtM2ZkNC00YjcyLWE0MDQtNGJiYTVkMTFkZTkzLnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2IEFw
-        ciAyMDE2IDIwOjUwOjIzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzVFNUQxMkQxNzNFMjwvRXRhZz48Q29udGVudC1MZW5ndGg+ODg0PC9Db250
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEFw
+        ciAyMDE2IDIzOjMyOjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzYyNjE3RjdGRTVFMDwvRXRhZz48Q29udGVudC1MZW5ndGg+ODg0PC9Db250
         ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
         cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+NE5KTTRHK1AyOWpFU1JqUXFB
-        eDlWQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+UVcwTGNHaWJzc3VLVnJhT0pW
+        MVBrZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
         LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
         PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
         ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
         QmxvYj48TmFtZT5taXEtdGVzdC13aW4xMjIwMTYyMTgxMTMwMTQudmhkPC9O
-        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDYgQXByIDIw
-        MTYgMjA6NTA6MzMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNUU1
-        RDE5MkZCQ0NDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgQXByIDIw
+        MTYgMjM6MzI6MTAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjI2
+        MTgwRjM3REJBPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8
         L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0
         ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
         Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpR
         VksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENv
         bnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
-        cj4xNDk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBh
+        cj4yMzE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBh
         Z2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0
         YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVy
         YXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwv
@@ -4990,7 +4225,7 @@ http_interactions:
         cnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0
         aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:37 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:12 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
@@ -5007,11 +4242,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:37 GMT
+      - Mon, 11 Apr 2016 23:32:12 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:nDEz6Ln5Xeh7F96JOPVpJJI28m3woB3dvEEHIXxCTrc=
+      - SharedKey miqazuretest14047:RNKhFqnAEQ1F309uHnTnDUzfpP41sFFis1ykoR0QTHU=
   response:
     status:
       code: 200
@@ -5032,7 +4267,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a3ae8f95-0001-00fe-4545-901a1a000000
+      - b20b0236-0001-0114-604a-94a34e000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5062,12 +4297,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 17:08:02 GMT
       Date:
-      - Wed, 06 Apr 2016 20:50:38 GMT
+      - Mon, 11 Apr 2016 23:32:12 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:38 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:12 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
@@ -5084,11 +4319,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:38 GMT
+      - Mon, 11 Apr 2016 23:32:12 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:JxfMzn1YxcC4Rj6Uw2eizs3SQOZ+/v3c1N6m+4oLJjw=
+      - SharedKey miqazuretest14047:BvfqRpO2l8UzctCyS2Zeakt9Qo0ufWqqAyo4fC22pdM=
   response:
     status:
       code: 200
@@ -5109,7 +4344,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 81c6a746-0001-008a-2345-909c5c000000
+      - 5f9c41c9-0001-0118-2b4a-944dbf000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -5131,12 +4366,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 16:17:06 GMT
       Date:
-      - Wed, 06 Apr 2016 20:50:38 GMT
+      - Mon, 11 Apr 2016 23:32:19 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:38 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:19 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2015-05-01-preview
@@ -5153,7 +4388,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
       Content-Length:
       - '0'
   response:
@@ -5174,26 +4409,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9775788c-24a2-4df3-be87-552524ba7545
+      - 39acb5c6-a931-40af-ba74-c129eabcd421
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 9775788c-24a2-4df3-be87-552524ba7545
+      - 39acb5c6-a931-40af-ba74-c129eabcd421
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205039Z:9775788c-24a2-4df3-be87-552524ba7545
+      - NORTHCENTRALUS:20160411T233219Z:39acb5c6-a931-40af-ba74-c129eabcd421
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:38 GMT
+      - Mon, 11 Apr 2016 23:32:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"key1":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ==","key2":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA=="}
 
 '
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:39 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:20 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
@@ -5210,11 +4445,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:39 GMT
+      - Mon, 11 Apr 2016 23:32:20 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:QYR9TWdtmxAZkj/Z5LfTxQFLVUpybzTvQZveAS24TKs=
+      - SharedKey miqazuretest16487:7U58qt/yqwnjP8GnfTZWj239Zwwrr5UOKLI4/6+ptYw=
   response:
     status:
       code: 200
@@ -5227,11 +4462,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b7d6cd3a-0001-0007-5845-90d0fa000000
+      - 8138306b-0001-0093-774a-94b034000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:40 GMT
+      - Mon, 11 Apr 2016 23:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5253,7 +4488,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:40 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:20 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e?comp=list&restype=container
@@ -5270,11 +4505,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:40 GMT
+      - Mon, 11 Apr 2016 23:32:20 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:kf7OVqS2y9+ev1EIYHmIHRF1Za6IA3eHSnQmJS1KvV0=
+      - SharedKey miqazuretest16487:jiM6hyYrToe+Faz9Yxd4QZ9FmzkYbAb9uuFvNN9HY/k=
   response:
     status:
       code: 200
@@ -5287,11 +4522,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e564c237-0001-001f-6f45-90fd6f000000
+      - 1d908918-0001-0097-794a-9445b6000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:40 GMT
+      - Mon, 11 Apr 2016 23:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5302,8 +4537,8 @@ http_interactions:
         ZTgtNDFjMS04NGY4LTY0MjMyMDkxMGE1ZSI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXVidW50dTEuYzRkNTc3YWUtNGJlOC00MWMxLTg0ZjgtNjQy
         MzIwOTEwYTVlLnNjcmVlbnNob3QuYm1wPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
-        YXN0LU1vZGlmaWVkPldlZCwgMDYgQXByIDIwMTYgMjA6NTA6MjMgR01UPC9M
-        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNUU1RDEzMEYyODQzPC9FdGFnPjxD
+        YXN0LU1vZGlmaWVkPk1vbiwgMTEgQXByIDIwMTYgMjM6MzE6NTcgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjI2MTc5Mzc3RTZDPC9FdGFnPjxD
         b250ZW50LUxlbmd0aD42MTQ5MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
         LVR5cGU+aW1hZ2UvYm1wPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
         bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNo
@@ -5314,19 +4549,19 @@ http_interactions:
         YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEt
         dGVzdC11YnVudHUxLmM0ZDU3N2FlLTRiZTgtNDFjMS04NGY4LTY0MjMyMDkx
         MGE1ZS5zZXJpYWxjb25zb2xlLmxvZzwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5XZWQsIDA2IEFwciAyMDE2IDIwOjUwOjIyIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzVFNUQxMkQwMTNGOTwvRXRhZz48Q29u
-        dGVudC1MZW5ndGg+MTU2NTY5NjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
-        VHlwZT50ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
-        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNo
-        ZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9i
-        LXNlcXVlbmNlLW51bWJlcj4wPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        PjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVu
-        bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xl
-        YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFy
-        a2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+        dC1Nb2RpZmllZD5Nb24sIDExIEFwciAyMDE2IDIzOjMxOjU3IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzYyNjE3OEZFQUQ5OTwvRXRhZz48Q29u
+        dGVudC1MZW5ndGg+NzMyMTY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+dGV4dC9wbGFpbjwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
+        Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1z
+        ZXF1ZW5jZS1udW1iZXI+MDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48
+        QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
+        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
+        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
+        ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:40 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:21 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5343,11 +4578,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:40 GMT
+      - Mon, 11 Apr 2016 23:32:21 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:18ZVtZ/hboWyjhfdSCXFJHQ52Y2jNhgK7tBehSeLLPI=
+      - SharedKey miqazuretest16487:QES9KyI9F/Kov3NoWiLk1erTzQaBggKapAs64CAIIak=
   response:
     status:
       code: 200
@@ -5360,11 +4595,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9561372f-0001-009b-6b45-90ab47000000
+      - 2d07d94b-0001-005e-324a-94d57c000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:40 GMT
+      - Mon, 11 Apr 2016 23:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5373,33 +4608,33 @@ http_interactions:
         enVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1
         bnR1MS5jNGQ1NzdhZS00YmU4LTQxYzEtODRmOC02NDIzMjA5MTBhNWUuc3Rh
-        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDYg
-        QXByIDIwMTYgMjA6NTA6NDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
-        OEQzNUU1RDFEM0Q2OURFPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY3PC9D
+        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEg
+        QXByIDIwMTYgMjM6MzI6MTYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzNjI2MTg0NjE2MkI5PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY3PC9D
         b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
         LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
-        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+T252d0VaSXRZWVN0cXlM
-        eUwwRWVlQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+SVNmWWlHYkhqSTZDazdh
+        WW4vTUR2dz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
         ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
         cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
         dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
         Yj48QmxvYj48TmFtZT5taXEtdGVzdC11YnVudHUxMjAxNjIxODExMjY0Ny52
-        aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBB
-        cHIgMjAxNiAyMDo1MDoyNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
-        RDM1RTVEMTRFNjMwODY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3Mjgw
+        aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMSBB
+        cHIgMjAxNiAyMzozMjowNCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDM2MjYxN0Q5QUZBOUM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3Mjgw
         NTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
         L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVw
         N3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
         PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1u
-        dW1iZXI+NDc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
+        dW1iZXI+NzI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
         PlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFz
         ZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNl
         RHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVz
         PjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJl
         c3VsdHM+
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:41 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:21 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2015-05-01-preview
@@ -5416,7 +4651,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
       Content-Length:
       - '0'
   response:
@@ -5437,26 +4672,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 88ddd1d4-a13b-48d5-a479-1c0225a1b499
+      - 135613fa-8d62-41c2-89f9-18c650029d9d
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 88ddd1d4-a13b-48d5-a479-1c0225a1b499
+      - 135613fa-8d62-41c2-89f9-18c650029d9d
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205041Z:88ddd1d4-a13b-48d5-a479-1c0225a1b499
+      - NORTHCENTRALUS:20160411T233221Z:135613fa-8d62-41c2-89f9-18c650029d9d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:41 GMT
+      - Mon, 11 Apr 2016 23:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"key1":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","key2":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w=="}
 
 '
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:41 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:22 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
@@ -5473,11 +4708,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:41 GMT
+      - Mon, 11 Apr 2016 23:32:22 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:rlYU2n3p08IRdXiw16s/KDG7Pwzl6NujOLdfrLQqXiE=
+      - SharedKey miqazuretest18686:JpndLEkuMW/zK8EiIy5c3e99VOuciCmgpVqTipnlgZg=
   response:
     status:
       code: 200
@@ -5490,11 +4725,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 547ff7af-0001-011c-5645-90b83d000000
+      - acd2620b-0001-0119-114a-944c42000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:41 GMT
+      - Mon, 11 Apr 2016 23:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5516,7 +4751,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:42 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:22 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4?comp=list&restype=container
@@ -5533,11 +4768,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:42 GMT
+      - Mon, 11 Apr 2016 23:32:22 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:ZiiI8wFVSXKquTY2sMPX+XBNbwf4waPha1tChpaMHrk=
+      - SharedKey miqazuretest18686:NlPYccuGOsK7I7kNn98PfDTbGQPo1A1MkW8n3FgPndU=
   response:
     status:
       code: 200
@@ -5550,11 +4785,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1baf0529-0001-0134-6645-90cf82000000
+      - 1f82653c-0001-007d-174a-94bab7000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:42 GMT
+      - Mon, 11 Apr 2016 23:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5565,8 +4800,8 @@ http_interactions:
         YWItNDg2Ny05Y2M0LTE1NzMzNmI3ZTJlNCI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXJoZWwxLjAzZTg0NjdiLWJhYWItNDg2Ny05Y2M0LTE1NzMz
         NmI3ZTJlNC5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5XZWQsIDA2IEFwciAyMDE2IDIwOjQ5OjUxIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzVFNUNGRkQ2RDM0NjwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5Nb24sIDExIEFwciAyMDE2IDIzOjMyOjA5IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzYyNjE4MDc0Qjk5NjwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -5577,9 +4812,9 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRl
         c3QtcmhlbDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0
         LnNlcmlhbGNvbnNvbGUubG9nPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPldlZCwgMDYgQXByIDIwMTYgMTk6MTc6NTAgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQzNUU1MDI1NzFDNzM0PC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD44NDk5MjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
+        ZGlmaWVkPk1vbiwgMTEgQXByIDIwMTYgMjE6MTY6MDggR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzNjI0RTgwMjE1M0YzPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4xMDc1MjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
         ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
         Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNoZS1Db250
         cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVl
@@ -5589,7 +4824,7 @@ http_interactions:
         dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:42 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:23 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5606,11 +4841,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:42 GMT
+      - Mon, 11 Apr 2016 23:32:23 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:gCvnSiXPtVyWU2fcaWyLOkNYVzp2pRCi2HQekRpc+NA=
+      - SharedKey miqazuretest18686:/6V+7N1W8725DgUW3cBzBVIs6gvrh4ZyGQ315QviKJg=
   response:
     status:
       code: 200
@@ -5623,11 +4858,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 09fb0055-0001-0021-5e45-904b4e000000
+      - f7992b87-0001-0121-7a4a-940d1b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:43 GMT
+      - Mon, 11 Apr 2016 23:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5636,33 +4871,33 @@ http_interactions:
         enVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtcmhl
         bDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0LnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2IEFw
-        ciAyMDE2IDIwOjUwOjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzVFNUQxQ0MzRkQ2QTwvRXRhZz48Q29udGVudC1MZW5ndGg+ODgwPC9Db250
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEFw
+        ciAyMDE2IDIzOjMyOjE0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzYyNjE4MzJCMzBCNDwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250
         ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
         cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+UEhlRmdzbVloeE05RmEvY3pr
-        VEVOdz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+d256MVRuREYyVDBjaFNwL2ZV
+        MXRlUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
         LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
         PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
         ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
         QmxvYj48TmFtZT5taXEtdGVzdC1yaGVsMTIwMTYyMTgxMTIyNDMudmhkPC9O
-        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDYgQXByIDIw
-        MTYgMjA6NTA6NDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNUU1
-        RDFFNDY4RjgwPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgQXByIDIw
+        MTYgMjM6MzI6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjI2
+        MTdGNTdCQURBPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
         Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
         dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
         b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmRRTCtYSGpGTlBkb01F
         d2VJNjNmd1E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
         dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        PjYxPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdl
-        QmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0
-        dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0
-        aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0Js
-        b2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRz
-        Pg==
+        PjExNzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
+        dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
+        dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9C
+        bG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0
+        cz4=
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:43 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:23 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2015-05-01-preview
@@ -5679,7 +4914,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NTk5NzU1MTAsIm5iZiI6MTQ1OTk3NTUxMCwiZXhwIjoxNDU5OTc5NDEwLCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.qGRUKwwnvUoIwenrbZ1VO2B1M1KMuxQ3GFDAF9XjkBjhJCxuHlskUz02ihF4AQQ4TkKphsihqZSDJ0v9ByGaV7Y1T94uuU5P3A7wt60hUaRa4QLLTd7TFgoBl4rjC4hcRwZj_kI2ach6rDEvWINq1L15zGlMBFar_C7zf-Pt1zD93T_ADPHpLPmwy2jDSq1ZHtgC9_w95VjFbfxycPzBDrEez61DXugtwHiezpLd7oQCADbzic2Dw_sV3es9feIvXMcp0xzSWJQXqtkQqFNrZ4TvJzG_ip0t55kTmkXxOiglaV5MUzQTk2JLL0nAh5q_nP0JyDUYuKix5O5GUeWVKQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjA0MTcxOTcsIm5iZiI6MTQ2MDQxNzE5NywiZXhwIjoxNDYwNDIxMDk3LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.KHUHjs5QhFpvaQcsyrh1JruqIas1_7J9uzwFvUpM5XY8jXqO_-dBX_vJUMbyE5zLPAUF5MJ_TzXiZGOG4jUrJASy1WR5q6ldsmfjqEMruS7pplKeXPJ-kJjNz24FzipGYFkx0aDCEDS63fSuboxdk54RYqu-ry7YPkdUmjSHeM_qfhsv4EbBr2pl7ngin9lkNRnzVu7YezH2I58JDR5aw2eh7ET4wxado8E0s1XJaFC-G2vFNaAg5XMOSYqAAc9lM-lT-jC8NOUORc-wrJu9fiy3pS6dbkI5Y-nwepg64-kxDljem5k3L6F_o5TfiNqhCE14oZvg3Zj2nvPTFznVtA
       Content-Length:
       - '0'
   response:
@@ -5700,26 +4935,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9dace736-b2a4-4919-ab6f-df5351eb8457
+      - c8edca63-2d16-45ba-bd55-2979deaeab99
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 9dace736-b2a4-4919-ab6f-df5351eb8457
+      - c8edca63-2d16-45ba-bd55-2979deaeab99
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160406T205043Z:9dace736-b2a4-4919-ab6f-df5351eb8457
+      - NORTHCENTRALUS:20160411T233224Z:c8edca63-2d16-45ba-bd55-2979deaeab99
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 06 Apr 2016 20:50:43 GMT
+      - Mon, 11 Apr 2016 23:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"key1":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","key2":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw=="}
 
 '
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:44 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:24 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
@@ -5736,11 +4971,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:44 GMT
+      - Mon, 11 Apr 2016 23:32:24 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:Xcf7xiZdNx3BpYmxhGVfAVLBnzf9Zy2/A+2Fpx6UjcQ=
+      - SharedKey spec0deply1stor:fM7KSnydlfOZtGftvdPRi3qkgcut4fpNkNVe//7z0zs=
   response:
     status:
       code: 200
@@ -5753,11 +4988,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8ade0855-0001-008d-2a45-906ad9000000
+      - 243aae6b-0001-0100-134a-94602a000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:44 GMT
+      - Mon, 11 Apr 2016 23:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5785,7 +5020,7 @@ http_interactions:
         b3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2Vy
         IC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:44 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:25 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68?comp=list&restype=container
@@ -5802,11 +5037,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:44 GMT
+      - Mon, 11 Apr 2016 23:32:25 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:6BdrINZI/i7px1zsKGmX3VkWIAujvNdZ+Eu1U3NL86c=
+      - SharedKey spec0deply1stor:FFLPJiUr5rD6LrEnmawhoZK9LxW6wPH+54ckf+GD7k4=
   response:
     status:
       code: 200
@@ -5819,11 +5054,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3b4272de-0001-0069-5b45-9079d3000000
+      - 06a40235-0001-008b-514a-949da1000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:44 GMT
+      - Mon, 11 Apr 2016 23:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5846,7 +5081,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:44 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:25 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261?comp=list&restype=container
@@ -5863,11 +5098,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:44 GMT
+      - Mon, 11 Apr 2016 23:32:25 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:mHyMFuCS+ThJq1moFd2AW7SO/QcIbYZLvuGRZ584O7E=
+      - SharedKey spec0deply1stor:EbdMU6ze52kXNYy1tX55ngnqGnECSfnKDN4QmquNrG0=
   response:
     status:
       code: 200
@@ -5880,11 +5115,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3e730c96-0001-00aa-7045-90f090000000
+      - a3009039-0001-011b-1d4a-944eb8000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:45 GMT
+      - Mon, 11 Apr 2016 23:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5907,7 +5142,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:45 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:25 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5924,11 +5159,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 06 Apr 2016 20:50:45 GMT
+      - Mon, 11 Apr 2016 23:32:25 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:+ntlBxXIf8AIvWe2mN775gnAcojH1/+Mk8j4GwLb3CI=
+      - SharedKey spec0deply1stor:Rn0IZL8Edk6A0kHj/k/Kh51XSCBhU93/iaZZKdin590=
   response:
     status:
       code: 200
@@ -5941,11 +5176,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 54ab1bbe-0001-0022-1245-904849000000
+      - 0ed0f144-0001-00bb-4a4a-94c78b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 06 Apr 2016 20:50:45 GMT
+      - Mon, 11 Apr 2016 23:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6003,5 +5238,5 @@ http_interactions:
         PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4
         dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 06 Apr 2016 20:50:45 GMT
+  recorded_at: Mon, 11 Apr 2016 23:32:26 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This modifies the gather_data_for_this_region method so that it accepts an optional subscription_id, and gathers data for all subscriptions if no subscription ID is provided.

Internally, it now also defaults to 'list_all' instead of 'list', which uses a threaded approach to gathering resource information within the armrest gem. So, whatever slowdown we suffer from iterating over multiple subscriptions should be made up by using list_all. Of course, this depends on just how many subscriptions a client has.

The optional subscription_id parameter leaves room for https://github.com/ManageIQ/manageiq/issues/7327. If a client does specify a subscription_id in the UI (assuming that feature is added), we can pass the subscription id as an argument, and only resources for that subscription id would be collected.