### PR TITLE
Handle dsn containing keys which don't match an attribute name

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -83,7 +83,7 @@ class PglogicalSubscription < ActsAsArModel
 
   def self.dsn_attributes(dsn)
     attrs = connection.class.parse_dsn(dsn)
-    attrs.delete(:password)
+    attrs.select! { |k, _v| [:dbname, :host, :user, :port].include?(k) }
     port = attrs.delete(:port)
     attrs[:port] = port.to_i unless port.blank?
     attrs

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -14,7 +14,7 @@ describe PglogicalSubscription do
         "subscription_name" => "subscription_test_example_com",
         "status"            => "disabled",
         "provider_node"     => "region_1",
-        "provider_dsn"      => "dbname = vmdb_test2 host=test.example.com user = postgres port=5432",
+        "provider_dsn"      => "dbname = vmdb_test2 host=test.example.com user = postgres port=5432 fallback_application_name='bin/rails'",
         "slot_name"         => "pgl_vmdb_test_region_1_subscripdb71d61",
         "replication_sets"  => ["miq"],
         "forward_origins"   => ["all"]


### PR DESCRIPTION
The hash we use to construct a new object in `PglogicalSubscription.find` needs to only contain keys which match defined attributes.

@gtanzillo @Fryguy 