### PR TITLE
Sporadic factories

### DIFF
--- a/spec/factories/assigned_server_role.rb
+++ b/spec/factories/assigned_server_role.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :assigned_server_role do
-    active          TRUE
-    priority        AssignedServerRole::HIGH_PRIORITY
+    active          { true }
+    priority        { AssignedServerRole::HIGH_PRIORITY }
   end
 end

--- a/spec/factories/condition.rb
+++ b/spec/factories/condition.rb
@@ -4,6 +4,6 @@ FactoryGirl.define do
     sequence(:description) { |num| "Condition #{seq_padded_for_sorting(num)}" }
     modifier               "allow"
     towhat                 "Vm"
-    expression             MiqExpression.new(">=" => {"field" => "Vm-num_cpu", "value" => "2"})
+    expression             { MiqExpression.new(">=" => {"field" => "Vm-num_cpu", "value" => "2"}) }
   end
 end

--- a/spec/factories/miq_ems_refresh_core_worker.rb
+++ b/spec/factories/miq_ems_refresh_core_worker.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :miq_ems_refresh_core_worker do
-    pid Process.pid
+    pid { Process.pid }
   end
 end

--- a/spec/factories/miq_ems_refresh_worker.rb
+++ b/spec/factories/miq_ems_refresh_worker.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :miq_ems_refresh_worker do
-    pid Process.pid
+    pid { Process.pid }
   end
 end

--- a/spec/factories/vmware_refresh_worker.rb
+++ b/spec/factories/vmware_refresh_worker.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :vmware_refresh_worker, :class => 'ManageIQ::Providers::Vmware::InfraManager::RefreshWorker' do
-    pid Process.pid
+    pid { Process.pid }
   end
 end


### PR DESCRIPTION
A PR is failing because of a factory reference to `MiqExpression`.

Migration specs have tables not loaded.
Referencing this class tried to read the columns from the database, and blew up the spec. [travis ref](https://travis-ci.org/ManageIQ/manageiq/jobs/118581352#L710)

This PR reduced the realtime references to these classes.
