### PR TITLE
Correct validate_smartstate_analysis method

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/template.rb
@@ -15,6 +15,6 @@ class ManageIQ::Providers::Openstack::InfraManager::Template < ManageIQ::Provide
   end
 
   def validate_smartstate_analysis
-    validate_unsupported_check("Smartstate Analysis")
+    validate_unsupported("Smartstate Analysis")
   end
 end


### PR DESCRIPTION
This method currently calls validate_unsupported_check, which does
not exist.  validate_unsupported should be sufficient

Issue #7612