### PR TITLE
Save location for GlusterFS data stores

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -31,7 +31,7 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       mor = storage_inv[:id]
 
       storage_type = storage_inv[:storage][:type].to_s.upcase
-      location = if storage_type == 'NFS'
+      location = if storage_type == 'NFS' || storage_type == 'GLUSTERFS'
                    "#{storage_inv[:storage][:address]}:#{storage_inv[:storage][:path]}"
                  else
                    storage_inv.attributes.fetch_path(:storage, :volume_group, :logical_unit, :id)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -35,7 +35,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(VmOrTemplate.count).to eq(38)
     expect(Vm.count).to eq(27)
     expect(MiqTemplate.count).to eq(11)
-    expect(Storage.count).to eq(7)
+    expect(Storage.count).to eq(8)
 
     expect(CustomAttribute.count).to eq(0) # TODO: 3.0 spec has values for this
     expect(CustomizationSpec.count).to eq(0)
@@ -138,6 +138,22 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :uncommitted                   => 45097156608,
       :multiplehostaccess            => 1, # TODO: Should this be a boolean column?
       :location                      => nil,
+      :directory_hierarchy_supported => nil,
+      :thin_provisioning_supported   => nil,
+      :raw_disk_mappings_supported   => nil
+    )
+
+    @storage3 = Storage.find_by_name("RHEVM31-gluster")
+    expect(@storage3).to have_attributes(
+      :ems_ref                       => "/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f",
+      :ems_ref_obj                   => "/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f",
+      :name                          => "RHEVM31-gluster",
+      :store_type                    => "GLUSTERFS",
+      :total_space                   => 20_401_094_656,
+      :free_space                    => 16_106_127_360,
+      :uncommitted                   => 19_327_352_832,
+      :multiplehostaccess            => 1, # TODO: Should this be a boolean column?
+      :location                      => "example.gluster.server.com:/gv0",
       :directory_hierarchy_supported => nil,
       :thin_provisioning_supported   => nil,
       :raw_disk_mappings_supported   => nil

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
@@ -393,7 +393,14 @@ http_interactions:
         \       <storage>\n            <type>iscsi</type>\n            <volume_group
         id=\"FXdwmR-2eBU-wyhv-Pbxn-XECC-kdRC-KjXk31\"/>\n        </storage>\n        <available>10737418240</available>\n
         \       <used>4294967296</used>\n        <committed>0</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n</storage_domains>\n"
+        \   </storage_domain>\n    <storage_domain href=\"/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f\"
+        id=\"efbe372b-7634-49f0-901e-0c05d526181f\">\n        <name>RHEVM31-gluster</name>\n
+        \       <link href=\"/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f/permissions\"
+        rel=\"permissions\"/>\n        <type>data</type>\n        <master>false</master>\n
+        \       <storage>\n            <address>example.gluster.server.com</address>        <type>glusterfs</type>\n
+        \        <path>/gv0</path>        </storage>\n        <available>16106127360</available>\n
+        \       <used>4294967296</used>\n        <committed>1073741824</committed>\n        <storage_format>v3</storage_format>\n
+        \   </storage_domain></storage_domains>\n"
     http_version: 
   recorded_at: Wed, 08 Oct 2014 01:27:22 GMT
 - request:


### PR DESCRIPTION
The GlusterFS storage domain as retrieved from ovirt-engine contains the same information as NFS storage domain does regarding the address and path and should be stored as well.