### PR TITLE
Block find_or_create_by and find_or_initialize_by

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -27,11 +27,17 @@ module MiqAeMethodService
       super
     end
 
+    def self.allowed_find_method?(m)
+      return false if m.starts_with?('find_or_create') || m.starts_with?('find_or_initialize')
+      m.starts_with?('find')
+    end
+
     # Expose the ActiveRecord find, all, count, and first
     def self.class_method_exposed?(m)
-      m.to_s.starts_with?('find_') || [:where, :find, :all, :count, :first].include?(m)
+      allowed_find_method?(m.to_s) || [:where, :find, :all, :count, :first].include?(m)
     end
     private_class_method :class_method_exposed?
+    private_class_method :allowed_find_method?
 
     def self.inherited(subclass)
       subclass.class_eval do

--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -22,9 +22,8 @@ module MiqAeMethodService
       raise MiqAeException::ServiceNotFound, "Service Model not found"
     end
 
-    def self.respond_to?(m, *args)
-      return true if class_method_exposed?(m.to_sym)
-      super
+    def self.respond_to_missing?(method_name, include_private = false)
+      class_method_exposed?(method_name.to_sym) || super
     end
 
     def self.allowed_find_method?(m)
@@ -36,6 +35,7 @@ module MiqAeMethodService
     def self.class_method_exposed?(m)
       allowed_find_method?(m.to_s) || [:where, :find, :all, :count, :first].include?(m)
     end
+
     private_class_method :class_method_exposed?
     private_class_method :allowed_find_method?
 

--- a/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -100,4 +100,20 @@ module MiqAeServiceModelSpec
       expect(svc_vm.id).to eq(vm.id)
     end
   end
+
+  describe "find_or_create_by" do
+    it "blocks" do
+      expect do
+        MiqAeMethodService::MiqAeServiceVmOrTemplate.find_or_create_by(:name => 'test123')
+      end.to raise_error(NoMethodError)
+    end
+  end
+
+  describe "find_or_initialize_by" do
+    it "blocks" do
+      expect do
+        MiqAeMethodService::MiqAeServiceVmOrTemplate.find_or_initialize_by(:name => 'test123')
+      end.to raise_error(NoMethodError)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/DkQ9rJtQ

Automate methods use the Service model wrapped Active Record objects. The find_ methods get delegated to the Active Record objects. The current implementation uses find_* to decide which methods get delegated to Active Record, this will allow the find_or_create_by and find_or_initialize_by methods to get called. We don't want Automate Methods creating new Active Record objects, even while they are wrapped in Service Model. 

Prevent Automate methods from calling any of the find_or_create_by
and find_or_initialize_by methods.