### PR TITLE
VDS Support: Relationship between hosts and switches are now has_many through

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -49,7 +49,8 @@ class Host < ApplicationRecord
   has_many                  :miq_templates, :inverse_of => :host
   has_many                  :host_storages
   has_many                  :storages, :through => :host_storages
-  has_many                  :switches, :dependent => :destroy
+  has_many                  :host_switches, :dependent => :destroy
+  has_many                  :switches, :through => :host_switches
   has_many                  :patches, :dependent => :destroy
   has_many                  :system_services, :dependent => :destroy
   has_many                  :host_services, :class_name => "SystemService", :foreign_key => "host_id", :inverse_of => :host

--- a/app/models/host_switch.rb
+++ b/app/models/host_switch.rb
@@ -1,0 +1,4 @@
+class HostSwitch < ApplicationRecord
+  belongs_to :host
+  belongs_to :switch
+end

--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -1,5 +1,6 @@
 class Switch < ApplicationRecord
-  belongs_to :host
+  has_many :host_switches, :dependent => :destroy
+  has_many :hosts, :through => :host_switches
 
   has_many :guest_devices
   has_many :lans, :dependent => :destroy

--- a/db/migrate/20160322141934_create_join_table_host_switch.rb
+++ b/db/migrate/20160322141934_create_join_table_host_switch.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableHostSwitch < ActiveRecord::Migration[5.0]
+  def change
+    create_table :host_switches do |t|
+      t.bigint  :host_id
+      t.bigint  :switch_id
+    end
+  end
+end

--- a/db/migrate/20160322195653_move_switch_host_to_jointable.rb
+++ b/db/migrate/20160322195653_move_switch_host_to_jointable.rb
@@ -1,13 +1,11 @@
 class MoveSwitchHostToJointable < ActiveRecord::Migration[5.0]
   class Host < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
-    has_many :switches,
-             :class_name => 'MoveSwitchHostToJointable::Switch'
+    has_many :switches, :class_name => 'MoveSwitchHostToJointable::Switch'
   end
 
   class Switch < ActiveRecord::Base
-    belongs_to :host,
-               :class_name => 'MoveSwitchHostToJointable::Host'
+    belongs_to :host, :class_name => 'MoveSwitchHostToJointable::Host'
   end
 
   class HostSwitch < ActiveRecord::Base
@@ -15,7 +13,7 @@ class MoveSwitchHostToJointable < ActiveRecord::Migration[5.0]
 
   def up
     say_with_time('Populating host_switches table with (host.id, switch.id)') do
-      Host.all.each do |host|
+      Host.includes(:switches).find_each do |host|
         host.switches.each do |switch|
           HostSwitch.create!(:host_id => host.id, :switch_id => switch.id)
         end

--- a/db/migrate/20160322195653_move_switch_host_to_jointable.rb
+++ b/db/migrate/20160322195653_move_switch_host_to_jointable.rb
@@ -1,0 +1,25 @@
+class MoveSwitchHostToJointable < ActiveRecord::Migration[5.0]
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    has_many :switches,
+             :class_name => 'MoveSwitchHostToJointable::Switch'
+  end
+
+  class Switch < ActiveRecord::Base
+    belongs_to :host,
+               :class_name => 'MoveSwitchHostToJointable::Host'
+  end
+
+  class HostSwitch < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time('Populating host_switches table with (host.id, switch.id)') do
+      Host.all.each do |host|
+        host.switches.each do |switch|
+          HostSwitch.create!(:host_id => host.id, :switch_id => switch.id)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20160322205357_remove_host_id_from_switch.rb
+++ b/db/migrate/20160322205357_remove_host_id_from_switch.rb
@@ -1,0 +1,5 @@
+class RemoveHostIdFromSwitch < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :switches, :host_id, :bigint
+  end
+end

--- a/db/migrate/20160322205357_remove_host_id_from_switch.rb
+++ b/db/migrate/20160322205357_remove_host_id_from_switch.rb
@@ -1,28 +1,18 @@
 class RemoveHostIdFromSwitch < ActiveRecord::Migration[5.0]
   class Host < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
-    has_many :host_switches,
-             :dependent   => :destroy,
-             :class_name  => 'RemoveHostIdFromSwitch::HostSwitch'
-    has_many :switches,
-             :through => :host_switches,
-             :class_name  => 'RemoveHostIdFromSwitch::Switch'
+    has_many :host_switches, :dependent => :destroy, :class_name => 'RemoveHostIdFromSwitch::HostSwitch'
+    has_many :switches, :through => :host_switches, :class_name => 'RemoveHostIdFromSwitch::Switch'
   end
 
   class Switch < ActiveRecord::Base
-    has_many :host_switches,
-             :dependent   => :destroy,
-             :class_name  => 'RemoveHostIdFromSwitch::HostSwitch'
-    has_many :hosts,
-             :through => :host_switches,
-             :class_name => 'RemoveHostIdFromSwitch::Host'
+    has_many :host_switches, :dependent => :destroy, :class_name  => 'RemoveHostIdFromSwitch::HostSwitch'
+    has_many :hosts, :through => :host_switches, :class_name  => 'RemoveHostIdFromSwitch::Host'
   end
 
   class HostSwitch < ActiveRecord::Base
-    belongs_to :host,
-               :class_name  => 'RemoveHostIdFromSwitch::Host'
-    belongs_to :switch,
-               :class_name => 'RemoveHostIdFromSwitch::Switch'
+    belongs_to :host, :class_name => 'RemoveHostIdFromSwitch::Host'
+    belongs_to :switch, :class_name => 'RemoveHostIdFromSwitch::Switch'
   end
 
   def up
@@ -32,8 +22,8 @@ class RemoveHostIdFromSwitch < ActiveRecord::Migration[5.0]
   def down
     add_column :switches, :host_id, :bigint
     say_with_time('Populating switches.host_id from host_switches table') do
-      Switch.all.each do |switch|
-        switch.host_id = switch.hosts[0].id
+      Switch.includes(:hosts).find_each do |switch|
+        switch.host_id = switch.hosts.first.id
         switch.save!
       end
     end

--- a/db/migrate/20160322205357_remove_host_id_from_switch.rb
+++ b/db/migrate/20160322205357_remove_host_id_from_switch.rb
@@ -6,8 +6,8 @@ class RemoveHostIdFromSwitch < ActiveRecord::Migration[5.0]
   end
 
   class Switch < ActiveRecord::Base
-    has_many :host_switches, :dependent => :destroy, :class_name  => 'RemoveHostIdFromSwitch::HostSwitch'
-    has_many :hosts, :through => :host_switches, :class_name  => 'RemoveHostIdFromSwitch::Host'
+    has_many :host_switches, :dependent => :destroy, :class_name => 'RemoveHostIdFromSwitch::HostSwitch'
+    has_many :hosts, :through => :host_switches, :class_name => 'RemoveHostIdFromSwitch::Host'
   end
 
   class HostSwitch < ActiveRecord::Base

--- a/db/migrate/20160322205357_remove_host_id_from_switch.rb
+++ b/db/migrate/20160322205357_remove_host_id_from_switch.rb
@@ -1,5 +1,41 @@
 class RemoveHostIdFromSwitch < ActiveRecord::Migration[5.0]
-  def change
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    has_many :host_switches,
+             :dependent   => :destroy,
+             :class_name  => 'RemoveHostIdFromSwitch::HostSwitch'
+    has_many :switches,
+             :through => :host_switches,
+             :class_name  => 'RemoveHostIdFromSwitch::Switch'
+  end
+
+  class Switch < ActiveRecord::Base
+    has_many :host_switches,
+             :dependent   => :destroy,
+             :class_name  => 'RemoveHostIdFromSwitch::HostSwitch'
+    has_many :hosts,
+             :through => :host_switches,
+             :class_name => 'RemoveHostIdFromSwitch::Host'
+  end
+
+  class HostSwitch < ActiveRecord::Base
+    belongs_to :host,
+               :class_name  => 'RemoveHostIdFromSwitch::Host'
+    belongs_to :switch,
+               :class_name => 'RemoveHostIdFromSwitch::Switch'
+  end
+
+  def up
     remove_column :switches, :host_id, :bigint
+  end
+
+  def down
+    add_column :switches, :host_id, :bigint
+    say_with_time('Populating switches.host_id from host_switches table') do
+      Switch.all.each do |switch|
+        switch.host_id = switch.hosts[0].id
+        switch.save!
+      end
+    end
   end
 end

--- a/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
+++ b/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
@@ -1,0 +1,21 @@
+require_migration
+
+describe MoveSwitchHostToJointable do
+  migration_context :up do
+    let(:switch_stub) { migration_stub(:Switch) }
+    let(:host_stub) { migration_stub(:Host) }
+    let(:host_switches_stub) { migration_stub(:HostSwitch) }
+    it 'Move host-to-switch relationship to host_switches table' do
+      host = host_stub.create!
+      switch1 = switch_stub.create!(:host_id => host.id)
+      switch2 = switch_stub.create!(:host_id => host.id)
+      expect(host.switches.length).to eq 2
+
+      migrate
+
+      expect(host_switches_stub.count).to eq 2
+      expect(host_switches_stub.where(:host_id => host.id, :switch_id => switch1.id).count).to eq 1
+      expect(host_switches_stub.where(:host_id => host.id, :switch_id => switch2.id).count).to eq 1
+    end
+  end
+end

--- a/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
+++ b/spec/migrations/20160322195653_move_switch_host_to_jointable_spec.rb
@@ -9,7 +9,6 @@ describe MoveSwitchHostToJointable do
       host = host_stub.create!
       switch1 = switch_stub.create!(:host_id => host.id)
       switch2 = switch_stub.create!(:host_id => host.id)
-      expect(host.switches.length).to eq 2
 
       migrate
 

--- a/spec/migrations/20160322205357_remove_host_id_from_switch_spec.rb
+++ b/spec/migrations/20160322205357_remove_host_id_from_switch_spec.rb
@@ -12,7 +12,6 @@ describe RemoveHostIdFromSwitch do
     let(:host_stub) { migration_stub(:Host) }
     let(:host_switches_stub) { migration_stub(:HostSwitch) }
     it 'Move host-to-switch relationship back to switches.host_id' do
-
       migrate
 
       @host.reload

--- a/spec/migrations/20160322205357_remove_host_id_from_switch_spec.rb
+++ b/spec/migrations/20160322205357_remove_host_id_from_switch_spec.rb
@@ -7,29 +7,11 @@ describe RemoveHostIdFromSwitch do
     @switch2 = switch_stub.create!(:hosts => [@host])
   end
 
-  migration_context :up do
-    let(:host_stub) { migration_stub(:Host) }
-    let(:switch_stub) { migration_stub(:Switch) }
-    it 'Remove column switches.host_id' do
-      expect(@switch1).to respond_to('host_id')
-      expect(@host.switches.length).to eq 2
-
-      migrate
-
-      @host.reload
-      expect(@host.switches.length).to eq 2
-      @switch1.reload
-      expect(@switch1).not_to respond_to('host_id')
-    end
-  end
-
   migration_context :down do
     let(:switch_stub) { migration_stub(:Switch) }
     let(:host_stub) { migration_stub(:Host) }
     let(:host_switches_stub) { migration_stub(:HostSwitch) }
     it 'Move host-to-switch relationship back to switches.host_id' do
-      expect(@host.switches.length).to eq 2
-      expect(host_switches_stub.count).to eq 2
 
       migrate
 

--- a/spec/migrations/20160322205357_remove_host_id_from_switch_spec.rb
+++ b/spec/migrations/20160322205357_remove_host_id_from_switch_spec.rb
@@ -1,0 +1,42 @@
+require_migration
+
+describe RemoveHostIdFromSwitch do
+  before(:each) do
+    @host = host_stub.create!
+    @switch1 = switch_stub.create!(:hosts => [@host])
+    @switch2 = switch_stub.create!(:hosts => [@host])
+  end
+
+  migration_context :up do
+    let(:host_stub) { migration_stub(:Host) }
+    let(:switch_stub) { migration_stub(:Switch) }
+    it 'Remove column switches.host_id' do
+      expect(@switch1).to respond_to('host_id')
+      expect(@host.switches.length).to eq 2
+
+      migrate
+
+      @host.reload
+      expect(@host.switches.length).to eq 2
+      @switch1.reload
+      expect(@switch1).not_to respond_to('host_id')
+    end
+  end
+
+  migration_context :down do
+    let(:switch_stub) { migration_stub(:Switch) }
+    let(:host_stub) { migration_stub(:Host) }
+    let(:host_switches_stub) { migration_stub(:HostSwitch) }
+    it 'Move host-to-switch relationship back to switches.host_id' do
+      expect(@host.switches.length).to eq 2
+      expect(host_switches_stub.count).to eq 2
+
+      migrate
+
+      @host.reload
+      expect(@host.switches.length).to eq 2
+      expect(switch_stub.where(:host_id => @host.id, :id => @switch1.id).count).to eq 1
+      expect(switch_stub.where(:host_id => @host.id, :id => @switch2.id).count).to eq 1
+    end
+  end
+end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -29,7 +29,7 @@ describe MiqProvisionWorkflow do
           @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro",
                                             :memory_mb => 512,
                                             :cpu_sockets => 2)
-          @switch      = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :host => @host)
+          @switch      = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :hosts => [@host])
           @lan         = FactoryGirl.create(:lan, :name => "VM Network", :switch => @switch)
           @ethernet    = FactoryGirl.create(:guest_device, :hardware => @hardware, :lan => @lan,
                                             :device_type => 'ethernet',


### PR DESCRIPTION
HostSwitch model for relating hosts and switches. This is a re-work of #7490 and differs from that,
* no data migration on switches.uid_ems
* using has_many through instead of HABTM
The is to prepare for VDS inventory. VDS is different from local vSwitch in that one VDS can be accessed by many hosts.  Currently we embed host_id in switches table and that can't accommodate VDS.