### PR TITLE
Delete BinaryBlob #dump_binary and #store_binary

### DIFF
--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -36,55 +36,6 @@ class BinaryBlob < ApplicationRecord
     self
   end
 
-  # Write binary file from the database into a file
-  def dump_binary(path_or_io)
-    dump_size = 0
-    hasher = Digest::MD5.new
-
-    begin
-      fd = path_or_io.respond_to?(:write) ? path_or_io : File.open(path_or_io, "wb")
-
-      # TODO: Change this to collect the binary_blob_parts in batches, so we are not pulling in every row into memory at once
-      binary_blob_parts.each do |b|
-        data = b.data
-        dump_size += data.bytesize
-        hasher.update(data)
-        fd.write(data)
-      end
-    ensure
-      fd.close unless path_or_io.respond_to?(:write)
-    end
-
-    raise "size of #{self.class.name} id [#{id}] is incorrect" unless size.nil? || size == dump_size
-    raise "md5 of #{self.class.name} id [#{id}] is incorrect" unless md5.nil? || md5 == hasher.hexdigest
-    true
-  end
-
-  # Set binary file into the database from a file
-  def store_binary(path)
-    delete_binary unless parts == 0
-
-    self.part_size ||= BinaryBlobPart.default_part_size
-    self.md5 = nil
-    self.size = 0
-
-    hasher = Digest::MD5.new
-
-    File.open(path, "rb") do |f|
-      until f.eof?
-        buf = f.read(self.part_size)
-        self.size += buf.length
-        hasher.update(buf)
-        binary_blob_parts << BinaryBlobPart.new(:data => buf)
-      end
-    end
-
-    self.md5 = hasher.hexdigest
-    self.save!
-
-    self
-  end
-
   def parts
     binary_blob_parts.size
   end

--- a/spec/models/binary_blob_spec.rb
+++ b/spec/models/binary_blob_spec.rb
@@ -46,35 +46,6 @@ describe BinaryBlob do
     end
   end
 
-  context "#dump_binary" do
-    before { @blob = FactoryGirl.build(:binary_blob, :name => "test") }
-
-    subject do
-      @blob.binary = @data.dup
-      @string = StringIO.new
-      @blob.save
-      @blob.reload
-      @blob.dump_binary(@string)
-      @string.rewind
-      @string.read
-    end
-
-    it "without UTF-8 data" do
-      @data = "--- Quota - Max CPUs\n...\n"
-      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
-    end
-
-    it "with UTF-8 data" do
-      @data = "--- Quota \xE2\x80\x93 Max CPUs\n...\n"
-      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
-    end
-
-    it "with UTF-8 data with bad encoding" do
-      @data = "%PDF-1.4\n%\xE2"
-      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
-    end
-  end
-
   describe "serializing and deserializing data" do
     it "can store and load data as YAML" do
       bb = FactoryGirl.build(:binary_blob)


### PR DESCRIPTION
AFAICT these are not being used, and were made obsolete by
4c6fbbebc0db9c5b3b48bba21607bd3df902ac7a

***

/cc @jrafanie :fire: :scissors: 