### PR TITLE
Add MiqAction to annotate container images as non secure at openshift 

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -119,4 +119,15 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
                           client.headers.stringify_keys,
                           scan_data[:guest_os])
   end
+
+  def annotate(provider_entity_name, ems_indentifier, annotations, container_project_name = nil)
+    with_provider_connection do |conn|
+      conn.send(
+        "patch_#{provider_entity_name}".to_sym,
+        ems_indentifier,
+        {"metadata" => {"annotations" => annotations}},
+        container_project_name # nil is ok for non namespaced entities (e.g images)
+      )
+    end
+  end
 end

--- a/db/fixtures/miq_actions.csv
+++ b/db/fixtures/miq_actions.csv
@@ -10,6 +10,7 @@ evm_event,Show EVM Event on Timeline
 script,Execute an external script
 prevent,Prevent current event from proceeding
 container_image_analyze,Initiate SmartState Analysis for Container Image
+container_image_annotate_deny_execution,Prevent container image from running on OpenShift
 vm_start,Start Virtual Machine
 vm_stop,Stop Virtual Machine
 vm_suspend,Suspend Virtual Machine


### PR DESCRIPTION
Based on:
- https://github.com/abonas/kubeclient/pull/161
- https://github.com/abonas/openshift_client/pull/22

The metadata created by the MiqAction is meant to be used by Openshift to prevent tagged images from running.