### PR TITLE
[WIP] call save! instead of save to raise an exception if something goes wrong

### DIFF
--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
 
     # Mark all instances no longer found as terminated
     power_state == "off"
-    save
+    save!
   end
 
   def proxies4job(_job = nil)


### PR DESCRIPTION
call `save!` instead of `save` to raise an exception if something goes wrong

@Fryguy I spotted this in a couple of other places - do you think its worth going through the code and change this where we dont check the return value of `save` ?
