### PR TITLE
Fix for tag control issues on dialog imports across appliances

### DIFF
--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -13,11 +13,7 @@ class DialogFieldImporter
       resource_action = ResourceAction.new(resource_action_attributes)
       dialog_field = dialog_field_type_class.new(dialog_field_attributes.merge("resource_action" => resource_action))
       if dialog_field_attributes["type"] == "DialogFieldTagControl"
-        dialog_field_attributes["options"].delete(:category_id)
-        category_name = dialog_field_attributes["options"][:category_name]
-        category_description = dialog_field_attributes["options"][:category_description]
-        category = Category.find_by_name(category_name)
-        dialog_field.category = category.try(:description) == category_description ? category.id.to_s : nil
+        set_category_for_tag_control(dialog_field, dialog_field_attributes)
       end
       dialog_field.save
 
@@ -27,6 +23,19 @@ class DialogFieldImporter
       DialogField.create(dialog_field_attributes)
     else
       raise InvalidDialogFieldTypeError
+    end
+  end
+
+  private
+
+  def set_category_for_tag_control(dialog_field, dialog_field_attributes)
+    category_name = dialog_field_attributes["options"][:category_name]
+    if category_name
+      category_description = dialog_field_attributes["options"][:category_description]
+      category = Category.find_by_name(category_name)
+      dialog_field.category = category.try(:description) == category_description ? category.id.to_s : nil
+    else
+      dialog_field.category = dialog_field_attributes["options"][:category_id]
     end
   end
 end

--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -12,6 +12,13 @@ class DialogFieldImporter
       resource_action_attributes = dialog_field_attributes.delete("resource_action")
       resource_action = ResourceAction.new(resource_action_attributes)
       dialog_field = dialog_field_type_class.new(dialog_field_attributes.merge("resource_action" => resource_action))
+      if dialog_field_attributes["type"] == "DialogFieldTagControl"
+        dialog_field_attributes["options"].delete(:category_id)
+        category_name = dialog_field_attributes["options"][:category_name]
+        category_description = dialog_field_attributes["options"][:category_description]
+        category = Category.find_by_name(category_name)
+        dialog_field.category = category.try(:description) == category_description ? category.id.to_s : nil
+      end
       dialog_field.save
 
       dialog_field

--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -21,6 +21,11 @@ class DialogFieldSerializer < Serializer
       extra_attributes["values"] = dynamic_values
     end
 
+    if dialog_field.type == "DialogFieldTagControl"
+      category = Category.find_by(:id => dialog_field.category)
+      dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
+    end
+
     included_attributes(dialog_field.attributes).merge(extra_attributes)
   end
 end

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -4,12 +4,14 @@ describe DialogFieldSerializer do
 
   describe "#serialize" do
     let(:dialog_field) { DialogFieldTextBox.new(expected_serialized_values.merge(:resource_action => resource_action)) }
+    let(:type) { "DialogFieldTextBox" }
     let(:resource_action) { ResourceAction.new }
+    let(:options) { {"options" => true} }
     let(:expected_serialized_values) do
       {
         "name"                    => "name",
         "description"             => "description",
-        "type"                    => "DialogFieldTextBox",
+        "type"                    => type,
         "data_type"               => "data_type",
         "notes"                   => "notes",
         "notes_display"           => "notes display",
@@ -25,7 +27,7 @@ describe DialogFieldSerializer do
         "values"                  => "values",
         "values_method"           => "values method",
         "values_method_options"   => {"values method options" => true},
-        "options"                 => {"options" => true},
+        "options"                 => options,
         "label"                   => "label",
         "load_values_on_init"     => false,
         "position"                => 1,
@@ -63,6 +65,32 @@ describe DialogFieldSerializer do
       it "serializes the dialog_field" do
         expect(dialog_field_serializer.serialize(dialog_field)).to eq(expected_serialized_values.merge(
           "resource_action" => "serialized resource action"
+        ))
+      end
+    end
+
+    context "when the dialog_field is a tag control type" do
+      let(:dialog_field) do
+        DialogFieldTagControl.new(expected_serialized_values.merge(:resource_action => resource_action))
+      end
+
+      let(:type) { "DialogFieldTagControl" }
+      let(:options) { {:category_id => "123"} }
+      let(:dynamic) { false }
+      let(:category) { double("Category", :name => "best category ever", :description => "best category ever") }
+
+      before do
+        allow(Category).to receive(:find_by).with(:id => "123").and_return(category)
+      end
+
+      it "serializes the category name and description" do
+        expect(dialog_field_serializer.serialize(dialog_field)).to eq(expected_serialized_values.merge(
+          "resource_action" => "serialized resource action",
+          "options"         => {
+            :category_id          => "123",
+            :category_name        => "best category ever",
+            :category_description => "best category ever"
+          }
         ))
       end
     end


### PR DESCRIPTION
It was using the ID before to try to look up the category, so now it will export category name/description so that imports can then use those to look up the category.

Fixes #7449
https://bugzilla.redhat.com/show_bug.cgi?id=1319952