### PR TITLE
Added missing "Storage" maintab to permissions yml

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -5,6 +5,7 @@
 - :inf
 - :con
 - :cnt
+- :sto
 - :mdl
 - :net
 - :aut


### PR DESCRIPTION
Changes in sha 85406c43244230e9fc62385ec6f2c2f4c91cb9cf sets permission store to a null store that always returns true in test environment but on appliance it reads from `vmdb/config/permissions.yml`. This was causing Storage tab to not be visible on appliance as it was missing from permissions.yml

https://bugzilla.redhat.com/show_bug.cgi?id=1316733

before:
![before](https://cloud.githubusercontent.com/assets/3450808/14089010/a35c8d22-f500-11e5-8815-d97ad9452508.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/14089017/aa2cdf80-f500-11e5-99aa-24a946929596.png)

@dclarizio please review, this can only be tested on an appliance