### PR TITLE
Log attempts to do shelve operations on GCE instances

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
@@ -1,10 +1,26 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Power
   def validate_suspend
-    validate_unsupported("Suspend Operation")
+    validate_unsupported(_("Suspend Operation"))
   end
 
   def validate_pause
-    validate_unsupported("Pause Operation")
+    validate_unsupported(_("Pause Operation"))
+  end
+
+  def raw_suspend
+    validate_unsupported(_("Suspend Operation"))
+  end
+
+  def raw_pause
+    validate_unsupported(_("Pause Operation"))
+  end
+
+  def raw_shelve
+    validate_unsupported(_("Shelve Operation"))
+  end
+
+  def raw_shelve_offload
+    validate_unsupported(_("Shelve Offload Operation"))
   end
 
   def raw_start


### PR DESCRIPTION
I feel like there must be a more elegant way to handle this, but could not figure it out. I was expecting to perhaps add a method to some higher-level class that logged a "not implemented" entry. Then providers, like OpenStack, could override the method.

If such a way exists, I'm happy to re-work the PR if I can be pointed in the right direction.  But, this PR does address the immediate problem.

Snippet from EVM log now looks like,

```
[----] I, [2016-03-19T15:49:22.686322 #1342:3fb410055998]  INFO -- : MIQ(policy-enforce_policy): Event: [request_vm_shelve], To: [godev]
[----] I, [2016-03-19T15:49:22.704581 #1342:3fb410055998]  INFO -- : MIQ(MiqAlert.evaluate_alerts) [request_vm_shelve] Target: ManageIQ::Providers::Google::CloudManager::Vm Name: [godev], Id: [422]
[----] E, [2016-03-19T15:49:22.766015 #1342:3fb410055998] ERROR -- : MIQ(ManageIQ::Providers::Google::CloudManager#vm_shelve) vm=[godev], error: Shelve operations are not supported by Google Compute Engine.
```