### PR TITLE
Make `Vm#vendor_display` a virtual column

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -132,6 +132,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :is_evm_appliance,                     :type => :boolean,    :uses => :miq_server
   virtual_column :os_image_name,                        :type => :string,     :uses => [:operating_system, :hardware]
   virtual_column :platform,                             :type => :string,     :uses => [:operating_system, :hardware]
+  virtual_column :vendor_display,                       :type => :string
   virtual_column :v_host_vmm_product,                   :type => :string,     :uses => :host
   virtual_column :v_is_a_template,                      :type => :string
   virtual_column :v_owning_cluster,                     :type => :string,     :uses => :ems_cluster


### PR DESCRIPTION
Reports that rely on this data will not work because it doesn't see it
as a "column". Turning it into a virtual column will make it reportable.

/cc @gtanzillo