### PR TITLE
Have inventory refresh set hidden on folders

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -22,19 +22,6 @@ class EmsFolder < ApplicationRecord
 
   NON_DISPLAY_FOLDERS = %w(Datacenters vm host datastore).freeze
 
-  def hidden?(overrides = {})
-    ems = overrides[:ext_management_system] || ext_management_system
-    return false unless ems.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
-
-    p = overrides[:parent] || parent if NON_DISPLAY_FOLDERS.include?(name)
-
-    case name
-    when "Datacenters"              then p.kind_of?(ExtManagementSystem)
-    when "vm", "host", "datastore"  then p.kind_of?(Datacenter)
-    else                            false
-    end
-  end
-
   #
   # Provider Object methods
   #

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -20,8 +20,6 @@ class EmsFolder < ApplicationRecord
   virtual_has_many :miq_templates,     :uses => :all_relationships
   virtual_has_many :hosts,             :uses => :all_relationships
 
-  NON_DISPLAY_FOLDERS = %w(Datacenters vm host datastore).freeze
-
   #
   # Provider Object methods
   #
@@ -164,7 +162,7 @@ class EmsFolder < ApplicationRecord
     options = args.extract_options!
     folders = path(:of_type => "EmsFolder")
     folders = folders[1..-1] if options[:exclude_root_folder]
-    folders = folders.reject { |f| NON_DISPLAY_FOLDERS.include?(f.name) } if options[:exclude_non_display_folders]
+    folders = folders.reject(&:hidden?) if options[:exclude_non_display_folders]
     folders
   end
 
@@ -189,7 +187,7 @@ class EmsFolder < ApplicationRecord
     options[:prefix] ||= ""
     subtree.each_with_object({}) do |(f, children), h|
       path = options[:prefix]
-      unless options[:exclude_non_display_folders] && NON_DISPLAY_FOLDERS.include?(f.name)
+      unless options[:exclude_non_display_folders] && f.hidden?
         path = path.blank? ? f.name : "#{path}/#{f.name}"
         h[f.id] = path unless options[:exclude_datacenters] && f.kind_of?(Datacenter)
       end

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -504,6 +504,7 @@ module ManageIQ::Providers::Microsoft
         :type         => 'EmsFolder',
         :uid_ems      => "host_folder",
         :ems_ref      => "host_folder",
+        :hidden       => true,
         :ems_children => set_host_folder_children
 
       }
@@ -512,6 +513,7 @@ module ManageIQ::Providers::Microsoft
         :type         => 'EmsFolder',
         :uid_ems      => "vm_folder",
         :ems_ref      => "vm_folder",
+        :hidden       => true,
         :ems_children => {:vms => @data[:vms]}
       }
       scvmm_folder = {
@@ -519,6 +521,7 @@ module ManageIQ::Providers::Microsoft
         :type         => 'Datacenter',
         :uid_ems      => "scvmm",
         :ems_ref      => "scvmm",
+        :hidden       => false,
         :ems_children => {:folders => [host_folder, vm_folder]}
       }
       dc_folder = {
@@ -526,6 +529,7 @@ module ManageIQ::Providers::Microsoft
         :type         => 'EmsFolder',
         :uid_ems      => 'root_dc',
         :ems_ref      => 'root_dc',
+        :hidden       => true,
         :ems_children => {:folders => [scvmm_folder]}
       }
       @data[:folders]  = [dc_folder, scvmm_folder, host_folder, vm_folder]

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -613,6 +613,7 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       :name         => 'Datacenters',
       :type         => 'EmsFolder',
       :uid_ems      => 'root_dc',
+      :hidden       => true,
 
       :ems_children => {:folders => []}
     }]
@@ -623,8 +624,8 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
     inv.each do |data|
       uid = data[:id]
 
-      host_folder = {:name => 'host', :type => 'EmsFolder', :uid_ems => "#{uid}_host"}
-      vm_folder   = {:name => 'vm',   :type => 'EmsFolder', :uid_ems => "#{uid}_vm"}
+      host_folder = {:name => 'host', :type => 'EmsFolder', :uid_ems => "#{uid}_host", :hidden => true}
+      vm_folder   = {:name => 'vm',   :type => 'EmsFolder', :uid_ems => "#{uid}_vm",   :hidden => true}
 
       # Link clusters to datacenter host folder
       clusters = cluster_uids.values.select { |c| c[:datacenter_id] == uid }

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1055,12 +1055,13 @@ module ManageIQ::Providers
           child_mors = get_mors(data, 'childEntity')
 
           new_result = {
-            :type          => EmsFolder.name,
-            :ems_ref       => mor,
-            :ems_ref_obj   => mor,
-            :uid_ems       => mor,
-            :name          => data["name"],
-            :child_uids    => child_mors
+            :type        => EmsFolder.name,
+            :ems_ref     => mor,
+            :ems_ref_obj => mor,
+            :uid_ems     => mor,
+            :name        => data["name"],
+            :child_uids  => child_mors,
+            :hidden      => false
           }
           result << new_result
           result_uids[mor] = new_result
@@ -1077,12 +1078,13 @@ module ManageIQ::Providers
           child_mors = get_mors(data, 'hostFolder') + get_mors(data, 'vmFolder') + get_mors(data, 'datastoreFolder')
 
           new_result = {
-            :type          => Datacenter.name,
-            :ems_ref       => mor,
-            :ems_ref_obj   => mor,
-            :uid_ems       => mor,
-            :name          => data["name"],
-            :child_uids    => child_mors
+            :type        => Datacenter.name,
+            :ems_ref     => mor,
+            :ems_ref_obj => mor,
+            :uid_ems     => mor,
+            :name        => data["name"],
+            :child_uids  => child_mors,
+            :hidden      => false
           }
           result << new_result
           result_uids[mor] = new_result
@@ -1100,12 +1102,13 @@ module ManageIQ::Providers
           name       = data.fetch_path('summary', 'name')
 
           new_result = {
-            :type          => StorageCluster.name,
-            :ems_ref       => mor,
-            :ems_ref_obj   => mor,
-            :uid_ems       => mor,
-            :name          => name,
-            :child_uids    => child_mors
+            :type        => StorageCluster.name,
+            :ems_ref     => mor,
+            :ems_ref_obj => mor,
+            :uid_ems     => mor,
+            :name        => name,
+            :child_uids  => child_mors,
+            :hidden      => false
           }
 
           result << new_result
@@ -1287,9 +1290,6 @@ module ManageIQ::Providers
             f[:hidden] = true
           end
         end
-
-        # Set all other folders to be not hidden
-        data[:folders].each { |f| f[:hidden] = false unless f[:hidden] }
       end
 
       def self.set_default_rps(data)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -908,7 +908,7 @@ class MiqRequestWorkflow
   end
 
   def get_ems_folders(folder, dh = {}, full_path = "")
-    if folder.evm_object_class == :EmsFolder && !EmsFolder::NON_DISPLAY_FOLDERS.include?(folder.name)
+    if folder.evm_object_class == :EmsFolder && !folder.hidden?
       full_path += full_path.blank? ? "#{folder.name}" : " / #{folder.name}"
       dh[folder.id] = full_path unless folder.type == "Datacenter"
     end

--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -37,7 +37,7 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
   def hidden_child_folder?(object, children)
     return false unless children.length == 1
     child = children.keys.first
-    child.kind_of?(EmsFolder) && child.hidden?(:ext_management_system => root_ems, :parent => object)
+    child.kind_of?(EmsFolder) && child.hidden?
   end
 
   def reparent_hidden_folders(tree)

--- a/db/migrate/20160324131349_add_hidden_to_ems_folders.rb
+++ b/db/migrate/20160324131349_add_hidden_to_ems_folders.rb
@@ -1,0 +1,9 @@
+class AddHiddenToEmsFolders < ActiveRecord::Migration[5.0]
+  class EmsFolder < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def change
+    add_column :ems_folders, :hidden, :boolean
+  end
+end

--- a/db/migrate/20160324131349_add_hidden_to_ems_folders.rb
+++ b/db/migrate/20160324131349_add_hidden_to_ems_folders.rb
@@ -3,7 +3,15 @@ class AddHiddenToEmsFolders < ActiveRecord::Migration[5.0]
     self.inheritance_column = :_type_disabled # disable STI
   end
 
-  def change
+  def up
     add_column :ems_folders, :hidden, :boolean
+
+    say_with_time('Setting ems_folders.hidden to false') do
+      EmsFolder.update_all(:hidden => false)
+    end
+  end
+
+  def down
+    remove_column :ems_folders, :hidden
   end
 end

--- a/spec/migrations/20160324131349_add_hidden_to_ems_folders_spec.rb
+++ b/spec/migrations/20160324131349_add_hidden_to_ems_folders_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe AddHiddenToEmsFolders do
+  migration_context :up do
+    let(:ems_folder_stub) { migration_stub(:EmsFolder) }
+    it 'sets EmsFolder.hidden to false' do
+      folder = ems_folder_stub.create!
+
+      migrate
+
+      folder.reload
+      expect(folder.hidden).to be false
+    end
+  end
+end

--- a/spec/models/ems_folder_spec.rb
+++ b/spec/models/ems_folder_spec.rb
@@ -1,49 +1,19 @@
 describe EmsFolder do
   context "#hidden?" do
-    it "when not VMware" do
+    it "when not hidden" do
       folder = FactoryGirl.build(:ems_folder, :name                  => "vm",
+                                              :hidden                => false,
                                               :ext_management_system => FactoryGirl.build(:ems_openstack)
                                 )
       expect(folder).to_not be_hidden
     end
 
-    context "when VMware" do
-      let(:ems) { FactoryGirl.build(:ems_vmware) }
-
-      context "and named Datacenters" do
-        let(:folder) { FactoryGirl.create(:ems_folder, :name => "Datacenters", :ext_management_system => ems) }
-
-        it "and parent is the EMS" do
-          folder.parent = ems
-          expect(folder).to be_hidden
-        end
-
-        it "and parent is not the EMS" do
-          folder.parent = FactoryGirl.create(:ems_folder)
-          expect(folder).to_not be_hidden
-        end
-      end
-
-      ["vm", "host"].each do |name|
-        context "and named #{name}" do
-          let(:folder) { FactoryGirl.create(:ems_folder, :name => name, :ext_management_system => ems) }
-
-          it "and parent is a datacenter" do
-            folder.parent = FactoryGirl.create(:datacenter)
-            expect(folder).to be_hidden
-          end
-
-          it "and parent is not a datacenter" do
-            folder.parent = FactoryGirl.create(:ems_folder)
-            expect(folder).to_not be_hidden
-          end
-        end
-      end
-
-      it "and not named with a hidden name" do
-        folder = FactoryGirl.build(:ems_folder, :ext_management_system => ems)
-        expect(folder).to_not be_hidden
-      end
+    it "when hidden" do
+      folder = FactoryGirl.build(:ems_folder, :name                  => "vm",
+                                              :hidden                => true,
+                                              :ext_management_system => FactoryGirl.build(:ems_vmware)
+                                )
+      expect(folder).to be_hidden
     end
   end
 

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -238,13 +238,13 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
 
   def assert_relationship_tree
     expect(@ems.descendants_arranged).to match_relationship_tree(
-      [EmsFolder, "Datacenters"] => {
+      [EmsFolder, "Datacenters", {:hidden => true}] => {
         [Datacenter, "SCVMM"] => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [ManageIQ::Providers::Microsoft::InfraManager::Host, "dell-r410-01.cloudformswin.lab.redhat.com"] => {},
             [ManageIQ::Providers::Microsoft::InfraManager::Host, "dell-r410-03.cloudformswin.lab.redhat.com"] => {},
           },
-          [EmsFolder, "vm"]   => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
             [ManageIQ::Providers::Microsoft::InfraManager::Template, "linux_template"] => {},
             [ManageIQ::Providers::Microsoft::InfraManager::Vm, "linux2"]               => {},
             [ManageIQ::Providers::Microsoft::InfraManager::Vm, "vm_linux1"]            => {},

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
@@ -630,9 +630,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_relationship_tree
     expect(@ems.descendants_arranged).to match_relationship_tree(
-      [EmsFolder, "Datacenters"] => {
+      [EmsFolder, "Datacenters", {:hidden => true}] => {
         [Datacenter, "DC-iSCSI"] => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [EmsCluster, "Cluster1-iSCSI"] => {
               [ResourcePool, "Default for Cluster Cluster1-iSCSI"] => {
                 [ManageIQ::Providers::Redhat::InfraManager::Vm, "Brandon-Clone1"]   => {},
@@ -642,7 +642,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
               }
             }
           },
-          [EmsFolder, "vm"]   => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
             [ManageIQ::Providers::Redhat::InfraManager::Template, "Template1"]  => {},
             [ManageIQ::Providers::Redhat::InfraManager::Vm, "Brandon-Clone1"]   => {},
             [ManageIQ::Providers::Redhat::InfraManager::Vm, "CLI-Provision-1"]  => {},
@@ -651,7 +651,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
           }
         },
         [Datacenter, "DC2"]      => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [EmsCluster, "DC2-iSCSI"]   => {
               [ResourcePool, "Default for Cluster DC2-iSCSI"] => {}
             },
@@ -666,7 +666,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
               }
             }
           },
-          [EmsFolder, "vm"]   => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
             [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM"]         => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM-V5"]      => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM-v5-Base"] => {},
@@ -680,7 +680,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
           }
         },
         [Datacenter, "Default"]  => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [EmsCluster, "Cluster2"] => {
               [ResourcePool, "Default for Cluster Cluster2"] => {
                 [ManageIQ::Providers::Redhat::InfraManager::Vm, "EmsRefreshSpec-PoweredOff"] => {},
@@ -700,7 +700,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
               [ResourcePool, "Default for Cluster Default"] => {}
             }
           },
-          [EmsFolder, "vm"]   => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
             [ManageIQ::Providers::Redhat::InfraManager::Template, "empty"]               => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "EmsRefreshSpec"]      => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM-50011"]           => {},

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -675,9 +675,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_relationship_tree
     expect(@ems.descendants_arranged).to match_relationship_tree(
-      [EmsFolder, "Datacenters"] => {
+      [EmsFolder, "Datacenters", {:hidden => true}] => {
         [Datacenter, "Default"] => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [EmsCluster, "iSCSI"] => {
               [ResourcePool, "Default for Cluster iSCSI"] => {
                 [ManageIQ::Providers::Redhat::InfraManager::Vm, "BD-F17-Desktop"]                => {},
@@ -704,7 +704,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
               }
             }
           },
-          [EmsFolder, "vm"]   => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
             [ManageIQ::Providers::Redhat::InfraManager::Template, "CFME_Base"]               => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM-v50017"]              => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM-v50025"]              => {},
@@ -736,7 +736,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
           }
         },
         [Datacenter, "NFS"]     => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [EmsCluster, "NFS"] => {
               [ResourcePool, "Default for Cluster NFS"] => {
                 [ManageIQ::Providers::Redhat::InfraManager::Vm, "MK_AUG_05_003_DELETE"] => {},
@@ -748,7 +748,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
               }
             }
           },
-          [EmsFolder, "vm"]   => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
             [ManageIQ::Providers::Redhat::InfraManager::Template, "757e824d-6d97-4568-be29-9346c354e802"] => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "bd-clone-template"]                    => {},
             [ManageIQ::Providers::Redhat::InfraManager::Template, "bd-temp1"]                             => {},

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -498,9 +498,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
   def assert_relationship_tree
     expect(@ems.descendants_arranged).to match_relationship_tree(
-      [EmsFolder, "Datacenters"] => {
+      [EmsFolder, "Datacenters", {:hidden => true}] => {
         [Datacenter, "Dev"]            => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [ManageIQ::Providers::Vmware::InfraManager::HostEsx, "vi4esxm3.manageiq.com"] => {
               [ResourcePool, "Default for Host / Node vi4esxm3.manageiq.com", {:is_default => true}] => {
                 [ManageIQ::Providers::Vmware::InfraManager::Vm, "Dev Cucumber Nightly Appl 2011-05-19"]              => {},
@@ -541,24 +541,24 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
               }
             }
           },
-          [EmsFolder, "vm"]   => {
-            [EmsFolder, "Discovered virtual machine"]                                               => {},
-            [EmsFolder, "GreggT"]                                                                   => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
+            [EmsFolder, "Discovered virtual machine", {:hidden => false}]                           => {},
+            [EmsFolder, "GreggT", {:hidden => false}]                                               => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "DEV-GreggT"]                 => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "GT Nightly Appl 2011-02-19"] => {}
             },
-            [EmsFolder, "GregM"]                                                                    => {
+            [EmsFolder, "GregM", {:hidden => false}]                                                => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "DEV-GregM"]                  => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "GM Nightly Appl 2011-05-19"] => {}
             },
-            [EmsFolder, "Harpreet"]                                                                 => {
+            [EmsFolder, "Harpreet", {:hidden => false}]                                             => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "DEV-HarpreetK"]                           => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "HK-Dev Cucumber Nightly Appl 2011-05-19"] => {}
             },
-            [EmsFolder, "Jason"]                                                                    => {
+            [EmsFolder, "Jason", {:hidden => false}]                                                => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "Jason Nightly Appl 2011-02-19"] => {}
             },
-            [EmsFolder, "JoeR"]                                                                     => {
+            [EmsFolder, "JoeR", {:hidden => false}]                                                 => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "DEV-JoeR"]                                          => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "JR- Dev Cucumber Nightly Appl 2011-05-19 - backup"] => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "JR-cruisecontrol-sandback-testing-April14_backup"]  => {},
@@ -595,11 +595,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
           }
         },
         [Datacenter, "New Datacenter"] => {
-          [EmsFolder, "host"] => {},
-          [EmsFolder, "vm"]   => {}
+          [EmsFolder, "host", {:hidden => true}] => {},
+          [EmsFolder, "vm", {:hidden => true}]   => {}
         },
         [Datacenter, "Prod"]           => {
-          [EmsFolder, "host"] => {
+          [EmsFolder, "host", {:hidden => true}] => {
             [EmsCluster, "Testing-Production Cluster"] => {
               [ResourcePool, "Default for Cluster / Deployment Role Testing-Production Cluster",
                {:is_default => true}] => {
@@ -690,28 +690,28 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
                  [ManageIQ::Providers::Vmware::InfraManager::Vm, "Xav COS 40114"]      => {}
                }
             },
-            [EmsFolder, "Test"]                        => {
+            [EmsFolder, "Test", {:hidden => false}]    => {
               [ManageIQ::Providers::Vmware::InfraManager::HostEsx, "localhost"] => {
                 [ResourcePool, "Default for Host / Node localhost", {:is_default => true}] => {}
               }
             }
           },
-          [EmsFolder, "vm"]   => {
-            [EmsFolder, "BHelgeson"]                                                    => {},
-            [EmsFolder, "Brandon"]                                                      => {
+          [EmsFolder, "vm", {:hidden => true}]   => {
+            [EmsFolder, "BHelgeson", {:hidden => false}]                                => {},
+            [EmsFolder, "Brandon", {:hidden => false}]                                  => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "BD-EVM-Nightly 28939-svn"] => {}
             },
-            [EmsFolder, "Discovered virtual machine"]                                   => {
+            [EmsFolder, "Discovered virtual machine", {:hidden => false}]               => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "3.3.2.22"]                => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "tch-cos64-nightly-26322"] => {}
             },
-            [EmsFolder, "Infra"]                                                        => {
+            [EmsFolder, "Infra", {:hidden => false}]                                    => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "M-TestDC1"] => {}
             },
-            [EmsFolder, "JFitzgerald"]                                                  => {
+            [EmsFolder, "JFitzgerald", {:hidden => false}]                              => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "JoeF 4.0.1"] => {}
             },
-            [EmsFolder, "MFeifer"]                                                      => {
+            [EmsFolder, "MFeifer", {:hidden => false}]                                  => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "mgf_3_3_2_34"]               => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "mgf_40115_svn_formigrate"]   => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "MGF_Branch_332_svn"]         => {},
@@ -723,7 +723,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "mgf_nightly_trunk_svn"]      => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "mgf_trunk_nightly_v4"]       => {}
             },
-            [EmsFolder, "Rich"]                                                         => {
+            [EmsFolder, "Rich", {:hidden => false}]                                     => {
               [ManageIQ::Providers::Vmware::InfraManager::Template, "netapp-sim-host-template"]   => {},
               [ManageIQ::Providers::Vmware::InfraManager::Template, "netapp-smis-agent-template"] => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "ESX-TESTVCINTEGRATION"]            => {},
@@ -741,27 +741,27 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "NetAppDsTest6"]                    => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "NetAppDsTest7"]                    => {}
             },
-            [EmsFolder, "RMoore"]                                                       => {
+            [EmsFolder, "RMoore", {:hidden => false}]                                   => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "RM-4.0.1.12C"] => {}
             },
-            [EmsFolder, "THennessy"]                                                    => {
+            [EmsFolder, "THennessy", {:hidden => false}]                                => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "tch-cos64_19GB_restore_"] => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "tch-cos64-V4_import_tes"] => {}
             },
-            [EmsFolder, "Training"]                                                     => {
+            [EmsFolder, "Training", {:hidden => false}]                                 => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "Training Master DB"]        => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "Training Region 10 UI"]     => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "Training Region 10 Worker"] => {}
             },
-            [EmsFolder, "VCs"]                                                          => {
+            [EmsFolder, "VCs", {:hidden => false}]                                      => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "VC41Test"]      => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "VC41Test-Prod"] => {}
             },
-            [EmsFolder, "View Environment"]                                             => {
+            [EmsFolder, "View Environment", {:hidden => false}]                         => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "View Broker"]               => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "View Windows 7 Parent x64"] => {}
             },
-            [EmsFolder, "Xlecauchois"]                                                  => {
+            [EmsFolder, "Xlecauchois", {:hidden => false}]                              => {
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "Xav 4014"]      => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "Xav 4018"]      => {},
               [ManageIQ::Providers::Vmware::InfraManager::Vm, "Xav COS 40114"] => {},


### PR DESCRIPTION
Rather than computing if a folder is hidden at runtime, have each provider inventory refresh parser set if a folder is_default, similar to the way hidden ResourcePools are handled.