### PR TITLE
Add provider_region_name attribute to PglogicalSubscription model

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -3,14 +3,15 @@
 # This model then exposes select values returned from that method
 class PglogicalSubscription < ActsAsArModel
   set_columns_hash(
-    :id              => :string,
-    :status          => :string,
-    :dbname          => :string,
-    :host            => :string,
-    :user            => :string,
-    :password        => :string,
-    :port            => :integer,
-    :provider_region => :integer
+    :id                   => :string,
+    :status               => :string,
+    :dbname               => :string,
+    :host                 => :string,
+    :user                 => :string,
+    :password             => :string,
+    :port                 => :integer,
+    :provider_region      => :integer,
+    :provider_region_name => :string
   )
 
   def self.find(*args)
@@ -76,8 +77,7 @@ class PglogicalSubscription < ActsAsArModel
     # create the individual dsn columns
     cols.merge!(dsn_attributes(cols.delete(:provider_dsn)))
 
-    cols[:provider_region] = cols.delete(:provider_node).sub("region_", "").to_i
-    cols
+    cols.merge!(provider_node_attributes(cols.delete(:provider_node)))
   end
   private_class_method :subscription_to_columns
 
@@ -89,6 +89,15 @@ class PglogicalSubscription < ActsAsArModel
     attrs
   end
   private_class_method :dsn_attributes
+
+  def self.provider_node_attributes(node_name)
+    attrs = {}
+    attrs[:provider_region] = node_name.sub(MiqPglogical::NODE_PREFIX, "").to_i
+    region = MiqRegion.find_by_region(attrs[:provider_region])
+    attrs[:provider_region_name] = region.description if region
+    attrs
+  end
+  private_class_method :provider_node_attributes
 
   private
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -25,12 +25,13 @@ describe PglogicalSubscription do
   let(:expected_attrs) do
     [
       {
-        "id"              => "subscription_example_com",
-        "status"          => "replicating",
-        "dbname"          => "vmdb's_test",
-        "host"            => "example.com",
-        "user"            => "root",
-        "provider_region" => 0
+        "id"                   => "subscription_example_com",
+        "status"               => "replicating",
+        "dbname"               => "vmdb's_test",
+        "host"                 => "example.com",
+        "user"                 => "root",
+        "provider_region"      => 0,
+        "provider_region_name" => "The region"
       },
       {
         "id"              => "subscription_test_example_com",
@@ -47,6 +48,7 @@ describe PglogicalSubscription do
   let(:pglogical) { double }
 
   before do
+    FactoryGirl.create(:miq_region, :region => 0, :description => "The region")
     allow(described_class).to receive(:pglogical).and_return(pglogical)
   end
 


### PR DESCRIPTION
@gtanzillo @h-kataria 

This will return `MiqRegion#description` in the `provider_region_name` attribute assuming there is a region record with the required region number, otherwise it will be `nil`