### PR TITLE
Only compute deltas for configurations types we care about.

### DIFF
--- a/db/migrate/20160127210624_convert_configurations_to_settings_changes.rb
+++ b/db/migrate/20160127210624_convert_configurations_to_settings_changes.rb
@@ -11,7 +11,7 @@ class ConvertConfigurationsToSettingsChanges < ActiveRecord::Migration
 
   def up
     say_with_time("Migrating configuration changes") do
-      deltas = Configuration.all.flat_map { |f| full_to_deltas(f) }
+      deltas = Configuration.where(:typ => TEMPLATES.keys).all.flat_map { |f| full_to_deltas(f) }
       deltas.each { |d| SettingsChange.create!(d) }
     end
   end

--- a/spec/migrations/20160127210624_convert_configurations_to_settings_changes_spec.rb
+++ b/spec/migrations/20160127210624_convert_configurations_to_settings_changes_spec.rb
@@ -43,6 +43,16 @@ describe ConvertConfigurationsToSettingsChanges do
         }
       )
 
+      _non_existing_tmpl_file = config_stub.create!(
+        :typ           => "hostdefaults",
+        :miq_server_id => 2,
+        :settings      => {
+          "values" => {
+            "string" => "hostdefaults value",
+          },
+        }
+      )
+
       test_templates = {
         "simple" => YAML.load_file(data_dir.join("simple.tmpl.yml")).deep_symbolize_keys,
         "vmdb"   => YAML.load_file(data_dir.join("simple.tmpl.yml")).deep_symbolize_keys


### PR DESCRIPTION
hostdefaults.tmpl.yml was removed in #5794 but could still be in the configurations table.
We can skip deleting them because they will be dropped when we remove the table in the next
migration.

Fixes #7571