### PR TITLE
UI changes to allow add and remove disks when reconfiguring one VM

### DIFF
--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -6,7 +6,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         socket_count:            '1',
         cores_per_socket_count:  '1',
         total_cpus:              '1',
-        vmDisks:                 [],
+        vmdisks:                 [],
         hdFilename:              '',
         hdType:                  'thick',
         hdMode:                  'nonpersistent',
@@ -45,13 +45,13 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         $scope.mem_type_prev = $scope.reconfigureModel.memory_type;
         $scope.cb_memory = data.cb_memory;
         $scope.cb_cpu = data.cb_cpu;
-        $scope.reconfigureModel.vmDisks = angular.copy(data.disks);
+        $scope.reconfigureModel.vmdisks = angular.copy(data.disks);
 
         $scope.updateDisksAddRemove();
 
-        for (var disk in $scope.reconfigureModel.vmDisks)
-          if($scope.reconfigureModel.vmDisks[disk]['add_remove'] == '' )
-            $scope.reconfigureModel.vmDisks[disk]['cb_deletebacking'] = false;
+        for (var disk in $scope.reconfigureModel.vmdisks)
+          if($scope.reconfigureModel.vmdisks[disk]['add_remove'] == '' )
+            $scope.reconfigureModel.vmdisks[disk]['cb_deletebacking'] = false;
 
         if(data.socket_count && data.cores_per_socket_count)
           $scope.reconfigureModel.total_cpus = (parseInt($scope.reconfigureModel.socket_count, 10) * parseInt($scope.reconfigureModel.cores_per_socket_count, 10)).toString();
@@ -149,28 +149,28 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     $scope.updateDisksAddRemove = function() {
       $scope.reconfigureModel.vmAddDisks.length = 0;
       $scope.reconfigureModel.vmRemoveDisks.length = 0;
-      for (var disk in $scope.reconfigureModel.vmDisks) {
-        if ($scope.reconfigureModel.vmDisks[disk]['add_remove'] === 'remove') {
-          $scope.reconfigureModel.vmRemoveDisks.push({disk_name: $scope.reconfigureModel.vmDisks[disk].hdFilename,
-                                     delete_backing: $scope.reconfigureModel.vmDisks[disk].cb_deletebacking});
+      for (var disk in $scope.reconfigureModel.vmdisks) {
+        if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'remove') {
+          $scope.reconfigureModel.vmRemoveDisks.push({disk_name: $scope.reconfigureModel.vmdisks[disk].hdFilename,
+                                     delete_backing: $scope.reconfigureModel.vmdisks[disk].cb_deletebacking});
         }
-        else if ($scope.reconfigureModel.vmDisks[disk]['add_remove'] === 'add') {
-          var dsize = parseInt($scope.reconfigureModel.vmDisks[disk].hdSize);
-          if($scope.reconfigureModel.vmDisks[disk].hdUnit == 'GB')
+        else if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'add') {
+          var dsize = parseInt($scope.reconfigureModel.vmdisks[disk].hdSize);
+          if($scope.reconfigureModel.vmdisks[disk].hdUnit == 'GB')
             dsize *= 1024;
-          dmode = ($scope.reconfigureModel.vmDisks[disk].hdMode == 'persistent');
-          dtype = ($scope.reconfigureModel.vmDisks[disk].hdType == 'thin');
-          $scope.reconfigureModel.vmAddDisks.push({disk_name: $scope.reconfigureModel.vmDisks[disk].hdFilename,
+          dmode = ($scope.reconfigureModel.vmdisks[disk].hdMode == 'persistent');
+          dtype = ($scope.reconfigureModel.vmdisks[disk].hdType == 'thin');
+          $scope.reconfigureModel.vmAddDisks.push({disk_name: $scope.reconfigureModel.vmdisks[disk].hdFilename,
                                   disk_size_in_mb: dsize,
                                   persistent: dmode,
                                   thin_provisioned: dtype,
-                                  dependent: $scope.reconfigureModel.vmDisks[disk].cb_dependent});
+                                  dependent: $scope.reconfigureModel.vmdisks[disk].cb_dependent});
         }
       }
     };
 
     $scope.addDisk = function() {
-      $scope.reconfigureModel.vmDisks.push({hdFilename: $scope.reconfigureModel.hdFilename,
+      $scope.reconfigureModel.vmdisks.push({hdFilename: $scope.reconfigureModel.hdFilename,
                                             hdType: $scope.reconfigureModel.hdType,
                                             hdMode: $scope.reconfigureModel.hdMode,
                                             hdSize: $scope.reconfigureModel.hdSize,
@@ -198,9 +198,9 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     };
 
     $scope.deleteDisk = function(name) {
-      for (var disk in $scope.reconfigureModel.vmDisks) {
-        if ($scope.reconfigureModel.vmDisks[disk].hdFilename === name)
-          $scope.reconfigureModel.vmDisks[disk]['add_remove'] = 'remove';
+      for (var disk in $scope.reconfigureModel.vmdisks) {
+        if ($scope.reconfigureModel.vmdisks[disk].hdFilename === name)
+          $scope.reconfigureModel.vmdisks[disk]['add_remove'] = 'remove';
       }
       $scope.updateDisksAddRemove();
 
@@ -211,15 +211,15 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     };
 
     $scope.cancelAddRemoveDisk = function(vmDisk) {
-      for (var disk in $scope.reconfigureModel.vmDisks) {
-        if ($scope.reconfigureModel.vmDisks[disk].hdFilename === vmDisk['hdFilename']) {
-          if ($scope.reconfigureModel.vmDisks[disk]['add_remove'] === 'remove') {
-            $scope.reconfigureModel.vmDisks[disk]['add_remove'] = '';
-            $scope.reconfigureModel.vmDisks[disk]['cb_deletebacking'] = false;
+      for (var disk in $scope.reconfigureModel.vmdisks) {
+        if ($scope.reconfigureModel.vmdisks[disk].hdFilename === vmDisk['hdFilename']) {
+          if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'remove') {
+            $scope.reconfigureModel.vmdisks[disk]['add_remove'] = '';
+            $scope.reconfigureModel.vmdisks[disk]['cb_deletebacking'] = false;
           }
-          else if ($scope.reconfigureModel.vmDisks[disk]['add_remove'] === 'add') {
-            var index = $scope.reconfigureModel.vmDisks.indexOf(vmDisk);
-            $scope.reconfigureModel.vmDisks.splice(index, 1);
+          else if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'add') {
+            var index = $scope.reconfigureModel.vmdisks.indexOf(vmDisk);
+            $scope.reconfigureModel.vmdisks.splice(index, 1);
             break;
           }
         }

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -17,13 +17,13 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         vmAddDisks:              [],
         vmRemoveDisks:           []
       };
+      $scope.cb_disks = false;
+      $scope.hdpattern = "^[1-9][0-9]*$";
       $scope.reconfigureFormId = reconfigureFormId;
       $scope.afterGet = false;
       $scope.objectIds = objectIds;
       $scope.cb_memory = $scope.cb_memoryCopy = false;
       $scope.cb_cpu = $scope.cb_cpuCopy = false;
-      $scope.cb_disks = false;
-
       $scope.mem_type_prev = $scope.reconfigureModel.memory_type;
       $scope.validateClicked = miqService.validateWithAjax;
       $scope.modelCopy = angular.copy( $scope.reconfigureModel );
@@ -186,7 +186,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       $scope.reconfigureModel.addEnabled = false;
 
       $scope.updateDisksAddRemove();
-      $scope.angularForm.$setPristine(false);
 
       if( $scope.reconfigureModel.vmAddDisks.length > 0  || $scope.reconfigureModel.vmRemoveDisks.length > 0)
         $scope.cb_disks = true;
@@ -204,7 +203,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
           $scope.reconfigureModel.vmDisks[disk]['add_remove'] = 'remove';
       }
       $scope.updateDisksAddRemove();
-      $scope.angularForm.$setPristine(false);
 
       if( $scope.reconfigureModel.vmAddDisks.length > 0  || $scope.reconfigureModel.vmRemoveDisks.length > 0)
         $scope.cb_disks = true;
@@ -227,7 +225,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         }
       }
       $scope.updateDisksAddRemove();
-      if( $scope.reconfigureModel.vmAddDisks.length > 0  || $scope.reconfigureModel.vmRemoveDisks.length > 0)
+
+      if(!_.isEqual($scope.reconfigureModel.vmAddDisks,$scope.modelCopy.vmAddDisks) || !_.isEqual($scope.reconfigureModel.vmRemoveDisks, $scope.modelCopy.vmRemoveDisks))
         $scope.cb_disks = true;
       else
         $scope.cb_disks = false;

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -7,7 +7,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         cores_per_socket_count:  '1',
         total_cpus:              '1',
         vmdisks:                 [],
-        hdFilename:              '',
         hdType:                  'thick',
         hdMode:                  'nonpersistent',
         hdSize:                  '',
@@ -51,7 +50,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
         for (var disk in $scope.reconfigureModel.vmdisks)
           if($scope.reconfigureModel.vmdisks[disk]['add_remove'] == '' )
-            $scope.reconfigureModel.vmdisks[disk]['cb_deletebacking'] = false;
+            $scope.reconfigureModel.vmdisks[disk]['delete_backing'] = false;
 
         if(data.socket_count && data.cores_per_socket_count)
           $scope.reconfigureModel.total_cpus = (parseInt($scope.reconfigureModel.socket_count, 10) * parseInt($scope.reconfigureModel.cores_per_socket_count, 10)).toString();
@@ -152,7 +151,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       for (var disk in $scope.reconfigureModel.vmdisks) {
         if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'remove') {
           $scope.reconfigureModel.vmRemoveDisks.push({disk_name: $scope.reconfigureModel.vmdisks[disk].hdFilename,
-                                     delete_backing: $scope.reconfigureModel.vmdisks[disk].cb_deletebacking});
+                                     delete_backing: $scope.reconfigureModel.vmdisks[disk].delete_backing});
         }
         else if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'add') {
           var dsize = parseInt($scope.reconfigureModel.vmdisks[disk].hdSize);
@@ -170,14 +169,13 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     };
 
     $scope.addDisk = function() {
-      $scope.reconfigureModel.vmdisks.push({hdFilename: $scope.reconfigureModel.hdFilename,
+      $scope.reconfigureModel.vmdisks.push({hdFilename:'',
                                             hdType: $scope.reconfigureModel.hdType,
                                             hdMode: $scope.reconfigureModel.hdMode,
                                             hdSize: $scope.reconfigureModel.hdSize,
                                             hdUnit: $scope.reconfigureModel.hdUnit,
                                             cb_dependent: $scope.reconfigureModel.cb_dependent,
                                             add_remove: 'add'});
-      $scope.reconfigureModel.hdFilename = '';
       $scope.reconfigureModel.hdType = 'thick';
       $scope.reconfigureModel.hdMode = 'nonpersistent';
       $scope.reconfigureModel.hdSize = '';
@@ -258,7 +256,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
     $scope.resetClicked = function() {
       $scope.$broadcast ('resetClicked');
-      $scope.reconfigureModel = angular.copy( $scope.modelCopy );
+      $scope.reconfigureModel = angular.copy($scope.modelCopy);
       $scope.cb_memory = $scope.cb_memoryCopy;
       $scope.cb_cpu = $scope.cb_cpuCopy;
       $scope.mem_type_prev = $scope.reconfigureModel.memory_type;

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -163,7 +163,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
           $scope.reconfigureModel.vmAddDisks.push({disk_name: $scope.reconfigureModel.vmDisks[disk].hdFilename,
                                   size: dsize,
                                   mode: dmode,
-                                  disk_type: dtype});
+                                  disk_type: dtype,
+                                  dependent: $scope.reconfigureModel.vmDisks[disk].cb_dependent});
         }
       }
     };

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -159,11 +159,10 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
             dsize *= 1024;
           dmode = ($scope.reconfigureModel.vmdisks[disk].hdMode == 'persistent');
           dtype = ($scope.reconfigureModel.vmdisks[disk].hdType == 'thin');
-          $scope.reconfigureModel.vmAddDisks.push({disk_name: $scope.reconfigureModel.vmdisks[disk].hdFilename,
-                                  disk_size_in_mb: dsize,
-                                  persistent: dmode,
-                                  thin_provisioned: dtype,
-                                  dependent: $scope.reconfigureModel.vmdisks[disk].cb_dependent});
+          $scope.reconfigureModel.vmAddDisks.push({disk_size_in_mb: dsize,
+                                                   persistent: dmode,
+                                                   thin_provisioned: dtype,
+                                                   dependent: $scope.reconfigureModel.vmdisks[disk].cb_dependent});
         }
       }
     };
@@ -224,7 +223,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       }
       $scope.updateDisksAddRemove();
 
-      if(!_.isEqual($scope.reconfigureModel.vmAddDisks,$scope.modelCopy.vmAddDisks) || !_.isEqual($scope.reconfigureModel.vmRemoveDisks, $scope.modelCopy.vmRemoveDisks))
+      if(!angular.equals($scope.reconfigureModel.vmAddDisks,$scope.modelCopy.vmAddDisks) || !angular.equals($scope.reconfigureModel.vmRemoveDisks, $scope.modelCopy.vmRemoveDisks))
         $scope.cb_disks = true;
       else
         $scope.cb_disks = false;
@@ -261,6 +260,11 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       $scope.cb_cpu = $scope.cb_cpuCopy;
       $scope.mem_type_prev = $scope.reconfigureModel.memory_type;
       $scope.angularForm.$setPristine(true);
+      $scope.updateDisksAddRemove();
+      if(!angular.equals($scope.reconfigureModel.vmAddDisks,$scope.modelCopy.vmAddDisks) || !angular.equals($scope.reconfigureModel.vmRemoveDisks, $scope.modelCopy.vmRemoveDisks))
+        $scope.cb_disks = true;
+      else
+        $scope.cb_disks = false;
       miqService.miqFlash("warn", __("All changes have been reset"));
     };
 

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -7,11 +7,11 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         cores_per_socket_count:  '1',
         total_cpus:              '1',
         vmdisks:                 [],
-        hdType:                  'thick',
-        hdMode:                  'nonpersistent',
+        hdType:                  'thin',
+        hdMode:                  'persistent',
         hdSize:                  '',
         hdUnit:                  'MB',
-        cb_dependent:            false,
+        cb_dependent:            true,
         addEnabled:              false,
         vmAddDisks:              [],
         vmRemoveDisks:           []
@@ -167,6 +167,15 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       }
     };
 
+    $scope.resetAddValues = function() {
+      $scope.reconfigureModel.hdType = 'thin';
+      $scope.reconfigureModel.hdMode = 'persistent';
+      $scope.reconfigureModel.hdSize = '';
+      $scope.reconfigureModel.hdUnit = 'MB';
+      $scope.reconfigureModel.cb_dependent = true;
+      $scope.reconfigureModel.addEnabled = false;
+    };
+
     $scope.addDisk = function() {
       $scope.reconfigureModel.vmdisks.push({hdFilename:'',
                                             hdType: $scope.reconfigureModel.hdType,
@@ -175,12 +184,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
                                             hdUnit: $scope.reconfigureModel.hdUnit,
                                             cb_dependent: $scope.reconfigureModel.cb_dependent,
                                             add_remove: 'add'});
-      $scope.reconfigureModel.hdType = 'thick';
-      $scope.reconfigureModel.hdMode = 'nonpersistent';
-      $scope.reconfigureModel.hdSize = '';
-      $scope.reconfigureModel.hdUnit = 'MB';
-      $scope.reconfigureModel.cb_dependent = false;
-      $scope.reconfigureModel.addEnabled = false;
+      $scope.resetAddValues();
 
       $scope.updateDisksAddRemove();
 
@@ -192,6 +196,11 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
     $scope.enableDiskAdd = function(){
       $scope.reconfigureModel.addEnabled = true;
+    };
+
+    $scope.hideAddDisk = function(){
+      $scope.reconfigureModel.addEnabled = false;
+      $scope.resetAddValues();
     };
 
     $scope.deleteDisk = function(name) {

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -159,11 +159,11 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
           if($scope.reconfigureModel.vmDisks[disk].hdUnit == 'GB')
             dsize *= 1024;
           dmode = ($scope.reconfigureModel.vmDisks[disk].hdMode == 'persistent');
-          dtype = ($scope.reconfigureModel.vmDisks[disk].hdType != 'thin');
+          dtype = ($scope.reconfigureModel.vmDisks[disk].hdType == 'thin');
           $scope.reconfigureModel.vmAddDisks.push({disk_name: $scope.reconfigureModel.vmDisks[disk].hdFilename,
-                                  size: dsize,
-                                  mode: dmode,
-                                  disk_type: dtype,
+                                  disk_size_in_mb: dsize,
+                                  persistent: dmode,
+                                  thin_provisioned: dtype,
                                   dependent: $scope.reconfigureModel.vmDisks[disk].cb_dependent});
         }
       }

--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -72,7 +72,7 @@ var checkForOverallFormPristinity = function(scope, ctrl) {
   var modelObject = _.cloneDeep(scope[scope.model]);
   delete modelObject[ctrl.$name];
 
-  scope.angularForm.$pristine = _.isEqual(modelCopyObject, modelObject);
+  scope.angularForm.$pristine = angular.equals(modelCopyObject, modelObject);
 
   if (scope.angularForm.$pristine)
     scope.angularForm.$setPristine();

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -181,6 +181,7 @@ table.table td {
 }
 
 table.table tbody td img {
+  height: 20px;
   width: 20px;
 }
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -409,8 +409,8 @@ module ApplicationController::CiProcessing
         options[:number_of_cpus] = vccores.to_i * vsockets.to_i
       end
       # set the disk_add and disk_remove options
-      options[:disk_add] = params[:vmAddDisks].deep_symbolize_keys if params[:vmAddDisks]
-      options[:disk_remove] = params[:vmRemoveDisks].deep_symbolize_keys if params[:vmRemoveDisks]
+      options[:disk_add] = params[:vmAddDisks].deep_symbolize_keys.values if params[:vmAddDisks]
+      options[:disk_remove] = params[:vmRemoveDisks].deep_symbolize_keys.values if params[:vmRemoveDisks]
       if(params[:id] && params[:id] != 'new')
         @request_id = params[:id]
       end
@@ -1173,7 +1173,7 @@ module ApplicationController::CiProcessing
       @reconfig_values[:disk_remove] = @req.options[:disk_remove]
       vmdisks = []
       if @req.options[:disk_add]
-        @req.options[:disk_add].values.each do |disk|
+        @req.options[:disk_add].each do |disk|
           adsize, adunit = reconfigure_calculations(disk[:disk_size_in_mb])
           vmdisks << {:hdFilename   => disk[:disk_name],
                       :hdType       => disk[:thin_provisioned] == 'true' ? 'thin' : 'thick',
@@ -1192,7 +1192,7 @@ module ApplicationController::CiProcessing
           removing = ''
           delbacking = false
           if disk.filename && @req.options[:disk_remove]
-            @req.options[:disk_remove].values.each do |remdisk|
+            @req.options[:disk_remove].each do |remdisk|
               if remdisk[:disk_name] == disk.filename
                 removing = 'remove'
                 delbacking = remdisk[:delete_backing] == 'true'

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1118,15 +1118,14 @@ module ApplicationController::CiProcessing
     # if only one vm that supports disk reconfiguration is selected, get the disks information
     vmdisks = []
     @reconfigureitems.first.hardware.disks.each do |disk|
-      if disk.device_type == 'disk'
-        dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-        vmdisks << {:hdFilename => disk.filename,
-                    :hdType     => disk.disk_type,
-                    :hdMode     => disk.mode,
-                    :hdSize     => dsize,
-                    :hdUnit     => dunit,
-                    :add_remove => ''}
-      end
+      next if disk.device_type != 'disk'
+      dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
+      vmdisks << {:hdFilename => disk.filename,
+                  :hdType     => disk.disk_type,
+                  :hdMode     => disk.mode,
+                  :hdSize     => dsize,
+                  :hdUnit     => dunit,
+                  :add_remove => ''}
     end
 
     {:objectIds              => @reconfigure_items,

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1195,7 +1195,7 @@ module ApplicationController::CiProcessing
             @req.options[:disk_remove].values.each do |remdisk|
               if remdisk[:disk_name] == disk.filename
                 removing = 'remove'
-                delbacking = remdisk[:delete_backing]
+                delbacking = remdisk[:delete_backing] == 'true'
               end
             end
           end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1163,13 +1163,13 @@ module ApplicationController::CiProcessing
       vmDisks = []
       if(@req.options[:disk_add])
         @req.options[:disk_add].values.each do |disk|
-          adsize, adunit = reconfigure_calculations(disk[:size])
-          vmDisks << {:hdFilename => "#{disk[:disk_name]}",
-                      :hdType => "#{disk[:disk_type] ? 'thick' : 'thin'}",
-                      :hdMode =>"#{disk[:mode] == true ? 'persistent' : 'nonpersistent'}",
+          adsize, adunit = reconfigure_calculations(disk[:disk_size_in_mb])
+          vmDisks << {:hdFilename => disk[:disk_name],
+                      :hdType => disk[:thin_provisioned] ? 'thin' : 'thick',
+                      :hdMode =>disk[:persistent] == true ? 'persistent' : 'nonpersistent',
                       :hdSize => adsize.to_s,
                       :hdUnit => adunit,
-                      :cb_dependent => disk[:dependent],
+                      :cb_dependent => disk[:dependent] == true,
                       :add_remove => 'add'}
         end
       end
@@ -1188,11 +1188,11 @@ module ApplicationController::CiProcessing
             end
           end
           dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-          vmDisks << {:hdFilename => "#{disk.filename}",
-                      :hdType => "#{disk.disk_type}",
-                      :hdMode =>"#{disk.mode}",
-                      :hdSize => "#{dsize}",
-                      :hdUnit => "#{dunit}",
+          vmDisks << {:hdFilename => disk.filename,
+                      :hdType => disk.disk_type.to_s,
+                      :hdMode => disk.mode.to_s,
+                      :hdSize => dsize.to_s,
+                      :hdUnit => dunit.to_s,
                       :delete_backing => delbacking,
                       :add_remove => removing}
         end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -411,14 +411,30 @@ module ApplicationController::CiProcessing
       # set the disk_add and disk_remove options
       if params[:vmAddDisks]
         params[:vmAddDisks].values.each do |p|
-          p.transform_values!{|v| v == 'true' ? true : v == 'false' ? false : v }
-          end
+          p.transform_values!{ |v|
+            case v
+              when 'true'
+                true
+              when 'false'
+                false
+              else
+                v
+            end }
+        end
         options[:disk_add] = params[:vmAddDisks].values
       end
 
       if params[:vmRemoveDisks]
         params[:vmRemoveDisks].values.each do |p|
-          p.transform_values!{|v| v == 'true' ? true : v == 'false' ? false : v }
+          p.transform_values!{ |v|
+            case v
+            when 'true'
+              true
+            when 'false'
+              false
+            else
+              v
+            end }
         end
         options[:disk_remove] = params[:vmRemoveDisks].values
       end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1169,7 +1169,7 @@ module ApplicationController::CiProcessing
                       :hdMode =>disk[:persistent] == true ? 'persistent' : 'nonpersistent',
                       :hdSize => adsize.to_s,
                       :hdUnit => adunit,
-                      :cb_dependent => disk[:dependent] == true,
+                      :cb_dependent => disk[:dependent] == 'true',
                       :add_remove => 'add'}
         end
       end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1163,12 +1163,13 @@ module ApplicationController::CiProcessing
       vmDisks = []
       if(@req.options[:disk_add])
         @req.options[:disk_add].values.each do |disk|
-          adsize, adunit = reconfigure_calculations(disk.size)
+          adsize, adunit = reconfigure_calculations(disk[:size])
           vmDisks << {:hdFilename => "#{disk[:disk_name]}",
-                      :hdType => "#{disk[:disk_type] ? 'thin' : 'thick'}",
-                      :hdMode =>"#{disk[:mode] ? 'persistent' : 'nonpersistent'}",
+                      :hdType => "#{disk[:disk_type] ? 'thick' : 'thin'}",
+                      :hdMode =>"#{disk[:mode] == true ? 'persistent' : 'nonpersistent'}",
                       :hdSize => adsize.to_s,
                       :hdUnit => adunit,
+                      :cb_dependent => disk[:dependent],
                       :add_remove => 'add'}
         end
       end

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -32,6 +32,8 @@ class VmReconfigureTask < MiqRequestTask
     new_settings << "Processor Sockets: #{req_obj.options[:number_of_sockets].to_i}" unless req_obj.options[:number_of_sockets].blank?
     new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" unless req_obj.options[:cores_per_socket].blank?
     new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" unless req_obj.options[:number_of_cpus].blank?
+    new_settings << "Add Disks: #{req_obj.options[:disk_add].length}" unless req_obj.options[:disk_add].blank?
+    new_settings << "Remove Disks: #{req_obj.options[:disk_remove].length}" unless req_obj.options[:disk_remove].blank?
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
   end
 

--- a/app/views/miq_request/_reconfigure_show.html.haml
+++ b/app/views/miq_request/_reconfigure_show.html.haml
@@ -34,14 +34,14 @@
           %label.control-label.col-md-2
             = _("Add Disks")
           .col-md-8
-            = h(@options[:add_disks])
+            = h(@options[:disk_add].size)
             &nbsp;
       - if @options[:disk_remove]
         .form-group
           %label.control-label.col-md-2
             = _("Remove Disks")
           .col-md-8
-            = h(@options[:remove_disks])
+            = h(@options[:disk_remove].size)
             &nbsp;
 
   %fieldset

--- a/app/views/miq_request/_reconfigure_show.html.haml
+++ b/app/views/miq_request/_reconfigure_show.html.haml
@@ -29,6 +29,20 @@
             = _("Total Processors")
           %td
             = h(@options[:number_of_cpus])
+      - if @options[:disk_add]
+        .form-group
+          %label.control-label.col-md-2
+            = _("Add Disks")
+          .col-md-8
+            = h(@options[:add_disks])
+            &nbsp;
+      - if @options[:disk_remove]
+        .form-group
+          %label.control-label.col-md-2
+            = _("Remove Disks")
+          .col-md-8
+            = h(@options[:remove_disks])
+            &nbsp;
 
   %fieldset
     %h3

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -113,8 +113,8 @@
         %table{:width => "100%", :align => "bottom"}
           %tr
             %td#buttons_on{:align => "right"}
-              %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
-      %table.table.table-striped.table-hover.table-condensed
+              %button.btn.btn-default.btn-sm{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
+      %table.table.table-striped.table-hover.table-condensed.table-bordered
         %thead
           %th= _('Name')
           %th= _('Type')
@@ -174,7 +174,7 @@
                      "ng-model" => "reconfigureModel.cb_dependent"}
             %td.narrow
             %td
-              %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
           %tr{"ng-repeat" => "disk in reconfigureModel.vmdisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
             %td
               {{disk.hdFilename}}
@@ -200,13 +200,13 @@
                      "ng-if"       => "disk.add_remove!='add'",
                      "ng-disabled" => "disk.add_remove=='remove'"}
             %td
-              %button.btn.btn-danger.btn-sm{:type      => "button",
+              %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                             "ng-if"    => "disk.add_remove == ''",
                                             "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
-              %button.btn.btn-primary.btn-sm{:type      => "button",
+              %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                              "ng-if"    => "disk.add_remove == 'remove'",
                                              "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
-              %button.btn.btn-primary.btn-sm{:type      => "button",
+              %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                              "ng-if"    => "disk.add_remove == 'add'",
                                              "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
   %hr
@@ -224,7 +224,7 @@
     %tr
       %td#buttons_on{:align => "right"}
         = button_tag(_("Submit"),
-                     :class        => "btn btn-primary",
+                     :class        => "btn btn-default",
                      :alt          => _("Submit"),
                      "ng-click"    => "submitClicked()",
                      "ng-disabled" => "(angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)",

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -235,9 +235,9 @@
              :class        => "btn btn-default btn-disabled",
              :alt          => "Reset changes",
              :title        => "Reset changes",
-             "ng-class"    => "{'btn-disabled': angularForm.$pristine}",
+             "ng-class"    => "{'btn-disabled': angularForm.$pristine && !cb_disks}",
              "ng-click"    => "resetClicked()",
-             "ng-disabled" => "angularForm.$pristine",
+             "ng-disabled" => "angularForm.$pristine && !cb_disks",
              "ng-hide"     => "newRecord")
         = button_tag(_("Cancel"),
                      :class     => "btn btn-default",

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -105,105 +105,106 @@
                                 "auto-focus"  => ""}
             %span{"style"=>"color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
               = _(" Total processors value larger than the maximum allowed")
-  %hr
-  %div
-    %h3
-      = _('Disks')
-      %table{:width => "100%", :align => "bottom"}
-        %tr
-          %td#buttons_on{:align => "right"}
-            %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
-    %table.table.table-striped.table-hover.table-condensed
-      %thead
-        %th= _('Name')
-        %th= _('Type')
-        %th= _('Mode')
-        %th= _('Size')
-        %th.narrow
-        %th.narrow= _('Dependent')
-        %th.narrow= _('Delete Backing')
-        %th
-      %tbody
-        %tr{"ng-show" => "reconfigureModel.addEnabled"}
-          %td
-            %input.form-control{"type"        => "text",
-                                "id"          => "hdName",
-                                "name"        => "hdName",
-                                "ng-model"    => "reconfigureModel.hdFilename",
-                                "placeholder" => "Enter Disk Name",
-                                "ng-change"   => "hdChanged()"}
-          %td
-            = select_tag('hdType',
-                         options_for_select(%w(thick thin)),
-                         "ng-model"                    => "reconfigureModel.hdType",
-                         "ng-change"                   => "hdTypeChanged()",
-                         "data-width"                  => "auto",
-                         "required"                    => "",
-                         "selectpicker-for-select-tag" => "")
-          %td
-            = select_tag('hdMode',
-                          options_for_select(['persistent', 'nonpersistent']),
-                          "ng-model"                    => "reconfigureModel.hdMode",
-                          "ng-change"                   => "hdModeChanged()",
-                          "data-width"                  => "auto",
-                          "required"                    => "",
-                          "selectpicker-for-select-tag" => "",
-                          "width"                       => "10")
-          %td
-            %input.form-control{"type"        => "text",
-                                "id"          => "dvcSize",
-                                "name"        => "dvcSize",
-                                "ng-model"    => "reconfigureModel.hdSize",
-                                "placeholder" => "Enter New Size",
-                                "ng-change"   => "hdChanged()"}
-          %td.narrow
-            = select_tag('hdUnit',
-                     options_for_select(%w(MB GB)),
-                     "ng-model"                    => "reconfigureModel.hdUnit",
-                     "ng-change"                   => "hdUnitChanged()",
-                     "data-width"                  => "auto",
-                     "required"                    => "",
-                     "selectpicker-for-select-tag" => "")
-          %td.narrow
-            %input{"type"      => "checkbox",
-                   "name"      => "cb_dependent",
-                   "ng-model"  => "reconfigureModel.cb_dependent",
-                   "ng-change" => ""}
-          %td.narrow
-          %td
-            %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
-        %tr{"ng-repeat" => "disk in reconfigureModel.vmDisks", "ng-form" => "rowForm", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
-          %td
-            {{disk.hdFilename}}
-          %td
-            {{disk.hdType}}
-          %td
-            {{disk.hdMode}}
-          %td
-            {{disk.hdSize}}
-          %td.narrow
-            {{disk.hdUnit}}
-          %td.narrow
-            %input{"type"      => "checkbox",
-                   "name"      => "cb_dependent",
-                   "ng-model"  => "disk.cb_dependent",
-                   "ng-if"     => "disk.add_remove=='add'",
-                   "ng-disabled" => "disk.add_remove=='add'",
-                   "checkchange" => ""}
-          %td.narrow
-            %input{"type"      => "checkbox",
-                   "name"      => "cb_deletebacking",
-                   "ng-model"  => "disk.cb_deletebacking",
-                   "ng-if"     => "disk.add_remove!='add'",
-                   "ng-disabled" => "disk.add_remove=='remove'"}
-          %td
-            %button.btn.btn-danger.btn-sm{:type => "button",
-                                          "ng-if" => "disk.add_remove == ''",
-                                          "ng-model" => "cb_disks",
-                                          "ng-change" => "",
-                                          "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
-            %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'remove'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
-            %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'add'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
+  - if @reconfigitems.length == 1 && @reconfigitems.first.vendor && @reconfigitems.first.vendor == 'vmware'
+    %hr
+    %div
+      %h3
+        = _('Disks')
+        %table{:width => "100%", :align => "bottom"}
+          %tr
+            %td#buttons_on{:align => "right"}
+              %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
+      %table.table.table-striped.table-hover.table-condensed
+        %thead
+          %th= _('Name')
+          %th= _('Type')
+          %th= _('Mode')
+          %th= _('Size')
+          %th.narrow
+          %th.narrow= _('Dependent')
+          %th.narrow= _('Delete Backing')
+          %th
+        %tbody
+          %tr{"ng-show" => "reconfigureModel.addEnabled"}
+            %td
+              %input.form-control{"type"        => "text",
+                                  "id"          => "hdName",
+                                  "name"        => "hdName",
+                                  "ng-model"    => "reconfigureModel.hdFilename",
+                                  "placeholder" => "Enter Disk Name",
+                                  "ng-change"   => "hdChanged()"}
+            %td
+              = select_tag('hdType',
+                           options_for_select(%w(thick thin)),
+                           "ng-model"                    => "reconfigureModel.hdType",
+                           "ng-change"                   => "hdTypeChanged()",
+                           "data-width"                  => "auto",
+                           "required"                    => "",
+                           "selectpicker-for-select-tag" => "")
+            %td
+              = select_tag('hdMode',
+                            options_for_select(['persistent', 'nonpersistent']),
+                            "ng-model"                    => "reconfigureModel.hdMode",
+                            "ng-change"                   => "hdModeChanged()",
+                            "data-width"                  => "auto",
+                            "required"                    => "",
+                            "selectpicker-for-select-tag" => "",
+                            "width"                       => "10")
+            %td
+              %input.form-control{"type"        => "text",
+                                  "id"          => "dvcSize",
+                                  "name"        => "dvcSize",
+                                  "ng-model"    => "reconfigureModel.hdSize",
+                                  "placeholder" => "Enter New Size",
+                                  "ng-change"   => "hdChanged()"}
+            %td.narrow
+              = select_tag('hdUnit',
+                       options_for_select(%w(MB GB)),
+                       "ng-model"                    => "reconfigureModel.hdUnit",
+                       "ng-change"                   => "hdUnitChanged()",
+                       "data-width"                  => "auto",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+            %td.narrow
+              %input{"type"      => "checkbox",
+                     "name"      => "cb_dependent",
+                     "ng-model"  => "reconfigureModel.cb_dependent",
+                     "ng-change" => ""}
+            %td.narrow
+            %td
+              %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
+          %tr{"ng-repeat" => "disk in reconfigureModel.vmDisks", "ng-form" => "rowForm", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
+            %td
+              {{disk.hdFilename}}
+            %td
+              {{disk.hdType}}
+            %td
+              {{disk.hdMode}}
+            %td
+              {{disk.hdSize}}
+            %td.narrow
+              {{disk.hdUnit}}
+            %td.narrow
+              %input{"type"      => "checkbox",
+                     "name"      => "cb_dependent",
+                     "ng-model"  => "disk.cb_dependent",
+                     "ng-if"     => "disk.add_remove=='add'",
+                     "ng-disabled" => "disk.add_remove=='add'",
+                     "checkchange" => ""}
+            %td.narrow
+              %input{"type"      => "checkbox",
+                     "name"      => "cb_deletebacking",
+                     "ng-model"  => "disk.cb_deletebacking",
+                     "ng-if"     => "disk.add_remove!='add'",
+                     "ng-disabled" => "disk.add_remove=='remove'"}
+            %td
+              %button.btn.btn-danger.btn-sm{:type => "button",
+                                            "ng-if" => "disk.add_remove == ''",
+                                            "ng-model" => "cb_disks",
+                                            "ng-change" => "",
+                                            "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
+              %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'remove'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
+              %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'add'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
   %hr
   %h3= _('Affected VMs')
   %table.admintable{:height => "75"}

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -127,12 +127,6 @@
         %tbody
           %tr{"ng-show" => "reconfigureModel.addEnabled",  "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
             %td
-              %input.form-control{"type"        => "text",
-                                  "id"          => "hdName",
-                                  "name"        => "hdName",
-                                  "ng-model"    => "reconfigureModel.hdFilename",
-                                  "placeholder" => "Enter Disk Name",
-                                  "ng-change"   => "hdChanged()"}
             %td
               = select_tag('hdType',
                            options_for_select(%w(thick thin)),
@@ -189,22 +183,23 @@
             %td.narrow
               {{disk.hdUnit}}
             %td.narrow
-              %input{"bs-switch"   => "",
-                     :data         => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
-                     "type"        => "checkbox",
-                     "name"        => "cb_dependent",
-                     "ng-model"    => "disk.cb_dependent",
-                     "ng-if"       => "disk.add_remove=='add'",
-                     "ng-disabled" => "disk.add_remove=='add'",
-                     "checkchange" => ""}
+              %input{"bs-switch"     => "",
+                     :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
+                     "type"          => "checkbox",
+                     "name"          => "cb_dependent",
+                     "ng-model"      => "disk.cb_dependent",
+                     "switch-active" => "{{disk.add_remove!='add'}}",
+                     "ng-readonly"   => "disk.add_remove=='add'",
+                     "ng-if"         => "disk.add_remove=='add'"}
             %td.narrow
-              %input{"bs-switch"   => "",
-                     :data         => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
-                     "type"        => "checkbox",
-                     "name"        => "cb_deletebacking",
-                     "ng-model"    => "disk.cb_deletebacking",
-                     "ng-if"       => "disk.add_remove!='add'",
-                     "ng-disabled" => "disk.add_remove=='remove'"}
+              %input{"bs-switch"     => "",
+                     :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
+                     "type"          => "checkbox",
+                     "name"          => "cb_deletebacking",
+                     "ng-model"      => "disk.delete_backing",
+                     "ng-readonly"   => "disk.add_remove=='remove'",
+                     "switch-active" => "{{disk.add_remove!='remove'}}",
+                     "ng-if"         => "disk.add_remove!='add'"}
             %td.action-cell
               %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                             "ng-if"    => "disk.add_remove == ''",
@@ -226,11 +221,16 @@
     %tr
       %td#buttons_on{:align => "right"}
         = button_tag(_("Submit"),
-                     :class        => "btn btn-primary",
-                     :alt          => _("Submit"),
-                     "ng-click"    => "submitClicked()",
-                     "ng-disabled" => "(angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)",
-                     "ng-class"    => "{'btn-disabled': (angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)}")
+                     :class     => "btn btn-primary btn-disabled",
+                     :alt       => _("Submit"),
+                     :style     => "cursor:not-allowed",
+                     "ng-click" => "disabledClick($event)",
+                     "ng-show"  => "(angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)")
+        = button_tag(_("Submit"),
+                     :class     => "btn btn-primary",
+                     :alt       => _("Submit"),
+                     "ng-click" => "submitClicked()",
+                     "ng-show"  => "!((angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks))")
         = button_tag("Reset",
              :class        => "btn btn-default btn-disabled",
              :alt          => "Reset changes",

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -56,12 +56,9 @@
          "ng-change"       => "cbChange()",
          "switch-on-text"  => "Yes",
          "switch-off-text" => "No"}
-
-    #cpu_div{"ng-if" => "cb_cpu"}
-
-      %hr
-      %h3
-        = _('Processor Options')
+    %br
+    #cpu_div{"ng-if" => "cb_cpu", :style => "margin-left: 20px"}
+      %h3= _(' Processor Options')
       - if @socket_options.length > 1
         .form-group{"ng-class" => "{'has-error': angularForm.socket_count.$invalid}"}
           %label.col-md-2.control-label
@@ -108,8 +105,105 @@
                                 "auto-focus"  => ""}
             %span{"style"=>"color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
               = _(" Total processors value larger than the maximum allowed")
-
   %hr
+  %div
+    %h3
+      = _('Disks')
+      %table{:width => "100%", :align => "bottom"}
+        %tr
+          %td#buttons_on{:align => "right"}
+            %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
+    %table.table.table-striped.table-hover.table-condensed
+      %thead
+        %th= _('Name')
+        %th= _('Type')
+        %th= _('Mode')
+        %th= _('Size')
+        %th.narrow
+        %th.narrow= _('Dependent')
+        %th.narrow= _('Delete Backing')
+        %th
+      %tbody
+        %tr{"ng-show" => "reconfigureModel.addEnabled"}
+          %td
+            %input.form-control{"type"        => "text",
+                                "id"          => "hdName",
+                                "name"        => "hdName",
+                                "ng-model"    => "reconfigureModel.hdFilename",
+                                "placeholder" => "Enter Disk Name",
+                                "ng-change"   => "hdChanged()"}
+          %td
+            = select_tag('hdType',
+                         options_for_select(%w(thick thin)),
+                         "ng-model"                    => "reconfigureModel.hdType",
+                         "ng-change"                   => "hdTypeChanged()",
+                         "data-width"                  => "auto",
+                         "required"                    => "",
+                         "selectpicker-for-select-tag" => "")
+          %td
+            = select_tag('hdMode',
+                          options_for_select(['persistent', 'nonpersistent']),
+                          "ng-model"                    => "reconfigureModel.hdMode",
+                          "ng-change"                   => "hdModeChanged()",
+                          "data-width"                  => "auto",
+                          "required"                    => "",
+                          "selectpicker-for-select-tag" => "",
+                          "width"                       => "10")
+          %td
+            %input.form-control{"type"        => "text",
+                                "id"          => "dvcSize",
+                                "name"        => "dvcSize",
+                                "ng-model"    => "reconfigureModel.hdSize",
+                                "placeholder" => "Enter New Size",
+                                "ng-change"   => "hdChanged()"}
+          %td.narrow
+            = select_tag('hdUnit',
+                     options_for_select(%w(MB GB)),
+                     "ng-model"                    => "reconfigureModel.hdUnit",
+                     "ng-change"                   => "hdUnitChanged()",
+                     "data-width"                  => "auto",
+                     "required"                    => "",
+                     "selectpicker-for-select-tag" => "")
+          %td.narrow
+            %input{"type"      => "checkbox",
+                   "name"      => "cb_dependent",
+                   "ng-model"  => "reconfigureModel.cb_dependent",
+                   "ng-change" => ""}
+          %td.narrow
+          %td
+            %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
+        %tr{"ng-repeat" => "disk in reconfigureModel.vmDisks", "ng-form" => "rowForm", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
+          %td
+            {{disk.hdFilename}}
+          %td
+            {{disk.hdType}}
+          %td
+            {{disk.hdMode}}
+          %td
+            {{disk.hdSize}}
+          %td.narrow
+            {{disk.hdUnit}}
+          %td.narrow
+            %input{"type"      => "checkbox",
+                   "name"      => "cb_dependent",
+                   "ng-model"  => "disk.cb_dependent",
+                   "ng-if"     => "disk.add_remove=='add'",
+                   "ng-disabled" => "disk.add_remove=='add'",
+                   "checkchange" => ""}
+          %td.narrow
+            %input{"type"      => "checkbox",
+                   "name"      => "cb_deletebacking",
+                   "ng-model"  => "disk.cb_deletebacking",
+                   "ng-if"     => "disk.add_remove!='add'",
+                   "ng-disabled" => "disk.add_remove=='remove'"}
+          %td
+            %button.btn.btn-danger.btn-sm{:type => "button",
+                                          "ng-if" => "disk.add_remove == ''",
+                                          "ng-model" => "cb_disks",
+                                          "ng-change" => "",
+                                          "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
+            %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'remove'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
+            %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'add'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
   %hr
   %h3= _('Affected VMs')
   %table.admintable{:height => "75"}
@@ -128,7 +222,7 @@
                      :class        => "btn btn-primary",
                      :alt          => _("Submit"),
                      "ng-click"    => "submitClicked()",
-                     "ng-disabled" => "angularForm.$pristine || angularForm.$invalid || (!cb_memory && !cb_cpu)",
+                     "ng-disabled" => "angularForm.$pristine || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)",
                      "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
         = button_tag("Reset",
              :class        => "btn btn-default btn-disabled",

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -113,7 +113,13 @@
         %table{:width => "100%", :align => "bottom"}
           %tr
             %td#buttons_on{:align => "right"}
-              %button.btn.btn-primary{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
+              %button.btn.btn-primary{:type      => "button",
+                                      "ng-click" => "enableDiskAdd()",
+                                      :align     => "left",
+                                      "ng-show"  => "!reconfigureModel.addEnabled"}= _('Add Disk')
+              %button.btn.btn-default.btn-sm{:type      => "button",
+                                             "ng-click" => "hideAddDisk()",
+                                             "ng-show"  => "reconfigureModel.addEnabled"}= ('Cancel Add')
       %table.table.table-striped.table-hover.table-condensed.table-bordered
         %thead
           %th= _('Name')
@@ -125,7 +131,7 @@
           %th.narrow= _('Delete Backing')
           %th= _('Actions')
         %tbody
-          %tr{"ng-show" => "reconfigureModel.addEnabled",  "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
+          %tr{"ng-if" => "reconfigureModel.addEnabled",  "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
             %td
             %td
               = select_tag('hdType',
@@ -149,6 +155,7 @@
                                   "id"          => "dvcSize",
                                   "name"        => "dvcSize",
                                   "ng-model"    => "reconfigureModel.hdSize",
+                                  "required"    => "",
                                   "ng-pattern"  => "hdpattern",
                                   "placeholder" => "Enter New Size",
                                   "ng-change"   => "hdChanged()"}
@@ -170,7 +177,7 @@
                      "ng-model"  => "reconfigureModel.cb_dependent"}
             %td.narrow
             %td.action-cell
-              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Add ')
           %tr{"ng-repeat" => "disk in reconfigureModel.vmdisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
             %td
               {{disk.hdFilename}}

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -131,7 +131,9 @@
           %th.narrow= _('Delete Backing')
           %th= _('Actions')
         %tbody
-          %tr{"ng-if" => "reconfigureModel.addEnabled",  "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
+          %tr{"ng-if"       => "reconfigureModel.addEnabled",
+              "ng-form"     => "rowForm",
+              "ng-disabled" => "{'has-error': rowForm.value.$invalid}"}
             %td
             %td
               = select_tag('hdType',
@@ -177,7 +179,7 @@
                      "ng-model"  => "reconfigureModel.cb_dependent"}
             %td.narrow
             %td.action-cell
-              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Add ')
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()", "ng-disabled" => "rowForm.dvcSize.$invalid"}= _(' Add ')
           %tr{"ng-repeat" => "disk in reconfigureModel.vmdisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
             %td
               {{disk.hdFilename}}
@@ -213,10 +215,10 @@
                                             "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
               %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                              "ng-if"    => "disk.add_remove == 'remove'",
-                                             "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
+                                             "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel Delete')
               %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                              "ng-if"    => "disk.add_remove == 'add'",
-                                             "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
+                                             "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel Add')
   %hr
   %h3= _('Affected VMs')
   - if @reconfigitems

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -18,20 +18,20 @@
              "switch-off-text" => "No"}
     #memory_div{"ng-if" => "cb_memory"}
       .col-md-4
-        %input.form-control{"type"        => "text",
-                            "id"          => "textInput-markup",
-                            "name"        => "memory",
-                            "ng-model"    => "reconfigureModel.memory",
-                            "ng-change"    => "cbChange()",
-                            "maxlength"   => "50",
-                            "ng-pattern"  => "/^[-+]?[0-9]+$/",
-                            "miqrequired" => "",
-                            "checkchange" => "",
-                            "auto-focus"  => "",
+        %input.form-control{"type"              => "text",
+                            "id"                => "textInput-markup",
+                            "name"              => "memory",
+                            "ng-model"          => "reconfigureModel.memory",
+                            "ng-change"         => "cbChange()",
+                            "maxlength"         => "50",
+                            "ng-pattern"        => "/^[-+]?[0-9]+$/",
+                            "miqrequired"       => "",
+                            "checkchange"       => "",
+                            "auto-focus"        => "",
                             "validate-multiple" => "4",
-                            :miqmin       => "#{@reconfig_limits[:min__vm_memory]}",
-                            :miqmax       => "#{@reconfig_limits[:max__vm_memory]}",
-                            :memtype      => "{{reconfigureModel.memory_type}}"}
+                            :miqmin             => "#{@reconfig_limits[:min__vm_memory]}",
+                            :miqmax             => "#{@reconfig_limits[:max__vm_memory]}",
+                            :memtype            => "{{reconfigureModel.memory_type}}"}
         %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$invalid"}
           = _(" Memory value not in range or not a multiple of 4")
         %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$required"}
@@ -94,16 +94,16 @@
           %label.col-sm-2.control-label
             = _('Total Processors')
           .col-md-2
-            %input.form-control{"type"        => "text",
-                                "id"          => "total_cpus",
-                                "name"        => "total_cpus",
-                                "ng-model"    => "reconfigureModel.total_cpus",
-                                :readonly     => '',
-                                "maxlength"   => "50",
-                                "validate_total"  => "",
-                                "miqmax"      => "#{@reconfig_limits[:max__total_vcpus]}",
-                                "auto-focus"  => ""}
-            %span{"style"=>"color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
+            %input.form-control{"type"           => "text",
+                                "id"             => "total_cpus",
+                                "name"           => "total_cpus",
+                                "ng-model"       => "reconfigureModel.total_cpus",
+                                :readonly        => '',
+                                "maxlength"      => "50",
+                                "validate_total" => "",
+                                "miqmax"         => "#{@reconfig_limits[:max__total_vcpus]}",
+                                "auto-focus"     => ""}
+            %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
               = _(" Total processors value larger than the maximum allowed")
   - if @reconfigitems.length == 1 && @reconfigitems.first.vendor && @reconfigitems.first.vendor == 'vmware'
     %hr
@@ -143,7 +143,7 @@
                            "selectpicker-for-select-tag" => "")
             %td
               = select_tag('hdMode',
-                            options_for_select(['persistent', 'nonpersistent']),
+                            options_for_select(%w(persistent nonpersistent)),
                             "ng-model"                    => "reconfigureModel.hdMode",
                             "ng-change"                   => "hdModeChanged()",
                             "data-width"                  => "auto",
@@ -158,7 +158,7 @@
                                   "ng-pattern"  => "hdpattern",
                                   "placeholder" => "Enter New Size",
                                   "ng-change"   => "hdChanged()"}
-              %span{"style"=>"color:red", "ng-show" => "rowForm.dvcSize.$invalid"}
+              %span{"style" => "color:red", "ng-show" => "rowForm.dvcSize.$invalid"}
                 = _(" Valid numeric disk size required ")
             %td.narrow
               = select_tag('hdUnit',
@@ -169,14 +169,13 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
             %td.narrow
-              %input{"type"      => "checkbox",
-                     "name"      => "cb_dependent",
-                     "ng-model"  => "reconfigureModel.cb_dependent",
-                     "ng-change" => ""}
+              %input{"type"     => "checkbox",
+                     "name"     => "cb_dependent",
+                     "ng-model" => "reconfigureModel.cb_dependent"}
             %td.narrow
             %td
               %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
-          %tr{"ng-repeat" => "disk in reconfigureModel.vmDisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
+          %tr{"ng-repeat" => "disk in reconfigureModel.vmdisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
             %td
               {{disk.hdFilename}}
             %td
@@ -188,24 +187,28 @@
             %td.narrow
               {{disk.hdUnit}}
             %td.narrow
-              %input{"type"      => "checkbox",
-                     "name"      => "cb_dependent",
-                     "ng-model"  => "disk.cb_dependent",
-                     "ng-if"     => "disk.add_remove=='add'",
+              %input{"type"        => "checkbox",
+                     "name"        => "cb_dependent",
+                     "ng-model"    => "disk.cb_dependent",
+                     "ng-if"       => "disk.add_remove=='add'",
                      "ng-disabled" => "disk.add_remove=='add'",
                      "checkchange" => ""}
             %td.narrow
-              %input{"type"      => "checkbox",
-                     "name"      => "cb_deletebacking",
-                     "ng-model"  => "disk.cb_deletebacking",
-                     "ng-if"     => "disk.add_remove!='add'",
+              %input{"type"        => "checkbox",
+                     "name"        => "cb_deletebacking",
+                     "ng-model"    => "disk.cb_deletebacking",
+                     "ng-if"       => "disk.add_remove!='add'",
                      "ng-disabled" => "disk.add_remove=='remove'"}
             %td
-              %button.btn.btn-danger.btn-sm{:type => "button",
-                                            "ng-if" => "disk.add_remove == ''",
+              %button.btn.btn-danger.btn-sm{:type      => "button",
+                                            "ng-if"    => "disk.add_remove == ''",
                                             "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
-              %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'remove'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
-              %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'add'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
+              %button.btn.btn-primary.btn-sm{:type      => "button",
+                                             "ng-if"    => "disk.add_remove == 'remove'",
+                                             "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
+              %button.btn.btn-primary.btn-sm{:type      => "button",
+                                             "ng-if"    => "disk.add_remove == 'add'",
+                                             "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
   %hr
   %h3= _('Affected VMs')
   %table.admintable{:height => "75"}
@@ -236,7 +239,7 @@
              "ng-hide"     => "newRecord")
         = button_tag(_("Cancel"),
                      :class     => "btn btn-default",
-                     :alt          => _("Cancel"),
+                     :alt       => _("Cancel"),
                      "ng-click" => "cancelClicked()")
 
 :javascript

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -113,7 +113,7 @@
         %table{:width => "100%", :align => "bottom"}
           %tr
             %td#buttons_on{:align => "right"}
-              %button.btn.btn-default.btn-sm{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
+              %button.btn.btn-primary{:type => "button", "ng-click" => "enableDiskAdd()",  :align => "left"}= _('Add Disk')
       %table.table.table-striped.table-hover.table-condensed.table-bordered
         %thead
           %th= _('Name')
@@ -123,7 +123,7 @@
           %th.narrow
           %th.narrow= _('Dependent')
           %th.narrow= _('Delete Backing')
-          %th
+          %th= _('Action')
         %tbody
           %tr{"ng-show" => "reconfigureModel.addEnabled",  "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
             %td
@@ -173,7 +173,7 @@
                      "name"     => "cb_dependent",
                      "ng-model" => "reconfigureModel.cb_dependent"}
             %td.narrow
-            %td
+            %td.action-cell
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
           %tr{"ng-repeat" => "disk in reconfigureModel.vmdisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
             %td
@@ -199,7 +199,7 @@
                      "ng-model"    => "disk.cb_deletebacking",
                      "ng-if"       => "disk.add_remove!='add'",
                      "ng-disabled" => "disk.add_remove=='remove'"}
-            %td
+            %td.action-cell
               %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                             "ng-if"    => "disk.add_remove == ''",
                                             "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
@@ -211,20 +211,16 @@
                                              "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
   %hr
   %h3= _('Affected VMs')
-  %table.admintable{:height => "75"}
-    %tbody
-      %tr
-        %td
-          - if @reconfigitems
-            - @embedded = true
-            - @gtl_type = "list"
-            = render :partial => "layouts/gtl"
+  - if @reconfigitems
+    - @embedded = true
+    - @gtl_type = "list"
+    = render :partial => "layouts/gtl"
 
   %table{:width => "100%", :align => "bottom"}
     %tr
       %td#buttons_on{:align => "right"}
         = button_tag(_("Submit"),
-                     :class        => "btn btn-default",
+                     :class        => "btn btn-primary",
                      :alt          => _("Submit"),
                      "ng-click"    => "submitClicked()",
                      "ng-disabled" => "(angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)",

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -137,7 +137,7 @@
               = select_tag('hdType',
                            options_for_select(%w(thick thin)),
                            "ng-model"                    => "reconfigureModel.hdType",
-                           "ng-change"                   => "hdTypeChanged()",
+                           "ng-change"                   => "",
                            "data-width"                  => "auto",
                            "required"                    => "",
                            "selectpicker-for-select-tag" => "")

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -123,7 +123,7 @@
           %th.narrow
           %th.narrow= _('Dependent')
           %th.narrow= _('Delete Backing')
-          %th= _('Action')
+          %th= _('Actions')
         %tbody
           %tr{"ng-show" => "reconfigureModel.addEnabled",  "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
             %td
@@ -169,9 +169,11 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
             %td.narrow
-              %input{"type"     => "checkbox",
-                     "name"     => "cb_dependent",
-                     "ng-model" => "reconfigureModel.cb_dependent"}
+              %input{"bs-switch" => "",
+                     :data       => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
+                     "type"      => "checkbox",
+                     "name"      => "cb_dependent",
+                     "ng-model"  => "reconfigureModel.cb_dependent"}
             %td.narrow
             %td.action-cell
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
@@ -187,14 +189,18 @@
             %td.narrow
               {{disk.hdUnit}}
             %td.narrow
-              %input{"type"        => "checkbox",
+              %input{"bs-switch"   => "",
+                     :data         => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
+                     "type"        => "checkbox",
                      "name"        => "cb_dependent",
                      "ng-model"    => "disk.cb_dependent",
                      "ng-if"       => "disk.add_remove=='add'",
                      "ng-disabled" => "disk.add_remove=='add'",
                      "checkchange" => ""}
             %td.narrow
-              %input{"type"        => "checkbox",
+              %input{"bs-switch"   => "",
+                     :data         => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
+                     "type"        => "checkbox",
                      "name"        => "cb_deletebacking",
                      "ng-model"    => "disk.cb_deletebacking",
                      "ng-if"       => "disk.add_remove!='add'",

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -125,7 +125,7 @@
           %th.narrow= _('Delete Backing')
           %th
         %tbody
-          %tr{"ng-show" => "reconfigureModel.addEnabled"}
+          %tr{"ng-show" => "reconfigureModel.addEnabled",  "ng-form" => "rowForm", "ng-class" => "{'has-error': rowForm.value.$invalid}"}
             %td
               %input.form-control{"type"        => "text",
                                   "id"          => "hdName",
@@ -155,8 +155,11 @@
                                   "id"          => "dvcSize",
                                   "name"        => "dvcSize",
                                   "ng-model"    => "reconfigureModel.hdSize",
+                                  "ng-pattern"  => "hdpattern",
                                   "placeholder" => "Enter New Size",
                                   "ng-change"   => "hdChanged()"}
+              %span{"style"=>"color:red", "ng-show" => "rowForm.dvcSize.$invalid"}
+                = _(" Valid numeric disk size required ")
             %td.narrow
               = select_tag('hdUnit',
                        options_for_select(%w(MB GB)),
@@ -173,7 +176,7 @@
             %td.narrow
             %td
               %button.btn.btn-primary.btn-sm{:type => "button", "ng-click" => "addDisk()"}= _(' Save ')
-          %tr{"ng-repeat" => "disk in reconfigureModel.vmDisks", "ng-form" => "rowForm", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
+          %tr{"ng-repeat" => "disk in reconfigureModel.vmDisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
             %td
               {{disk.hdFilename}}
             %td
@@ -200,8 +203,6 @@
             %td
               %button.btn.btn-danger.btn-sm{:type => "button",
                                             "ng-if" => "disk.add_remove == ''",
-                                            "ng-model" => "cb_disks",
-                                            "ng-change" => "",
                                             "ng-click" => "deleteDisk(disk.hdFilename)"}= _('Delete')
               %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'remove'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel delete')
               %button.btn.btn-primary.btn-sm{:type => "button", "ng-if" => "disk.add_remove == 'add'", "ng-click" => "cancelAddRemoveDisk(disk)"}= _('Cancel add')
@@ -223,8 +224,8 @@
                      :class        => "btn btn-primary",
                      :alt          => _("Submit"),
                      "ng-click"    => "submitClicked()",
-                     "ng-disabled" => "angularForm.$pristine || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)",
-                     "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+                     "ng-disabled" => "(angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)",
+                     "ng-class"    => "{'btn-disabled': (angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)}")
         = button_tag("Reset",
              :class        => "btn btn-default btn-disabled",
              :alt          => "Reset changes",

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -348,6 +348,23 @@ describe VmInfraController do
     expect(response.body).to include('Total Processors')
   end
 
+  it 'the reconfigure tab for a single vmware vm should display the list of disks' do
+    vm = FactoryGirl.create(:vm_vmware,
+                            :host     => host_2x2,
+                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
+    allow(controller).to receive(:x_node).and_return("v-#{vm.compressed_id}")
+
+    get :show, :params => { :id => vm.id }
+    expect(response).to redirect_to(:action => 'explorer')
+
+    post :explorer
+    expect(response.status).to eq(200)
+
+    post :x_button, :params => { :pressed => 'vm_reconfigure', :id => vm.id }
+    expect(response.status).to eq(200)
+    expect(response.body).to include('Disks')
+  end
+
   it 'the reconfigure tab displays the submit and cancel buttons' do
     vm = FactoryGirl.create(:vm_vmware,
                             :host     => host_2x2,

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -354,13 +354,13 @@ describe VmInfraController do
                             :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     allow(controller).to receive(:x_node).and_return("v-#{vm.compressed_id}")
 
-    get :show, :params => { :id => vm.id }
+    get :show, :params => {:id => vm.id}
     expect(response).to redirect_to(:action => 'explorer')
 
     post :explorer
     expect(response.status).to eq(200)
 
-    post :x_button, :params => { :pressed => 'vm_reconfigure', :id => vm.id }
+    post :x_button, :params => {:pressed => 'vm_reconfigure', :id => vm.id}
     expect(response.status).to eq(200)
     expect(response.body).to include('Disks')
   end

--- a/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
+++ b/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
@@ -97,7 +97,8 @@ describe('reconfigureFormController', function() {
                            memory:                 $scope.reconfigureModel.memory,
                            memory_type:            $scope.reconfigureModel.memory_type,
                            socket_count:           $scope.reconfigureModel.socket_count,
-                           cores_per_socket_count: $scope.reconfigureModel.cores_per_socket_count};
+                           cores_per_socket_count: $scope.reconfigureModel.cores_per_socket_count,
+                           vmAddDisks: [  ], vmRemoveDisks: [  ] };
 
       expect(miqService.miqAjaxButton).toHaveBeenCalledWith('reconfigure_update/1000000000003?button=submit', submitContent);
     });


### PR DESCRIPTION
Added support for adding and removing disks to a virtual machine in the reconfigure screen.
Only VMWare is supported at this time.

https://trello.com/c/jLmQKPct/167-5-vm-reconfigure-to-support-adding-removing-of-disks-to-vm
