### PR TITLE
Add warnings to deploy Azure stack in complete mode

### DIFF
--- a/app/services/orchestration_template_dialog_service.rb
+++ b/app/services/orchestration_template_dialog_service.rb
@@ -108,28 +108,33 @@ class OrchestrationTemplateDialogService
 
   def add_timeout_field(group, position)
     group.dialog_fields.build(
-      :type           => "DialogFieldTextBox",
-      :name           => "stack_timeout",
-      :description    => "Abort the creation if it does not complete in a proper time window",
-      :data_type      => "integer",
-      :display        => "edit",
-      :required       => false,
-      :options        => {:protected => false},
-      :label          => "Timeout(minutes, optional)",
-      :position       => position,
-      :dialog_group   => group
+      :type         => "DialogFieldTextBox",
+      :name         => "stack_timeout",
+      :description  => "Abort the creation if it does not complete in a proper time window",
+      :data_type    => "integer",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "Timeout(minutes, optional)",
+      :position     => position,
+      :dialog_group => group
     )
   end
 
   def add_mode_field(group, position)
+    description = "Select deployment mode.\n"\
+                  "WARNING: Complete mode will delete all resources from "\
+                  "the group that are not in the template."
+
     group.dialog_fields.build(
       :type          => "DialogFieldDropDownList",
       :name          => "deploy_mode",
-      :description   => "Select deployment mode",
+      :description   => description,
       :data_type     => "string",
       :display       => "edit",
       :required      => true,
-      :values        => [%w(Incremental Incremental), %w(Complete Complete)],
+      :values        => [["Incremental", "Incremental (Default)"],
+                         ["Complete",    "Complete (Delete other resources in the group)"]],
       :default_value => "Incremental",
       :options       => {:sort_by => :description, :sort_order => :ascending},
       :label         => "Mode",

--- a/product/dialogs/service_dialogs/azure-single-vm-from-user-image.yml
+++ b/product/dialogs/service_dialogs/azure-single-vm-from-user-image.yml
@@ -164,7 +164,9 @@
           ae_message: 
           ae_attributes: {}
       - name: deploy_mode
-        description: Select deployment mode
+        description: |-
+          Select deployment mode.
+          WARNING: Complete mode will delete all resources from the group that are not in the template.
         type: DialogFieldDropDownList
         data_type: string
         notes: 
@@ -178,9 +180,9 @@
         default_value: Incremental
         values:
         - - Complete
-          - Complete
+          - Complete (Delete other resources in the group)
         - - Incremental
-          - Incremental
+          - Incremental (Default)
         values_method: 
         values_method_options: {}
         options:

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -83,7 +83,10 @@ describe OrchestrationTemplateDialogService do
     assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",         :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
     assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
     assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
-    assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode",        :values => [%w(Complete Complete), %w(Incremental Incremental)])
+
+    mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
+                   ["Incremental", "Incremental (Default)"]]
+    assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
   end
 
   def assert_field(field, clss, attributes)


### PR DESCRIPTION
Complete mode will delete all resources in the same group but not defined in the template. Reminding text is added to the provisioning dialog so that the user may know the consequence of the selection

https://bugzilla.redhat.com/show_bug.cgi?id=1321127

The dialog created from our sample template "azure-single-vm-from-user-image" is also updated. Users who already used this dialog will see the warning text. Any dialog user previously generated from Azure orchestration templates using our tool is not impacted. New dialogs based on Azure templates will bear this warning text.