### PR TITLE
Fix method for finding a table's primary key

### DIFF
--- a/app/models/vmdb_table_evm.rb
+++ b/app/models/vmdb_table_evm.rb
@@ -6,7 +6,8 @@ class VmdbTableEvm < VmdbTable
 
   def sql_indexes
     actual  = self.class.connection.indexes(name)
-    actual += self.class.connection.respond_to?(:primary_key_indexes) ? self.class.connection.primary_key_indexes(name) : []
+    pk = self.class.connection.primary_key_index(name)
+    actual << pk if pk
     actual
   end
 end

--- a/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -518,37 +518,24 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
     end.compact
   end
 
-  # Returns an array of primary-key indexes (indisprimary = true) for the given table.
-  def primary_key_indexes(table_name, name = nil)
-    schemas = schema_search_path.split(/,/).map { |p| quote(p) }.join(',')
-    result = query(<<-SQL, name)
-       SELECT distinct i.relname, d.indisunique, d.indkey, t.oid
-       FROM pg_class t
-       INNER JOIN pg_index d ON t.oid = d.indrelid
-       INNER JOIN pg_class i ON d.indexrelid = i.oid
-       WHERE i.relkind = 'i'
-         AND d.indisprimary = 't'
-         AND t.relname = '#{table_name}'
-         AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN (#{schemas}) )
-      ORDER BY i.relname
+  # Returns the primary-key index definition for the given table if it exists
+  def primary_key_index(table_name)
+    result = select_all(<<-SQL).cast_values.first
+      SELECT c.relname, array_agg(a.attname)
+      FROM pg_index i
+      JOIN pg_attribute a ON
+        a.attrelid = i.indrelid AND
+        a.attnum = ANY(i.indkey)
+      JOIN pg_class c ON
+        i.indexrelid = c.oid
+      WHERE
+        i.indrelid = '#{table_name}'::regclass AND
+        i.indisprimary group by c.relname;
     SQL
 
-    result.map do |row|
-      index_name = row[0]
-      unique     = row[1] == 't'
-      indkey     = row[2].split(" ")
-      oid        = row[3]
+    return nil unless result
 
-      columns = Hash[query(<<-SQL, "Columns for index #{row[0]} on #{table_name}")]
-      SELECT a.attnum, a.attname
-      FROM pg_attribute a
-      WHERE a.attrelid = #{oid}
-      AND a.attnum IN (#{indkey.join(",")})
-      SQL
-
-      column_names = columns.values_at(*indkey).compact
-      column_names.empty? ? nil : IndexDefinition.new(table_name, index_name, unique, column_names)
-    end.compact
+    ActiveRecord::ConnectionAdapters::IndexDefinition.new(table_name, result[0], true, result[1])
   end
 
   def primary_key?(table_name)

--- a/spec/lib/extensions/ar_dba_spec.rb
+++ b/spec/lib/extensions/ar_dba_spec.rb
@@ -1,6 +1,32 @@
 describe "ar_dba extension" do
   let(:connection) { ApplicationRecord.connection }
 
+  describe "#primary_key_index" do
+    it "returns nil when there is no primary key" do
+      table_name = "no_pk_test"
+      connection.select_value("CREATE TABLE #{table_name} (id INTEGER)")
+      expect(connection.primary_key_index(table_name)).to be nil
+    end
+
+    it "returns the correct primary key" do
+      index_def = connection.primary_key_index("miq_databases")
+      expect(index_def.table).to eq("miq_databases")
+      expect(index_def.unique).to be true
+      expect(index_def.columns).to eq(["id"])
+    end
+
+    it "works with composite primary keys" do
+      table_name = "comp_pk_test"
+      connection.select_value("CREATE TABLE #{table_name} (id1 INTEGER, id2 INTEGER)")
+      connection.select_value("ALTER TABLE #{table_name} ADD PRIMARY KEY (id1, id2)")
+
+      index_def = connection.primary_key_index(table_name)
+      expect(index_def.table).to eq(table_name)
+      expect(index_def.unique).to be true
+      expect(index_def.columns).to match_array(%w(id1 id2))
+    end
+  end
+
   describe "#primary_key?" do
     it "returns false for a table without a primary key" do
       table_name = "no_pk_test"


### PR DESCRIPTION
Previously this method did not work and was not tested.
This implementation is also simpler and takes advantage of the fact that a table can only ever have one primary key.

Planning on using this method to determine if all tables have a primary key of "id" in a follow up.

@Fryguy @matthewd please review.