### PR TITLE
Typo change openStack vendor to openstack

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -281,7 +281,7 @@ class JobProxyDispatcher
     end
 
     if @vm.storage.nil?
-      unless %w(amazon openStack microsoft).include?(@vm.vendor)
+      unless %w(amazon openstack microsoft).include?(@vm.vendor)
         msg = "Vm [#{@vm.path}] is not located on a storage, aborting job [#{job.guid}]."
         queue_signal(job, {:args => [:abort, msg, "error"]})
         return []


### PR DESCRIPTION
Typo change openStack vendor to openstack, this typo prevents
openstack SSA from working.