### PR TITLE
Upgrade winrm-elevated Gem to version 0.3

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -47,7 +47,7 @@ gem "sys-uname",               "~>1.0.1",           :require => false
 gem "trollop",                 "~>2.0",             :require => false
 gem "uuidtools",               "~>2.1.3",           :require => false
 gem "winrm",                   "~>1.7.2",           :require => false
-gem "winrm-elevated",          "~>0.2.0",           :require => false
+gem "winrm-elevated",          "~>0.3.0",           :require => false
 gem 'sys-proctable',           "~> 1.0",            :require => false
 
 # Linux-only section


### PR DESCRIPTION
winrm-elevated version 0.3 fixes a bug in the gem which causes
concurrent attempts to run SSA against the same Windows HyperV Server
(from two different appliances) to fail by making powershell script and
log file names unique.

@roliveri @chessbyte @Fryguy please review and merge.