### PR TITLE
Remove miq_servers_product_updates table

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1297,7 +1297,6 @@
         - miq_report_results
         - miq_reports
         - miq_searches
-        - miq_servers_product_updates
         - miq_sets
         - miq_schedules
         - miq_shortcuts

--- a/db/migrate/20160328204930_remove_miq_server_product_update_join_table.rb
+++ b/db/migrate/20160328204930_remove_miq_server_product_update_join_table.rb
@@ -1,0 +1,37 @@
+class RemoveMiqServerProductUpdateJoinTable < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    serialize :value
+  end
+
+  EXCLUDES_KEY = "/workers/worker_base/replication_worker/replication/exclude_tables".freeze
+
+  def up
+    drop_join_table(:miq_servers, :product_updates)
+
+    say_with_time("Removing miq_servers_product_updates from replication excludes") do
+      SettingsChange.where(:key => EXCLUDES_KEY).each do |s|
+        s.value.delete("miq_servers_product_updates")
+        s.save!
+      end
+    end
+  end
+
+  def down
+    create_join_table(:miq_servers, :product_updates) do |t|
+      t.bigint :miq_server_id, :null => false
+      t.bigint :product_update_id, :null => false
+    end
+
+    say_with_time("Adding composite primary key for miq_servers_product_updates") do
+      execute("ALTER TABLE miq_servers_product_updates ADD PRIMARY KEY (product_update_id, miq_server_id)")
+    end
+
+    say_with_time("Adding miq_servers_product_updates to replication excludes") do
+      SettingsChange.where(:key => EXCLUDES_KEY).each do |s|
+        s.value << "miq_servers_product_updates"
+        s.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20160328204930_remove_miq_server_product_update_join_table_spec.rb
+++ b/spec/migrations/20160328204930_remove_miq_server_product_update_join_table_spec.rb
@@ -1,0 +1,45 @@
+require_migration
+
+describe RemoveMiqServerProductUpdateJoinTable do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+  let(:my_server)            { FactoryGirl.create(:miq_server) }
+  let(:other_server)         { FactoryGirl.create(:miq_server) }
+
+  migration_context :up do
+    it "removes miq_servers_product_updates from replication excludes" do
+      my_server.settings_changes
+               .create!(:key   => described_class::EXCLUDES_KEY,
+                        :value => %w(miq_servers_product_updates schema_migrations))
+
+      other_server.settings_changes
+                  .create!(:key   => described_class::EXCLUDES_KEY,
+                           :value => %w(miq_servers_product_updates ar_internal_metadata))
+
+      migrate
+
+      changes = settings_change_stub.where(:key => described_class::EXCLUDES_KEY)
+      changes.each do |c|
+        expect(c.value).not_to include("miq_servers_product_updates")
+      end
+    end
+  end
+
+  migration_context :down do
+    it "adds miq_servers_product_updates to replication excludes" do
+      my_server.settings_changes
+               .create!(:key   => described_class::EXCLUDES_KEY,
+                        :value => ["schema_migrations"])
+
+      other_server.settings_changes
+                  .create!(:key   => described_class::EXCLUDES_KEY,
+                           :value => ["ar_internal_metadata"])
+
+      migrate
+
+      changes = settings_change_stub.where(:key => described_class::EXCLUDES_KEY)
+      changes.each do |c|
+        expect(c.value).to include("miq_servers_product_updates")
+      end
+    end
+  end
+end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -50,7 +50,7 @@ describe VmdbTable do
       VmdbTable.atStartup
       MiqDatabase.seed
       @db = MiqDatabase.first
-      @test_tables = %w(miq_servers_product_updates ui_tasks miq_regions miq_databases)
+      @test_tables = %w(schema_migrations ui_tasks miq_regions miq_databases)
       @unpopulated_tables = %w(hosts vms)
       @populated_tables = %w(miq_regions miq_databases)
     end
@@ -107,19 +107,11 @@ describe VmdbTable do
       it "will handle tables with models" do
         expect(VmdbTable.new(:name => "miq_databases").record_count).to eq(1)
       end
-
-      it "will handle tables without models" do
-        expect(VmdbTable.new(:name => "miq_servers_product_updates").record_count).to be >= 0
-      end
     end
 
     context "#model_name" do
       it "will handle tables with models" do
         expect(VmdbTable.new(:name => "miq_databases").model_name).to eq("MiqDatabase")
-      end
-
-      it "will handle tables without models" do
-        expect(VmdbTable.new(:name => "miq_servers_product_updates").model_name).to eq("MiqServersProductUpdates")
       end
     end
 
@@ -127,17 +119,9 @@ describe VmdbTable do
       it "will handle tables with models" do
         expect(VmdbTable.new(:name => "miq_databases").model).to eq(MiqDatabase)
       end
-
-      it "will handle tables without models" do
-        expect(VmdbTable.new(:name => "miq_servers_product_updates").model).to be_nil
-      end
     end
 
     context "#export" do
-      it "will handle tables without models" do
-        expect { VmdbTable.new(:name => "miq_servers_product_updates").export }.not_to raise_error
-      end
-
       it "will return nil if no data in tables" do
         expect(YAML).to receive(:dump).never
         expect(VmdbTable.new(:name => "vms").export).to be_nil


### PR DESCRIPTION
The `product_updates` table was removed in commit 681518f6adc8e519d60a1e9020c9e899ba5adfea