### PR TITLE
Rbac descendants

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -222,7 +222,7 @@ module ApplicationController::Explorer
   end
 
   def rbac_filtered_objects(objects, options = {})
-    TreeBuilder.rbac_filtered_objects(objects, options)
+    Rbac.filtered(objects, options)
   end
 
   # FIXME: move partly to Tree once Trees are made from TreeBuilder

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -374,11 +374,9 @@ module Rbac
 
   def self.lookup_method_for_descendant_class(klass, descendant_klass)
     key = "#{descendant_klass.base_class}::#{klass.base_class}"
-    method_name = MATCH_VIA_DESCENDANT_RELATIONSHIPS[key]
-    if method_name.nil?
-      _log.warn "could not find method name for #{key}"
+    MATCH_VIA_DESCENDANT_RELATIONSHIPS[key].tap do |method_name|
+      _log.warn "could not find method name for #{key}" if method_name.nil?
     end
-    method_name
   end
 
   def self.parse_descendant_type(descendant_type, klass)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -331,18 +331,10 @@ module Rbac
     Rbac.search(options.merge(:targets => objects, :results_format => :objects, :empty_means_empty => true)).first
   end
 
+  # @param klass [Class] base_class found in CLASSES_THAT_PARTICIPATE_IN_RBAC
   def self.find_via_descendants(descendants, method_name, klass)
-    matches = []
-    descendants.each do |object|
-      match = object.send(method_name)
-      match = [match] unless match.kind_of?(Array)
-      match.each do |m|
-        next unless m.kind_of?(klass)
-        next if matches.include?(m)
-        matches << m
-      end
-    end
-    matches
+    MiqPreloader.preload(descendants, method_name)
+    descendants.flat_map { |object| object.send(method_name) }.grep(klass).uniq
   end
 
   # @option options :user [User]

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -345,8 +345,10 @@ module Rbac
     matches
   end
 
-  def self.find_descendants(descendant_klass, options)
-    search(options.merge(:class => descendant_klass, :results_format => :objects)).first
+  # @option options :user [User]
+  # @option options :miq_group [MiqGroup]
+  def self.find_descendants(scope, options)
+    filtered(scope, options)
   end
 
   def self.ids_via_descendants(klass, descendant_types, options)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -464,7 +464,7 @@ class TreeBuilder
   end
 
   def rbac_filtered_objects(objects, options = {})
-    self.class.rbac_filtered_objects(objects, options)
+    Rbac.filtered(objects, options)
   end
 
   # Add child nodes to the active tree below node 'id'
@@ -476,27 +476,7 @@ class TreeBuilder
   end
 
   def self.rbac_filtered_objects(objects, options = {})
-    return objects if objects.empty?
-
-    # Remove VmOrTemplate :match_via_descendants option if present, comment to let Rbac.search process it
-    descendants = false
-    descendants = options.delete(:match_via_descendants) if %w(ConfiguredSystems VmOrTemplate).include?(options[:match_via_descendants])
-
-    results = Rbac.filtered(objects, options)
-
-    # If we are processing :match_via_descendants and user is filtered (i.e. not like admin/super-admin)
-    if descendants && User.current_user.has_filters?
-      filtered_objects = objects - results
-      results = objects.select do |o|
-        if o.kind_of?(EmsFolder) || filtered_objects.include?(o)
-          rbac_has_visible_descendants?(o, descendants)
-        else
-          true
-        end
-      end
-    end
-
-    results
+    Rbac.filtered(objects, options)
   end
 
   def self.rbac_has_visible_descendants?(o, type)

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -37,7 +37,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
     assigned_configuration_profile_objs =
       count_only_or_objects(count_only,
                             rbac_filtered_objects(ConfigurationProfile.where(:configuration_manager_id => object[:id]),
-                                                  :match_via_descendants => %w(ConfiguredSystem)),
+                                                  :match_via_descendants => ConfiguredSystem),
                             "name")
     unassigned_configuration_profile_objs =
       fetch_unassigned_configuration_profile_objects(count_only, object[:id])
@@ -77,7 +77,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
     objects =
       case object_hash[:id]
       when "fr" then rbac_filtered_objects(ManageIQ::Providers::Foreman::ConfigurationManager.order("lower(name)"),
-                                           :match_via_descendants => %w(ConfiguredSystem))
+                                           :match_via_descendants => ConfiguredSystem)
       when "at" then rbac_filtered_objects(ManageIQ::Providers::AnsibleTower::ConfigurationManager.order("lower(name)"))
       end
     count_only_or_objects(count_only, objects, "name")

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -16,7 +16,7 @@ class TreeBuilderImages < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = rbac_filtered_objects(EmsCloud.order("lower(name)"), :match_via_descendants => "TemplateCloud")
+    objects = rbac_filtered_objects(EmsCloud.order("lower(name)"), :match_via_descendants => TemplateCloud)
     objects += [
       {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived Images")},
       {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned Images")}

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -16,7 +16,7 @@ class TreeBuilderInstances < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = rbac_filtered_objects(EmsCloud.order("lower(name)"), :match_via_descendants => "VmCloud")
+    objects = rbac_filtered_objects(EmsCloud.order("lower(name)"), :match_via_descendants => VmCloud)
     objects += [
       {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived Instances")},
       {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned Instances")}

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -31,14 +31,14 @@ class TreeBuilderUtilization < TreeBuilderRegion
 
   def x_get_tree_vandt_datacenter_kids(object)
     # Count clusters directly in this folder
-    objects = rbac_filtered_sorted_objects(object.clusters, "name", :match_via_descendants => "VmOrTemplate")
+    objects = rbac_filtered_sorted_objects(object.clusters, "name", :match_via_descendants => VmOrTemplate)
     object.folders.each do |f|
       if f.name == "vm"                 # Count vm folder children
-        objects += rbac_filtered_sorted_objects(f.folders, "name", :match_via_descendants => "VmOrTemplate")
+        objects += rbac_filtered_sorted_objects(f.folders, "name", :match_via_descendants => VmOrTemplate)
         objects += rbac_filtered_sorted_objects(f.vms_and_templates, "name")
       elsif f.name == "host"            # Don't count host folder children
       else                              # add in other folders
-        objects += rbac_filtered_objects([f], :match_via_descendants => "VmOrTemplate")
+        objects += rbac_filtered_objects([f], :match_via_descendants => VmOrTemplate)
       end
     end
   end
@@ -61,10 +61,10 @@ class TreeBuilderUtilization < TreeBuilderRegion
     objects = []
     case type
     when :vandt, :handc
-      objects =  rbac_filtered_sorted_objects(object.folders_only, "name", :match_via_descendants => "VmOrTemplate")
-      objects += rbac_filtered_sorted_objects(object.datacenters_only, "name", :match_via_descendants => "VmOrTemplate")
-      objects += rbac_filtered_sorted_objects(object.clusters, "name", :match_via_descendants => "VmOrTemplate")
-      objects += rbac_filtered_sorted_objects(object.hosts, "name", :match_via_descendants => "VmOrTemplate")
+      objects =  rbac_filtered_sorted_objects(object.folders_only, "name", :match_via_descendants => VmOrTemplate)
+      objects += rbac_filtered_sorted_objects(object.datacenters_only, "name", :match_via_descendants => VmOrTemplate)
+      objects += rbac_filtered_sorted_objects(object.clusters, "name", :match_via_descendants => VmOrTemplate)
+      objects += rbac_filtered_sorted_objects(object.hosts, "name", :match_via_descendants => VmOrTemplate)
       objects += rbac_filtered_sorted_objects(object.vms_and_templates, "name")
     end
     count_only_or_objects(count_only, objects, nil)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -4,7 +4,7 @@ class TreeBuilderVandt < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, options)
-    objects = rbac_filtered_objects(EmsInfra.order("lower(name)"), :match_via_descendants => "VmOrTemplate")
+    objects = rbac_filtered_objects(EmsInfra.order("lower(name)"), :match_via_descendants => VmOrTemplate)
 
     if count_only
       objects.length + 2

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -42,11 +42,8 @@ describe VmInfraController do
         user = FactoryGirl.create(:user_admin)
         user.current_group.set_managed_filters([["/managed/service_level/gold"]])
         login_as user
-
-        expect(Rbac).to receive(:search).with(:targets           => [ems_folder],
-                                              :empty_means_empty => true,
-                                              :results_format    => :objects).and_call_original
-        controller.send(:rbac_filtered_objects, [ems_folder], :match_via_descendants => "VmOrTemplate")
+        expect(controller.send(:rbac_filtered_objects, [ems_folder], :match_via_descendants => "VmOrTemplate")).to(
+          eq([ems_folder]))
       end
     end
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -333,14 +333,8 @@ describe Rbac do
           it ".search filters out the wrong HostPerformance rows with :match_via_descendants option" do
             @vm = FactoryGirl.create(:vm_vmware, :name => "VM1", :host => @host2)
             @vm.tag_with(@tags.join(' '), :ns => '*')
-            results, attrs = Rbac.search(:targets => HostPerformance, :class => "HostPerformance", :user => user, :results_format => :objects, :match_via_descendants => {"VmOrTemplate" => :host})
-            expect(attrs[:user_filters]).to eq(group.filters)
-            expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
-            expect(attrs[:auth_count]).to eq(@timestamps.length)
-            expect(results.length).to eq(@timestamps.length)
-            results.each { |vp| expect(vp.resource).to eq(@host2) }
 
-            results, attrs = Rbac.search(:targets => HostPerformance, :class => "HostPerformance", :user => user, :results_format => :objects, :match_via_descendants => "Vm")
+            results, attrs = Rbac.search(:targets => HostPerformance, :class => "HostPerformance", :user => user, :results_format => :objects, :match_via_descendants => Vm)
             expect(attrs[:user_filters]).to eq(group.filters)
             expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
             expect(attrs[:auth_count]).to eq(@timestamps.length)


### PR DESCRIPTION
Larger goal is to use sql to determine valid ids instead of bring all resource ids back

1. remove the N+1 query that fetches every parent resource and every descendant resource
2. convert `match_via_descendants` option to just take a class (and simplify our logic)

/cc @gtanzillo I cut up into commits that are pretty tame. may want to go one by one.
/cc @matthewd thanks for your help so far here.
**UPDATED:** rewrite description to focus on `descendant_resource`