### PR TITLE
remove coupling of amazon in ems_event

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -76,10 +76,6 @@ class EmsEvent < EventStream
     add(ems_id, ManageIQ::Providers::Openstack::InfraManager::EventParser.event_to_hash(event, ems_id))
   end
 
-  def self.add_amazon(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Amazon::CloudManager::EventParser.event_to_hash(event, ems_id))
-  end
-
   def self.add_kubernetes(ems_id, event)
     add(ems_id, ManageIQ::Providers::Kubernetes::ContainerManager::EventParser.event_to_hash(event, ems_id))
   end

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
@@ -20,7 +20,8 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Runner < ManageIQ
       _log.info "#{log_prefix} Skipping filtered Amazon event [#{event["messageId"]}]"
     else
       _log.info "#{log_prefix} Caught event [#{event["messageId"]}]"
-      EmsEvent.add_queue('add_amazon', @cfg[:ems_id], event)
+      event_hash = ManageIQ::Providers::Amazon::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+      EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
     end
   end
 


### PR DESCRIPTION
opening this because #7104 shifted towards refactoring the event_catcher api

@miq-bot add_labels providers/amazon refactoring