### PR TITLE
Fix spec for tenant quotas, it causes sporadic failing of specs

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -579,10 +579,7 @@ describe MiqReport do
       it "returns expected html outputs with formatted values" do
         allow(User).to receive(:server_timezone).and_return("UTC")
         report.generate_table
-        rows_array = report.build_html_rows
-        rows_array.each_with_index do |row, index|
-          expect(@expected_html_rows[index]).to eq(row)
-        end
+        expect(report.build_html_rows).to match_array(@expected_html_rows)
       end
 
       it "returns only rows for tenant with any tenant_quotas" do


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/7444

match_array used instead, this matcher doesn't take into account order of array

I was able to reproduce it - I just run it several times and got failure and

and for this change I tried to run it 100 times and no error appeared.

I beliieve that there is no reason to use each_with_index here 

thanks @jrafanie ! 
