### PR TITLE
[WIP] Added REST API support to return config product setting for SSUI work.

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -133,6 +133,10 @@ class ApiController
       pf_result
     end
 
+    def product_settings
+      VMDB::Config.new("vmdb").config[:product]
+    end
+
     def add_product_feature(pf_result, ident)
       details  = MiqProductFeature.features[ident.to_s][:details]
       children = MiqProductFeature.feature_children(ident)

--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -11,6 +11,7 @@ class ApiController
         :version     => @version,
         :versions    => entrypoint_versions,
         :settings    => user_settings,
+        :product_settings  => product_settings,
         :identity    => auth_identity
       }
       res[:authorization] = auth_authorization if attribute_selection.include?("authorization")


### PR DESCRIPTION
Need to fetch VMDB::Config.new("vmdb").config[:product] setting in order to show/hide "Blueprints" accordion in SSUI.

@Fryguy @abellotti @dclarizio please review/suggest if there is another way to fetch those settings.