### PR TITLE
Add missing chart layout files for ExtManagementSystem

### DIFF
--- a/product/charts/layouts/daily_perf_charts/ExtManagementSystem.yaml
+++ b/product/charts/layouts/daily_perf_charts/ExtManagementSystem.yaml
@@ -1,0 +1,17 @@
+# Container node daily performance chart layouts
+---
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available
+
+- :title: Network I/O (KBps)
+  :type: Line
+  :columns:
+  - net_usage_rate_average

--- a/product/charts/layouts/hourly_perf_charts/ExtManagementSystem.yaml
+++ b/product/charts/layouts/hourly_perf_charts/ExtManagementSystem.yaml
@@ -1,0 +1,17 @@
+# Container node daily performance chart layouts
+---
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available
+
+- :title: Network I/O (KBps)
+  :type: Line
+  :columns:
+  - net_usage_rate_average


### PR DESCRIPTION
Add missing files for chart layout of ExtManagmentSystem.
Address issue: https://github.com/ManageIQ/manageiq/issues/7534

Before:
![screenshot-2016-03-27-12-09-25](https://cloud.githubusercontent.com/assets/2181522/14079566/76e6d340-f507-11e5-9059-107fa058a268.png)

After:
![screenshot-2016-03-28-17-05-42](https://cloud.githubusercontent.com/assets/2181522/14079581/7d12fdf2-f507-11e5-859e-37f8bae99f83.png)

