### PR TITLE
Gettext with multiple arguments missing n_

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -417,7 +417,7 @@ module HostHelper::TextualSummary
     num = @record.number_of(:groups)
     h = {:label => _("Groups"), :image => "group", :value => num}
     if num > 0
-      h[:title] = _("Show the Group defined on this %{title}", "Show the Groups defined on this %{title}", num) %
+      h[:title] = n_("Show the Group defined on this %{title}", "Show the Groups defined on this %{title}", num) %
         {:title => host_title}
       h[:link]  = url_for(:action => 'groups', :id => @record, :db => controller.controller_name)
     end


### PR DESCRIPTION
Typo in i18n conversion for host page:
![screenshot from 2016-03-24 09-52-12](https://cloud.githubusercontent.com/assets/12769982/14018832/1be7c0c6-f1a6-11e5-848b-59e745eaf771.png)
