### PR TITLE
Refactor `MiqExpression#_to_sql` to use Arel for EQUAL expressions

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -638,7 +638,12 @@ class MiqExpression
     operator = exp.keys.first
 
     case operator.downcase
-    when "equal", "=", "<", ">", ">=", "<=", "!=", "before", "after"
+    when "equal", "="
+      field = Field.parse(exp[operator]["field"])
+      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
+      table = Arel::Table.new(field.table_name)
+      clause = table[field.column].eq(Arel::Nodes::Quoted.new(exp[operator]["value"])).to_sql
+    when "<", ">", ">=", "<=", "!=", "before", "after"
       col_type = self.class.get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if col_type == :date || col_type == :datetime
 

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -1,6 +1,6 @@
 class MiqExpression::Field
   FIELD_REGEX = /
-(?<model_name>[[:upper:]][[:alnum:]]*)
+(?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
 \.?(?<association>[a-z_]+)?
 -(?<column>[a-z]+(_[a-z]+)*)
 /x

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -1,0 +1,43 @@
+class MiqExpression::Field
+  FIELD_REGEX = /
+(?<model_name>[[:upper:]][[:alnum:]]*)
+\.?(?<associations>[a-z_\.]+)*
+-(?<column>[a-z]+(_[a-z]+)*)
+/x
+
+  def self.parse(field)
+    match = FIELD_REGEX.match(field)
+    new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:column])
+  end
+
+  attr_reader :model, :associations, :column
+  delegate :table_name, :to => :target
+
+  def initialize(model, associations, column)
+    @model = model
+    @associations = associations
+    @column = column
+  end
+
+  def date?
+    column_type == :date
+  end
+
+  def datetime?
+    column_type == :datetime
+  end
+
+  private
+
+  def target
+    if associations.none?
+      model
+    else
+      associations.last.classify.constantize
+    end
+  end
+
+  def column_type
+    target.type_for_attribute(column).type
+  end
+end

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe MiqExpression::Field do
       expect(described_class.parse(field).model).to be(Vm)
     end
 
+    it "can parse a namespaced model name" do
+      field = "ManageIQ::Providers::CloudManager::Vm-name"
+      expect(described_class.parse(field).model).to be(ManageIQ::Providers::CloudManager::Vm)
+    end
+
     it "can parse the model name with associations present" do
       field = "Vm.host-name"
       expect(described_class.parse(field).model).to be(Vm)

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe MiqExpression::Field do
+  describe ".parse" do
+    it "can parse the model name" do
+      field = "Vm-name"
+      expect(described_class.parse(field).model).to be(Vm)
+    end
+
+    it "can parse the model name with associations present" do
+      field = "Vm.host-name"
+      expect(described_class.parse(field).model).to be(Vm)
+    end
+
+    it "can parse the column name" do
+      field = "Vm-name"
+      expect(described_class.parse(field).column).to eq("name")
+    end
+
+    it "can parse the column name with associations present" do
+      field = "Vm.host-name"
+      expect(described_class.parse(field).column).to eq("name")
+    end
+
+    it "can parse the column name with pivot table suffix" do
+      field = "Vm-name__pv"
+      expect(described_class.parse(field).column).to eq("name")
+    end
+
+    it "can parse column names with snakecase" do
+      field = "Vm-last_scan_on"
+      expect(described_class.parse(field).column).to eq("last_scan_on")
+    end
+
+    it "can parse the associations when there is none present" do
+      field = "Vm-name"
+      expect(described_class.parse(field).associations).to be_empty
+    end
+
+    it "can parse the associations when there is one present" do
+      field = "Vm.host-name"
+      expect(described_class.parse(field).associations).to contain_exactly("host")
+    end
+
+    it "can parse the associations when there are many present" do
+      field = "Vm.host.hardware-id"
+      expect(described_class.parse(field).associations).to contain_exactly("host", "hardware")
+    end
+  end
+
+  describe "#date?" do
+    it "returns true for fields of column type :date" do
+      field = described_class.new(Vm, [], "retires_on")
+      expect(field).to be_date
+    end
+
+    it "returns false for fields of column type other than :date" do
+      field = described_class.new(Vm, [], "name")
+      expect(field).not_to be_date
+    end
+  end
+
+  describe "#datetime?" do
+    it "returns true for fields of column type :datetime" do
+      field = described_class.new(Vm, [], "created_on")
+      expect(field).to be_datetime
+    end
+
+    it "returns false for fields of column type other than :datetime" do
+      field = described_class.new(Vm, [], "name")
+      expect(field).not_to be_datetime
+    end
+
+    it "returns true for a :datetime type column on an association" do
+      field = described_class.new(Vm, ["guest_applications"], "install_time")
+      expect(field).to be_datetime
+    end
+  end
+
+  describe "#table_name" do
+    it "returns the table name of the model when there are no associations" do
+      field = described_class.new(Vm, [], "name")
+      expect(field.table_name).to eq("vms")
+    end
+
+    it "returns the table name of the target association if there are associations" do
+      field = described_class.new(Vm, ["guest_applications"], "name")
+      expect(field.table_name).to eq("guest_applications")
+    end
+  end
+end

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -32,59 +32,59 @@ RSpec.describe MiqExpression::Field do
       expect(described_class.parse(field).column).to eq("last_scan_on")
     end
 
-    it "can parse the associations when there is none present" do
+    it "can parse the association when there is none present" do
       field = "Vm-name"
-      expect(described_class.parse(field).associations).to be_empty
+      expect(described_class.parse(field).association).to be_nil
     end
 
-    it "can parse the associations when there is one present" do
+    it "can parse the association when there is one present" do
       field = "Vm.host-name"
-      expect(described_class.parse(field).associations).to contain_exactly("host")
+      expect(described_class.parse(field).association).to eq("host")
     end
 
-    it "can parse the associations when there are many present" do
+    it "will raise a parse error if there are many associations present" do
       field = "Vm.host.hardware-id"
-      expect(described_class.parse(field).associations).to contain_exactly("host", "hardware")
+      expect { described_class.parse(field) }.to raise_error(MiqExpression::Field::ParseError)
     end
   end
 
   describe "#date?" do
     it "returns true for fields of column type :date" do
-      field = described_class.new(Vm, [], "retires_on")
+      field = described_class.new(Vm, nil, "retires_on")
       expect(field).to be_date
     end
 
     it "returns false for fields of column type other than :date" do
-      field = described_class.new(Vm, [], "name")
+      field = described_class.new(Vm, nil, "name")
       expect(field).not_to be_date
     end
   end
 
   describe "#datetime?" do
     it "returns true for fields of column type :datetime" do
-      field = described_class.new(Vm, [], "created_on")
+      field = described_class.new(Vm, nil, "created_on")
       expect(field).to be_datetime
     end
 
     it "returns false for fields of column type other than :datetime" do
-      field = described_class.new(Vm, [], "name")
+      field = described_class.new(Vm, nil, "name")
       expect(field).not_to be_datetime
     end
 
     it "returns true for a :datetime type column on an association" do
-      field = described_class.new(Vm, ["guest_applications"], "install_time")
+      field = described_class.new(Vm, "guest_applications", "install_time")
       expect(field).to be_datetime
     end
   end
 
   describe "#table_name" do
-    it "returns the table name of the model when there are no associations" do
-      field = described_class.new(Vm, [], "name")
+    it "returns the table name of the model when there is no association" do
+      field = described_class.new(Vm, nil, "name")
       expect(field.table_name).to eq("vms")
     end
 
-    it "returns the table name of the target association if there are associations" do
-      field = described_class.new(Vm, ["guest_applications"], "name")
+    it "returns the table name of the target association if there is an association" do
+      field = described_class.new(Vm, "guest_applications", "name")
       expect(field.table_name).to eq("guest_applications")
     end
   end

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -5,6 +5,13 @@ describe MiqExpression do
       expect(sql).to eq("vms.name = 'foo'")
     end
 
+    it "generates the SQL for an EQUAL expression with an association" do
+      exp = {"EQUAL" => {"field" => "Vm.guest_applications-name", "value" => 'foo'}}
+      sql, includes, * = MiqExpression.new(exp).to_sql
+      expect(sql).to eq("guest_applications.name = 'foo'")
+      expect(includes).to eq(:guest_applications => {})
+    end
+
     it "generates the SQL for a = expression" do
       sql, * = MiqExpression.new("=" => {"field" => "Vm-name", "value" => "foo"}).to_sql
       expect(sql).to eq("vms.name = 'foo'")

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -2,19 +2,19 @@ describe MiqExpression do
   describe "#to_sql" do
     it "generates the SQL for an EQUAL expression" do
       sql, * = MiqExpression.new("EQUAL" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("vms.name = 'foo'")
+      expect(sql).to eq("\"vms\".\"name\" = 'foo'")
     end
 
     it "generates the SQL for an EQUAL expression with an association" do
       exp = {"EQUAL" => {"field" => "Vm.guest_applications-name", "value" => 'foo'}}
       sql, includes, * = MiqExpression.new(exp).to_sql
-      expect(sql).to eq("guest_applications.name = 'foo'")
+      expect(sql).to eq("\"guest_applications\".\"name\" = 'foo'")
       expect(includes).to eq(:guest_applications => {})
     end
 
     it "generates the SQL for a = expression" do
       sql, * = MiqExpression.new("=" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("vms.name = 'foo'")
+      expect(sql).to eq("\"vms\".\"name\" = 'foo'")
     end
 
     it "generates the SQL for a LIKE expression" do
@@ -86,12 +86,12 @@ describe MiqExpression do
 
     it "generates the SQL for a NOT expression" do
       sql, * = MiqExpression.new("NOT" => {"=" => {"field" => "Vm-name", "value" => "foo"}}).to_sql
-      expect(sql).to eq("NOT vms.name = 'foo'")
+      expect(sql).to eq("NOT \"vms\".\"name\" = 'foo'")
     end
 
     it "generates the SQL for a ! expression" do
       sql, * = MiqExpression.new("!" => {"=" => {"field" => "Vm-name", "value" => "foo"}}).to_sql
-      expect(sql).to eq("NOT vms.name = 'foo'")
+      expect(sql).to eq("NOT \"vms\".\"name\" = 'foo'")
     end
 
     it "generates the SQL for an IS NULL expression" do


### PR DESCRIPTION
This pulls out a tiny chunk of the `#_to_sql` method and refactors it to use Arel. In this clause, Arel replaces most of the work done by `.operands2sqlvalue`. The only thing it can't do is parse the field.

It's worth noting that we parse the field data (typically doing `split("-")`, etc..) in a number of different places throughout `MiqExpression`, and not always in the same way. There is a `.parse_field` method, but that's currently only used by one other method `.get_col_type` (which is a bit problematic in itself - it treats tags and fields as interchangeable, even though their structure is subtly different), and I'd rather have an object here with some behavior, so I don't continue to spread knowledge of the field's structure around as I go. That's why I created a `Field` object - eventually I'd like it to be the only place that fields are parsed.

This is part 1 of a series of PRs, where I plan to continue going through this method replacing with Arel. Hopefully at the end we can :scissors: :fire: some of the code that is doing what Arel is probably doing much better. I think trying to do it all at once would result in a big diff, so I'm aiming to do this in smaller refactorings to make it easier to review.

/cc @gtanzillo @jrafanie @yrudman
@miq-bot add-label core, refactoring

Part of https://trello.com/c/Vje3DjhW
