### PR TITLE
Fix css loading order

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -3,6 +3,7 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *
+ *= require c3
  *= require main
  *= require slickgrid/slick.grid
  *= require jquery.jqplot
@@ -24,5 +25,4 @@
  *= require container_topology
  *= require service_dialogs
  *= require xml_display
- *= require c3
 */


### PR DESCRIPTION
The current css loading order makes c3.css load _after_ patternfly.css, the correct loading order is c3 _before_ patternfly.

Patternfly is included in the main.scss, this PR loads c3.css before main.css.

Before:
![manageiq container dashboards before](https://cloud.githubusercontent.com/assets/2181522/14106767/2e9a1c4a-f5bc-11e5-993b-d5d82aeb5ee9.jpg)

After:
![manageiq container dashboards](https://cloud.githubusercontent.com/assets/2181522/14106769/320a445e-f5bc-11e5-8d70-a86e7cce231f.jpg)


