### PR TITLE
Lazily set csrf secret token

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -120,7 +120,7 @@ class ApiController < ApplicationController
   # not have these. They would instead dealing with the /api/auth
   # mechanism.
   #
-  if Vmdb::Application.config.action_controller.allow_forgery_protection
+  if respond_to?(:verify_authenticity_token)
     skip_before_action :verify_authenticity_token, :only => [:show, :update, :destroy, :handle_options_request]
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,12 @@ class ApplicationController < ActionController::Base
   include Vmdb::Logging
 
   if Vmdb::Application.config.action_controller.allow_forgery_protection
-    db = MiqDatabase.connected? ? MiqDatabase.first : nil
-    protect_from_forgery :secret => db ? db.csrf_secret_token : SecureRandom.hex(64), :except => :csp_report, :with => :exception
+    # Add CSRF protection for this controller, which enables the
+    # verify_authenticity_token before_action, with a random secret.
+    # This secret is reset to a value found in the miq_databases table in
+    # MiqWebServerWorkerMixin.configure_secret_token for rails server, UI, and
+    # web service worker processes.
+    protect_from_forgery :secret => SecureRandom.hex(64), :except => :csp_report, :with => :exception
   end
 
   helper ChartingHelper

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -12,8 +12,10 @@ module Vmdb
       #   * command line(rails server)
       #   * debugger
       if defined?(Rails::Server)
-        MiqUiWorker.preload_for_worker_role
+        # preload_for_worker_role depends on seeding, principally MiqDatabase
         EvmDatabase.seed_primordial
+
+        MiqUiWorker.preload_for_worker_role
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update_attributes(:status => "started")
       end


### PR DESCRIPTION
**Seed MiqDatabase before preloading for the UI worker**

MiqUiWorker.preload_for_worker_role will end up calling
MiqDatabase.first.csrf_secret_token, so we need to seed first.


**Lazily set the CSRF secret token in the Rails Server processes**

Why? Because rake tasks can load Rails and ApplicationController and we don't
need the CSRF secret token there.  Even worse, the existing code could end up
trying to look for the token in MiqDatabase.first.csrf_secret_token.

Note: ApiController should skip verify_authenticity_token if it responds to this before_action.

Note: config.action_controller.allow_forgery_protection=true in production enables the forgery protection but we need to call protect_from_forgery within the controller(s) we want to use this protection.

Therefore, we call protect_from_forgery in ApplicationController with a random secret token by default.

We can then reset the secret token in Rails::Server based processes such as dev mode rails server and the forked UI Worker / Web Service Worker.

[bin/rails server](https://github.com/ManageIQ/manageiq/blob/38ddfd08ff1aab6d32bb3281c1ddc185b65f8fcd/lib/vmdb/initializer.rb#L15)
[UI/WS worker](https://github.com/ManageIQ/manageiq/blob/40f797a0d4d07496905f6c45e120ad0218037e05/app/models/mixins/miq_web_server_runner_mixin.rb#L29)

Both end up calling [configure_secret_token](https://github.com/ManageIQ/manageiq/blob/40f797a0d4d07496905f6c45e120ad0218037e05/app/models/mixins/miq_web_server_worker_mixin.rb#L25-L34)
to set the secret_token.

I hope this works. It worked locally.  :pray:

