### PR TITLE
Simplify CapacityController call into rbac.search

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -184,11 +184,7 @@ class MiqCapacityController < ApplicationController
             vms, count = EmsCluster.find(@sb[:planning][:options][:filter_value]).find_filtered_children("all_vms")
             vms.each { |v| @sb[:planning][:vms][v.id.to_s] = v.name }
           when "filter"
-            s = MiqSearch.find(@sb[:planning][:options][:filter_value])     # Get the chosen search filter
-            s.options ||= {}                                         # Create options as a Hash
-            s.options[:userid] = session[:userid]                           # Set the userid
-            s.options[:results_format] = :objects                           # Return objects, not ids
-            vms, attrs = s.search                                           # Get the VM objects and search attributes
+            vms = MiqSearch.find(@sb[:planning][:options][:filter_value]).results(:userid => current_userid)
             vms.each { |v| @sb[:planning][:vms][v.id.to_s] = v.name }   # Add the VMs to the pulldown hash
           end
         end

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -26,6 +26,10 @@ class MiqSearch < ApplicationRecord
     Rbac.filtered(targets, options.merge(:class => db, :filter => filter).merge(opts))
   end
 
+  def results(opts = {})
+    filtered(db, opts)
+  end
+
   def self.search(filter_id, klass, opts = {})
     if filter_id.nil? || filter_id.zero?
       Rbac.search(opts.merge(:class => klass))

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -52,6 +52,13 @@ describe MiqSearch do
     end
   end
 
+  describe "#results" do
+    it "respects filter" do
+      all_vms
+      expect(vm_location_search.results).to match_array(matched_vms)
+    end
+  end
+
   describe "#filtered" do
     it "works with models" do
       all_vms
@@ -66,11 +73,6 @@ describe MiqSearch do
     it "finds elements only in the array" do
       all_vms
       expect(vm_location_search.filtered(partial_vms)).to match_array(partial_matched_vms)
-    end
-
-    it "brings back all for unspecified target" do
-      all_vms
-      expect(vm_location_search.filtered(nil)).to match_array(matched_vms)
     end
 
     it "brings back empty array for empty arrays" do


### PR DESCRIPTION
We don't use rbac's attrs, using results to signify that. (this means we won't have to execute the counts)

Removing spec that was testing passing a `nil` into `Rbac.filtered`. We'll be using `MiqSearch.results` instead.
