### PR TITLE
Re-set the miq_user_role_id on groups on entitlement rollback

### DIFF
--- a/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
+++ b/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
@@ -1,5 +1,27 @@
 class RemoveMiqUserRoleFromMiqGroups < ActiveRecord::Migration[5.0]
-  def change
-    remove_column :miq_groups, :miq_user_role_id, :bigint
+  class MiqGroup < ActiveRecord::Base
+    has_one :entitlement, :class_name => RemoveMiqUserRoleFromMiqGroups::Entitlement
+  end
+
+  class Entitlement < ActiveRecord::Base
+    belongs_to :miq_group,     :class_name => RemoveMiqUserRoleFromMiqGroups::MiqGroup
+    belongs_to :miq_user_role, :class_name => RemoveMiqUserRoleFromMiqGroups::MiqUserRole
+  end
+
+  class MiqUserRole < ActiveRecord::Base
+    has_many :entitlements, :class_name => RemoveMiqUserRoleFromMiqGroups::Entitlement
+  end
+
+  def up
+    remove_column :miq_groups, :miq_user_role_id
+  end
+
+  def down
+    add_column :miq_groups, :miq_user_role_id, :bigint
+
+    MiqGroup.includes(:entitlement).where.not(:entitlements => {:miq_user_role_id => nil}).find_each do |group|
+      group.miq_user_role_id = group.entitlement.miq_user_role_id
+      group.save!
+    end
   end
 end

--- a/spec/migrations/20160317194215_remove_miq_user_role_from_miq_groups_spec.rb
+++ b/spec/migrations/20160317194215_remove_miq_user_role_from_miq_groups_spec.rb
@@ -1,0 +1,14 @@
+require_migration
+
+describe RemoveMiqUserRoleFromMiqGroups do
+  let(:miq_group_stub)   { migration_stub(:MiqGroup) }
+  let(:entitlement_stub) { migration_stub(:Entitlement) }
+  let!(:miq_group)       { miq_group_stub.create!(:entitlement => entitlement_stub.create!(:miq_user_role_id => 25)) }
+
+  migration_context :down do
+    it "sets the miq_user_role_id back on miq_groups" do
+      migrate
+      expect(miq_group.reload.miq_user_role_id).to eq 25
+    end
+  end
+end


### PR DESCRIPTION
Fixes issue where one rolls back migrations and finds that seeding (aka starting the app...) fails because seeds try and change an entitlement, which is read-only in the :through association.

Fixes #7553