### PR TITLE
[api] Fix skipping of `:verify_authenticity_token`

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -120,7 +120,7 @@ class ApiController < ApplicationController
   # not have these. They would instead dealing with the /api/auth
   # mechanism.
   #
-  if respond_to?(:verify_authenticity_token)
+  if Vmdb::Application.config.action_controller.allow_forgery_protection
     skip_before_action :verify_authenticity_token, :only => [:show, :update, :destroy, :handle_options_request]
   end
 


### PR DESCRIPTION
This condition will never be true, because:

* it's asking the class if it responds to an instance method
* the instance method is private
* it seems to be defined whether or not we call `protect_from_forgery`
  in the superclass

This change reverts part of
https://github.com/ManageIQ/manageiq/commit/df041ad7771bea7c6364389f1eef4a32655f085e. Since
there doesn't seem to be a public API for determining which callbacks
have been defined, this seems to be the best way to express whether we
have enabled `protect_from_forgery` at runtime.

/cc @jrafanie (thanks for your help in debugging this :bow:)
/cc @alongoldboim 

@miq-bot add-label api bug