### PR TITLE
Configure a random secret token for Rails console.

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -22,10 +22,10 @@ module MiqWebServerWorkerMixin
       configure_secret_token
     end
 
-    def self.configure_secret_token
+    def self.configure_secret_token(token = MiqDatabase.first.session_secret_token)
       return if Rails.application.config.secret_token
 
-      Rails.application.config.secret_token = MiqDatabase.first.session_secret_token
+      Rails.application.config.secret_token = token
 
       # To set a secret token after the Rails.application is initialized,
       # we need to reset the secrets since they are cached:

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -13,6 +13,10 @@ module MiqWebServerWorkerMixin
       BINDING_ADDRESS
     end
 
+    def self.preload_for_console
+      configure_secret_token(SecureRandom.hex(64))
+    end
+
     def self.preload_for_worker_role
       require 'hamlit-rails'
 

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -20,7 +20,7 @@ module Vmdb
 
       # Rails console needs session store configured
       if defined?(Rails::Console)
-        MiqUiWorker.preload_for_worker_role
+        MiqUiWorker.preload_for_console
       end
     end
   end

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -25,14 +25,22 @@ describe MiqWebServerWorkerMixin do
     Rails.application.secrets = @secrets
   end
 
-  it ".configure_secret_token resets secrets when token unconfigured" do
+  it ".configure_secret_token defaults to MiqDatabase session_secret_token" do
     Rails.application.config.secret_token = nil
 
     test_class.configure_secret_token
     expect(Rails.application.secrets[:secret_token]).to eq(MiqDatabase.first.session_secret_token)
   end
 
-  it ".configure_secret_token does not reset secrets when token configured" do
+  it ".configure_secret_token accepts an input token" do
+    Rails.application.config.secret_token = nil
+
+    token = SecureRandom.hex(64)
+    test_class.configure_secret_token(token)
+    expect(Rails.application.secrets[:secret_token]).to eq(token)
+  end
+
+  it ".configure_secret_token does not reset secrets when token already configured" do
     Rails.application.config.secret_token = SecureRandom.hex(64)
     Rails.application.secrets = nil
     Rails.application.secrets


### PR DESCRIPTION
Previously, MiqUiWorker.preload_for_worker_role would do more than what
rails console required.  Because of this rails console would fail to start if
MiqDatabase.seed was not run.


**Before:**
```
$ be rails r "MiqDatabase.destroy_all"
** Using session_store: ActionDispatch::Session::MemCacheStore
$ be rails c
** Using session_store: ActionDispatch::Session::MemCacheStore
/Users/joerafaniello/Code/manageiq/app/models/mixins/miq_web_server_worker_mixin.rb:28:in `configure_secret_token': undefined method `session_secret_token' for nil:NilClass (NoMethodError)
	from /Users/joerafaniello/Code/manageiq/app/models/mixins/miq_web_server_worker_mixin.rb:22:in `preload_for_worker_role'
	from /Users/joerafaniello/Code/manageiq/lib/vmdb/initializer.rb:23:in `init'
	from /Users/joerafaniello/Code/manageiq/config/application.rb:110:in `block in <class:Application>'
    ...
```

**After:**

```
$ be rails r "MiqDatabase.destroy_all"
** Using session_store: ActionDispatch::Session::MemCacheStore
$ be rails c
** Using session_store: ActionDispatch::Session::MemCacheStore
DEPRECATION WARNING: You didn't set `secret_key_base`. Read the upgrade documentation to learn more about this new config option. (called from block in controller at /Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/draper-a788c38eab4a/lib/draper/view_context/build_strategy.rb:43)
Loading development environment (Rails 5.0.0.beta3)
irb(main):001:0>
```

**After, it even works with no database!!!**
```
$ dropdb vmdb_development
$ be rails c
** Using session_store: ActionDispatch::Session::MemCacheStore
DEPRECATION WARNING: You didn't set `secret_key_base`. Read the upgrade documentation to learn more about this new config option. (called from block in controller at /Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/draper-a788c38eab4a/lib/draper/view_context/build_strategy.rb:43)
Loading development environment (Rails 5.0.0.beta3)
irb(main):001:0> 
```
