### PR TITLE
Specify class name in cloud & instance timeline buttons

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -66,6 +66,7 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
           'product product-timeline fa-lg',
           N_('Show Timelines for this #{ui_lookup(:table=>"ems_cloud")}'),
           N_('Timelines'),
+          :klass     => ApplicationHelper::Button::EmsCloudTimeline,
           :url_parms => "?display=timeline"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -115,6 +115,7 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           'product product-timeline fa-lg',
           N_('Show Timelines for this Instance'),
           N_('Timelines'),
+          :klass     => ApplicationHelper::Button::InstanceTimeline,
           :url_parms => "?display=timeline"),
       ]
     ),


### PR DESCRIPTION
This is explicitly needed after d3200670029aaa0aeff962f1f55bbc779fa2aa4e