### PR TITLE
Refactoring: extract related code to dest_resource_pool method

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -34,18 +34,11 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
       :host          => dest_host,
       :datastore     => dest_datastore,
       :folder        => dest_folder,
+      :pool          => dest_resource_pool,
       :config        => build_config_spec,
       :customization => build_customization_spec,
       :transform     => build_transform_spec
     }
-
-    # Find destination resource pool
-    respool_id = get_option(:placement_rp_name)
-    clone_options[:pool] = ResourcePool.find_by_id(respool_id) unless respool_id.nil?
-    clone_options[:pool] ||= begin
-      cluster = dest_host.owning_cluster
-      cluster ? cluster.default_resource_pool : dest_host.default_resource_pool
-    end
 
     # Determine if we are doing a linked-clone provision
     clone_options[:linked_clone] = get_option(:linked_clone).to_s == 'true'
@@ -54,6 +47,15 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     validate_customization_spec(clone_options[:customization])
 
     clone_options
+  end
+
+  def dest_resource_pool
+    respool_id = get_option(:placement_rp_name)
+    resource_pool = ResourcePool.find_by(:id => respool_id) unless respool_id.nil?
+    return resource_pool unless resource_pool.nil?
+
+    cluster = dest_host.owning_cluster
+    cluster ? cluster.default_resource_pool : dest_host.default_resource_pool
   end
 
   def dest_folder

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -164,6 +164,38 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           expect(@vm_prov.dest_folder).to eq(vm_folder)
         end
       end
+
+      context "#dest_resource_pool" do
+        let(:resource_pool) { FactoryGirl.create(:resource_pool) }
+
+        let(:dest_host) do
+          host = FactoryGirl.create(:host_vmware, :ext_management_system => @ems)
+          FactoryGirl.create(:resource_pool).parent = host
+          host
+        end
+
+        let(:cluster) do
+          cluster = FactoryGirl.create(:ems_cluster)
+          FactoryGirl.create(:resource_pool).parent = cluster
+        end
+
+        let(:dest_host_with_cluster) { FactoryGirl.create(:host_vmware, :ems_cluster => cluster) }
+
+        it "uses the resource pool from options" do
+          @vm_prov.options[:placement_rp_name] = resource_pool.id
+          expect(@vm_prov.dest_resource_pool).to eq(resource_pool)
+        end
+
+        it "uses the resource pool from the cluster" do
+          @vm_prov.options[:dest_host] = [dest_host_with_cluster.id, dest_host_with_cluster.name]
+          expect(@vm_prov.dest_resource_pool).to eq(cluster.default_resource_pool)
+        end
+
+        it "uses the resource pool from destination host" do
+          @vm_prov.options[:dest_host] = [dest_host.id, dest_host.name]
+          expect(@vm_prov.dest_resource_pool).to eq(dest_host.default_resource_pool)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This a follow up refactoring suggested in #7150 

Move logic to determine destination resource group to its own method, which can be separately unit tested.

Spec test was added.