### PR TITLE
[api] Ensure `log_request_initiated` is called

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -88,7 +88,7 @@ class ApiController < ApplicationController
   extend ErrorHandler::ClassMethods
   respond_to :json
   rescue_from_api_errors
-  before_action :require_api_user_or_token, :except => [:handle_options_request]
+  prepend_before_action :require_api_user_or_token, :except => [:handle_options_request]
 
   TAG_NAMESPACE = "/managed"
 


### PR DESCRIPTION
If an error is raised in a filter registered in `ApplicationController`,
`require_api_user_or_token` (which is further down the filter chain)
won't have been called, which ultimately won't set the `@requested_at`
value. If we attempt to handle the error and present it in the JSON API,
a new error will be raised because it assumes that the `@requested_at`
value has been set. This revision mitigates that by prepending the filter
in question to the filter chain, ensuring that it is run first.

Fixes https://github.com/ManageIQ/manageiq/issues/7561

***

/cc @jrafanie @abellotti @alongoldboim 

@miq-bot add-label api, bug