### PR TITLE
The if and else both do the same thing so remove the if.

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -692,23 +692,15 @@ class ChargebackController < ApplicationController
     elsif @edit[:new][:cbshow_typ]
       get_cis_all
     end
-    if @edit[:new][:cbshow_typ] && @edit[:new][:cbshow_typ].ends_with?("-tags") && @edit[:cb_assign][:tags]
-      @edit[:current_assignment].each do |el|
-        if el[:object]
-          @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{el[:object]["id"]}"] = el[:cb_rate]["id"].to_s
-        elsif el[:tag]
-          @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{el[:tag][0]["id"]}"] = el[:cb_rate]["id"].to_s
-        end
-      end
-    else
-      @edit[:current_assignment].each do |el|
-        if el[:object]
-          @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{el[:object]["id"]}"] = el[:cb_rate]["id"].to_s
-        elsif el[:tag]
-          @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{el[:tag][0]["id"]}"] = el[:cb_rate]["id"].to_s
-        end
+
+    @edit[:current_assignment].each do |el|
+      if el[:object]
+        @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{el[:object]["id"]}"] = el[:cb_rate]["id"].to_s
+      elsif el[:tag]
+        @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{el[:tag][0]["id"]}"] = el[:cb_rate]["id"].to_s
       end
     end
+
     @edit[:current] = copy_hash(@edit[:new])
     session[:edit] = @edit
     @in_a_form = true


### PR DESCRIPTION
Seen, while reviewing the chargeback pull requests.

Flay:
2) IDENTICAL code found in :iter (mass*2 = 256)
  app/controllers/chargeback_controller.rb:696
  app/controllers/chargeback_controller.rb:704

Flog before and after:
147.2: ChargebackController#cb_assign_set_form_vars app/controllers/chargeback_controller.rb:655
105.0: ChargebackController#cb_assign_set_form_vars app/controllers/chargeback_controller.rb:655

To be very careful, since I don't think this method is tested or easily testable... Here is the output of `git log -p --color-words` showing that the code is identical... Because, yes, I didn't believe it either.

![screen shot 2016-03-24 at 10 08 16 am](https://cloud.githubusercontent.com/assets/19339/14019303/7cd237fc-f1a8-11e5-9e82-29db24d950c7.png)
