### PR TITLE
Replace deprecated RetrieveProperties with RetrievePropertiesEx

### DIFF
--- a/gems/pending/VMwareWebService/MiqVimCoreUpdater.rb
+++ b/gems/pending/VMwareWebService/MiqVimCoreUpdater.rb
@@ -333,7 +333,7 @@ class MiqVimCoreUpdater < MiqVimClientBase
       end
     end
 
-    oca = retrieveProperties(@propCol, pfSpec)
+    oca = retrievePropertiesCompat(@propCol, pfSpec)
 
     return nil if !oca || !oca[0] || !oca[0].propSet
 

--- a/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -1899,7 +1899,7 @@ class MiqVimInventory < MiqVimClientBase
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
       $vim_log.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: calling retrieveProperties" if $vim_log
-      rv = retrieveProperties(@propCol, @spec)
+      rv = retrievePropertiesCompat(@propCol, @spec)
       $vim_log.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: returned from retrieveProperties" if $vim_log
       @inventoryHash = {}
       rv.each { |v| (@inventoryHash[v.obj.vimType] ||= []) << v.obj }
@@ -2141,7 +2141,7 @@ class MiqVimInventory < MiqVimClientBase
     state = result = error = nil
 
     until state
-      oca = retrieveProperties(@propCol, args)
+      oca = retrievePropertiesCompat(@propCol, args)
       raise "waitForTask: task not found #{tmor}" if !oca || !oca[0] || !oca[0].propSet
 
       oca[0].propSet.each do |ps|
@@ -2183,7 +2183,7 @@ class MiqVimInventory < MiqVimClientBase
 
     state = result = error = progress = nil
 
-    oca = retrieveProperties(@propCol, args)
+    oca = retrievePropertiesCompat(@propCol, args)
     raise "pollTask: task not found #{tmor}" if !oca || !oca[0] || !oca[0].propSet
 
     oca[0].propSet.each do |ps|
@@ -2239,7 +2239,7 @@ class MiqVimInventory < MiqVimClientBase
     end
 
     $vim_log.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: calling retrieveProperties(#{mo.vimType})" if $vim_log
-    oca = retrieveProperties(@propCol, pfSpec)
+    oca = retrievePropertiesCompat(@propCol, pfSpec)
     $vim_log.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: return from retrieveProperties(#{mo.vimType})" if $vim_log
 
     return nil if !oca || !oca[0] || !oca[0].propSet
@@ -2314,7 +2314,7 @@ class MiqVimInventory < MiqVimClientBase
     end
 
     begin
-      oca = retrieveProperties(@propCol, args)
+      oca = retrievePropertiesCompat(@propCol, args)
     rescue HTTPClient::ReceiveTimeoutError => rte
       $vim_log.info "MiqVimInventory(#{@server}, #{@username}).getMoPropMulti: retrieveProperties timed out, reverting to getMoPropMultiIter" if $vim_log
       return getMoPropMultiIter(moa, path)

--- a/gems/pending/VMwareWebService/VimService.rb
+++ b/gems/pending/VMwareWebService/VimService.rb
@@ -870,6 +870,32 @@ class VimService < Handsoap::Service
     (parse_response(response, 'RetrievePropertiesResponse')['returnval'])
   end
 
+  def retrievePropertiesEx(propCol, specSet, max_objects = nil)
+    options = VimHash.new("RetrieveOptions") do |opts|
+      opts.maxObjects = max_objects.to_s if max_objects
+    end
+
+    response = invoke("n1:RetrievePropertiesEx") do |message|
+      message.add "n1:_this", propCol do |i|
+        i.set_attr "type", propCol.vimType
+      end
+      message.add "n1:specSet" do |i|
+        i.set_attr "xsi:type", "PropertyFilterSpec"
+        marshalObj(i, specSet)
+      end
+      message.add "n1:options" do |i|
+        i.set_attr "xsi:type", "RetrieveOptions"
+        marshalObj(i, options)
+      end
+    end
+    (parse_response(response, 'RetrievePropertiesExResponse')['returnval'])
+  end
+
+  def retrievePropertiesCompat(propCol, specSet, max_objects = nil)
+    rv = retrievePropertiesEx(propCol, specSet, max_objects)
+    rv ? rv['objects'] : []
+  end
+
   def retrieveServiceContent
     response = invoke("n1:RetrieveServiceContent") do |message|
       message.add "n1:_this", @serviceInstanceMor do |i|


### PR DESCRIPTION
RetrieveProperties was deprecated in vSphere 4.1 and all callers should be moved to the new RetrievePropertiesEx.

https://www.vmware.com/support/developer/vc-sdk/wssdk_4_1_releasenotes.html#deprecations

API prototype:
https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vmodl.query.PropertyCollector.html#retrievePropertiesEx