### PR TITLE
Pull back vms method for openstack infracture stack

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
@@ -3,17 +3,44 @@ class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::Orche
   belongs_to :orchestration_template
   belongs_to :cloud_tenant
 
-  def self.create_stack(orchestration_manager, stack_name, template, options = {})
-    klass = orchestration_manager.class::OrchestrationStack
-    ems_ref = klass.raw_create_stack(orchestration_manager, stack_name, template, options)
+  has_many   :direct_vms,             :class_name => "Manageiq::Providers::InfraManager::Vm"
+  has_many   :direct_security_groups, :class_name => "SecurityGroup"
+  has_many   :direct_cloud_networks,  :class_name => "CloudNetwork"
 
-    klass.create(:name                   => stack_name,
-                 :ems_ref                => ems_ref,
-                 :status                 => 'CREATE_IN_PROGRESS',
-                 :resource_group         => options[:resource_group],
-                 :ext_management_system  => orchestration_manager,
-                 :cloud_tenant           => tenant,
-                 :orchestration_template => template)
+  virtual_has_many :vms, :class_name => "ManageIQ::Providers::InfraManager::Vm"
+  virtual_has_many :security_groups
+  virtual_has_many :cloud_networks
+
+  virtual_column :total_vms,             :type => :integer
+  virtual_column :total_security_groups, :type => :integer
+  virtual_column :total_cloud_networks,  :type => :integer
+
+  def total_vms
+    vms.size
+  end
+
+  def indirect_vms
+    MiqPreloader.preload_and_map(children, :direct_vms)
+  end
+
+  def total_security_groups
+    security_groups.size
+  end
+
+  def total_cloud_networks
+    cloud_networks.size
+  end
+
+  def vms
+    directs_and_indirects(:direct_vms)
+  end
+
+  def security_groups
+    directs_and_indirects(:direct_security_groups)
+  end
+
+  def cloud_networks
+    directs_and_indirects(:direct_cloud_networks)
   end
 
   def raw_update_stack(template, parameters)


### PR DESCRIPTION
In #7165 we split the base `OrchstrationStack` into `OrchestrationStack` and `CloudManager::OrchestrationStack`. As a result  `InfraManager::OrchestrationStack` no longer contains `vms`, `cloud_networks`, and `security_groups`. This breaks the UI when showing a infrastructure stack reported in #7382.

The first attempt to fix the problem is to copy some code from `CloudManager::OrchestrationStack` to `InfraManager::OrchestrationStack`. This ensures it works the same as before the refactoring by #7165. I don't know the true relationship between infrastructure stack and vms, cloud networks, and security groups. We may simply return empty array if such relationship does not exist.
  
Also removed `create_stack` because `raw_create_stack` was never implemented. 

Need @Ladas to review and comment. Is there a reason we don't support creation for infrastructure stacks?
