### PR TITLE
map all powerstates for aws and default to terminated

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
@@ -12,7 +12,7 @@ if vm
   $evm.log('info', "Instance:<#{vm.name}> on EMS:<#{ems.try(:name)} has Power State:<#{power_state}>")
 
   # If VM is powered off or this instance is running on an instance store
-  if %w(off suspended).include?(power_state) || vm.hardware.root_device_type == "instance_store"
+  if %w(off suspended terminated).include?(power_state) || vm.hardware.root_device_type == "instance_store"
     # Bump State
     $evm.root['ae_result'] = 'ok'
   elsif power_state == "never"

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -62,6 +62,7 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
     when "pending"       then "suspended"
     when "terminated"    then "terminated"
     when "stopped"       then "off"
+    when "off"           then "off"
     # 'unknown' will be set by #disconnect_ems - which means 'terminated' in our case
     when "unknown"       then "terminated"
     else                      "terminated"

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -52,13 +52,19 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
   end
 
   def self.calculate_power_state(raw_power_state)
-    case raw_power_state
+    # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceState.html
+    case raw_power_state.to_s
     when "running"       then "on"
     when "powering_up"   then "powering_up"
     when "shutting_down" then "powering_down"
+    when "shutting-down" then "powering_down"
+    when "stopping"      then "powering_down"
     when "pending"       then "suspended"
     when "terminated"    then "terminated"
-    else                      "off"
+    when "stopped"       then "off"
+    # 'unknown' will be set by #disconnect_ems - which means 'terminated' in our case
+    when "unknown"       then "terminated"
+    else                      "terminated"
     end
   end
 


### PR DESCRIPTION
without this, the default state would be 'off', which in case of ec2
would mean you can start an instance again. But for ec2 the final
state is 'terminate'

adresses #6955

Edit (@blomquisg):  https://bugzilla.redhat.com/show_bug.cgi?id=1322015