### PR TITLE
Fix all nil case in performance charts.

### DIFF
--- a/lib/report_formatter/c3_series.rb
+++ b/lib/report_formatter/c3_series.rb
@@ -19,5 +19,9 @@ module ReportFormatter
     def add_to_value(index, addition)
       self[index][:value] += addition
     end
+
+    def set_to_zero(index)
+      self[index][:value] = 0
+    end
   end
 end

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -112,7 +112,7 @@ module ReportFormatter
           end
           allnil = false if !val.nil? || nils2zero
         end
-        series[-1] = 0 if allnil                    # XML/SWF Charts can't handle all nils, set the last value to 0
+        series.set_to_zero(-1) if allnil # XML/SWF Charts can't handle all nils, set the last value to 0
         add_axis_category_text(categories)
 
         #### To do - Uncomment to handle long term averages

--- a/lib/report_formatter/jqplot_series.rb
+++ b/lib/report_formatter/jqplot_series.rb
@@ -34,6 +34,13 @@ module ReportFormatter
       end
     end
 
+    def set_to_zero(index)
+      case @type
+      when :flat then self[index] = 0
+      when :pie  then self[index][1] = 0
+      end
+    end
+
     private
 
     def shorten_label(label)

--- a/lib/report_formatter/zgraph_series.rb
+++ b/lib/report_formatter/zgraph_series.rb
@@ -24,5 +24,9 @@ module ReportFormatter
     def add_to_value(index, addition)
       self[index][:value] += addition
     end
+
+    def set_to_zero(index)
+      self[index][:value] = 0
+    end
   end
 end


### PR DESCRIPTION
```
[----] F, [2016-03-31T11:16:37.998706 #27957:3f832ecd35d4] FATAL -- : Error caught: [TypeError] no implicit conversion of Symbol into Integer
/home/martin/Projects/manageiq-2/lib/report_formatter/c3.rb:26:in `[]'
/home/martin/Projects/manageiq-2/lib/report_formatter/c3.rb:26:in `block in add_series'
/home/martin/Projects/manageiq-2/lib/report_formatter/c3.rb:26:in `map'
/home/martin/Projects/manageiq-2/lib/report_formatter/c3.rb:26:in `add_series'
/home/martin/Projects/manageiq-2/lib/report_formatter/chart_common.rb:126:in `block in build_performance_chart_area'
/home/martin/Projects/manageiq-2/lib/report_formatter/chart_common.rb:80:in `each'
/home/martin/Projects/manageiq-2/lib/report_formatter/chart_common.rb:80:in `each_with_index'
```