### PR TITLE
[api] Fix service_dialogs query to not ask for content when specific attributes are asked for.

### DIFF
--- a/app/controllers/api_controller/service_dialogs.rb
+++ b/app/controllers/api_controller/service_dialogs.rb
@@ -9,9 +9,7 @@ class ApiController
     end
 
     def show_service_dialogs
-      if @req[:s_id] || expand?(:resources) || attribute_selection == "all"
-        @req[:additional_attributes] = %w(content) if attribute_selection == "all"
-      end
+      @req[:additional_attributes] = %w(content) if attribute_selection == "all"
       show_generic(:service_dialogs)
     end
   end

--- a/app/controllers/api_controller/service_dialogs.rb
+++ b/app/controllers/api_controller/service_dialogs.rb
@@ -10,7 +10,7 @@ class ApiController
 
     def show_service_dialogs
       if @req[:s_id] || expand?(:resources) || attribute_selection == "all"
-        @req[:additional_attributes] = %w(content)
+        @req[:additional_attributes] = %w(content) if attribute_selection == "all"
       end
       show_generic(:service_dialogs)
     end

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -46,6 +46,12 @@ describe ApiController do
       )
       expect_result_to_have_keys(%w(content))
     end
+
+    it "query single dialog to exclude content when attributes are asked for" do
+      run_get service_dialogs_url(dialog1.id), :attributes => "id,label"
+
+      expect_result_to_have_only_keys(%w(href id label))
+    end
   end
 
   context "Service Dialogs subcollection" do


### PR DESCRIPTION

When asking for individual service_dialogs, we always returned the content which is time consuming. This was even the case when specific attributes were being asked for, i.e. GET /api/service_dialogs/:id?attributes=id,label,description also returned the content.
