### PR TITLE
Generate ChargeBack report by Tenant

### DIFF
--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -248,6 +248,9 @@ module ReportController::Reports
             add_flash(_("An Owner must be selected"), :error)
             active_tab = "edit_3"
           end
+        elsif @edit[:new][:cb_show_typ] == "tenant" && !@edit[:new][:cb_tenant_id]
+          add_flash(_("A Tenant Category must be selected"), :error)
+          active_tab = "edit_3"
         elsif @edit[:new][:cb_show_typ] == "tag"
           unless @edit[:new][:cb_tag_cat]
             add_flash(_("A Tag Category must be selected"), :error)
@@ -301,6 +304,19 @@ module ReportController::Reports
     @flash_array.nil?
   end
 
+  # Check if chargeback field is valid
+  def valid_chargeback_fields
+    is_valid = false
+    # There are valid show typ fields
+    if %w(owner tenant tag).include?(@edit[:new][:cb_show_typ])
+      is_valid = case @edit[:new][:cb_show_typ]
+                 when "owner" then @edit[:new][:cb_owner_id]
+                 when "tenant" then @edit[:new][:cb_tenant_id]
+                 when "tag" then @edit[:new][:cb_tag_cat] && @edit[:new][:cb_tag_value]
+                 end
+    end
+    is_valid
+  end
   # Check for tab switch error conditions
   def check_tabs
     @sb[:miq_tab] = params[:tab]
@@ -370,13 +386,9 @@ module ReportController::Reports
       else
         if @edit[:new][:fields].length == 0
           add_flash(_("Preview tab is not available until at least 1 field has been selected"), :error)
-        elsif @edit[:new][:model] == "Chargeback"
-          unless @edit[:new][:cb_show_typ] &&
-                 ((@edit[:new][:cb_show_typ] == "owner" && @edit[:new][:cb_owner_id]) ||
-                   (@edit[:new][:cb_show_typ] == "tag" && @edit[:new][:cb_tag_cat] && @edit[:new][:cb_tag_value]))
-            add_flash(_("Preview tab is not available until Chargeback Filters has been configured"), :error)
-            active_tab = "edit_3"
-          end
+        elsif @edit[:new][:model] == "Chargeback" && !valid_chargeback_fields
+          add_flash(_("Preview tab is not available until Chargeback Filters has been configured"), :error)
+          active_tab = "edit_3"
         end
       end
     when "9"

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -625,6 +625,8 @@ module ReportController::Reports::Editor
       end
     elsif params.key?(:cb_owner_id)
       @edit[:new][:cb_owner_id] = params[:cb_owner_id].blank? ? nil : params[:cb_owner_id]
+    elsif params.key?(:cb_tenant_id)
+      @edit[:new][:cb_tenant_id] = params[:cb_tenant_id].blank? ? nil : params[:cb_tenant_id].to_i
     elsif params.key?(:cb_tag_value)
       @edit[:new][:cb_tag_value] = params[:cb_tag_value].blank? ? nil : params[:cb_tag_value]
     elsif params.key?(:cb_groupby)
@@ -1171,6 +1173,8 @@ module ReportController::Reports::Editor
       options[:end_interval_offset] = @edit[:new][:cb_end_interval_offset]
       if @edit[:new][:cb_show_typ] == "owner"
         options[:owner] = @edit[:new][:cb_owner_id]
+      elsif @edit[:new][:cb_show_typ] == "tenant"
+        options[:tenant_id] = @edit[:new][:cb_tenant_id]
       elsif @edit[:new][:cb_show_typ] == "tag"
         if @edit[:new][:cb_tag_cat] && @edit[:new][:cb_tag_value]
           options[:tag] = "/managed/#{@edit[:new][:cb_tag_cat]}/#{@edit[:new][:cb_tag_value]}"
@@ -1453,6 +1457,9 @@ module ReportController::Reports::Editor
       if options.key?(:owner) # Get the owner options
         @edit[:new][:cb_show_typ] = "owner"
         @edit[:new][:cb_owner_id] = options[:owner]
+      elsif options.key?(:tenant_id) # Get the tenant options
+        @edit[:new][:cb_show_typ] = "tenant"
+        @edit[:new][:cb_tenant_id] = options[:tenant_id]
       elsif options.key?(:tag)  # Get the tag options
         @edit[:new][:cb_show_typ] = "tag"
         @edit[:new][:cb_tag_cat] = options[:tag].split("/")[-2]
@@ -1471,6 +1478,8 @@ module ReportController::Reports::Editor
     if admin_user?
       @edit[:cb_users] = {}
       User.all.each { |u| @edit[:cb_users][u.userid] = u.name }
+      @edit[:cb_tenant] = {}
+      Tenant.all.each { |t| @edit[:cb_tenant][t.id] = t.name }
     else
       @edit[:new][:cb_show_typ] = "owner"
       @edit[:new][:cb_owner_id] = session[:userid]
@@ -1612,6 +1621,8 @@ module ReportController::Reports::Editor
     if admin_user?
       @edit[:cb_users] = {}
       User.all.each { |u| @edit[:cb_users][u.userid] = u.name }
+      @edit[:cb_tenant] = {}
+      Tenant.all.each { |t| @edit[:cb_tenant][t.id] = t.name }
     else
       @edit[:new][:cb_show_typ] = "owner"
       @edit[:new][:cb_owner_id] = session[:userid]

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -72,6 +72,13 @@ class Chargeback < ActsAsArModel
     elsif options[:tag]
       vms = Vm.find_tagged_with(:all => options[:tag], :ns => "*")
       vms &= report_user.accessible_vms if report_user && report_user.self_service?
+    elsif options[:tenant_id]
+      tenant = Tenant.find(options[:tenant_id])
+      if tenant.nil?
+        _log.error("Unable to find tenant '#{options[:tenant_id]}'. Calculating chargeback costs aborted.")
+        raise MiqException::Error, "Unable to find tenant '#{options[:tenant_id]}'"
+      end
+      vms = tenant.vms
     else
       raise "must provide options :owner or :tag"
     end

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -8,7 +8,7 @@
         %label.control-label.col-md-2
           = _('Show Costs by')
         .col-md-8
-          - opts = [["<#{_('Choose')}>", nil], [_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"]]
+          - opts = [["<#{_('Choose')}>", nil], [_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"], [_('Tenant'), "tenant"]]
           = select_tag("cb_show_typ",
             options_for_select(opts, @edit[:new][:cb_show_typ]),
             :class                 => "selectpicker")
@@ -27,6 +27,18 @@
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent('cb_owner_id', '#{url}', {beforeSend: true, complete: true});
+      - elsif @edit[:new][:cb_show_typ] == "tenant"
+        .form-group
+          %label.control-label.col-md-2
+            = _('Tenant')
+          .col-md-8
+            - opts = [["<#{_('Choose a tenant')}>", nil]] + Array(@edit[:cb_tenant].invert).sort_by { |a| a.first.downcase }
+            = select_tag("cb_tenant_id",
+              options_for_select(opts, @edit[:new][:cb_tenant_id]),
+              :class                 => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('cb_tenant_id', '#{url}', {beforeSend: true, complete: true});
       - elsif @edit[:new][:cb_show_typ] == "tag"
         .form-group
           %label.control-label.col-md-2


### PR DESCRIPTION
After have assignment to tenant #7202 we need make a chargeback report by tenant.

## Description

This pull request provides a chargeback report by tenant

Now we can show costs by Tenant

<img width="1014" alt="captura de pantalla 2016-03-21 a las 16 26 03" src="https://cloud.githubusercontent.com/assets/3019213/13923616/ac560464-ef81-11e5-8072-4cad13347be1.png">

And select the tenant that we wanna get the report

<img width="1028" alt="captura de pantalla 2016-03-21 a las 16 26 15" src="https://cloud.githubusercontent.com/assets/3019213/13923617/ac560ba8-ef81-11e5-8543-7ea6209a9dd6.png">

### Working with
@lpichler 

## More Information 
Taiga:
https://tree.taiga.io/project/sergioocon-charging-in-manageiq/task/40