### PR TITLE
Introduce AnsibleTowerJob subclassed from OrchestrationStack

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/configuration_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager < ManageIQ::Provid
   require_nested :Refresher
   require_nested :RefreshParser
   require_nested :RefreshWorker
+  require_nested :Job
 
   include ProcessTasksMixin
   delegate :authentications,

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
@@ -1,0 +1,61 @@
+require 'ansible_tower_client'
+class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job < ::OrchestrationStack
+  require_nested :Status
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::ConfigurationManager"
+  belongs_to :job_template, :foreign_key => :orchestration_template_id, :class_name => "ConfigurationScript"
+
+  #
+  # Allowed options are
+  #   :limit      => String
+  #   :extra_vars => Hash
+  #
+  def self.create_stack(template, options = {})
+    stack = new(:name                  => template.name,
+                :ext_management_system => template.manager,
+                :job_template          => template)
+    stack.send(:update_with_provider_object, raw_create_stack(template, options))
+    stack
+  end
+
+  def self.raw_create_stack(template, options = {})
+    template.run(options[:extra_vars] || {})
+  rescue => err
+    _log.error "Failed to create job from template(#{name}), error: #{err}"
+    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+  end
+
+  class << self
+    alias create_job create_stack
+    alias raw_create_job raw_create_stack
+  end
+
+  def refresh_ems
+    ext_management_system.with_provider_connection do |connection|
+      update_with_provider_object(connection.api.jobs.find(ems_ref))
+    end
+  rescue => err
+    _log.error "Refreshing job(#{name}, ems_ref=#{ems_ref}), error: #{err}"
+    raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
+  end
+
+  def update_with_provider_object(raw_job)
+    self.ems_ref = raw_job.id
+    self.status = raw_job.status
+    save!
+  end
+  private :update_with_provider_object
+
+  def raw_status
+    ext_management_system.with_provider_connection do |connection|
+      raw_job = connection.api.jobs.find(ems_ref)
+      Status.new(raw_job.status, nil)
+    end
+  rescue AnsibleTowerClient::ResourceNotFound
+    msg = "AnsibleTower Job #{name} with id(#{id}) does not exist on #{ext_management_system.name}"
+    raise MiqException::MiqOrchestrationStackNotExistError, msg
+  rescue => err
+    _log.error "AnsibleTower Job #{name} with id(#{id}) status error: #{err}"
+    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+  end
+end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/job/status.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/job/status.rb
@@ -1,0 +1,13 @@
+class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job::Status < ::OrchestrationStack::Status
+  def succeeded?
+    status.casecmp("successful").zero?
+  end
+
+  def failed?
+    status.casecmp("failed").zero?
+  end
+
+  def canceled?
+    status.casecmp("canceled").zero?
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-job.rb
@@ -1,0 +1,12 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_Job < MiqAeServiceOrchestrationStack
+    expose :job_template, :association => true
+    expose :refresh_ems
+
+    def self.create_job(template, args = {})
+      template_object = ConfigurationScript.find_by(:id => template.id)
+      klass = ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job
+      wrap_results(klass.create_job(template_object, args))
+    end
+  end
+end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -37,4 +37,7 @@ FactoryGirl.define do
       x.value = "1"
     end
   end
+
+  factory :ansible_tower_job, :class => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job" do
+  end
 end

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/job/status_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/job/status_spec.rb
@@ -1,0 +1,41 @@
+describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job::Status do
+  it 'parses Succeeded' do
+    status = described_class.new('Successful', '')
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_truthy
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['create_complete', ''])
+  end
+
+  it 'parses Failed' do
+    status = described_class.new('Failed', nil)
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['failed', 'Stack creation failed'])
+  end
+
+  it 'parses Canceled' do
+    status = described_class.new('Canceled', nil)
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.canceled?).to    be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['create_canceled', 'Stack creation was canceled'])
+  end
+
+  it 'parses transient status' do
+    status = described_class.new('Running', nil)
+    expect(status.completed?).to   be_falsey
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(%w(transient Running))
+  end
+end

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/job_spec.rb
@@ -1,0 +1,93 @@
+require 'ansible_tower_client'
+require 'faraday'
+describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job do
+  let(:faraday_connection) { instance_double("Faraday::Connection", :post => post, :get => get) }
+  let(:post) { instance_double("Faraday::Result", :body => {}.to_json) }
+  let(:get) { instance_double("Faraday::Result", :body => {'id' => 1}.to_json) }
+
+  let(:connection) { double(:connection, :api => double(:api, :jobs => double(:jobs, :find => the_raw_job))) }
+
+  let(:manager)      { FactoryGirl.create(:configuration_manager_ansible_tower, :provider) }
+  let(:mock_api)     { AnsibleTowerClient::Api.new(faraday_connection) }
+  let(:the_raw_job) do
+    AnsibleTowerClient::Job.new(
+      mock_api,
+      'id'     => '1',
+      'name'   => template.name,
+      'status' => 'Successful'
+    )
+  end
+
+  let(:template) { FactoryGirl.create(:configuration_script, :manager => manager) }
+  subject { FactoryGirl.create(:ansible_tower_job, :job_template => template, :ext_management_system => manager) }
+
+  describe 'job operations' do
+    context ".create_job" do
+      it 'creates a job' do
+        expect(template).to receive(:run).and_return(the_raw_job)
+
+        job = ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job.create_job(template, {})
+        expect(job.class).to                 eq(described_class)
+        expect(job.name).to                  eq(template.name)
+        expect(job.ems_ref).to               eq(the_raw_job.id)
+        expect(job.job_template).to          eq(template)
+        expect(job.status).to                eq(the_raw_job.status)
+        expect(job.ext_management_system).to eq(manager)
+      end
+
+      it 'catches errors from provider' do
+        expect(template).to receive(:run).and_raise('bad request')
+
+        expect do
+          ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job.create_job(template, {})
+        end.to raise_error(MiqException::MiqOrchestrationProvisionError)
+      end
+    end
+
+    context "#refres_ems" do
+      before do
+        allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+      end
+
+      it 'syncs the job with the provider' do
+        subject.refresh_ems
+        expect(subject.ems_ref).to eq(the_raw_job.id)
+        expect(subject.status).to  eq(the_raw_job.status)
+      end
+
+      it 'catches errors from provider' do
+        expect(connection.api.jobs).to receive(:find).and_raise('bad request')
+        expect { subject.refresh_ems }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+      end
+    end
+  end
+
+  describe 'job status' do
+    before do
+      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+    end
+
+    context '#raw_status and #raw_exists' do
+      it 'gets the stack status' do
+        rstatus = subject.raw_status
+        expect(rstatus).to have_attributes(:status => 'Successful', :reason => nil)
+
+        expect(subject.raw_exists?).to be_truthy
+      end
+
+      it 'detects job not exist' do
+        expect(connection.api.jobs).to receive(:find).twice.and_raise(AnsibleTowerClient::ResourceNotFound.new(nil))
+        expect { subject.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+
+        expect(subject.raw_exists?).to be_falsey
+      end
+
+      it 'catches errors from provider' do
+        expect(connection.api.jobs).to receive(:find).twice.and_raise("bad happened")
+        expect { subject.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+
+        expect { subject.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`AnsibleTowerJob` syncs with Ansible Tower's Job. 
Refreshing Ansible Tower does not collect jobs. We will only store `AnsibleTowerJob` in `orchestration_stacks` table for the jobs that are launched by manageiq.

Currently `AnsibleTowerJob#refresh_ems` only sync the job. In a future PR we will sync the job's parameters, resources, and outputs.