### PR TITLE
Use /tmp for RSpec --only-failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,9 +108,6 @@ public/stylesheets/jmaki-3column-footer.css
 public/stylesheets/jmaki-standard-no-sidebars.css
 public/stylesheets/jmaki-standard-right-sidebar.css
 
-# spec/
-spec/examples.txt
-
 # tmp/
 tmp/*
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
 
   unless ENV['CI']
     # File store for --only-failures option
-    config.example_status_persistence_file_path = "./spec/examples.txt"
+    config.example_status_persistence_file_path = "./tmp/rspec_example_store.txt"
   end
 
   config.include VMDBConfigurationHelper


### PR DESCRIPTION
Because it will be ignored across more older versions of MIQ, so switching to an older version won't have a random examples.txt lying around