### PR TITLE
Vim performance scope 4

### DIFF
--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -74,6 +74,19 @@ module Metric::Helper
     (start_time..end_time).step_value(1.day).collect! { |t| t.in_time_zone(tz).beginning_of_day.utc.iso8601 }
   end
 
+  # @option range :start_date start of the range (if not present, sets to end_date - days)
+  # @option range :end_date end of time range (default: now)
+  # @option range :days number of days for range (default: 20)
+  # @return Range<DateTime,DateTime>
+  def self.time_range_from_hash(range)
+    return range unless range.kind_of?(Hash)
+    end_time = (range[:end_date] || Time.now.utc).utc
+    days = range[:days] || 20
+    start_time = (range[:start_date] || (end_time - days.days)).utc
+
+    start_time..end_time
+  end
+
   def self.days_from_range_by_time_profile(start_time, end_time = nil)
     TimeProfile.rollup_daily_metrics.each_with_object({}) do |tp, h|
       days = days_from_range(start_time, end_time, tp.tz_or_default)

--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -1,8 +1,8 @@
 class MetricRollup < ApplicationRecord
   include Metric::Common
 
-  def self.find_all_by_interval_and_time_range(interval, start_time, end_time)
-    where(:capture_interval_name => interval, :timestamp => start_time..end_time)
+  def self.with_interval_and_time_range(interval, timestamp)
+    where(:capture_interval_name => interval, :timestamp => timestamp)
   end
 
   #

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -253,9 +253,8 @@ module MiqReport::Generator
       exp_sql, exp_includes = conditions.to_sql(tz) unless conditions.nil? || klass.respond_to?(:instances_are_derived?)
       where_clause, includes = MiqExpression.merge_where_clauses_and_includes([where_clause, exp_sql], [includes, exp_includes])
 
-      results = klass.find_all_by_interval_and_time_range(
-        db_options[:interval], start_time, end_time
-      ).where(where_clause).includes(includes).limit(options[:limit])
+      results = klass.with_interval_and_time_range(db_options[:interval], start_time..end_time)
+                     .where(where_clause).includes(includes).limit(options[:limit])
 
       results = Rbac.filtered(results, :class        => db,
                                        :filter       => conditions,

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -44,7 +44,7 @@ module MiqReport::Generator::Trend
 
       # Search and filter performance data
       trend_klass = db_options[:trend_db].kind_of?(Class) ? db_options[:trend_db] : Object.const_get(db_options[:trend_db])
-      recs = trend_klass.find_all_by_interval_and_time_range('hourly', start_time, end_time).where(where_clause)
+      recs = trend_klass.with_interval_and_time_range('hourly', start_time..end_time).where(where_clause)
       results = Rbac.filtered(recs, :class        => db_options[:trend_db],
                                     :filter       => db_options[:trend_filter],
                                     :userid       => options[:userid],

--- a/app/models/mixins/ontap_metrics_rollup_mixin.rb
+++ b/app/models/mixins/ontap_metrics_rollup_mixin.rb
@@ -68,8 +68,8 @@ module OntapMetricsRollupMixin
       @baseCounterNames = counterNames & bca
     end
 
-    def find_all_by_interval_and_time_range(interval, start_time, end_time)
-      where(:rollup_type => interval, :statistic_time => start_time..end_time)
+    def with_interval_and_time_range(interval, timestamp)
+      where(:rollup_type => interval, :statistic_time => timestamp)
     end
   end # module ClassMethods
 

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -134,7 +134,7 @@ module VimPerformanceAnalysis
       end
 
       if VimPerformanceAnalysis.needs_perf_data?(options[:target_options])
-        perf_cols = [:cpu, :memory, :storage].collect do |t|
+        perf_cols = [:cpu, :vcpus, :memory, :storage].collect do |t|
           [options[:target_options].fetch_path(t, :metric), options[:target_options].fetch_path(t, :limit_col)]
         end.flatten.compact
       end

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -141,11 +141,10 @@ module VimPerformanceAnalysis
 
       result = compute_hosts.collect do |c|
         count_hash = {}
-        hash = {:target => c, :count => count_hash}
 
         compute_perf = VimPerformanceAnalysis.get_daily_perf(c, options[:range], options[:ext_options], perf_cols)
         # if we rely upon daily perf columns, make sure we have values for them
-        unless perf_cols && compute_perf.blank?
+        if perf_cols.nil? || compute_perf.present?
           ts = compute_perf.last.timestamp if compute_perf
 
           [:cpu, :vcpus, :memory].each do |type|
@@ -171,7 +170,7 @@ module VimPerformanceAnalysis
           end
         end
         count_hash[:total] = {:total => count_hash.each_value.pluck(:total).compact.max}
-        hash
+        {:target => c, :count => count_hash}
       end
 
       result = how_many_more_can_fit_host_to_cluster_results(result) if @compute.first.kind_of?(EmsCluster)

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -141,7 +141,7 @@ module VimPerformanceAnalysis
 
       result = compute_hosts.collect do |c|
         count_hash = {}
-        hash = { :target => c, :count => count_hash }
+        hash = {:target => c, :count => count_hash}
 
         compute_perf = VimPerformanceAnalysis.get_daily_perf(c, options[:range], options[:ext_options], perf_cols)
         # if we rely upon daily perf columns, make sure we have values for them
@@ -151,7 +151,7 @@ module VimPerformanceAnalysis
           [:cpu, :vcpus, :memory].each do |type|
             next if vm_needs[type].nil? || options[:target_options][type].nil?
             if type == :vcpus && vm_needs[type] > c.total_vcpus
-              count_hash[type] = { :total => 0 }
+              count_hash[type] = {:total => 0}
               next
             end
             avail, usage = compute_offers(compute_perf, ts, options[:target_options][type], type, c)
@@ -167,10 +167,10 @@ module VimPerformanceAnalysis
               details << {s.id => fits}
               total += fits unless fits.nil?
             end
-            count_hash[:storage] = { :total => total, :details => details }
+            count_hash[:storage] = {:total => total, :details => details}
           end
         end
-        count_hash[:total] = { :total => count_hash.each_value.pluck(:total).compact.max }
+        count_hash[:total] = {:total => count_hash.each_value.pluck(:total).compact.max}
         hash
       end
 

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -191,7 +191,7 @@ class ContainerDashboardService
     resource_ids = @ems.present? ? [@ems.id] : ManageIQ::Providers::ContainerManager.select(:id)
     hourly_network_trend = Hash.new(0)
     hourly_metrics =
-      MetricRollup.find_all_by_interval_and_time_range("hourly", 1.day.ago.beginning_of_hour.utc, Time.now.utc)
+      MetricRollup.with_interval_and_time_range("hourly", (1.day.ago.beginning_of_hour.utc)..(Time.now.utc))
     hourly_metrics =
       hourly_metrics.where('resource_type = ? AND resource_id in (?)', 'ExtManagementSystem', resource_ids)
 


### PR DESCRIPTION
This was extracted from #7284

This is focused on simplifying the timestamps being passed into `VimPerformanceDaily`.
It also replaces the `ext_options[:only_cols]` with `select`. `:only_cols` has not been respected by `VimPerformanecDaily` for some time. This gets those optimizations back.

After this is merged, we can focus on extracting common logic between `MetricRollup` and `VmdbPerformanceDaily`

/cc @matthewd @chessbyte avoided the whole extra time arguments