### PR TITLE
[WIP] Add a new mixin for seeding

### DIFF
--- a/app/models/mixins/seeding_mixin.rb
+++ b/app/models/mixins/seeding_mixin.rb
@@ -1,0 +1,66 @@
+module SeedingMixin
+  extend ActiveSupport::Concern
+
+  AssociationSeed = Struct.new(:name, :type, :find_by, :add_proc)
+  module ClassMethods
+    def with_many(association, find_by = :guid, add_proc = nil)
+      add_proc ||= ->(p, c) { p.send("#{association}=", p.send(association) << c) }
+      AssociationSeed.new(association, :has_many, find_by, add_proc)
+    end
+
+    def with_one(association, find_by = :guid)
+      add_proc = ->(p, c) { p.send("#{association}=", c) }
+      AssociationSeed.new(association, :has_one, find_by, add_proc)
+    end
+
+    def seed_model(*associations)
+      load_fixtures(name.tableize).each do |hash|
+        rec = seed_attributes!(self, hash.except(*associations.map(&:name)))
+        seed_associations(rec, hash, associations)
+        rec.save!
+      end
+    end
+
+    private
+
+    def seed_attributes!(model, hash)
+      rec = model.find_by(:guid => hash[:guid])
+      if rec.nil?
+        _log.info("Creating #{model.name}: [#{hash[:guid]}]")
+        rec = model.create(hash)
+      else
+        _log.info("Updating #{model.name}: [#{hash[:guid]}]")
+        rec.assign_attributes(hash)
+      end
+      rec
+    end
+
+    def seed_associations(rec, hash, associations)
+      associations.each do |association|
+        seed_association(rec, hash, association)
+      end
+    end
+
+    def seed_association(parent, hash, association)
+      return if hash[association.name].blank?
+      if association.type == :has_one
+        seed_association_item(parent, hash[association.name], association)
+      else
+        hash[association.name].each do |relation|
+          seed_association_item(parent, relation, association)
+        end
+      end
+    end
+
+    def seed_association_item(parent, relation, association)
+      clazz = association.name.to_s.classify.constantize
+      item = clazz.find_by(association.find_by => relation)
+      association.add_proc.call(parent, item) unless item.nil?
+    end
+
+    def load_fixtures(fixture_name)
+      fixture_file = File.join(ApplicationRecord::FIXTURE_DIR, "#{fixture_name}.yml")
+      File.exist?(fixture_file) ? YAML.load_file(fixture_file) : []
+    end
+  end
+end

--- a/spec/models/mixins/seeding_mixin_spec.rb
+++ b/spec/models/mixins/seeding_mixin_spec.rb
@@ -1,0 +1,285 @@
+describe SeedingMixin do
+  class CreateAllOfTheThings < ActiveRecord::Migration
+    def self.up
+      create_table :some_things do |t|
+        t.column   :name, :string
+        t.column   :description, :string
+        t.column   :guid, :string, :limit => 36
+      end
+
+      create_table :some_other_things do |t|
+        t.column     :name, :string
+        t.column     :description, :string
+        t.column     :guid, :string, :limit => 36
+        t.belongs_to :some_thing, :type => :bigint
+      end
+    end
+
+    def self.down
+      drop_table :some_things
+      drop_table :some_other_things
+    end
+  end
+
+  class SomeThing < ApplicationRecord
+    include SeedingMixin
+  end
+
+  class SomeOtherThing < ApplicationRecord
+    include SeedingMixin
+  end
+
+  FIRST_THING = {
+    :name        => 'thinga',
+    :description => 'very important!',
+    :guid        => 'b330acc8-5898-434f-9e9e-4099453fbb52'
+  }.freeze
+
+  SECOND_THING = {
+    :name        => 'mabob',
+    :description => 'less important!',
+    :guid        => '90a8ef74-0e20-44b1-aefd-8075a5a616be'
+  }.freeze
+
+  before(:each) do
+    stub_const("ApplicationRecord::FIXTURE_DIR", Rails.root.join("spec/fixtures/files"))
+  end
+
+  before(:all) do
+    silence_stdout do
+      CreateAllOfTheThings.up
+    end
+  end
+
+  after(:all) do
+    silence_stdout do
+      CreateAllOfTheThings.down
+    end
+  end
+
+  def silence_stdout
+    original = STDOUT
+    $stdout = File.new(File.join('/', 'dev', 'null'), 'w')
+    yield
+  ensure
+    $stdout = original
+  end
+
+  it "ignores a class with no fixture file" do
+    SomeThing.seed_model
+    expect(SomeThing.count).to be(0)
+  end
+
+  it "seeds two records" do
+    expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return([FIRST_THING, SECOND_THING])
+    SomeThing.seed_model
+
+    expect(SomeThing.count).to be(2)
+    expect(SomeThing.first).to have_attributes(FIRST_THING)
+    expect(SomeThing.second).to have_attributes(SECOND_THING)
+  end
+
+  it "updates a record" do
+    expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return([FIRST_THING])
+    SomeThing.seed_model
+    expect(SomeThing.first.name).to eq(FIRST_THING[:name])
+    expect(SomeThing).to receive(:load_fixtures).once.with('some_things')
+      .and_return([FIRST_THING.merge(:name => 'NO!')])
+    SomeThing.seed_model
+    expect(SomeThing.first.name).to eq('NO!')
+  end
+
+  # has many
+
+  context "has many" do
+    before do
+      SomeThing.class_eval do
+        has_many :some_other_things
+      end
+    end
+
+    it "seeds something with :some_other_things missing" do
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return([FIRST_THING])
+
+      SomeThing.seed_model(SomeThing.with_many(:some_other_things, :name))
+
+      expect(SomeThing.first.some_other_things).to eq([])
+    end
+
+    it "seeds something with :some_other_things = nil" do
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_things => nil
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_many(:some_other_things, :name))
+
+      expect(SomeThing.first.some_other_things).to eq([])
+    end
+
+    it "seeds something with :some_other_things = []" do
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_things => []
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_many(:some_other_things, :name))
+
+      expect(SomeThing.first.some_other_things).to eq([])
+    end
+
+    it "seeds something with :some_other_things = [record that does not exists]" do
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_things => ['oh-no-i-dont-exist']
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_many(:some_other_things, :name))
+
+      expect(SomeThing.first.some_other_things).to eq([])
+    end
+
+    it "searches some_other_things by guid by default" do
+      guid = '77b756e5-4f47-4c57-9aca-e9b269925cdf'
+
+      some_other_thing = SomeOtherThing.new
+      some_other_thing.guid = guid
+      some_other_thing.save
+
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_things => [guid]
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_many(:some_other_things))
+
+      expect(SomeThing.first.some_other_things.first).to eq(SomeOtherThing.first)
+    end
+
+    it "searches some_other_things by requested keys too" do
+      name = 'mike'
+
+      some_other_thing = SomeOtherThing.new
+      some_other_thing.name = name
+      some_other_thing.save
+
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_things => [name]
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_many(:some_other_things, :name))
+
+      expect(SomeThing.first.some_other_things.first).to eq(SomeOtherThing.first)
+    end
+
+    it "uses add proc to add some_other_things" do
+      name = 'mike'.freeze
+
+      some_other_thing = SomeOtherThing.new
+      some_other_thing.name = name
+      some_other_thing.save
+
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_things => [name]
+          )
+        ]
+      )
+      calls = 0
+      SomeThing.seed_model(SomeThing.with_many(:some_other_things, :name, ->(_st, _sot) { calls += 1 }))
+      expect(calls).to eq(1)
+    end
+  end
+
+  context "has one" do
+    before do
+      SomeThing.class_eval do
+        has_one :some_other_thing
+      end
+    end
+
+    it "seeds something with :some_other_thing missing" do
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return([FIRST_THING])
+
+      SomeThing.seed_model(SomeThing.with_one(:some_other_thing, :name))
+
+      expect(SomeThing.first.some_other_thing).to eq(nil)
+    end
+
+    it "seeds something with :some_other_thing = nil" do
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_thing => nil
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_one(:some_other_thing, :name))
+
+      expect(SomeThing.first.some_other_thing).to eq(nil)
+    end
+
+    it "seeds something with :some_other_thing = record that does not exists" do
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_thing => 'oh-no-i-dont-exist'
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_one(:some_other_thing, :name))
+
+      expect(SomeThing.first.some_other_thing).to eq(nil)
+    end
+
+    it "searches associations by guid by default" do
+      guid = '77b756e5-4f47-4c57-9aca-e9b269925cdf'
+
+      some_other_thing = SomeOtherThing.new
+      some_other_thing.guid = guid
+      some_other_thing.save
+
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_thing => guid
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_one(:some_other_thing))
+
+      expect(SomeThing.first.some_other_thing).to eq(SomeOtherThing.first)
+    end
+
+    it "searches associations by requested keys too" do
+      name = 'mike'
+
+      some_other_thing = SomeOtherThing.new
+      some_other_thing.name = name
+      some_other_thing.save
+
+      expect(SomeThing).to receive(:load_fixtures).once.with('some_things').and_return(
+        [
+          FIRST_THING.merge(
+            :some_other_thing => name
+          )
+        ]
+      )
+      SomeThing.seed_model(SomeThing.with_one(:some_other_thing, :name))
+
+      expect(SomeThing.first.some_other_thing).to eq(SomeOtherThing.first)
+    end
+  end
+end


### PR DESCRIPTION
## Goal

Streamline seeding. Currently seeding classes each define a data model (mostly for relationships with other objects) and models seeded together are nested in the same yml and have code for parsing in one of the classes. Nesting does not fit all cases since [examples from #7558]: 
- conditions can belong to more then one policy
- policies can belong to more then one policySets
- policies don't have to actually belong to a policySet 
- conditions don't have to belong to a policy)

Advantages of current approach and relying on guid for relationships:
- each model is seeded separately at model.seed (with order defined at evm_database.rb)
- no need to design different yml structure and write custom parsing code for models
## Usage

From #7558 ;

``` ruby
# Condition
seed_model

# from db/fixtures/conditions.yml

---
- :name: b0868f00-f525-11e5-9643-0242a1565ed5
  :description: Does not have cve failures with high severity
  :modifier: allow
  :expression: !ruby/object:MiqExpression
       exp:
         FIND:
           search:
             =:
               field: ContainerImage.openscap_result.openscap_rule_results-result
               value: fail
           checkall:
             REGULAR EXPRESSION DOES NOT MATCH:
               field: ContainerImage.openscap_result.openscap_rule_results-severity
               value: High
       context_type:
  :towhat: ContainerImage
  :file_mtime:
  :created_on:
  :updated_on:
  :guid: b0868f00-f525-11e5-9643-0242a1565ed5
  :filename:
  :applies_to_exp:
  :notes:

# MiqPolicy
seed_model(
  with_many(:conditions)
)

# from db/fixtures/miq_policies.yml

---
- :name: c5ceab70-da38-11e5-9cae-0242782a2608
  :description: Analyze all new images
  :expression:
  :towhat: ContainerImage
  :guid: c5ceab70-da38-11e5-9cae-0242782a2608
  :created_by: admin
  :updated_by: admin
  :notes:
  :active: true
  :mode: control
  :conditions: []

# MiqPolicyContent
def self.seed
  seed_model(
    with_one(:miq_policy),
    with_one(:miq_action, :name),
    with_one(:miq_event_definition),
  )
end

# from db/fixtures/miq_policy_contents.yml

---
- :guid: 116d2cd0-e50b-4e91-a094-6a6e64c079f3
  :miq_policy: c5ceab70-da38-11e5-9cae-0242782a2608
  :miq_action: container_image_analyze
  :miq_event_definition: containerimage_created
  :qualifier: failure
  :success_sequence:
  :failure_sequence: 1
  :success_synchronous:
  :failure_synchronous:

# MiqPolicySet
seed_model(
  with_many(:miq_policies, :guid, -> (policy_set, policy) { policy_set.add_member(policy) })
)

# from db/fixtures/miq_policy_sets.yml

---
- :name: 747a70d0-a8bf-4b63-bdad-1676bc0c5356
  :description: Container Image default profile
  :guid: 747a70d0-a8bf-4b63-bdad-1676bc0c5356
  :miq_policies:
    - c5ceab70-da38-11e5-9cae-0242782a2608

```
