### PR TITLE
Fix tenant quota widget when it is selected in tree

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -436,7 +436,7 @@ module ReportController::Widgets
       @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivotby1] }
       @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivotby2] }
       @pivots4  = @pivots3.dup.delete_if { |g| g[1] == @edit[:new][:pivotby3] }
-      @edit[:new][:row_count] = @widget.options[:row_count] if @widget.options && @widget.options[:row_count]
+      @edit[:new][:row_count] = @widget.row_count
     elsif @sb[:wtype] == "rf"
       @edit[:rss_feeds] = {}
       rss_feeds = RssFeed.all
@@ -452,7 +452,7 @@ module ReportController::Widgets
         end
         @edit[:new][:txt_url] = @widget.options[:url] if @edit[:new][:url].blank?
       end
-      @edit[:new][:row_count]   = @widget.options[:row_count] if @widget.options && @widget.options[:row_count]
+      @edit[:new][:row_count]   = @widget.row_count
       @edit[:new][:rss_feed_id] = @widget.resource_id         if @widget.resource_id && @widget.resource_type == "RssFeed"
     end
     @edit[:current] = copy_hash(@edit[:new])
@@ -519,7 +519,7 @@ module ReportController::Widgets
     @edit[:new][:filter]      = params[:filter_typ]       if params[:filter_typ]
 
     # report/chart/menu options box
-    @edit[:new][:row_count] = params[:row_count] if params[:row_count]
+    @edit[:new][:row_count] = @widget.row_count(params[:row_count]) if params[:row_count]
     if @sb[:wtype] == "r"
       if params[:filter_typ] || params[:subfilter_typ] || params[:repfilter_typ]
         # reset columns if report has changed
@@ -645,9 +645,7 @@ module ReportController::Widgets
     widget.description = @edit[:new][:description]
     widget.enabled     = @edit[:new][:enabled]
     widget.options ||= {}
-    if ["r", "rf"].include?(@sb[:wtype])
-      widget.options[:row_count] = @edit[:new][:row_count].blank? ? 5 : @edit[:new][:row_count].to_i
-    end
+    widget.options[:row_count] = widget.row_count(@edit[:new][:row_count]) if %w(r rf).include?(@sb[:wtype])
     #    if @sb[:wtype] == "m"
     #      widget.miq_shortcuts = @edit[:new][:shortcuts].keys.collect{|s| MiqShortcut.find_by_id(s)}
     #      ws = Array.new  # Create an array of widget shortcuts

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -6,6 +6,8 @@ class MiqWidget < ApplicationRecord
   default_value_for :enabled, true
   default_value_for :read_only, false
 
+  DEFAULT_ROW_COUNT = 5
+
   belongs_to :resource, :polymorphic => true
   belongs_to :miq_schedule
   belongs_to :user
@@ -41,6 +43,10 @@ class MiqWidget < ApplicationRecord
   virtual_column :status_message, :type => :string,    :uses => :miq_task
   virtual_column :queued_at,      :type => :datetime,  :uses => :miq_task
   virtual_column :last_run_on,    :type => :datetime,  :uses => :miq_schedule
+
+  def row_count(row_count_param = nil)
+    row_count_param.try(:to_i) || options.try(:[], :row_count) || DEFAULT_ROW_COUNT
+  end
 
   def name
     description

--- a/app/models/miq_widget/report_content.rb
+++ b/app/models/miq_widget/report_content.rb
@@ -6,8 +6,7 @@ class MiqWidget::ReportContent < MiqWidget::ContentGeneration
 
     original_col_order = report.col_order
     report.col_order   = widget_options[:col_order] if widget_options[:col_order]
-
-    row_count   = widget_options[:row_count] || 10
+    row_count   = widget_options[:row_count] || MiqWidget::DEFAULT_ROW_COUNT
 
     headers     = report.col_order.inject([]) { |a, c| a << report.headers[original_col_order.index(c)] }
     col_formats = report.col_order.inject([]) { |a, c| a << report.col_formats[original_col_order.index(c)] }

--- a/app/views/report/_widget_show.html.haml
+++ b/app/views/report/_widget_show.html.haml
@@ -157,7 +157,7 @@
       .form-group
         %label.control-label.col-md-2= _('Row Count')
         .col-md-10
-          %p.form-control-static= h(@widget.options[:row_count].to_s)
+          %p.form-control-static= h(@widget.row_count)
 
   %hr
   - unless @sb[:wtype] == "m"

--- a/product/dashboard/widgets/tenant_quotas.yaml
+++ b/product/dashboard/widgets/tenant_quotas.yaml
@@ -1,7 +1,6 @@
 description: tenant_quotas
 title: Tenant Quotas
 content_type: report
-options:
 visibility:
   :roles:
   - _ALL_

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -115,6 +115,44 @@ describe ReportController do
         post :tree_select, :params => { :id => "xx-r_-#{widget.id}", :format => :js, :accord => 'widgets' }
         expect(response).to render_template('report/_widget_show')
       end
+
+      let(:default_row_count_value)        { 5 }
+      let(:other_row_count_value)          { 7 }
+      let(:widget_with_default_row_value)  { FactoryGirl.create(:miq_widget, :visibility => {:roles => ["_ALL_"]}) }
+      let(:widget_options)                 { {:row_count => other_row_count_value} }
+
+      let(:widget_with_row_value) do
+        FactoryGirl.create(:miq_widget, :visibility => {:roles => ["_ALL_"]}, :options => widget_options)
+      end
+
+      let(:params_default_row_value) do
+        {:id => "xx-r_-#{widget_with_default_row_value.compressed_id}", :format => :js, :accord => 'widgets'}
+      end
+
+      let(:params_row_value) do
+        {:id => "xx-r_-#{widget_with_row_value.compressed_id}", :format => :js, :accord => 'widgets'}
+      end
+
+      def row_count_html(row_count_value)
+        "<label class=\\'control-label col-md-2\\'>Row Count<\\/label>\\n" \
+        "<div class=\\'col-md-10\\'>\\n<p class=\\'form-control-static\\'>#{row_count_value}<\\/p>\\n<\\/div>"
+      end
+
+      it "renders show of Dashboard Widget in Widgets tree with default row_count value" do
+        post :tree_select, :params => params_default_row_value
+
+        expect(response).to render_template('report/_widget_show')
+        expect(response.status).to eq(200)
+        expect(response.body).to include(row_count_html(default_row_count_value))
+      end
+
+      it "renders show of Dashboard Widget in Widgets tree with row_count value from widget" do
+        post :tree_select, :params => params_row_value
+
+        expect(response).to render_template('report/_widget_show')
+        expect(response.status).to eq(200)
+        expect(response.body).to include(row_count_html(other_row_count_value))
+      end
     end
 
     context "role menus tree" do


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/7380

The bug was about fact that `:row_count` was missing in yaml file for tenant quota widget, and it throws error in view `app/views/report/_widget_show.html.haml`

So I fixed it n way that I moved default row value into one place and created method for it - this method `row_count` is used in this template and it is fixing this issue.

And I removed :options from yaml file - we have default value for row count of widget

cc @gtanzillo 
