### PR TITLE
Combine appliance console database options

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -463,9 +463,10 @@ Date and Time Configuration
         action = ask_with_menu("Database Operation", options)
 
         database_configuration =
-          if action == "create_internal"
+          case action
+          when "create_internal"
             ApplianceConsole::InternalDatabaseConfiguration.new
-          elsif action =~ /_external/
+          when /_external/
             ApplianceConsole::ExternalDatabaseConfiguration.new(:action => action.split("_").first.to_sym)
           else
             ApplianceConsole::DatabaseConfiguration.new
@@ -479,31 +480,11 @@ Date and Time Configuration
           else
             say("Failed to reset database")
           end
-          press_any_key
-        when "create_internal", "create_external", "join_external"
-          begin
-            database_configuration.ask_questions
-          rescue ArgumentError => e
-            say("\nConfiguration failed: #{e.message}\n")
-            press_any_key
-            raise MiqSignalError
-          end
-
-          clear_screen
-          say "Activating the configuration using the following settings...\n"
-          say "#{database_configuration.friendly_inspect}\n"
-
-          if database_configuration.activate
-            database_configuration.post_activation
-            say("\nConfiguration activated successfully.\n")
-            dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region
-            press_any_key
-          else
-            say("\nConfiguration activation failed!\n")
-            press_any_key
-            raise MiqSignalError
-          end
+        when "create_internal", /_external/
+          database_configuration.run_interactive
         end
+        dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region
+        press_any_key
 
       when I18n.t("advanced_settings.tmp_config")
         say("#{selection}\n\n")

--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -38,6 +38,22 @@ module ApplianceConsole
       self.interactive = true unless hash.key?(:interactive)
     end
 
+    def run_interactive
+      ask_questions
+
+      clear_screen
+      say "Activating the configuration using the following settings...\n#{friendly_inspect}\n"
+
+      raise MiqSignalError unless activate
+
+      post_activation
+      say("\nConfiguration activated successfully.\n")
+    rescue RuntimeError => e
+      puts "Configuration failed#{": " + e.message unless e.class == MiqSignalError}"
+      press_any_key
+      raise MiqSignalError
+    end
+
     def local?
       host.blank? || host.in?(%w(localhost 127.0.0.1))
     end

--- a/gems/pending/appliance_console/external_database_configuration.rb
+++ b/gems/pending/appliance_console/external_database_configuration.rb
@@ -1,5 +1,7 @@
 module ApplianceConsole
   class ExternalDatabaseConfiguration < DatabaseConfiguration
+    attr_accessor :action
+
     def initialize(hash = {})
       set_defaults
       super
@@ -16,18 +18,10 @@ module ApplianceConsole
     end
 
     def ask_questions
-      create_new_region_questions if create_or_join_region_question == :create
+      create_new_region_questions if action == :create
       clear_screen
       say("Database Configuration\n")
       ask_for_database_credentials
-    end
-
-    def create_or_join_region_question
-      clear_screen
-      ask_with_menu("Database Region",
-                    'Create new region'    => :create,
-                    'Join existing region' => :join
-                   )
     end
   end
 end

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -19,6 +19,10 @@ module ApplianceConsole
       PostgresAdmin.template_directory.join(postgres_dir)
     end
 
+    def self.database_initialized?
+      configured? && !Dir[PostgresAdmin.data_directory.join("*")].empty?
+    end
+
     def initialize(hash = {})
       set_defaults
       super
@@ -31,6 +35,13 @@ module ApplianceConsole
     end
 
     def activate
+      if self.class.database_initialized?
+        say(<<-EOF.gsub!(/^\s+/, ""))
+          An internal database already exists.
+          Choose "Reset Internal Database" to reset the existing installation
+          EOF
+        return false
+      end
       initialize_postgresql_disk if disk
       initialize_postgresql
       super

--- a/gems/pending/appliance_console/locales/en.yml
+++ b/gems/pending/appliance_console/locales/en.yml
@@ -10,7 +10,6 @@ en:
     - hostname
     - datetime
     - dbrestore
-    - dbregion_setup
     - db_config
     - httpdauth
     - key_gen
@@ -26,7 +25,6 @@ en:
     hostname: Set Hostname
     datetime: Set Timezone, Date, and Time
     dbrestore: Restore Database From Backup
-    dbregion_setup: Setup Database Region
     db_config: Configure Database
     httpdauth: Configure External Authentication (httpd)
     evmstop: Stop EVM Server Processes

--- a/gems/pending/spec/appliance_console/database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/database_configuration_spec.rb
@@ -120,11 +120,13 @@ describe ApplianceConsole::DatabaseConfiguration do
 
   context "#create_region" do
     it "normal case" do
+      expect(ApplianceConsole::Utilities).to receive(:bail_if_db_connections)
       allow(@config).to receive_messages(:log_and_feedback => :some_object)
       expect(@config.create_region).to be_truthy
     end
 
     it "failure" do
+      expect(ApplianceConsole::Utilities).to receive(:bail_if_db_connections)
       allow(@config).to receive_messages(:log_and_feedback => nil)
       expect(@config.create_region).to be_falsey
     end


### PR DESCRIPTION
Add a new menu after database config which lists more descriptive options instead of traversing multiple question menus.

Also, replace "Setup Database Region" with an explicit "Reset Configured Database" option which now lives in the database setup sub-menu.

https://bugzilla.redhat.com/show_bug.cgi?id=1277335

@Fryguy @kbrock 