### PR TITLE
[WIP] VDS Support: Relationship between hosts and switches are now has_and_belongs_to_many 

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -49,7 +49,7 @@ class Host < ApplicationRecord
   has_many                  :miq_templates, :inverse_of => :host
   has_many                  :host_storages
   has_many                  :storages, :through => :host_storages
-  has_many                  :switches, :dependent => :destroy
+  has_and_belongs_to_many   :switches
   has_many                  :patches, :dependent => :destroy
   has_many                  :system_services, :dependent => :destroy
   has_many                  :host_services, :class_name => "SystemService", :foreign_key => "host_id", :inverse_of => :host

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -333,6 +333,7 @@ module ManageIQ::Providers
       end
 
       def self.host_inv_to_switch_hashes(inv)
+        host_mor = inv['MOR']
         inv = inv.fetch_path('config', 'network')
 
         result = []
@@ -340,7 +341,8 @@ module ManageIQ::Providers
         return result, result_uids if inv.nil?
 
         inv['vswitch'].to_miq_a.each do |data|
-          name = uid = data['name']
+          name = data['name']
+          uid = "#{host_mor}|#{data['name']}"
           pnics = data['pnic'].to_miq_a
 
           security_policy = data.fetch_path('spec', 'policy', 'security') || {}

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -141,7 +141,7 @@ module ManageIQ::Providers
 
           # Collect the hardware, networking, and scsi inventories
           switches, switch_uids[mor] = host_inv_to_switch_hashes(host_inv, ems_inv[:ems].guid)
-          lans, lan_uids[mor] = host_inv_to_lan_hashes(host_inv, switch_uids[mor], ems_inv[:ems].guid)
+          _lans, lan_uids[mor] = host_inv_to_lan_hashes(host_inv, switch_uids[mor], ems_inv[:ems].guid)
 
           hardware = host_inv_to_hardware_hash(host_inv)
           hardware[:guest_devices], guest_device_uids[mor] = host_inv_to_guest_device_hashes(host_inv, switch_uids[mor])

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -84,7 +84,7 @@ module ManageIQ::Providers
           target, data = targets_with_data.shift
 
           _log.info "#{log_header} Refreshing target #{target.class} [#{target.name}] id [#{target.id}]..."
-
+          data[:ems] = target
           hashes = parse_data(data)
 
           # We no longer need the filtered VC data, so remove it to help the GC

--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -1,5 +1,5 @@
 class Switch < ApplicationRecord
-  belongs_to :host
+  has_and_belongs_to_many :hosts
 
   has_many :guest_devices
   has_many :lans, :dependent => :destroy

--- a/db/migrate/20160317031649_update_switch_uid_ems.rb
+++ b/db/migrate/20160317031649_update_switch_uid_ems.rb
@@ -17,7 +17,7 @@ class UpdateSwitchUidEms < ActiveRecord::Migration[5.0]
 
   class Switch < ActiveRecord::Base
     belongs_to :host,
-             :class_name => 'UpdateSwitchUidEms::Host'
+               :class_name => 'UpdateSwitchUidEms::Host'
   end
 
   def up

--- a/db/migrate/20160317031649_update_switch_uid_ems.rb
+++ b/db/migrate/20160317031649_update_switch_uid_ems.rb
@@ -1,11 +1,33 @@
 class UpdateSwitchUidEms < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    has_many :hosts,
+             :class_name => "UpdateSwitchUidEms::Host",
+             :foreign_key => "ems_id"
+  end
+
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    belongs_to :ext_management_system,
+               :class_name => "UpdateSwitchUidEms::ExtManagementSystem",
+               :foreign_key => "ems_id"
+    has_many :switches,
+             :class_name => "UpdateSwitchUidEms::Switch"
+  end
+
   class Switch < ActiveRecord::Base
+    belongs_to :host,
+             :class_name => "UpdateSwitchUidEms::Host"
   end
 
   def up
-    say_with_time("Updating switch uid_ems to be prefixed with host_id") do
-      Switch.all.each do |s|
-        s.update(:uid_ems => "#{s.host_id}|#{s.uid_ems}")
+    say_with_time("Updating switch uid_ems to be prefixed with ems_guid and host_id") do
+      ExtManagementSystem.all.each do |ems|
+        ems.hosts.each do |host|
+          host.switches.each do |s|
+            s.update(:uid_ems => "#{ems.guid}|#{host.ems_ref}|#{s.uid_ems}")
+          end
+        end
       end
     end
   end
@@ -13,7 +35,7 @@ class UpdateSwitchUidEms < ActiveRecord::Migration[5.0]
   def down
     Switch.all.each do |s|
       raise "Expected '|' not found in uid_ems" if s.uid_ems.index('|').nil?
-      s.update(:uid_ems => s.uid_ems[s.uid_ems.index('|') + 1..-1])
+      s.update(:uid_ems => s.uid_ems[s.uid_ems.rindex('|') + 1..-1])
     end
   end
 end

--- a/db/migrate/20160317031649_update_switch_uid_ems.rb
+++ b/db/migrate/20160317031649_update_switch_uid_ems.rb
@@ -1,0 +1,19 @@
+class UpdateSwitchUidEms < ActiveRecord::Migration[5.0]
+  class Switch < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Updating switch uid_ems to be prefixed with host_id") do
+      Switch.all.each do |s|
+        s.update(:uid_ems => "#{s.host_id}|#{s.uid_ems}")
+      end
+    end
+  end
+
+  def down
+    Switch.all.each do |s|
+      fail "Expected '|' not found in uid_ems" if s.uid_ems.index('|').nil?
+      s.update(:uid_ems => s.uid_ems[s.uid_ems.index('|')+1..-1])
+    end
+  end
+end

--- a/db/migrate/20160317031649_update_switch_uid_ems.rb
+++ b/db/migrate/20160317031649_update_switch_uid_ems.rb
@@ -2,26 +2,26 @@ class UpdateSwitchUidEms < ActiveRecord::Migration[5.0]
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
     has_many :hosts,
-             :class_name => "UpdateSwitchUidEms::Host",
-             :foreign_key => "ems_id"
+             :class_name => 'UpdateSwitchUidEms::Host',
+             :foreign_key => 'ems_id'
   end
 
   class Host < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
     belongs_to :ext_management_system,
-               :class_name => "UpdateSwitchUidEms::ExtManagementSystem",
-               :foreign_key => "ems_id"
+               :class_name => 'UpdateSwitchUidEms::ExtManagementSystem',
+               :foreign_key => 'ems_id'
     has_many :switches,
-             :class_name => "UpdateSwitchUidEms::Switch"
+             :class_name => 'UpdateSwitchUidEms::Switch'
   end
 
   class Switch < ActiveRecord::Base
     belongs_to :host,
-             :class_name => "UpdateSwitchUidEms::Host"
+             :class_name => 'UpdateSwitchUidEms::Host'
   end
 
   def up
-    say_with_time("Updating switch uid_ems to be prefixed with ems_guid and host_id") do
+    say_with_time('Updating switch uid_ems to be prefixed with ems_guid and host_id') do
       ExtManagementSystem.all.each do |ems|
         ems.hosts.each do |host|
           host.switches.each do |s|

--- a/db/migrate/20160317031649_update_switch_uid_ems.rb
+++ b/db/migrate/20160317031649_update_switch_uid_ems.rb
@@ -2,14 +2,14 @@ class UpdateSwitchUidEms < ActiveRecord::Migration[5.0]
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
     has_many :hosts,
-             :class_name => 'UpdateSwitchUidEms::Host',
+             :class_name  => 'UpdateSwitchUidEms::Host',
              :foreign_key => 'ems_id'
   end
 
   class Host < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
     belongs_to :ext_management_system,
-               :class_name => 'UpdateSwitchUidEms::ExtManagementSystem',
+               :class_name  => 'UpdateSwitchUidEms::ExtManagementSystem',
                :foreign_key => 'ems_id'
     has_many :switches,
              :class_name => 'UpdateSwitchUidEms::Switch'

--- a/db/migrate/20160317031649_update_switch_uid_ems.rb
+++ b/db/migrate/20160317031649_update_switch_uid_ems.rb
@@ -12,8 +12,8 @@ class UpdateSwitchUidEms < ActiveRecord::Migration[5.0]
 
   def down
     Switch.all.each do |s|
-      fail "Expected '|' not found in uid_ems" if s.uid_ems.index('|').nil?
-      s.update(:uid_ems => s.uid_ems[s.uid_ems.index('|')+1..-1])
+      raise "Expected '|' not found in uid_ems" if s.uid_ems.index('|').nil?
+      s.update(:uid_ems => s.uid_ems[s.uid_ems.index('|') + 1..-1])
     end
   end
 end

--- a/db/migrate/20160317142959_add_index_to_switch.rb
+++ b/db/migrate/20160317142959_add_index_to_switch.rb
@@ -1,0 +1,5 @@
+class AddIndexToSwitch < ActiveRecord::Migration[5.0]
+  def change
+    add_index :switches, :uid_ems, :unique => true
+  end
+end

--- a/db/migrate/20160322141934_create_join_table_host_switch.rb
+++ b/db/migrate/20160322141934_create_join_table_host_switch.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableHostSwitch < ActiveRecord::Migration[5.0]
+  def change
+    create_join_table :hosts, :switches do |t|
+      t.index [:host_id, :switch_id]
+      t.index [:switch_id, :host_id]
+    end
+  end
+end

--- a/db/migrate/20160322141934_create_join_table_host_switch.rb
+++ b/db/migrate/20160322141934_create_join_table_host_switch.rb
@@ -4,5 +4,6 @@ class CreateJoinTableHostSwitch < ActiveRecord::Migration[5.0]
       t.index [:host_id, :switch_id]
       t.index [:switch_id, :host_id]
     end
+    add_column :hosts_switches, :id, :primary_key
   end
 end

--- a/db/migrate/20160322141934_create_join_table_host_switch.rb
+++ b/db/migrate/20160322141934_create_join_table_host_switch.rb
@@ -1,9 +1,8 @@
 class CreateJoinTableHostSwitch < ActiveRecord::Migration[5.0]
   def change
-    create_join_table :hosts, :switches do |t|
-      t.index [:host_id, :switch_id]
-      t.index [:switch_id, :host_id]
+    create_table :hosts_switches do |t|
+      t.bigint  :host_id
+      t.bigint  :switch_id
     end
-    add_column :hosts_switches, :id, :primary_key
   end
 end

--- a/db/migrate/20160322195653_move_switch_host_to_jointable.rb
+++ b/db/migrate/20160322195653_move_switch_host_to_jointable.rb
@@ -2,13 +2,13 @@ class MoveSwitchHostToJointable < ActiveRecord::Migration[5.0]
   class Host < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
     has_many :switches,
-                            :class_name => 'MoveSwitchHostToJointable::Switch'
+             :class_name => 'MoveSwitchHostToJointable::Switch'
 
   end
 
   class Switch < ActiveRecord::Base
     belongs_to :host,
-                            :class_name => 'MoveSwitchHostToJointable::Host'
+               :class_name => 'MoveSwitchHostToJointable::Host'
   end
 
   class HostsSwitches < ActiveRecord::Base

--- a/db/migrate/20160322195653_move_switch_host_to_jointable.rb
+++ b/db/migrate/20160322195653_move_switch_host_to_jointable.rb
@@ -1,0 +1,26 @@
+class MoveSwitchHostToJointable < ActiveRecord::Migration[5.0]
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    has_many :switches,
+                            :class_name => 'MoveSwitchHostToJointable::Switch'
+
+  end
+
+  class Switch < ActiveRecord::Base
+    belongs_to :host,
+                            :class_name => 'MoveSwitchHostToJointable::Host'
+  end
+
+  class HostsSwitches < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time('Populating hosts_switches table with (host.id, switch.id)') do
+      Host.all.each do |host|
+        host.switches.each do |switch|
+          HostsSwitches.create!(:host_id => host.id, :switch_id => switch.id)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20160322205357_remove_host_id_from_switch.rb
+++ b/db/migrate/20160322205357_remove_host_id_from_switch.rb
@@ -1,0 +1,5 @@
+class RemoveHostIdFromSwitch < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :switches, :host_id, :bigint
+  end
+end

--- a/spec/migrations/20160317031649_update_switch_uid_ems_spec.rb
+++ b/spec/migrations/20160317031649_update_switch_uid_ems_spec.rb
@@ -25,7 +25,7 @@ describe UpdateSwitchUidEms do
       migrate
 
       switch.reload
-      expect(switch.uid_ems).to eq("#{uid_ems}")
+      expect(switch.uid_ems).to eq(uid_ems.to_s)
     end
 
     it "Rollback switches.uid_ems fails due to missing '|'" do
@@ -37,6 +37,5 @@ describe UpdateSwitchUidEms do
         migrate
       end.to raise_error RuntimeError, "Expected '|' not found in uid_ems"
     end
-
   end
 end

--- a/spec/migrations/20160317031649_update_switch_uid_ems_spec.rb
+++ b/spec/migrations/20160317031649_update_switch_uid_ems_spec.rb
@@ -1,37 +1,42 @@
 require_migration
 
 describe UpdateSwitchUidEms do
+  before(:each) do
+    @ems_guid = 'FFFF'
+    @uid_ems = 'vswtich0'
+    @host_ref = 'host-101'
+  end
+
   migration_context :up do
     let(:switch_stub) { migration_stub(:Switch) }
+    let(:host_stub) { migration_stub(:Host) }
+    let(:ems_stub) { migration_stub(:ExtManagementSystem) }
     it 'Switch uid_ems gets updated' do
-      uid_ems = "vswtich0"
-      host_id = 101
-      switch = switch_stub.create!(:uid_ems => uid_ems, :host_id => host_id)
+      ems = ems_stub.create!(:guid => @ems_guid)
+      host = host_stub.create!(:ems_ref => @host_ref, :ems_id => ems.id)
+      switch = switch_stub.create!(:uid_ems => @uid_ems, :host_id => host.id)
+      expect(switch.uid_ems).to eq(@uid_ems)
 
       migrate
 
       switch.reload
-      expect(switch.uid_ems).to eq("#{host_id}|#{uid_ems}")
+      expect(switch.uid_ems).to eq("#{@ems_guid}|#{@host_ref}|#{@uid_ems}")
     end
   end
 
   migration_context :down do
     let(:switch_stub) { migration_stub(:Switch) }
     it 'Rollback switches.uid_ems successfully' do
-      uid_ems = "vswtich0"
-      host_id = 101
-      switch = switch_stub.create!(:uid_ems => "#{host_id}|#{uid_ems}")
+      switch = switch_stub.create!(:uid_ems => "#{@ems_guid}|#{@host_ref}|#{@uid_ems}")
 
       migrate
 
       switch.reload
-      expect(switch.uid_ems).to eq(uid_ems.to_s)
+      expect(switch.uid_ems).to eq(@uid_ems)
     end
 
     it "Rollback switches.uid_ems fails due to missing '|'" do
-      uid_ems = "vswtich0"
-      host_id = 101
-      switch_stub.create!(:uid_ems => "#{host_id}#{uid_ems}")
+      switch_stub.create!(:uid_ems => "#{@host_ref}#{@uid_ems}")
 
       expect do
         migrate

--- a/spec/migrations/20160317031649_update_switch_uid_ems_spec.rb
+++ b/spec/migrations/20160317031649_update_switch_uid_ems_spec.rb
@@ -1,0 +1,42 @@
+require_migration
+
+describe UpdateSwitchUidEms do
+  migration_context :up do
+    let(:switch_stub) { migration_stub(:Switch) }
+    it 'Switch uid_ems gets updated' do
+      uid_ems = "vswtich0"
+      host_id = 101
+      switch = switch_stub.create!(:uid_ems => uid_ems, :host_id => host_id)
+
+      migrate
+
+      switch.reload
+      expect(switch.uid_ems).to eq("#{host_id}|#{uid_ems}")
+    end
+  end
+
+  migration_context :down do
+    let(:switch_stub) { migration_stub(:Switch) }
+    it 'Rollback switches.uid_ems successfully' do
+      uid_ems = "vswtich0"
+      host_id = 101
+      switch = switch_stub.create!(:uid_ems => "#{host_id}|#{uid_ems}")
+
+      migrate
+
+      switch.reload
+      expect(switch.uid_ems).to eq("#{uid_ems}")
+    end
+
+    it "Rollback switches.uid_ems fails due to missing '|'" do
+      uid_ems = "vswtich0"
+      host_id = 101
+      switch_stub.create!(:uid_ems => "#{host_id}#{uid_ems}")
+
+      expect do
+        migrate
+      end.to raise_error RuntimeError, "Expected '|' not found in uid_ems"
+    end
+
+  end
+end

--- a/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
+++ b/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
@@ -6,7 +6,7 @@ describe MoveSwitchHostToJointable do
     let(:host_stub) { migration_stub(:Host) }
     let(:hosts_switches_stub) { migration_stub(:HostsSwitches) }
     it 'Move host-to-switch relationship to hosts_switches table' do
-      host = host_stub.create!()
+      host = host_stub.create!
       switch1 = switch_stub.create!(:host_id => host.id)
       switch2 = switch_stub.create!(:host_id => host.id)
       expect(host.switches.length).to eq 2

--- a/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
+++ b/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
@@ -1,0 +1,21 @@
+require_migration
+
+describe MoveSwitchHostToJointable do
+  migration_context :up do
+    let(:switch_stub) { migration_stub(:Switch) }
+    let(:host_stub) { migration_stub(:Host) }
+    let(:hosts_switches_stub) { migration_stub(:HostsSwitches) }
+    it 'Move host-to-switch relationship to hosts_switches table' do
+      host = host_stub.create!()
+      switch1 = switch_stub.create!(:host_id => host.id)
+      switch2 = switch_stub.create!(:host_id => host.id)
+      expect(host.switches.length).to eq 2
+
+      migrate
+
+      expect(hosts_switches_stub.count).to eq 2
+      expect(hosts_switches_stub.where(:host_id => host.id, :switch_id => switch1.id).count).to eq 1
+      expect(hosts_switches_stub.where(:host_id => host.id, :switch_id => switch2.id).count).to eq 1
+    end
+  end
+end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -223,7 +223,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(@host.switches.size).to eq(2)
     switch = @host.switches.find_by_name("vSwitch0")
     expect(switch).to have_attributes(
-      :uid_ems           => "vSwitch0",
+      :uid_ems           => "#{@ems.guid}|#{@host.ems_ref}|vSwitch0",
       :name              => "vSwitch0",
       :ports             => 128,
       :allow_promiscuous => false,

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -29,7 +29,7 @@ describe MiqProvisionWorkflow do
           @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro",
                                             :memory_mb => 512,
                                             :cpu_sockets => 2)
-          @switch      = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :host => @host)
+          @switch      = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :hosts => [@host])
           @lan         = FactoryGirl.create(:lan, :name => "VM Network", :switch => @switch)
           @ethernet    = FactoryGirl.create(:guest_device, :hardware => @hardware, :lan => @lan,
                                             :device_type => 'ethernet',


### PR DESCRIPTION
This is the second step after #7368 to prepare for VDS inventory. After this is done, the relationship between dvSwitches and hosts can be properly modeled as well.