### PR TITLE
Add 'cloud_network' to list of tables

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -827,6 +827,7 @@ en:
       based_volumes:               Cloud Volumes Based on Snapshot
       cdroms:                      CD/DVD Drives
       cim_base_storage_extent:     Base Extents
+      cloud_network:               Cloud Network
       cloud_tenants:               Cloud Tenants
       cloud_volume:                Cloud Volume
       cloud_volumes:               Cloud Volumes


### PR DESCRIPTION
'cloud_network' is being used in `app/helpers/orchestration_stack_helper/textual_summary.rb`