### PR TITLE
Automate - Fixed quota running twice in service provisioning

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvisionRequestApproval.class/default.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvisionRequestApproval.class/default.yaml
@@ -7,7 +7,4 @@ object:
     name: Default
     inherits: 
     description: 
-  fields:
-  - ValidateRequest:
-      value: "/System/CommonMethods/QuotaStateMachine/quota"
-      on_entry: "#"
+  fields: []


### PR DESCRIPTION
Removed quota from the ServiceProvisionRequestApproval instance

Modified ServiceProvisionRequestApproval.class/default.yaml

https://bugzilla.redhat.com/show_bug.cgi?id=1317698