### PR TITLE
bower instead of rails-assets

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "vendor/assets/bower_components"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -115,19 +115,9 @@ public/stylesheets/jmaki-standard-right-sidebar.css
 # tmp/
 tmp/*
 
-# vendor/bundle
+# vendor/
 vendor/bundle
-
-# vendor/plugins/
-vendor/plugins/rails-dev-boost
-vendor/plugins/ruby-prof
-vendor/plugins/rails_upgrade
-
-# vendor/plugins/princely/
-vendor/plugins/princely/.gitignore
-
-# vendor/plugins/rails_sql_views/
-vendor/plugins/rails_sql_views/.gitignore
+vendor/assets/bower_components/
 
 # ignore included plugins in bundler.d
 bundler.d/*

--- a/Gemfile
+++ b/Gemfile
@@ -125,32 +125,6 @@ unless ENV['APPLIANCE']
   end
 end
 
-# Assets from rails-assets.org
-source "https://rails-assets.org" do
-  gem "rails-assets-angular",                         "~>1.5.0"
-  gem "rails-assets-angular-animate",                 "~>1.5.0"
-  gem "rails-assets-angular-mocks",                   "~>1.5.0"
-  gem "rails-assets-angular-patternfly-sass",         "~>3.3.3"
-  gem "rails-assets-angular-sanitize",                "~>1.5.0"
-  gem "rails-assets-bootstrap-filestyle",             "~>1.2.1"
-  gem "rails-assets-bootstrap-hover-dropdown",        "~>2.0.11"
-  gem "rails-assets-himdel--jquery.observe_field",    "~>0.1.0"
-  gem "rails-assets-jasmine-jquery",                  "~>2.1.1"
-  gem "rails-assets-jquery-1.8",                      "~>1.8.3"
-  gem "rails-assets-jquery-ujs",                      "~>1.1.0"
-  gem "rails-assets-jqueryui",                        "~>1.9.2"
-  gem "rails-assets-bootstrap-switch",                "~>3.3.2"
-  gem "rails-assets-angular-bootstrap-switch",        "~>0.5.0"
-  gem "rails-assets-kubernetes-topology-graph",       "= 0.0.23"
-  gem "rails-assets-moment-timezone",                 "~>0.4.0"
-  gem "rails-assets-himdel--moment-strftime",         "~>0.1.7"
-  gem "rails-assets-numeral",                         "~>1.5.3"
-  gem "rails-assets-himdel--spice-html5-bower",       "~>0.1.5"
-  gem "rails-assets-spin.js",                         "~>2.3.2"
-  gem "rails-assets-sprintf",                         "~>1.0.3"
-  gem "rails-assets-xml_display",                     "~>0.1.1"
-end
-
 #
 # Custom Gemfile modifications
 #

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,12 +5,12 @@
 //= require patternfly
 //= require jquery-ujs
 //= require angular
-//= require angular-patternfly-sass/angular-patternfly
+//= require angular-patternfly-sass/dist/angular-patternfly
 //= require angular-ui-bootstrap
 //= require angular-ui-bootstrap-tpls
 //= require angular-sanitize
 //= require moment
-//= require moment-strftime
+//= require moment-strftime/build/moment-strftime.min
 //= require moment-timezone
 //= require sprintf
 //= require numeral
@@ -22,7 +22,7 @@
 //= require d3
 //= require c3
 //= require lodash
-//= require kubernetes-topology-graph/topology-graph
+//= require kubernetes-topology-graph/dist/topology-graph
 //= require miq_browser_detect
 //= require miq_application
 //= require miq_change_stored_password
@@ -43,7 +43,7 @@
 //= require jqplot-plugins/jqplot.canvasTextRenderer
 //= require miq_jqplot
 //= require miq_c3_config
-//= require jqueryui
+//= require jquery-ui
 //= require bootstrap
 //= require bootstrap-datepicker
 //= require bootstrap-filestyle

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,12 +11,12 @@
  *= require dialog_fields
  *= require angular
  *= require miq_timeline
- *= require angular-patternfly-sass/angular-patternfly
+ *= require angular-patternfly-sass/dist/styles/angular-patternfly
  *= require schedule_editor
  *= require miq_dynatree
  *= require codemirror
  *= require jqplot
- *= require kubernetes-topology-graph/topology-graph
+ *= require kubernetes-topology-graph/dist/topology-graph
  *= require jquery-ui-miq-theme/jquery-ui-1.9.2.custom
  *= require container_providers_dashboard
  *= require template

--- a/bin/setup
+++ b/bin/setup
@@ -9,7 +9,7 @@ Dir.chdir APP_ROOT do
   system "gem install bundler --conservative"
   system "bundle check || bundle install"
   system "which bower || npm install -g bower"
-  system "bower install -F"
+  system "bower install --allow-root -F --config.analytics=false"
 
   puts "\n== Copying sample files =="
   unless File.exist?("config/database.yml")

--- a/bin/setup
+++ b/bin/setup
@@ -8,6 +8,8 @@ Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system "gem install bundler --conservative"
   system "bundle check || bundle install"
+  system "which bower || npm install -g bower"
+  system "bower install -F"
 
   puts "\n== Copying sample files =="
   unless File.exist?("config/database.yml")

--- a/bin/update
+++ b/bin/update
@@ -7,6 +7,7 @@ APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
 Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system "bundle update"
+  system "bower update -F"
 
   puts "\n== Migrating database =="
   system "bin/rake db:migrate db:seed"

--- a/bin/update
+++ b/bin/update
@@ -7,7 +7,7 @@ APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
 Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system "bundle update"
-  system "bower update -F"
+  system "bower update --allow-root -F --config.analytics=false"
 
   puts "\n== Migrating database =="
   system "bin/rake db:migrate db:seed"

--- a/bower.json
+++ b/bower.json
@@ -15,5 +15,28 @@
     "vendor/assets/bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "dependencies": {
+    "angular": "^1.5.3",
+    "angular-animate": "^1.5.3",
+    "angular-mocks": "^1.5.3",
+    "angular-patternfly-sass": "^3.3.3",
+    "angular-sanitize": "^1.5.3",
+    "bootstrap-filestyle": "^1.2.1",
+    "bootstrap-hover-dropdown": "^2.0.11",
+    "jquery.observe_field": "himdel/jquery.observe_field#^0.1.0",
+    "jasmine-jquery": "^2.1.1",
+    "jquery-1.8": "^1.8.3",
+    "jquery-ujs": "^1.1.0",
+    "jquery-ui": "jqueryui#^1.9.2",
+    "bootstrap-switch": "^3.3.2",
+    "angular-bootstrap-switch": "^0.5.0",
+    "kubernetes-topology-graph": "0.0.23",
+    "moment-timezone": "^0.4.0",
+    "moment-strftime": "himdel/moment-strftime#^0.1.7",
+    "numeral": "^1.5.3",
+    "spin.js": "^2.3.2",
+    "sprintf": "^1.0.3",
+    "xml_display": "^0.1.1"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "manageiq",
+  "homepage": "http://manageiq.org/",
+  "authors": [
+    "ManageIQ"
+  ],
+  "description": "ManageIQ Cloud Management Platform",
+  "main": "",
+  "moduleType": [],
+  "license": "Apache-2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "vendor/assets/bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -37,6 +37,7 @@
     "numeral": "^1.5.3",
     "spin.js": "^2.3.2",
     "sprintf": "^1.0.3",
-    "xml_display": "^0.1.1"
+    "xml_display": "^0.1.1",
+    "spice-html5-bower": "himdel/spice-html5-bower#^0.1.5"
   }
 }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components')
+
 Rails.application.config.assets.precompile += %w(
   jquery-1.8/jquery.js jquery_overrides.js jquery
   novnc-rails noVNC/web-socket-js/WebSocketMain.swf

--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -14,4 +14,10 @@ else
 fi
 export BUNDLE_GEMFILE=${PWD}/Gemfile
 
+# suites that need bower assets to work: javascript, vmdb
+if [[ "$TEST_SUITE" = "javascript" ]] || [[ "$TEST_SUITE" = "vmdb" ]]; then
+  which bower || npm install -g bower
+  bower install --allow-root -F --config.analytics=false
+fi
+
 set +v


### PR DESCRIPTION
This replaces rails-assets with pure bower:

   * front-end (js & css) dependencies are defined in `bower.json`, to add a new one, do `bower install --save $whatever`
      * to add a pure devel-mode dependency, use `--save-dev` (however, as of now, we never call `bower install -p` so both always get installed)
   * these get downloaded under `vendor/assets/bower_components`, which is gitignored, and added to `config.assets.paths`
   * updated `bin/setup`, `bin/update`, `tools/ci/before_install.sh` to also handle bower
      * does `which bower || npm install -g bower` which may or may not be needed (and may not work, if it's not run as root)
   * I added no rake tasks to wrap bower since I don't see the need, please correct me if I'm wrong
      * expecting people to run either `bin/update` or `bundle install` + `bower install` manually

   * +minor tweaks in application.js/css for where the bower path is slightly different

Talk topic: http://talk.manageiq.org/t/using-bower-to-manage-frontend-deps/1349