### PR TITLE
disconnection for containers and container definitions

### DIFF
--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -9,6 +9,7 @@ class ContainerDefinition < ApplicationRecord
 
   def disconnect_inv
     _log.info "Disconnecting Container definition [#{name}] id [#{id}]"
+    self.container.disconnect_inv
     self.deleted_on = Time.now.utc
     self.container_group = nil
     self.old_ems_id = self.ems_id

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -79,6 +79,7 @@ class ContainerGroup < ApplicationRecord
   def disconnect_inv
     _log.info "Disconnecting Container group [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
+    self.container_definitions.each(&:disconnect_inv)
     self.old_ems_id = ems_id
     self.ext_management_system = nil
     self.container_node_id = nil


### PR DESCRIPTION
Fixes #7610 
So since recursion disconnection of sub-entities doesnt happen in save_inventory_* I implemented it in the ```disconnect_inv``` methods. Should this somehow be done [here](https://github.com/zeari/manageiq/blob/3c738fa4599dfed207d319436371f85d83d21015/app/models/ems_refresh/save_inventory_helper.rb#L61-61) instead? 

@matthewd @Fryguy Please review
cc @simon3z @moolitayer 

