### PR TITLE
MW Hawkular provider initial event catcher

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
@@ -1,0 +1,76 @@
+class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner <
+  ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  INCLUDE_EVENTS = {'Hawkular Deployment' => '.*'}.freeze
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  def stop_event_monitor
+    @event_monitor_handle.try(:stop)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_handle.each_batch do |events|
+      event_monitor_running
+      valid_events = events.select { |e| valid?(e) }
+      $mw_log.debug("#{log_prefix} Discarding events #{events - valid_events}") if valid_events.length < events.length
+      if valid_events.any?
+        $mw_log.debug "#{log_prefix} Queueing events #{valid_events}"
+        @queue.enq valid_events
+      end
+      # invoke the configured sleep before the next event fetch
+      sleep_poll_normal
+    end
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def process_event(event)
+    $mw_log.debug "Processing Event #{event}"
+
+    event_data = {
+      :timestamp => Time.zone.at(event.ctime / 1000),
+      :category  => event.category,
+      :message   => event.context['Message'],
+      :reason    => event.text,
+      :resource  => event.context['CanonicalPath']
+    }
+
+    $mw_log.debug "Processing EventData #{event_data}"
+
+    # normalize event type to be valid (no invalid chars) and to easily match any we've made available for automation
+    event_type              = "#{event_data[:category]}.#{event_data[:reason]}"
+    event_type              = event_type.strip.gsub(/\s+/, "_").downcase
+    event_data[:event_type] = event_type
+
+    if filtered?(event_data)
+      $mw_log.debug "#{log_prefix} Filtering event [#{event_data}]"
+    else
+      $mw_log.debug "#{log_prefix} Adding ems event [#{event_data}]"
+      event_hash = ManageIQ::Providers::Hawkular::MiddlewareManager::EventParser.event_to_hash(
+        event_data, @cfg[:ems_id])
+      EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+    end
+  end
+
+  private
+
+  def event_monitor_handle
+    @event_monitor_handle ||= ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream.new(@ems)
+  end
+
+  def valid?(event)
+    pattern = INCLUDE_EVENTS[event.category]
+    message = event.context['Message']
+    pattern && message && message.match(pattern)
+  end
+
+  # Check for blacklisted event type
+  def filtered?(event_data)
+    filtered_events.include?(event_data[:event_type])
+  end
+end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
@@ -1,0 +1,40 @@
+class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
+  def initialize(ems)
+    @ems               = ems
+    @alerts_client     = ems.alerts_connect
+    @collecting_events = false
+  end
+
+  def start
+    @collecting_events = true
+  end
+
+  def stop
+    @collecting_events = false
+  end
+
+  def each_batch
+    while @collecting_events
+      yield fetch
+    end
+  end
+
+  private
+
+  # Each fetch is performed from the time of the most recently caught event or 1 minute back for the first poll.
+  # This gives us some slack if hawkular events are timestamped behind the miq server time.
+  # Note: This assumes all Hawkular events at max-time T are fetched in one call. It is unlikely that there
+  # would be more than one for the same millisecond, and that the query would be performed in the midst of
+  # writes for the same ms. It may be a feasible scenario but I think it's unnecessary to handle it at this time.
+  def fetch
+    @start_time ||= (Time.current - 1.minute).to_i * 1000
+    $mw_log.debug "Catching Events since [#{@start_time}]"
+
+    new_events = @alerts_client.list_events("startTime" => @start_time)
+    @start_time = new_events.max_by(&:ctime).ctime + 1 unless new_events.empty? # add 1 ms to avoid dups with GTE filter
+    new_events
+  rescue => err
+    $mw_log.info "Error capturing events #{err}"
+    []
+  end
+end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_parser.rb
@@ -1,0 +1,14 @@
+module ManageIQ::Providers::Hawkular::MiddlewareManager::EventParser
+  def self.event_to_hash(event, ems_id = nil)
+    $mw_log.debug "ems_id: [#{ems_id}] event: [#{event.inspect}]"
+    {
+      :event_type => event[:event_type],
+      :source     => 'HAWKULAR',
+      :timestamp  => event[:timestamp],
+      :message    => event[:message],
+      :ems_ref    => event[:resource], # not sure about this, possible link from event to resource?
+      :full_data  => event,
+      :ems_id     => ems_id
+    }
+  end
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -36,6 +36,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
+    ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
     ManageIQ::Providers::Atomic::ContainerManager::EventCatcher
@@ -116,6 +117,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Openstack::InfraManager::EventCatcher
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
+    ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
     ManageIQ::Providers::Atomic::ContainerManager::EventCatcher

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -113,6 +113,8 @@
   :foreman_provisioning:
     :refresh_interval: 1.hour
   :full_refresh_threshold: 100
+  :hawkular:
+    :refresh_interval: 15.minutes
   :kubernetes:
     :refresh_interval: 15.minutes
   :openshift:
@@ -204,6 +206,12 @@
       - VmBeingCreatedEvent
       - VmBeingDeployedEvent
       :name: Creation/Addition
+    :application:
+      :critical:
+      - hawkular_deployment.error
+      :detail:
+      - hawkular_deployment.success
+      :name: Application
     :configuration:
       :critical:
       - ClusterReconfiguredEvent
@@ -903,6 +911,8 @@
   :level_rails: info
   :level_aws: info
   :level_aws_in_evm: error
+  :level_mw: info
+  :level_mw_in_evm: error
   :level_kube: info
   :level_kube_in_evm: error
   :level_api: info
@@ -1130,6 +1140,8 @@
         :poll: 15.seconds
       :event_catcher_azure:
         :poll: 15.seconds
+      :event_catcher_hawkular:
+        :poll: 10.seconds
       :event_catcher_kubernetes:
         :poll: 1.seconds
       :event_catcher_openshift:

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/__class__.yaml
@@ -1,0 +1,433 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Hawkular
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: assertion
+      name: guard
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: logical_event
+      display_name: 
+      datatype: 
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_entry
+      display_name: 
+      datatype: 
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel1
+      display_name: 
+      datatype: 
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth1
+      display_name: 
+      datatype: 
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel2
+      display_name: 
+      datatype: 
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth2
+      display_name: 
+      datatype: 
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel3
+      display_name: 
+      datatype: 
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth3
+      display_name: 
+      datatype: 
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel4
+      display_name: 
+      datatype: 
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth4
+      display_name: 
+      datatype: 
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel5
+      display_name: 
+      datatype: 
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth5
+      display_name: 
+      datatype: 
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel6
+      display_name: 
+      datatype: 
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth6
+      display_name: 
+      datatype: 
+      priority: 15
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel7
+      display_name: 
+      datatype: 
+      priority: 16
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth7
+      display_name: 
+      datatype: 
+      priority: 17
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel8
+      display_name: 
+      datatype: 
+      priority: 18
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth8
+      display_name: 
+      datatype: 
+      priority: 19
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel9
+      display_name: 
+      datatype: 
+      priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_exit
+      display_name: 
+      datatype: 
+      priority: 21
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/deployment_error.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/deployment_error.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Deployment Error
+    name: hawkular_deployment.error
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/deployment_success.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/deployment_success.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Deployment Success
+    name: hawkular_deployment.success 
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -123,12 +123,8 @@ module ReportFormatter
                       elsif rec[:container_node_name]
                         rec[:container_node_name]
                       end
-          elsif ems                             #   or EMS name
-            e_title = ems.name
-          else
-            e_title = "MS no longer exists"
           end
-          e_title ||= "No VM, Host, or MS"
+          e_title ||= ems ? ems.name : "No VM, Host, or MS"
           e_icon = ActionController::Base.helpers.image_path("timeline/#{timeline_icon("vm_event", rec.event_type.downcase)}.png")
           # See if this is EVM's special event
           if rec.event_type == "GeneralUserEvent"

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
@@ -1,0 +1,40 @@
+describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream do
+  subject do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    auth                 = AuthToken.new(:name     => "test",
+                                         :auth_key => "valid-token",
+                                         :userid   => "jdoe",
+                                         :password => "password")
+    ems                  = FactoryGirl.create(:ems_hawkular,
+                                              :hostname        => 'localhost',
+                                              :port            => 8080,
+                                              :authentications => [auth],
+                                              :zone            => zone)
+    described_class.new(ems)
+  end
+
+  context "#each_batch" do
+    # VCR.eject_cassette
+    # VCR.turn_off!(ignore_cassettes: true)
+
+    VCR.configure do |c|
+      c.default_cassette_options = {
+        :match_requests_on => [:method, VCR.request_matchers.uri_without_params(:startTime)]
+      }
+    end
+
+    it "yields a valid event" do
+      # if generating a cassette the polling window is the previous 1 minute
+      VCR.use_cassette(described_class.name.underscore.to_s) do # , :record => :new_episodes) do
+        result = []
+        subject.start
+        subject.each_batch do |events|
+          result = events
+          subject.stop
+        end
+        expect(result.count).to be == 1
+        expect(result[0].category).to eq 'Hawkular Deployment'
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -12,6 +12,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
     VCR.use_cassette(described_class.name.underscore.to_s) do # , :record => :new_episodes) do
       EmsRefresh.refresh(@ems_hawkular)
     end
+
     @ems_hawkular.reload
 
     expect(@ems_hawkular.middleware_servers.count).to be > 0

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?startTime=1460395364000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Apr 2016 17:23:44 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '558'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/events?startTime=1460395364000>; rel="current",
+        <http://localhost:8080/hawkular/alerts/events?startTime=1460395364000&page=0>;
+        rel="last"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAALVTXWvbMBT9K0J7rRx/xZFTNihpQgvd1iVhY7ONke3rVJ0j
+        uZacNJT2t+862WAPeyiUyU+6X+fco+PkicIOlF0fWqBTOv86/7SmZ9SCEspe
+        VxjyuetHRRAxXkPIwiDwGQ9LzsZ+CN4kEBEvauyQQy3EfDKOfc5CEBULx3XB
+        hHBd5nluGdVVBDz2sLa0cotoXhi5QTwO4jDwwjNaCStWuu/KgUiutIKcnqJH
+        HhMRRKEXe0gBYhZW45gVwH0Wcz7mHGrEDkY3uhRNfgltow8XbdvIUlip1RJM
+        q5WBAVtY2OjugBOvxP5n34iOnOq3KMNx9Uc7KLFcfl4O9VqdIk/0IxgjNgO7
+        me6biihtSQtdrbstSU4zMqIVEST5CzsjG4kKk+JApBqkRnDSCntHkpE9f426
+        o/r8Vct358f1X14y0sFDD8ZCNfBJfNeLmBviM6y9ydQPfmRTshCywbTVpDoy
+        J4nFBmbktm2ABY6L3150Waq8KbkXO+E0Qm2c+WMJ7bDWlDyl9Nvi5vtsfeN6
+        3J2SFXQ7WYIhe4nLbaUxUm1GvcJe2YiigQEJVAWqlGBSSt5/IEmqCJ6U3hfa
+        GAfVNBJpqxJ6Ja2Tpin9J6133d1D2w9pIs0fLJKcpiixxZvz++WcI/lTZjCT
+        OVrMOMurL5erLKVnb6bg5Pnierla57dXF6t5nr+ZUqqyZ7TeTOBPgC5qbtEt
+        6Lr/ZRf6/Jz9AkJCADQIBAAA
+    http_version: 
+  recorded_at: Mon, 11 Apr 2016 17:23:44 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
- Add event catcher/parser : 15s polling via REST as initial impl
- Add Deployment event definitions
- Add "Application" event group
  - add the deployment events (critical:failure, detail:success)
- set event[:ems_ref] as the hawkular inventory resource path. Not
  sure about this, but may be useful for linking events to the relevant
  resource.  Currently, no link like that exists and it seems like
  events are designed to be provider-level.

*** Changes to MIQ base code ***
- Alter the timeline logic slightly because it assumed only
  cloud or container providers. Now default to ems.name for
  event title for all events.
  - note: this eliminates the 'MS no longer exists' title, which
          seemed unlikely to get used anyway.
  - note: it would be nice if a provider could configure it's
       default event group filter. 'Power Activity' does not
       apply well to MW.  We'd like 'Application' or something
       more relevant. Perhaps we could tweak the base code for
       the MW case.
- Added $mw_log for middleware logfile
- A couple of minor format changes to make rubocop happier with
  some touched files.