### PR TITLE
Fix haml-lint issues on miq bot

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -6,7 +6,7 @@ linters:
 
   ClassAttributeWithStaticValue:
     enabled: true
-    severity: convention
+    severity: warning
 
   ClassesBeforeIds:
     enabled: false
@@ -19,24 +19,24 @@ linters:
 
   EmptyScript:
     enabled: true
-    severity: convention
+    severity: warning
 
   HtmlAttributes:
     enabled: true
-    severity: convention
+    severity: warning
 
   ImplicitDiv:
     enabled: true
-    severity: convention
+    severity: warning
 
   LeadingCommentSpace:
     enabled: true
-    severity: convention
+    severity: warning
 
   LineLength:
     enabled: true
     max: 160
-    severity: refactor
+    severity: warning
 
   MultilinePipe:
     enabled: false
@@ -46,7 +46,7 @@ linters:
 
   ObjectReferenceAttributes:
     enabled: true
-    severity: convention
+    severity: warning
 
   RuboCop:
     enabled: true
@@ -69,28 +69,28 @@ linters:
 
   RubyComments:
     enabled: true
-    severity: convention
+    severity: warning
 
   SpaceBeforeScript:
     enabled: true
-    severity: convention
+    severity: warning
 
   SpaceInsideHashAttributes:
     enabled: true
     style: no_space
-    severity: convention
+    severity: warning
 
   TagName:
     enabled: true
-    severity: convention
+    severity: warning
 
   TrailingWhitespace:
     enabled: false
 
   UnnecessaryInterpolation:
     enabled: true
-    severity: convention
+    severity: warning
 
   UnnecessaryStringOutput:
     enabled: true
-    severity: convention
+    severity: warning

--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ gem "sshkey",                         "~>1.8.0",   :require => false
 #
 unless ENV['APPLIANCE']
   group :development do
+    gem "haml_lint",        "~>0.16.1", :require => false
     gem "rubocop",          "~>0.37.2", :require => false
     gem "ruby-graphviz",                :require => false  # Used by state_machine:draw Rake Task
   end


### PR DESCRIPTION
Haml linting on the bot currently raises an error due to the severity in the configuration.  This causes rubocop and haml-lint bot comments to be missing from many PRs.

Update everything to "warning" since it seems more appropriate that "error".  