### PR TITLE
Honor feed_type when updating an RSS widget

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -655,7 +655,17 @@ module ReportController::Widgets
     #      end
     #      widget.miq_widget_shortcuts = ws
     #    end
-    widget.options[:url] = @edit[:new][:url] unless @edit[:new][:url].blank?
+    if @sb[:wtype] == "rf"
+      if @edit[:new][:feed_type] == "internal"
+        widget.resource = RssFeed.find(@edit[:new][:rss_feed_id]) if @edit[:new][:rss_feed_id]
+        widget.options.delete(:url)
+      else
+        widget.resource = nil
+        widget.options[:url] = @edit[:new][:url]
+      end
+    else
+      widget.resource = @edit[:rpt]
+    end
     widget.options[:col_order] = [] if @edit[:new][:pivotby1]
     widget.options[:col_order].push(@edit[:new][:pivotby1]) if !@edit[:new][:pivotby1].blank? && @edit[:new][:pivotby1] != "<<< Nothing >>>"
     widget.options[:col_order].push(@edit[:new][:pivotby2]) if !@edit[:new][:pivotby2].blank? && @edit[:new][:pivotby2] != "<<< Nothing >>>"
@@ -683,11 +693,6 @@ module ReportController::Widgets
         widget.visibility[:roles] = ["_ALL_"]
       end
       widget.visibility.delete(:groups) if widget.visibility[:groups]
-    end
-    if @edit[:new][:rss_feed_id]
-      widget.resource = RssFeed.find(@edit[:new][:rss_feed_id])
-    else
-      widget.resource = @edit[:rpt]
     end
 
     # schedule settings

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -656,13 +656,7 @@ module ReportController::Widgets
     #      widget.miq_widget_shortcuts = ws
     #    end
     if @sb[:wtype] == "rf"
-      if @edit[:new][:feed_type] == "internal"
-        widget.resource = RssFeed.find(@edit[:new][:rss_feed_id]) if @edit[:new][:rss_feed_id]
-        widget.options.delete(:url)
-      else
-        widget.resource = nil
-        widget.options[:url] = @edit[:new][:url]
-      end
+      widget.set_rss_properties(@edit[:new][:feed_type], @edit[:new][:rss_feed_id], @edit[:new][:url])
     else
       widget.resource = @edit[:rpt]
     end

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -548,6 +548,16 @@ class MiqWidget < ApplicationRecord
     widget
   end
 
+  def set_rss_properties(feed_type, rss_feed_id = nil, url = nil)
+    if feed_type == 'internal'
+      self.resource = RssFeed.find(rss_feed_id) if rss_feed_id
+      options.delete(:url)
+    else
+      options[:url] = url
+      self.resource = nil
+    end
+  end
+
   def sync_schedule(schedule_info)
     return if schedule_info.nil?
 

--- a/spec/controllers/miq_report_controller/widgets_spec.rb
+++ b/spec/controllers/miq_report_controller/widgets_spec.rb
@@ -107,5 +107,41 @@ describe ReportController do
         end
       end
     end
+
+    context 'edit existing widget' do
+      context 'rss widget' do
+        before do
+          RssFeed.seed
+          controller.instance_variable_set(:@sb, :wtype => 'rf') # RSS Feed widget
+        end
+
+        let(:rss_feed) { RssFeed.first }
+        let(:default_row_count_value) { 5 }
+
+        it 'can change type from external to internal' do
+          external_widget = FactoryGirl.create(:miq_widget, :content_type => 'rss')
+          controller.instance_variable_set(:@edit, :schedule  => miq_schedule,
+                                                   :widget_id => external_widget.id,
+                                                   :new       => {})
+          controller.instance_variable_set(:@_params, :button      => 'save',
+                                                      :start_min   => '10',
+                                                      :start_hour  => '00',
+                                                      :start_date  => '11/13/2015',
+                                                      :timer_typ   => 'Hourly',
+                                                      :title       => 'NewRssWidget',
+                                                      :description => 'All the news',
+                                                      :feed_type   => 'internal',
+                                                      :rss_feed    => rss_feed.id,
+                                                      :row_count   => default_row_count_value,
+                                          )
+          controller.send(:widget_edit)
+          expect(MiqWidget.count).to eq(@previous_count_of_widgets + 1)
+          expect(new_widget.errors.count).to eq(0)
+          expect(new_widget.title).to eq("NewRssWidget")
+          expect(new_widget.resource.id).to eq(rss_feed.id)
+          expect(new_widget.options).to eq(:row_count => default_row_count_value)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/miq_report_controller/widgets_spec.rb
+++ b/spec/controllers/miq_report_controller/widgets_spec.rb
@@ -75,6 +75,37 @@ describe ReportController do
           expect(new_widget.errors.count).not_to eq(0)
         end
       end
+
+      context "rss widget" do
+        before do
+          RssFeed.seed
+          controller.instance_variable_set(:@sb, :wtype => 'rf') # RSS Feed widget
+        end
+
+        let(:rss_feed) { RssFeed.first }
+        let(:default_row_count_value) { 5 }
+
+        it 'creates internal rss widget' do
+          controller.instance_variable_set(:@edit, :schedule => miq_schedule, :new => {})
+          controller.instance_variable_set(:@_params, :button      => 'add',
+                                                      :start_min   => '10',
+                                                      :start_hour  => '00',
+                                                      :start_date  => '11/13/2015',
+                                                      :timer_typ   => 'Hourly',
+                                                      :title       => 'NewRssWidget',
+                                                      :description => 'All the news',
+                                                      :feed_type   => 'internal',
+                                                      :row_count   => default_row_count_value,
+                                                      :rss_feed    => rss_feed.id,
+                                          )
+          controller.send(:widget_new)
+          expect(MiqWidget.count).to eq(@previous_count_of_widgets + 1)
+          expect(new_widget.errors.count).to eq(0)
+          expect(new_widget.title).to eq("NewRssWidget")
+          expect(new_widget.resource.id).to eq(rss_feed.id)
+          expect(new_widget.options).to eq(:row_count => default_row_count_value)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
On #show RSS widget is considered internal when `widget.resource` exists.
On #edit RSS widget is considered external when `widget.options[:url]` exists.
Messy. First step is to ensure data integrity on update.

This addresses broken RSS widget when user changes external to internal
or vice versa.

@miq-bot add_label ui, bug