### PR TITLE
bin/setup does not create REGION

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -16,9 +16,6 @@ Dir.chdir APP_ROOT do
   unless File.exist?("certs/v2_key")
     system "cp certs/v2_key.dev certs/v2_key"
   end
-  unless File.exist?("REGION")
-    File.open("REGION", "w") { |f| f.puts "0" }
-  end
 
   puts "\n== Preparing database =="
   system "bin/rake db:create"


### PR DESCRIPTION
There is no reason to setup a file with a value of `0` when if the file is missing, the code will default it to `0` anyway.

Extracted from #6295
/cc @jrafanie think you have the strongest opinion here. I can provide more information if you want, but to be honest, just merge or close. No real reason to discuss this any further.
/cc @carbonin 