### PR TITLE
Move log level to new config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -117,13 +117,6 @@ module Vmdb
     end
 
     console do
-      # Re-enable SQL logging in the console.  This log level setting gets set
-      #   to INFO, by default, for the loggers in Vmdb::Initializer.init.  So,
-      #   we set the value back to DEBUG for now.
-      # TODO: This can be removed once we can have separate config settings for
-      #   dev/test/prod in the config revamp.
-      ActiveRecord::Base.logger.level = Logger::DEBUG
-
       Rails::ConsoleMethods.include(Vmdb::ConsoleMethods)
     end
   end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,3 @@
+---
+:log:
+  :level_rails: debug


### PR DESCRIPTION
Moves the log level setting out of the application config and in to the sparkly new config revamp

TBH I just stole this from the main settings.yml and it might be redundant save for the actual setting in question. See [this](http://memesvault.com/wp-content/uploads/I-Have-No-Idea-What-Im-Doing-Dog-02.jpg) also.

@miq-bot add_labels core, technical debt

r? @Fryguy