### PR TITLE
Allow sorting using system_distribution on the ui container nodes table

### DIFF
--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -21,6 +21,8 @@ class ContainerNode < ApplicationRecord
   has_many :vim_performance_states, :as => :resource
 
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions
+  virtual_column :system_distribution, :type => :string
+  virtual_column :kernel_version, :type => :string
 
   # Needed for metrics
   delegate :my_zone, :to => :ext_management_system


### PR DESCRIPTION
Allow sorting using system_distribution on the ui container nodes table:

![screenshot-2016-03-21-19-33-31](https://cloud.githubusercontent.com/assets/2181522/13928053/ed092822-ef9c-11e5-8dd2-23fe0a56d1a8.png)
