### PR TITLE
[WIP] Display issue in foreman descendants rbac

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -480,7 +480,10 @@ class TreeBuilder
 
     # Remove VmOrTemplate :match_via_descendants option if present, comment to let Rbac.search process it
     descendants = false
-    descendants = options.delete(:match_via_descendants) if %w(ConfiguredSystems VmOrTemplate).include?(options[:match_via_descendants])
+    descendant = options[:match_via_descendants]
+    descendant = descendant.first if descendant.kind_of?(Array)
+    descendants = options.delete(:match_via_descendants) if %w(ConfiguredSystem ConfiguredSystems
+                                                               VmOrTemplate).include?(descendant.to_s)
 
     results = Rbac.filtered(objects, options)
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -206,6 +206,7 @@ describe ProviderForemanController do
   end
 
   it "builds foreman child tree" do
+    set_user_privileges
     controller.send(:build_configuration_manager_tree, :providers, :configuration_manager_providers_tree)
     tree_builder = TreeBuilderConfigurationManager.new("root", "", {})
     objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "fr"}, false, {})
@@ -214,6 +215,7 @@ describe ProviderForemanController do
   end
 
   it "builds ansible tower child tree" do
+    set_user_privileges
     controller.send(:build_configuration_manager_tree, :providers, :configuration_manager_providers_tree)
     tree_builder = TreeBuilderConfigurationManager.new("root", "", {})
     objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "at"}, false, {})
@@ -345,6 +347,7 @@ describe ProviderForemanController do
   end
 
   it "renders tree_select as js" do
+    set_user_privileges
     controller.send(:build_configuration_manager_tree, :providers, :configuration_manager_providers_tree)
 
     allow(controller).to receive(:process_show_list)
@@ -354,8 +357,6 @@ describe ProviderForemanController do
     allow(controller).to receive(:rebuild_toolbars)
     allow(controller).to receive(:replace_search_box)
     allow(controller).to receive(:update_partials)
-
-    set_user_privileges
 
     key = ems_key_for_provider(@provider)
     post :tree_select, :params => { :id => key, :format => :js }
@@ -443,7 +444,7 @@ describe ProviderForemanController do
     end
     it "builds foreman tree with no nodes after rbac filtering" do
       user_filters = {'belongs' => [], 'managed' => [["/managed/quota_max_memory/2048"]]}
-      allow_any_instance_of(User).to receive(:get_filters).and_return(user_filters)
+      User.current_user.current_group.update_attributes(:filters => user_filters)
       controller.send(:build_configuration_manager_tree, :providers, :configuration_manager_providers_tree)
       first_child = find_treenode_for_foreman_provider(@provider)
       expect(first_child).to eq(nil)
@@ -451,7 +452,7 @@ describe ProviderForemanController do
 
     it "builds foreman tree with only those nodes that contain the filtered configured systems" do
       user_filters = {'belongs' => [], 'managed' => [["/managed/quota_max_memory/2048"]]}
-      allow_any_instance_of(User).to receive(:get_filters).and_return(user_filters)
+      User.current_user.current_group.update_attributes(:filters => user_filters)
       Classification.seed
       quota_2gb_tag = Classification.where("description" => "2GB").first
       Classification.bulk_reassignment(:model      => "ConfiguredSystem",

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -333,12 +333,6 @@ describe Rbac do
           it ".search filters out the wrong HostPerformance rows with :match_via_descendants option" do
             @vm = FactoryGirl.create(:vm_vmware, :name => "VM1", :host => @host2)
             @vm.tag_with(@tags.join(' '), :ns => '*')
-            results, attrs = Rbac.search(:targets => HostPerformance, :class => "HostPerformance", :user => user, :results_format => :objects, :match_via_descendants => {"VmOrTemplate" => :host})
-            expect(attrs[:user_filters]).to eq(group.filters)
-            expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
-            expect(attrs[:auth_count]).to eq(@timestamps.length)
-            expect(results.length).to eq(@timestamps.length)
-            results.each { |vp| expect(vp.resource).to eq(@host2) }
 
             results, attrs = Rbac.search(:targets => HostPerformance, :class => "HostPerformance", :user => user, :results_format => :objects, :match_via_descendants => "Vm")
             expect(attrs[:user_filters]).to eq(group.filters)


### PR DESCRIPTION
I'm blocked by a spec that doesn't work like I would have expected.
It looks like we were not properly detecting the class type in the beginning, so not sure if it is a bug in code or the spec

a. it was passing in an array so preventing it from finding the class
b. it was passing in the plural name, which is not a valid class
c. I'm thinking about removing the array and hash syntax. I can keep around the string variant

@AparnaKarve @bdunne any ideas?