### PR TITLE
Limit objects returned by initial waitForUpdatesEx

### DIFF
--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -223,6 +223,8 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
     MiqVimBroker.notifyMethod = nil
     MiqVimBroker.cacheScope   = expected_broker_cache_scope
     MiqVimBroker.setSelector(EmsRefresh::VcUpdates::VIM_SELECTOR_SPEC)
+    MiqVimBroker.maxWait      = worker_settings[:vim_broker_max_wait]
+    MiqVimBroker.maxObjects   = worker_settings[:vim_broker_max_objects]
 
     _log.info("#{log_prefix} Creating broker server with [#{MiqVimBroker.cacheScope}]")
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1374,6 +1374,8 @@
       :reconnect_retry_interval: 5.minutes
       :vim_broker_status_interval: 15.minutes
       :vim_broker_update_interval: 0.seconds
+      :vim_broker_max_wait: 60
+      :vim_broker_max_objects: 250
     :web_service_worker:
       :connection_pool_size: 5
       :memory_threshold: 1.gigabytes

--- a/gems/pending/VMwareWebService/DMiqVim.rb
+++ b/gems/pending/VMwareWebService/DMiqVim.rb
@@ -25,7 +25,7 @@ class DMiqVim < MiqVim
 
   attr_reader :updateThread
 
-  def initialize(server, username, password, broker, preLoad = false, debugUpdates = false, notifyMethod = nil, cacheScope = nil, maxWait = 60)
+  def initialize(server, username, password, broker, preLoad = false, debugUpdates = false, notifyMethod = nil, cacheScope = nil, maxWait = 60, maxObjects = 250)
     super(server, username, password, cacheScope)
 
     log_prefix        = "DMiqVim.initialize (#{@connId})"
@@ -37,6 +37,7 @@ class DMiqVim < MiqVim
     @connectionRemoved    = false
     @debugUpdates     = debugUpdates
     @maxWait          = maxWait
+    @maxObjects       = maxObjects
 
     checkForOrphanedMonitors
     $vim_log.info "#{log_prefix}: starting update monitor thread" if $vim_log

--- a/gems/pending/VMwareWebService/MiqVimBroker.rb
+++ b/gems/pending/VMwareWebService/MiqVimBroker.rb
@@ -29,6 +29,8 @@ class MiqVimBroker
   @@updateDelay = nil
   @@cacheScope  = :cache_scope_full
   @@selectorHash  = {}
+  @@maxWait    = 60
+  @@maxObjects = 250
 
   def initialize(mode = :client, port = 9001)
     if mode == :client
@@ -314,6 +316,22 @@ class MiqVimBroker
     end
   end
 
+  def self.maxWait=(val)
+    @@maxWait = val
+  end
+
+  def self.maxWait
+    @@maxWait
+  end
+
+  def self.maxObjects=(val)
+    @@maxObjects = val
+  end
+
+  def self.maxObjects
+    @@maxObjects
+  end
+
   def releaseSession(sessionId)
     if @mode == :client
       $vim_log.info "Client releaseSession: #{sessionId}"
@@ -412,7 +430,7 @@ class MiqVimBroker
           removeMiqVimSS(key, vim)
         end
         begin
-          vim = DMiqVim.new(server.untaint, username, password, self, @@preLoad, @@debugUpdates, @@notifyMethod, @cacheScope)
+          vim = DMiqVim.new(server.untaint, username, password, self, @@preLoad, @@debugUpdates, @@notifyMethod, @cacheScope, @@maxWait, @@maxObjects)
           vim.updateDelay = @@updateDelay if @@updateDelay
           vim.setSelector(@selectorHash) unless @selectorHash.empty?
           $vim_log.info "MiqVimBroker.getMiqVim: returning new connection for #{key}"

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -36,6 +36,8 @@ describe MiqVimBrokerWorker::Runner do
     before(:each) do
       expect_any_instance_of(described_class).to receive(:after_initialize).once
       @vim_broker_worker = described_class.new({:guid => @worker_guid})
+      allow(@vim_broker_worker).to receive(:worker_settings).and_return(
+        :vim_broker_worker_max_wait => 60, :vim_broker_worker_max_objects => 250)
     end
 
     context "#start_broker_server" do


### PR DESCRIPTION
The initial call to waitForUpdatesEx will return every inventory
item in one call, with very large inventories this can bump up
against the 2min HTTP timeout requiring a number of retries and
an increasing timeout.  The new WaitForUpdatesEx method allows
the caller to specify a maximum number of objects to be returned
by any one waitForUpdatesEx call, which allows us to page through
the initial inventory without needing to increase the timeout.