### PR TITLE
Fix error when 'nothing' is selected in rate assigments

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -726,9 +726,12 @@ class ChargebackController < ApplicationController
   end
 
   WHITELIST_INSTANCE_TYPE = %w(enterprise storage ext_management_system ems_cluster tenant).freeze
+  NOTHING_FORM_VALUE = "nil".freeze
+
   def get_cis_all
     @edit[:cb_assign][:cis] = {}
     klass = @edit[:new][:cbshow_typ]
+    return if klass == NOTHING_FORM_VALUE || klass.nil? # no rate was selected
     unless WHITELIST_INSTANCE_TYPE.include?(klass)
       raise ArgumentError, "Received: #{klass}, expected one of #{WHITELIST_INSTANCE_TYPE}"
     end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -140,5 +140,12 @@ describe ChargebackController do
       controller.instance_variable_set(:@edit, :new => {:cbshow_typ => "None"}, :cb_assign => {})
       expect { controller.send(:get_cis_all) }.to raise_error(ArgumentError)
     end
+
+    it "doesn't names of instances when nothing is selected" do
+      controller.instance_variable_set(:@edit,
+                                       :new => {:cbshow_typ => described_class::NOTHING_FORM_VALUE}, :cb_assign => {})
+      controller.send(:get_cis_all)
+      expect(assigns(:edit)[:cb_assign][:cis]).to eq({})
+    end
   end
 end


### PR DESCRIPTION
Cloud inteligence -> Chargeback ->  Assigments -> Compute || Storage

error happens when "Nothing" is selected in select box 'Assign To'
![screen shot 2016-03-21 at 11 40 33](https://cloud.githubusercontent.com/assets/14937244/13916252/c84bf4a8-ef59-11e5-81de-cfdd17bb78a0.png)


cc @gtanzillo @aljesusg