### PR TITLE
Refactor MiqRegion.replication_type=

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -158,12 +158,13 @@ class MiqRegion < ApplicationRecord
 
   def self.replication_type=(desired_type)
     current_type = replication_type
-    return if desired_type == current_type
+    return desired_type if desired_type == current_type
 
     MiqPglogical.new.destroy_provider   if current_type == :remote
     PglogicalSubscription.delete_all    if current_type == :global
     MiqPglogical.new.configure_provider if desired_type == :remote
     # Do nothing to add a global
+    desired_type
   end
 
   def ems_clouds

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -158,22 +158,12 @@ class MiqRegion < ApplicationRecord
 
   def self.replication_type=(desired_type)
     current_type = replication_type
-    case desired_type
-    when :none
-      case current_type
-      when :remote then MiqPglogical.new.destroy_provider
-      when :global then PglogicalSubscription.delete_all
-      end
-    when :remote
-      case current_type
-      when :none then MiqPglogical.new.configure_provider
-      when :global
-        PglogicalSubscription.delete_all
-        MiqPglogical.new.configure_provider
-      end
-    when :global
-      MiqPglogical.new.destroy_provider if current_type == :remote
-    end
+    return if desired_type == current_type
+
+    MiqPglogical.new.destroy_provider   if current_type == :remote
+    PglogicalSubscription.delete_all    if current_type == :global
+    MiqPglogical.new.configure_provider if desired_type == :remote
+    # Do nothing to add a global
   end
 
   def ems_clouds

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -95,13 +95,19 @@ describe MiqRegion do
   end
 
   describe ".replication_type=" do
+    it "returns the replication_type, even when unchanged" do
+      pgl = double(:provider? => true, :subscriber? => false, :node? => true)
+      allow(MiqPglogical).to receive(:new).and_return(pgl)
+      expect(described_class.replication_type = :remote).to eq :remote
+    end
+
     it "destroys the provider when transition is :remote -> :none" do
       pgl = double(:provider? => true, :subscriber? => false, :node? => true)
       allow(MiqPglogical).to receive(:new).and_return(pgl)
 
       expect(pgl).to receive(:destroy_provider)
 
-      described_class.replication_type = :none
+      expect(described_class.replication_type = :none).to eq :none
     end
 
     it "deletes all subscriptions when transition is :global -> :none" do
@@ -110,7 +116,7 @@ describe MiqRegion do
 
       expect(PglogicalSubscription).to receive(:delete_all)
 
-      described_class.replication_type = :none
+      expect(described_class.replication_type = :none).to eq :none
     end
 
     it "creates a new provider when transition is :none -> :remote" do
@@ -119,7 +125,7 @@ describe MiqRegion do
 
       expect(pgl).to receive(:configure_provider)
 
-      described_class.replication_type = :remote
+      expect(described_class.replication_type = :remote).to eq :remote
     end
 
     it "deletes all subscriptions and creates a new provider when transition is :global -> :remote" do
@@ -129,7 +135,7 @@ describe MiqRegion do
       expect(PglogicalSubscription).to receive(:delete_all)
       expect(pgl).to receive(:configure_provider)
 
-      described_class.replication_type = :remote
+      expect(described_class.replication_type = :remote).to eq :remote
     end
 
     it "destroys the provider when transition is :remote -> :global" do
@@ -138,7 +144,7 @@ describe MiqRegion do
 
       expect(pgl).to receive(:destroy_provider)
 
-      described_class.replication_type = :global
+      expect(described_class.replication_type = :global).to eq :global
     end
   end
 end


### PR DESCRIPTION
This idea behind this refactoring:
* If the current replication_type and desired match, it's a no-op, so return early
* If it's a change (do the removals first... to keep the same behavior)
  * Remove remote if it's currently remote
  * Remove global if it's currently global
  * Add remote if remote is desired
  * Do nothing to add a global if desired (it's a no-op)

Additionally, I changed the setter to return the replication_type at the end of this method.  

Perhaps we want to return nil or false if it was not changed?