### PR TITLE
Improve provisioning StateMachine specs

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -28,6 +28,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
     configure_cpu(rhevm_vm)
     configure_host_affinity(rhevm_vm)
     configure_network_adapters
+    configure_cloud_init
   end
 
   private

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -40,13 +40,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
       _log.info("#{message} #{for_destination}")
       update_and_notify_parent(:message => message)
       configure_container
-      configure_destination
+      signal :poll_destination_powered_off_in_provider
     end
-  end
-
-  def configure_destination
-    configure_cloud_init
-    signal :poll_destination_powered_off_in_provider
   end
 
   def autostart_destination

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso < ManageIQ::Providers::Redhat::InfraManager::Provision
   include_concern 'Cloning'
+  include_concern 'Configuration'
   include_concern 'StateMachine'
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso/configuration.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso::Configuration
+  def configure_cloud_init
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe < ManageIQ::Providers::Redhat::InfraManager::Provision
   include_concern 'Cloning'
+  include_concern 'Configuration'
   include_concern 'StateMachine'
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/configuration.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe::Configuration
+  def configure_cloud_init
+  end
+end

--- a/spec/models/miq_provision/state_machine_spec_helper.rb
+++ b/spec/models/miq_provision/state_machine_spec_helper.rb
@@ -1,0 +1,72 @@
+module MiqProvision::StateMachineSpecHelper
+  include MiqRequestTaskHelper
+
+  def test_prepare_provision
+    call_method
+  end
+
+  def test_poll_destination_in_vmdb
+    @test_poll_destination_in_vmdb_setup ||= begin
+      expect(task).to receive(:requeue_phase).twice { requeue_phase }
+      expect(task).to receive(:find_destination_in_vmdb).and_return(nil, nil, vm)
+    end
+    expect(task.destination).to be_nil
+
+    call_method
+  end
+
+  def test_poll_destination_powered_off_in_provider
+    expect(task).to receive(:powered_off_in_provider?).and_return(true, false, false, true)
+    test_poll_destination_powered_off_in_provider_no_callback
+    test_poll_destination_powered_off_in_provider_with_callback_url
+  end
+
+  def test_poll_destination_powered_off_in_vmdb
+    @test_poll_destination_powered_off_in_vmdb_setup ||= begin
+      expect(task).to receive(:requeue_phase) do
+        requeue_phase(__method__)
+        vm.update_attributes(:raw_power_state => "down")
+      end
+      expect(EmsRefresh).to receive(:queue_refresh)
+    end
+
+    skip_post_install_check { call_method }
+  end
+
+  def test_post_create_destination
+    call_method
+
+    expect(task.destination.description).to eq(options[:vm_description])
+    expect(vm.reload.description).to        eq(options[:vm_description])
+  end
+
+  def test_post_provision
+    call_method
+  end
+
+  def test_mark_as_completed
+    expect(MiqEvent).to receive(:raise_evm_event)
+    expect(task).not_to receive(:call_automate_event)
+
+    call_method
+  end
+
+  def test_finish
+    call_method
+  end
+
+  ### BRANCH STATES
+  def test_poll_destination_powered_off_in_provider_with_callback_url
+    expect(vm).to receive(:stop)
+
+    call_method
+  end
+
+  def test_poll_destination_powered_off_in_provider_no_callback
+    @test_poll_destination_powered_off_in_provider_no_callback_setup ||= begin
+      expect(task).to receive(:requeue_phase).twice { requeue_phase(__method__) }
+    end
+
+    skip_post_install_check { call_method }
+  end
+end

--- a/spec/support/examples_group/shared_examples_for_provisioning_state_machine.rb
+++ b/spec/support/examples_group/shared_examples_for_provisioning_state_machine.rb
@@ -4,7 +4,6 @@ shared_examples_for "common rhev state machine methods" do
     allow(@task).to receive(:update_and_notify_parent)
 
     expect(@task).to receive(:configure_container)
-    expect(@task).to receive(:configure_destination)
 
     @task.customize_destination
   end

--- a/spec/support/miq_request_task_spec_helper.rb
+++ b/spec/support/miq_request_task_spec_helper.rb
@@ -1,0 +1,38 @@
+module MiqRequestTaskHelper
+  def call_method
+    @called_states << @current_state
+    task.update_attributes(:phase => @current_state)
+    check_post_install_callback
+    task.send(@current_state)
+  end
+
+  def check_post_install_callback
+    return if @skip_post_install_check
+    allow(task).to receive(:for_destination)
+    task.post_install_callback
+  end
+
+  def dequeue_method
+    return unless (method = @queue.shift)
+    if method.to_s.start_with?("test_")
+      send(method)
+    else
+      @current_state = method
+      send("test_#{@current_state}")
+    end
+    true
+  end
+
+  def requeue_phase(method = @current_state)
+    @queue.unshift(method)
+    nil
+  end
+
+  def skip_post_install_check
+    @skip_post_install_check = true
+    yield
+    @skip_post_install_check = false
+  end
+end
+
+Dir.glob(Rails.root.join("spec", "models", "**", "state_machine_spec_helper.rb")).each { |file| require file }


### PR DESCRIPTION
Replace Redhat provision StateMachine spec with end-to-end test
  - severely reduce stubbing
  - ensure state machine path is complete
  - reduce duplicate test setup
  - ensure all states are tested
