### PR TITLE
Remove `MiqExpression#_to_sql` guard

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -635,7 +635,7 @@ class MiqExpression
   end
 
   def _to_sql(exp, tz)
-    return exp unless exp.kind_of?(Hash) || exp.kind_of?(Array)
+    return exp unless exp.kind_of?(Hash)
 
     operator = exp.keys.first
     return if operator.nil?

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -629,16 +629,13 @@ class MiqExpression
   def to_sql(tz = nil)
     tz ||= "UTC"
     @pexp, attrs = preprocess_for_sql(@exp.deep_clone)
-    sql = _to_sql(@pexp, tz)
+    sql = _to_sql(@pexp, tz) if @pexp.present?
     incl = includes_for_sql unless sql.blank?
     [sql, incl, attrs]
   end
 
   def _to_sql(exp, tz)
-    return exp unless exp.kind_of?(Hash)
-
     operator = exp.keys.first
-    return if operator.nil?
 
     case operator.downcase
     when "equal", "=", "<", ">", ">=", "<=", "!=", "before", "after"
@@ -661,7 +658,7 @@ class MiqExpression
       clause = "!(" + clause + ")" if operator.downcase == "not like"
     when "and", "or"
       operands = exp[operator].collect do|operand|
-        o = _to_sql(operand, tz)
+        o = _to_sql(operand, tz) if operand.present?
         o.blank? ? nil : o
       end.compact
       if operands.length > 1


### PR DESCRIPTION
A couple of small changes here:

* the expression can't be an array, because it will blow up on the line after the guard
* `#_to_sql` is for all purposes a private method, so we should have more confidence over its input