### PR TITLE
Fix syntax error in 40aeadcac0c

### DIFF
--- a/gems/pending/VMwareWebService/test/migrateTest.rb
+++ b/gems/pending/VMwareWebService/test/migrateTest.rb
@@ -69,7 +69,8 @@ begin
   
   miqVm.refresh
   puts "VM: #{miqVm.name}, HOST: #{miqVm.hostSystem}"
-  puts  rescue => err
+  puts
+rescue => err
   puts err.to_s
   puts err.backtrace.join("\n")
 ensure


### PR DESCRIPTION
The mass reformat commit broke a test that is only ever run manually.