### PR TITLE
Fix the redirect in restful controllers when button with service dialog for providers is executed

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -53,10 +53,16 @@ module ApplicationController::DialogRunner
                                  :flash_msg  => flash
               end
             else
+              model = ("#{controller_name.camelize}Controller").constantize.model
               render :update do |page|
-                page.redirect_to :action    => 'show',
-                                 :id        => session[:edit][:target_id],
-                                 :flash_msg => flash  # redirect to miq_request show_list screen
+                if restful_routed?(model)
+                  page.redirect_to polymorphic_path(model.where(:id => session[:edit][:target_id]).first,
+                                                    :flash_msg => flash)
+                else
+                  page.redirect_to :action    => 'show',
+                                   :id        => session[:edit][:target_id],
+                                   :flash_msg => flash
+                end
               end
             end
           else

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -358,4 +358,27 @@ describe EmsCloudController do
       end
     end
   end
+
+  describe "#dialog_form_button_pressed" do
+    let(:dialog) { double("Dialog") }
+    let(:wf) { double(:dialog => dialog) }
+
+    before do
+      @ems = FactoryGirl.create(:ems_amazon)
+      edit = {:rec_id => 1, :wf => wf, :key => 'dialog_edit__foo', :target_id => @ems.id}
+      controller.instance_variable_set(:@edit, edit)
+      controller.instance_variable_set(:@sb, {})
+      session[:edit] = edit
+    end
+
+    it "redirects to requests show list after dialog is submitted" do
+      controller.instance_variable_set(:@_params, :button => 'submit', :id => 'foo')
+      allow(controller).to receive(:role_allows).and_return(true)
+      allow(wf).to receive(:submit_request).and_return({})
+      page = double('page')
+      expect(page).to receive(:redirect_to).with("/ems_cloud/#{@ems.id}?flash_msg=Order+Request+was+Submitted")
+      expect(controller).to receive(:render).with(:update).and_yield(page)
+      controller.send(:dialog_form_button_pressed)
+    end
+  end
 end


### PR DESCRIPTION
When the button with service dialog for providers is executed, redirect appropriately, based on whether the controller is restful or not.

https://bugzilla.redhat.com/show_bug.cgi?id=1319322