### PR TITLE
Fix displaying percent sign (to avoid confusion with format string)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1231,7 +1231,7 @@ class ApplicationController < ActionController::Base
                                                                                        :precision => 2)}
             end
             unless disk.used_percent_of_provisioned.nil?
-              dev += _(", Percent Used Provisioned Space: %{number}%") %
+              dev += _(", Percent Used Provisioned Space: %{number}%%") %
                 {:number => disk.used_percent_of_provisioned.to_s}
             end
             desc += _(", Mode: %{mode}") % {:mode => disk.mode} unless disk.mode.nil?
@@ -1244,7 +1244,7 @@ class ApplicationController < ActionController::Base
               dev += _(", Size on disk: %{number}") % {:number => number_to_human_size(disk.size_on_disk, :precision => 2)}
             end
             unless disk.used_percent_of_provisioned.nil?
-              dev += _(", Percent Used Provisioned Space: %{number}%") %
+              dev += _(", Percent Used Provisioned Space: %{number}%%") %
                 {:number => disk.used_percent_of_provisioned.to_s}
             end
             desc += _(", Mode: %{mode}") % {:mode => disk.mode} unless disk.mode.nil?
@@ -1259,7 +1259,7 @@ class ApplicationController < ActionController::Base
                                                                                        :precision => 2)}
             end
             unless disk.used_percent_of_provisioned.nil?
-              dev += _(", Percent Used Provisioned Space: %{number}%") %
+              dev += _(", Percent Used Provisioned Space: %{number}%%") %
                 {:number => disk.used_percent_of_provisioned.to_s}
             end
             desc += _(", Mode: %{mode}") % {:mode => disk.mode} unless disk.mode.nil?


### PR DESCRIPTION
This is to fix a traceback like the following:
```
FATAL -- : Error caught: [ArgumentError] malformed format string
lib/fast_gettext/vendor/string.rb:70:in `%'
lib/fast_gettext/vendor/string.rb:70:in `%'
app/controllers/application_controller.rb:1235:in `block in set_config'
...