### PR TITLE
Hack: Teach db:migrate to clear the schema cache after it runs.

### DIFF
--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -300,3 +300,10 @@ namespace :evm do
 end
 
 Rake::Task["db:migrate"].enhance(["evm:db:environmentlegacykey"])
+
+# HACK: Teach db:migrate to clear the schema cache, specifically the column
+# information, after it runs.  Without this, running `rake db:migrate db:seed`
+# in the same process can fail during seed with:
+#   `PG::UndefinedColumn: ERROR:  column XYZ does not exist`
+# We do exactly this, `rake db:migrate db:seed`, in bin/setup and bin/update.
+Rake::Task["db:migrate"].enhance { ActiveRecord::Base.clear_cache! }


### PR DESCRIPTION
Without this, running `rake db:migrate db:seed`
in the same process can fail during seed with:
  `PG::UndefinedColumn: ERROR:  column XYZ does not exist`

We do exactly this, `rake db:migrate db:seed`, in bin/setup and bin/update.

Note: This seems like a bug in Rails that we should try to upstream but this hack fixes a current problem where this fails: `bin/rake db:drop db:create db:migrate db:seed` with

```
== 20160317194215 RemoveMiqUserRoleFromMiqGroups: migrating ===================
-- remove_column(:miq_groups, :miq_user_role_id, :bigint)
   -> 0.0006s
== 20160317194215 RemoveMiqUserRoleFromMiqGroups: migrated (0.0006s) ==========

rake aborted!
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column miq_groups.miq_user_role_id does not exist
LINE 1: ...on" AS t0_r5, "miq_groups"."updated_on" AS t0_r6, "miq_group...
                                                             ^
: SELECT "miq_groups"."id" AS t0_r0, "miq_groups"."description" AS t0_r1, "miq_groups"."group_type" AS t0_r2, "miq_groups"."sequence" AS t0_r3, "miq_groups"."filters" AS t0_r4, "miq_groups"."created_on" AS t0_r5, "miq_groups"."updated_on" AS t0_r6, "miq_groups"."miq_user_role_id" AS t0_r7, "miq_groups"."settings" AS t0_r8, "miq_groups"."tenant_id" AS t0_r9, "entitlements"."id" AS t1_r0, "entitlements"."miq_group_id" AS t1_r1, "entitlements"."miq_user_role_id" AS t1_r2, "entitlements"."created_at" AS t1_r3, "entitlements"."updated_at" AS t1_r4 FROM "miq_groups" LEFT OUTER JOIN "entitlements" ON "entitlements"."miq_group_id" = "miq_groups"."id" WHERE "miq_groups"."group_type" = $1 AND "entitlements"."miq_user_role_id" IS NULL
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:590:in `async_exec'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:590:in `block in exec_no_cache'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:526:in `block in log'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:520:in `log'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:590:in `exec_no_cache'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:579:in `execute_and_clear'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:103:in `exec_query'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:377:in `select'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:41:in `select_all'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
/Users/joerafaniello/.gem/ruby/2.2.4/bundler/gems/rails-63f5a98bacbc/activerecord/lib/active_record/relation/finder_methods.rb:389:in `find_with_associations'
/Users/joerafaniello/Code/manageiq/lib/extensions/ar_virtual.rb:286:in `find_with_associations'
...
```