### PR TITLE
Miq expression specs housekeeping

### DIFF
--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -1,16 +1,12 @@
 describe MiqExpression do
   describe "#to_sql" do
-    let(:tag) { FactoryGirl.create(:tag, :name => "/managed/operations/analysis_failed") }
-
-    before do
-      @vm = FactoryGirl.create(:vm_vmware, :tags => [tag])
-    end
-
     it "returns condition with ids of the model, when operation is 'CONTAINS' some tag in expression" do
+      tag = FactoryGirl.create(:tag, :name => "/managed/operations/analysis_failed")
+      vm = FactoryGirl.create(:vm_vmware, :tags => [tag])
       expression_with_tag = {"CONTAINS" => {"tag" => "VmInfra.managed-operations", "value" => "analysis_failed"}}
       expression = MiqExpression.new(expression_with_tag)
       sql_clause = expression.to_sql.first
-      expect(sql_clause).to eq("vms.id IN (#{@vm.id})")
+      expect(sql_clause).to eq("vms.id IN (#{vm.id})")
     end
   end
 

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -8,6 +8,160 @@ describe MiqExpression do
       sql_clause = expression.to_sql.first
       expect(sql_clause).to eq("vms.id IN (#{vm.id})")
     end
+
+    context "date/time support" do
+      it "generates the SQL for an AFTER expression" do
+        exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on > '2011-01-10'")
+      end
+
+      it "generates the SQL for a > expression" do
+        exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on > '2011-01-10'")
+      end
+
+      it "generates the SQL for a BEFORE expression" do
+        exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on < '2011-01-10'")
+      end
+
+      it "generates the SQL for a < expression" do
+        exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on < '2011-01-10'")
+      end
+
+      it "generates the SQL for a >= expression" do
+        exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on >= '2011-01-10'")
+      end
+
+      it "generates the SQL for a <= expression" do
+        exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on <= '2011-01-10'")
+      end
+
+      it "generates the SQL for an AFTER expression with date/time" do
+        exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
+      end
+
+      it "generates the SQL for a > expression with date/time" do
+        exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
+      end
+
+      it "generates the SQL for an IS expression" do
+        exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on = '2011-01-10'")
+      end
+
+      it "generates the SQL for a FROM expression" do
+        exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'")
+      end
+
+      it "generates the SQL for a FROM expression with MM/DD/YYYY dates" do
+        exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'")
+      end
+
+      it "generates the SQL for a FROM expression with date/time" do
+        exp = MiqExpression.new(
+          "FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]}
+        )
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-10T08:00:00Z' AND '2011-01-10T17:00:00Z'")
+      end
+
+      it "generates the SQL for a FROM expression with two identical datetimes" do
+        exp = MiqExpression.new(
+          "FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]}
+        )
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-10T00:00:00Z' AND '2011-01-10T00:00:00Z'")
+      end
+    end
+
+    context "relative date/time support" do
+      around { |example| Timecop.freeze("2011-01-11 17:30 UTC") { example.run } }
+
+      it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a date field" do
+        exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on > '2011-01-09'")
+      end
+
+      it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a datetime field" do
+        exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on > '2011-01-09T23:59:59Z'")
+      end
+
+      it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a date field" do
+        exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on < '2011-01-09'")
+      end
+
+      it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a datetime field" do
+        exp = MiqExpression.new("BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on < '2011-01-09T00:00:00Z'")
+      end
+
+      it "generates the SQL for a FROM expression with a 'Last Hour'/'This Hour' value for a datetime field" do
+        exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-11T16:00:00Z' AND '2011-01-11T17:59:59Z'")
+      end
+
+      it "generates the SQL for a FROM expression with a 'Last Week'/'Last Week' value for a date field" do
+        exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-03' AND '2011-01-09'")
+      end
+
+      it "generates the SQL for a FROM expression with a 'Last Week'/'Last Week' value for a datetime field" do
+        exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-03T00:00:00Z' AND '2011-01-09T23:59:59Z'")
+      end
+
+      it "generates the SQL for a FROM expression with an 'n Months Ago'/'Last Month' value for a datetime field" do
+        exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2010-11-01T00:00:00Z' AND '2010-12-31T23:59:59Z'")
+      end
+
+      it "generates the SQL for an IS expression with a 'Today' value for a date field" do
+        exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'")
+      end
+
+      it "generates the SQL for an IS expression with an 'n Hours Ago' value for a date field" do
+        exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'")
+      end
+
+      it "generates the SQL for an IS expression with an 'n Hours Ago' value for a datetime field" do
+        exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
+        sql, * = exp.to_sql
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-11T14:00:00Z' AND '2011-01-11T14:59:59Z'")
+      end
+    end
   end
 
   describe ".to_ruby" do
@@ -439,85 +593,6 @@ describe MiqExpression do
         expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T05:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T05:00:00Z'.to_time(:utc)")
       end
 
-      describe "#to_sql" do
-        it "generates the SQL for an AFTER expression" do
-          exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on > '2011-01-10'")
-        end
-
-        it "generates the SQL for a > expression" do
-          exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on > '2011-01-10'")
-        end
-
-        it "generates the SQL for a BEFORE expression" do
-          exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on < '2011-01-10'")
-        end
-
-        it "generates the SQL for a < expression" do
-          exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on < '2011-01-10'")
-        end
-
-        it "generates the SQL for a >= expression" do
-          exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on >= '2011-01-10'")
-        end
-
-        it "generates the SQL for a <= expression" do
-          exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on <= '2011-01-10'")
-        end
-
-        it "generates the SQL for an AFTER expression with date/time" do
-          exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
-        end
-
-        it "generates the SQL for a > expression with date/time" do
-          exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
-        end
-
-        it "generates the SQL for an IS expression" do
-          exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on = '2011-01-10'")
-        end
-
-        it "generates the SQL for a FROM expression" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'")
-        end
-
-        it "generates the SQL for a FROM expression with MM/DD/YYYY dates" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'")
-        end
-
-        it "generates the SQL for a FROM expression with date/time" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-10T08:00:00Z' AND '2011-01-10T17:00:00Z'")
-        end
-
-        it "generates the SQL for a FROM expression with two identical datetimes" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-10T00:00:00Z' AND '2011-01-10T00:00:00Z'")
-        end
-      end
 
       it "should generate the correct human expression with an expression having static dates and times with no time zone" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
@@ -713,74 +788,6 @@ describe MiqExpression do
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
         expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)")
-      end
-
-      describe "#to_sql" do
-        it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a date field" do
-          exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on > '2011-01-09'")
-        end
-
-        it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a datetime field" do
-          exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on > '2011-01-09T23:59:59Z'")
-        end
-
-        it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a date field" do
-          exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on < '2011-01-09'")
-        end
-
-        it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a datetime field" do
-          exp = MiqExpression.new("BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on < '2011-01-09T00:00:00Z'")
-        end
-
-        it "generates the SQL for a FROM expression with a 'Last Hour'/'This Hour' value for a datetime field" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-11T16:00:00Z' AND '2011-01-11T17:59:59Z'")
-        end
-
-        it "generates the SQL for a FROM expression with a 'Last Week'/'Last Week' value for a date field" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on BETWEEN '2011-01-03' AND '2011-01-09'")
-        end
-
-        it "generates the SQL for a FROM expression with a 'Last Week'/'Last Week' value for a datetime field" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-03T00:00:00Z' AND '2011-01-09T23:59:59Z'")
-        end
-
-        it "generates the SQL for a FROM expression with an 'n Months Ago'/'Last Month' value for a datetime field" do
-          exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on BETWEEN '2010-11-01T00:00:00Z' AND '2010-12-31T23:59:59Z'")
-        end
-
-        it "generates the SQL for an IS expression with a 'Today' value for a date field" do
-          exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'")
-        end
-
-        it "generates the SQL for an IS expression with an 'n Hours Ago' value for a date field" do
-          exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'")
-        end
-
-        it "generates the SQL for an IS expression with an 'n Hours Ago' value for a datetime field" do
-          exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
-          sql, * = exp.to_sql
-          expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-11T14:00:00Z' AND '2011-01-11T14:59:59Z'")
-        end
       end
 
       it "should generate the correct human expression running to_ruby with an expression having relative dates with no time zone" do

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -1,12 +1,4 @@
 describe MiqExpression do
-  let(:exp) { {"=" => {"field" => "Vm-name", "value" => "test"}} }
-  let(:qs_exp) { {"=" => {"field" => "Vm-name", "value" => :user_input}} }
-  let(:complex_qs_exp) do
-    {"AND" => [
-      {"=" => {"field" => "Vm-name", "value" => "test"}}, {"=" => {"field" => "Vm-name", "value" => :user_input}}
-    ]}
-  end
-
   describe "#to_sql" do
     let(:tag) { FactoryGirl.create(:tag, :name => "/managed/operations/analysis_failed") }
 
@@ -881,39 +873,52 @@ describe MiqExpression do
     expect(attrs[:supported_by_sql]).to eq(false)
   end
 
-  describe ".quick_search?" do
-    it "detects false in hash" do
-      expect(MiqExpression.quick_search?(exp)).to be_falsey
+  context "quick search" do
+    let(:exp) { {"=" => {"field" => "Vm-name", "value" => "test"}} }
+    let(:qs_exp) { {"=" => {"field" => "Vm-name", "value" => :user_input}} }
+    let(:complex_qs_exp) do
+      {
+        "AND" => [
+          {"=" => {"field" => "Vm-name", "value" => "test"}},
+          {"=" => {"field" => "Vm-name", "value" => :user_input}}
+        ]
+      }
     end
 
-    it "detects in hash" do
-      expect(MiqExpression.quick_search?(qs_exp)).to be_truthy
+    describe ".quick_search?" do
+      it "detects false in hash" do
+        expect(MiqExpression.quick_search?(exp)).to be_falsey
+      end
+
+      it "detects in hash" do
+        expect(MiqExpression.quick_search?(qs_exp)).to be_truthy
+      end
+
+      it "detects in complex hash" do
+        expect(MiqExpression.quick_search?(complex_qs_exp)).to be_truthy
+      end
+
+      it "detects false in miq expression" do
+        expect(MiqExpression.quick_search?(MiqExpression.new(exp))).to be_falsey
+      end
+
+      it "detects in miq expression" do
+        expect(MiqExpression.quick_search?(MiqExpression.new(qs_exp))).to be_truthy
+      end
     end
 
-    it "detects in complex hash" do
-      expect(MiqExpression.quick_search?(complex_qs_exp)).to be_truthy
-    end
+    describe "#quick_search?" do
+      it "detects false in hash" do
+        expect(MiqExpression.new(exp).quick_search?).to be_falsey
+      end
 
-    it "detects false in miq expression" do
-      expect(MiqExpression.quick_search?(MiqExpression.new(exp))).to be_falsey
-    end
+      it "detects in hash" do
+        expect(MiqExpression.new(qs_exp).quick_search?).to be_truthy
+      end
 
-    it "detects in miq expression" do
-      expect(MiqExpression.quick_search?(MiqExpression.new(qs_exp))).to be_truthy
-    end
-  end
-
-  describe "#quick_search?" do
-    it "detects false in hash" do
-      expect(MiqExpression.new(exp).quick_search?).to be_falsey
-    end
-
-    it "detects in hash" do
-      expect(MiqExpression.new(qs_exp).quick_search?).to be_truthy
-    end
-
-    it "detects in complex hash" do
-      expect(MiqExpression.new(complex_qs_exp).quick_search?).to be_truthy
+      it "detects in complex hash" do
+        expect(MiqExpression.new(complex_qs_exp).quick_search?).to be_truthy
+      end
     end
   end
 

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -9,6 +9,19 @@ describe MiqExpression do
       expect(sql_clause).to eq("vms.id IN (#{vm.id})")
     end
 
+    it "should test virtual column FB15509" do
+      exp = YAML.load '--- !ruby/object:MiqExpression
+      context_type:
+      exp:
+        CONTAINS:
+          field: MiqGroup.vms-disconnected
+          value: "false"
+      '
+
+      *, attrs = exp.to_sql
+      expect(attrs[:supported_by_sql]).to eq(false)
+    end
+
     context "date/time support" do
       it "generates the SQL for an AFTER expression" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
@@ -861,19 +874,6 @@ describe MiqExpression do
         expect(exp.to_human).to eq("Env CONTAINS 'Production'")
       end
     end
-  end
-
-  it "should test virtual column FB15509" do
-    exp = YAML.load '--- !ruby/object:MiqExpression
-    context_type:
-    exp:
-      CONTAINS:
-        field: MiqGroup.vms-disconnected
-        value: "false"
-    '
-
-    sql, incl, attrs = exp.to_sql
-    expect(attrs[:supported_by_sql]).to eq(false)
   end
 
   context "quick search" do


### PR DESCRIPTION
I'm going to start adding specs for `MiqExpression#to_sql` in preparation for https://trello.com/c/Vje3DjhW so wanted to bring some order to the existing ones. This change moves all the `#to_sql` specs under the one describe block. It also moves/removes some lets/befores which had an unnecessarily large scope.

/cc @gtanzillo 
@miq-bot add-label test