### PR TITLE
added chargeback report spec test

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -490,6 +490,22 @@ describe MiqReport do
         report.generate_table(:userid => "admin")
       end
     end
+    context "chargeback report" do
+      let!(:report) do
+        MiqReport.new(
+            :title   => "chargeback_report",
+            :db      => "Chargeback",
+            :cols    => %w(start_date display_range entity_namecpu_cost cpu_metric cpu_used_cost
+                           cpu_used_metric fixed_compute_1_cost fixed_compute_2_cost fixed_cost
+                           memory_cost memory_metric memory_used_cost memory_used_metric total_cost),
+            :include => {})
+      end
+      let(:ems) { FactoryGirl.create(:ems_vmware, :zone => @server.zone) }
+
+      it "runs report" do
+        expect { report.generate_table(:userid => "admin") }.not_to raise_error
+      end
+    end
 
     context "Tenant Quota Report" do
       include QuotaHelper


### PR DESCRIPTION
Chargeback reports keep breaking due to infrastructure changes (maybe in ActsAsArModel)
This test could prevent that.
~~Right now chargeback reports (and this test) fail with this exception:~~
```Ruby
  1) MiqReport#generate_table chargeback report runs report
     Failure/Error: raise NotImplementedError
     
     NotImplementedError:
       NotImplementedError
     # ./lib/acts_as_ar_model.rb:156:in `find'
     # ./lib/acts_as_ar_model.rb:161:in `all'
     # ./app/models/rbac.rb:512:in `method_with_scope'
     # ./app/models/rbac.rb:290:in `find_targets_without_rbac'
     # ./app/models/rbac.rb:285:in `find_targets_with_rbac'
     # ./app/models/rbac.rb:471:in `search'
     # ./app/models/miq_report/generator.rb:270:in `_generate_table'
     # ./app/models/miq_report/generator.rb:176:in `block in generate_table'
     # ./app/models/user.rb:260:in `with_user'
     # ./app/models/miq_report/generator.rb:176:in `generate_table'
     # ./spec/models/miq_report_spec.rb:507:in `block (4 levels) in <top (required)>'

```

@gtanzillo @chrisarcand 
cc @simon3z 