### PR TITLE
Minor changes to ansible tower spec tests

### DIFF
--- a/spec/models/configuration_script_spec.rb
+++ b/spec/models/configuration_script_spec.rb
@@ -14,7 +14,7 @@ describe ConfigurationScript do
   end
   let(:manager)      { FactoryGirl.create(:configuration_manager_ansible_tower, :provider, :configuration_script) }
   let(:mock_api)     { AnsibleTowerClient::Api.new(faraday_connection) }
-  let(:job_template) { AnsibleTowerClient::JobTemplate.new(mock_api, "id" => 1, "name" => "template", "description" => "description", "extra_vars" => "{\n \"instance_ids\": [\"i-3434\"]}") }
+  let(:job_template) { AnsibleTowerClient::JobTemplate.new(mock_api, "id" => 1, "url" => "url", "name" => "template", "description" => "description", "extra_vars" => "{\n \"instance_ids\": [\"i-3434\"]}") }
 
   it "belongs_to the Ansible Tower manager" do
     expect(manager.configuration_scripts.size).to eq 1

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/refresh_parser_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshParser 
   let(:parser)            { described_class.new(manager) }
   let(:manager)           { FactoryGirl.create(:configuration_manager_ansible_tower, :provider) }
   let(:mock_api)          { double("AnsibleTowerClient::Api") }
-  let(:all_hosts)         { (1..2).collect { |i| AnsibleTowerClient::Host.new(mock_api, "id" => i, "name" => "host#{i}", "inventory" => i) } }
+  let(:all_hosts)         { (1..2).collect { |i| AnsibleTowerClient::Host.new(mock_api, "related" => {"inventory" => "url"}, "id" => i, "name" => "host#{i}", "inventory" => i) } }
   let(:all_inventories)   { (1..2).collect { |i| AnsibleTowerClient::Inventory.new(mock_api, "id" => i, "name" => "inventory#{i}") } }
   let(:all_job_templates) { (1..2).collect { |i| AnsibleTowerClient::JobTemplate.new(mock_api, "id" => i, "name" => "template#{i}", "description" => "description#{i}", "extra_vars" => "some_json_payload") } }
 


### PR DESCRIPTION
Made some slight changes to the existing spec tests so that they won't fail when we merge the refactoring work for `BaseModel` in  `ansible_tower_client` (https://github.com/ManageIQ/ansible_tower_client/pull/17)