### PR TITLE
Add ability to scale down an OpenStack infra provider

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -31,6 +31,12 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
           t,
           :url => "/scaling"),
         button(
+          :ems_infra_scaledown,
+          'pficon pficon-edit fa-lg',
+          t = N_('Scale this #{ui_lookup(:table=>"ems_infra")} down'),
+          t,
+          :url => "/scaledown"),
+        button(
           :ems_infra_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Remove this #{ui_lookup(:table=>"ems_infra")} from the VMDB'),

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -640,7 +640,7 @@ class ApplicationHelper::ToolbarBuilder
     end
 
     # Scale is only supported by OpenStack Infrastructure Provider
-    return true if id == "ems_infra_scale" &&
+    return true if (id == "ems_infra_scale" || id == "ems_infra_scaledown") &&
                    (@record.class != ManageIQ::Providers::Openstack::InfraManager ||
                     !role_allows(:feature => "ems_infra_scale") ||
                    (@record.class == ManageIQ::Providers::Openstack::InfraManager && @record.orchestration_stacks.count == 0))

--- a/app/views/ems_infra/scaledown.html.haml
+++ b/app/views/ems_infra/scaledown.html.haml
@@ -1,0 +1,51 @@
+= render :partial => "layouts/flash_msg"
+= form_tag('/ems_infra/scaledown', :method => :post)
+= hidden_field_tag('id', @infra.id)
+- unless @stack.nil?
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Orchestration Stack')
+      .col-md-8
+        = @stack.name
+    .form-group
+      %label.col-md-2.control-label
+        = _('Number of Compute Hosts')
+      .col-md-8
+        = @compute_hosts.count
+    %table.table.table-bordered.table-striped
+      %thead
+        %tr
+          %th
+          %th= _('Node')
+          %th= _('VMs')
+          %th= _('Maintenance')
+      %tbody
+        - @compute_hosts.each do |host|
+          %tr
+            %td
+              - if host.number_of(:vms) == 0 && host.maintenance
+                %input{:type => 'checkbox', :name => 'host_ids[]', :value => host.id}
+            %td
+              = host.uid_ems
+            %td
+              = host.number_of(:vms)
+            %td
+              = host.maintenance
+
+  %table{:width => "100%"}
+    %tr
+      %td{:align => "right"}
+        #buttons_on
+          = button_tag(_("Scale Down"),
+                       :name => "scaledown",
+                       :class => "btn btn-primary",
+                       :alt => t = _("Scale Infrastructure Provider Down"),
+                       :title => t,
+                       :type => "submit")
+          = button_tag(_("Cancel"),
+                       :name => "cancel",
+                       :class => "btn btn-default",
+                       :alt => t = _("Cancel"),
+                       :title => t,
+                       :type => "submit")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -941,6 +941,7 @@ Vmdb::Application.routes.draw do
         show_list
         tagging_edit
         scaling
+        scaledown
       ) +
                compare_get,
       :post => %w(
@@ -962,6 +963,7 @@ Vmdb::Application.routes.draw do
         update
         wait_for_task
         scaling
+        scaledown
       ) +
                adv_search_post +
                compare_post +

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -707,6 +707,10 @@
       :description: Scale an Infrastructure Provider
       :feature_type: admin
       :identifier: ems_infra_scale
+    - :name: Scale Down
+      :description: Scale an Infrastructure Provider down
+      :feature_type: admin
+      :identifier: ems_infra_scaledown
 
 # Datacenters
 - :name: Datacenters

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -106,6 +106,15 @@ FactoryGirl.define do
     end
   end
 
+  factory :ems_openstack_infra_with_stack_and_compute_nodes,
+          :parent => :ems_openstack_infra do
+    after :create do |x|
+      x.orchestration_stacks << FactoryGirl.create(:orchestration_stack_openstack_infra)
+      x.hosts += [FactoryGirl.create(:host_openstack_infra_compute),
+                  FactoryGirl.create(:host_openstack_infra_compute_maintenance)]
+    end
+  end
+
   factory :ems_openstack_infra_with_authentication,
           :parent => :ems_openstack_infra do
     after :create do |x|

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -56,6 +56,17 @@ FactoryGirl.define do
     ems_ref_obj "openstack-perf-host-nova-instance"
   end
 
+  factory :host_openstack_infra_compute, :parent => :host_openstack_infra,
+                                         :class  => "ManageIQ::Providers::Openstack::InfraManager::Host" do
+    name "host0 (NovaCompute)"
+  end
+
+  factory :host_openstack_infra_compute_maintenance, :parent => :host_openstack_infra,
+                                                     :class  => "ManageIQ::Providers::Openstack::InfraManager::Host" do
+    name        "host1 (NovaCompute)"
+    maintenance true
+  end
+
   factory :host_microsoft, :parent => :host, :class => "ManageIQ::Providers::Microsoft::InfraManager::Host" do
     vmm_vendor  "microsoft"
     vmm_product "Hyper-V"

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :orchestration_stack do
+    ems_ref "1"
   end
 
   factory :orchestration_stack_cloud, :parent => :orchestration_stack, :class => "ManageIQ::Providers::CloudManager::OrchestrationStack" do
@@ -14,11 +15,20 @@ FactoryGirl.define do
   factory :orchestration_stack_openstack, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack" do
   end
 
-  factory :orchestration_stack_openstack_infra, :class => "ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack" do
+  factory :orchestration_stack_openstack_infra,
+          :parent => :orchestration_stack,
+          :class  => "ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack" do
     after :create do |x|
       x.parameters << FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute)
       x.parameters << FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_controller)
+      x.resources << FactoryGirl.create(:orchestration_stack_resource_openstack_infra_compute)
+      x.resources << FactoryGirl.create(:orchestration_stack_resource_openstack_infra_compute_parent)
     end
+  end
+
+  factory :orchestration_stack_openstack_infra_nested,
+          :parent => :orchestration_stack,
+          :class  => "ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack" do
   end
 
   factory :orchestration_stack_parameter_openstack_infra, :class => "OrchestrationStackParameter" do
@@ -35,6 +45,25 @@ FactoryGirl.define do
     after :create do |x|
       x.name = "controller-1::count"
       x.value = "1"
+    end
+  end
+
+  factory :orchestration_stack_resource_openstack_infra, :class => "OrchestrationStackResource" do
+  end
+
+  factory :orchestration_stack_resource_openstack_infra_compute,
+          :parent => :orchestration_stack_resource_openstack_infra do
+    after :create do |x|
+      x.physical_resource = "openstack-perf-host-nova-instance"
+      x.stack = FactoryGirl.create(:orchestration_stack_openstack_infra_nested)
+    end
+  end
+
+  factory :orchestration_stack_resource_openstack_infra_compute_parent,
+          :parent => :orchestration_stack_resource_openstack_infra do
+    after :create do |x|
+      x.physical_resource = "1"
+      x.logical_resource = "1"
     end
   end
 

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1001 }
+  let(:expected_feature_count) { 1002 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
This patch addes the ability to scale down an OpenStack infra
provider through the UI.  Only compute nodes can be scaled down.