### PR TITLE
capacity controller trim

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -156,7 +156,6 @@ class MiqCapacityController < ApplicationController
   def planning_option_changed
     vms = nil
     if params[:filter_typ]
-      @sb[:planning][:options][:chosen_vm] = nil
       @sb[:planning][:options][:filter_typ] = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]
       @sb[:planning][:options][:filter_value] = nil
       if params[:filter_typ] == "all"
@@ -164,7 +163,6 @@ class MiqCapacityController < ApplicationController
       end
     end
     if params[:filter_value]
-      @sb[:planning][:options][:chosen_vm] = nil
       if params[:filter_value] == "<Choose>"
         @sb[:planning][:options][:filter_value] = nil
       else
@@ -185,7 +183,7 @@ class MiqCapacityController < ApplicationController
       end
     end
     @sb[:planning][:vms] = vms ? vms.each_with_object({}) { |v, h| h[v.id.to_s] = v.name } : nil
-    @sb[:planning][:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm] if params[:chosen_vm]
+    @sb[:planning][:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm]
     @sb[:planning][:options][:days] = params[:trend_days].to_i if params[:trend_days]
     @sb[:planning][:options][:vm_mode] = VALID_PLANNING_VM_MODES[params[:vm_mode]] if params[:vm_mode]
     @sb[:planning][:options][:trend_cpu] = (params[:trend_cpu] == "1") if params[:trend_cpu]

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -156,7 +156,6 @@ class MiqCapacityController < ApplicationController
   def planning_option_changed
     vms = nil
     if params[:filter_typ]
-      @sb[:planning][:options][:filter_typ] = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]
       @sb[:planning][:options][:filter_value] = nil
       if params[:filter_typ] == "all"
         vms = find_filtered(Vm).sort_by { |v| v.name.downcase }
@@ -169,7 +168,7 @@ class MiqCapacityController < ApplicationController
         @sb[:planning][:options][:filter_value] = params[:filter_value]
         vms = []
         if @sb[:planning][:options][:filter_value]
-          case @sb[:planning][:options][:filter_typ]
+          case params[:filter_typ]
           when "host"
             vms, count = Host.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
           when "ems"
@@ -183,6 +182,7 @@ class MiqCapacityController < ApplicationController
       end
     end
     @sb[:planning][:vms] = vms ? vms.each_with_object({}) { |v, h| h[v.id.to_s] = v.name } : nil
+    @sb[:planning][:options][:filter_typ] = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]
     @sb[:planning][:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm]
     @sb[:planning][:options][:days] = params[:trend_days].to_i if params[:trend_days]
     @sb[:planning][:options][:vm_mode] = VALID_PLANNING_VM_MODES[params[:vm_mode]] if params[:vm_mode]

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -156,21 +156,21 @@ class MiqCapacityController < ApplicationController
   def planning_option_changed
     vms = nil
     filter_value = params[:filter_value]
-    if params[:filter_typ] == "all"
-      vms = find_filtered(Vm).sort_by { |v| v.name.downcase }
-    end
     if filter_value && filter_value != "<Choose>"
-      vms = []
       case params[:filter_typ]
       when "host"
-        vms, count = Host.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
+        vms, = Host.find(filter_value).find_filtered_children("vms")
       when "ems"
-        vms, count = ExtManagementSystem.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
+        vms, = ExtManagementSystem.find(filter_value).find_filtered_children("vms")
       when "cluster"
-        vms, count = EmsCluster.find(@sb[:planning][:options][:filter_value]).find_filtered_children("all_vms")
+        vms, = EmsCluster.find(filter_value).find_filtered_children("all_vms")
       when "filter"
-        vms = MiqSearch.find(@sb[:planning][:options][:filter_value]).results(:userid => current_userid)
+        vms = MiqSearch.find(filter_value).results(:userid => current_userid)
+      else
+        vms = []
       end
+    elsif params[:filter_typ] == "all"
+      vms = find_filtered(Vm).sort_by { |v| v.name.downcase }
     end
     @sb[:planning][:vms] = vms ? vms.each_with_object({}) { |v, h| h[v.id.to_s] = v.name } : nil
     @sb[:planning][:options][:filter_typ] = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -155,34 +155,26 @@ class MiqCapacityController < ApplicationController
 
   def planning_option_changed
     vms = nil
-    if params[:filter_typ]
-      @sb[:planning][:options][:filter_value] = nil
-      if params[:filter_typ] == "all"
-        vms = find_filtered(Vm).sort_by { |v| v.name.downcase }
-      end
+    filter_value = params[:filter_value]
+    if params[:filter_typ] == "all"
+      vms = find_filtered(Vm).sort_by { |v| v.name.downcase }
     end
-    if params[:filter_value]
-      if params[:filter_value] == "<Choose>"
-        @sb[:planning][:options][:filter_value] = nil
-      else
-        @sb[:planning][:options][:filter_value] = params[:filter_value]
-        vms = []
-        if @sb[:planning][:options][:filter_value]
-          case params[:filter_typ]
-          when "host"
-            vms, count = Host.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
-          when "ems"
-            vms, count = ExtManagementSystem.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
-          when "cluster"
-            vms, count = EmsCluster.find(@sb[:planning][:options][:filter_value]).find_filtered_children("all_vms")
-          when "filter"
-            vms = MiqSearch.find(@sb[:planning][:options][:filter_value]).results(:userid => current_userid)
-          end
-        end
+    if filter_value && filter_value != "<Choose>"
+      vms = []
+      case params[:filter_typ]
+      when "host"
+        vms, count = Host.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
+      when "ems"
+        vms, count = ExtManagementSystem.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
+      when "cluster"
+        vms, count = EmsCluster.find(@sb[:planning][:options][:filter_value]).find_filtered_children("all_vms")
+      when "filter"
+        vms = MiqSearch.find(@sb[:planning][:options][:filter_value]).results(:userid => current_userid)
       end
     end
     @sb[:planning][:vms] = vms ? vms.each_with_object({}) { |v, h| h[v.id.to_s] = v.name } : nil
     @sb[:planning][:options][:filter_typ] = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]
+    @sb[:planning][:options][:filter_value] = params[:filter_value] == "<Choose>" ? nil : params[:filter_value]
     @sb[:planning][:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm]
     @sb[:planning][:options][:days] = params[:trend_days].to_i if params[:trend_days]
     @sb[:planning][:options][:vm_mode] = VALID_PLANNING_VM_MODES[params[:vm_mode]] if params[:vm_mode]

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -154,42 +154,37 @@ class MiqCapacityController < ApplicationController
   end
 
   def planning_option_changed
+    vms = nil
     if params[:filter_typ]
-      @sb[:planning][:vms] = nil
       @sb[:planning][:options][:chosen_vm] = nil
       @sb[:planning][:options][:filter_typ] = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]
       @sb[:planning][:options][:filter_value] = nil
       if params[:filter_typ] == "all"
-        @sb[:planning][:vms] = {}
-        find_filtered(Vm).sort_by { |v| v.name.downcase }.each { |e| @sb[:planning][:vms][e.id.to_s] = e.name }
+        vms = find_filtered(Vm).sort_by { |v| v.name.downcase }
       end
     end
     if params[:filter_value]
-      @sb[:planning][:vms] = nil
       @sb[:planning][:options][:chosen_vm] = nil
       if params[:filter_value] == "<Choose>"
         @sb[:planning][:options][:filter_value] = nil
       else
         @sb[:planning][:options][:filter_value] = params[:filter_value]
-        @sb[:planning][:vms] = {}
+        vms = []
         if @sb[:planning][:options][:filter_value]
           case @sb[:planning][:options][:filter_typ]
           when "host"
             vms, count = Host.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
-            vms.each { |v| @sb[:planning][:vms][v.id.to_s] = v.name }
           when "ems"
             vms, count = ExtManagementSystem.find(@sb[:planning][:options][:filter_value]).find_filtered_children("vms")
-            vms.each { |v| @sb[:planning][:vms][v.id.to_s] = v.name }
           when "cluster"
             vms, count = EmsCluster.find(@sb[:planning][:options][:filter_value]).find_filtered_children("all_vms")
-            vms.each { |v| @sb[:planning][:vms][v.id.to_s] = v.name }
           when "filter"
             vms = MiqSearch.find(@sb[:planning][:options][:filter_value]).results(:userid => current_userid)
-            vms.each { |v| @sb[:planning][:vms][v.id.to_s] = v.name }   # Add the VMs to the pulldown hash
           end
         end
       end
     end
+    @sb[:planning][:vms] = vms ? vms.each_with_object({}) { |v, h| h[v.id.to_s] = v.name } : nil
     @sb[:planning][:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm] if params[:chosen_vm]
     @sb[:planning][:options][:days] = params[:trend_days].to_i if params[:trend_days]
     @sb[:planning][:options][:vm_mode] = VALID_PLANNING_VM_MODES[params[:vm_mode]] if params[:vm_mode]


### PR DESCRIPTION
While I was just in `CapacityController` fixing up the rbac call and wanted to just clean up the rest of this method.

simply cleans up some rubocops and deletes duplicate code that I was having trouble following.

viewing with [whitespace off](7406/files?w=1) simplifies it a bit.
