### PR TITLE
Update post_install_callback logic based on new state

### DIFF
--- a/app/models/miq_provision/post_install_callback.rb
+++ b/app/models/miq_provision/post_install_callback.rb
@@ -1,11 +1,11 @@
 module MiqProvision::PostInstallCallback
   extend ActiveSupport::Concern
 
-  # This method will be called via callback if the VM is unable to shut itself down.
-  # If called, we just stop the VM.  The state machine (running on a different worker)
-  # will be waiting for the power off.
+  # This method will be called via callback if the installer is unable to shut itself down.  If the state machine is
+  # waiting for the VM poweroff, we stop the VM. (:poll_destination_powered_off_in_vmdb, :poll_destination_powered_off_in_provider)
+  # The state machine (running on a different worker) will continue when the VM is off.
   def post_install_callback
-    if phase.to_sym == :poll_destination_powered_off_in_vmdb
+    if phase.to_s.include?("poll_destination_powered_off")
       _log.info("Powering Off #{for_destination}")
 
       destination.stop

--- a/spec/models/miq_provision/post_install_callback_spec.rb
+++ b/spec/models/miq_provision/post_install_callback_spec.rb
@@ -1,0 +1,72 @@
+describe MiqProvision::PostInstallCallback do
+  let(:included_class) do
+    Class.new do
+      include MiqProvision::PostInstallCallback
+
+      attr_reader :destination, :phase
+
+      def initialize(destination, phase)
+        @destination = destination
+        @phase       = phase.to_s
+      end
+
+      def for_destination; end
+
+      def _log
+        @logger ||= Vmdb.null_logger
+      end
+    end
+  end
+
+  let(:destination) { FactoryGirl.build(:vm) }
+
+  ALLOWED_PHASES = [:poll_destination_powered_off_in_provider, :poll_destination_powered_off_in_vmdb].freeze
+  BLOCKED_PHASES = [
+    :autostart_destination,
+    :boot_from_cdrom,
+    :boot_from_network,
+    :configure_destination,
+    :create_destination,
+    :create_pxe_configuration_file,
+    :create_pxe_configuration_files,
+    :customize_destination,
+    :delete_pxe_configuration_files,
+    :determine_placement,
+    :enable_build_mode,
+    :finish,
+    :mark_as_completed,
+    :os_build,
+    :poll_clone_complete,
+    :poll_destination_in_vmdb,
+    :poll_destination_powered_on_in_provider,
+    :poll_os_built,
+    :poll_system_powered_off_in_foreman,
+    :post_create_destination,
+    :post_provision,
+    :prepare_provision,
+    :provision_error,
+    :reboot,
+    :reset_host_credentials,
+    :reset_host_in_vmdb,
+    :start_clone_task,
+    :start_configuration_task,
+    :system_power_off_in_foreman,
+    :update_configuration
+  ].freeze
+
+  context "#post_install_callback" do
+    BLOCKED_PHASES.each do |phase|
+      it "should not call power off for #{phase}" do
+        expect(destination).not_to receive(:stop)
+        included_class.new(destination, phase).post_install_callback
+      end
+    end
+
+    ALLOWED_PHASES.each do |phase|
+      it "should call power off for #{phase}" do
+        expect(destination).to receive(:stop)
+        included_class.new(destination, phase).post_install_callback
+      end
+    end
+  end
+end


### PR DESCRIPTION
Valid phases for shutdown are:
- poll_destination_powered_off_in_vmdb
- poll_destination_powered_off_in_provider

https://bugzilla.redhat.com/show_bug.cgi?id=1320689