### PR TITLE
Add container image registration rate to hourly daily metric rollup

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -640,10 +640,11 @@ module ManageIQ::Providers::Kubernetes
 
       [
         {
-          :name      => parts[:name],
-          :tag       => parts[:tag],
-          :digest    => parts[:digest],
-          :image_ref => image_ref,
+          :name          => parts[:name],
+          :tag           => parts[:tag],
+          :digest        => parts[:digest],
+          :image_ref     => image_ref,
+          :registered_on => Time.now.utc
         },
         (parts[:host] || parts[:host2]) && {
           :name => parts[:host] || parts[:host2],

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -1,6 +1,8 @@
 module Metric::Rollup
   ROLLUP_COLS  = Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float || c[0, 7] == "derived" }.compact +
-                 [:stat_container_group_create_rate, :stat_container_group_delete_rate]
+                 [:stat_container_group_create_rate,
+                  :stat_container_group_delete_rate,
+                  :stat_container_image_registration_rate]
   STORAGE_COLS = Metric.columns_hash.collect { |c, _h| c.to_sym if c.starts_with?("derived_storage_") }.compact
 
   NON_STORAGE_ROLLUP_COLS = (ROLLUP_COLS - STORAGE_COLS)

--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -1,13 +1,15 @@
 module Metric::Statistic
   def self.calculate_stat_columns(obj, timestamp)
     return {} unless obj.respond_to?(:container_groups)
+    return {} unless obj.respond_to?(:container_images)
 
     capture_interval = Metric::Helper.get_time_interval(obj, timestamp)
     container_groups = ContainerGroup.where(:ems_id => obj.id).or(ContainerGroup.where(:old_ems_id => obj.id))
 
     {
-      :stat_container_group_create_rate => container_groups.where(:created_on => capture_interval).count,
-      :stat_container_group_delete_rate => container_groups.where(:deleted_on => capture_interval).count
+      :stat_container_group_create_rate       => container_groups.where(:created_on => capture_interval).count,
+      :stat_container_group_delete_rate       => container_groups.where(:deleted_on => capture_interval).count,
+      :stat_container_image_registration_rate => obj.container_images.where(:registered_on => capture_interval).count
     }
   end
 end

--- a/db/migrate/20160331111338_add_registered_on_to_container_image.rb
+++ b/db/migrate/20160331111338_add_registered_on_to_container_image.rb
@@ -1,0 +1,5 @@
+class AddRegisteredOnToContainerImage < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_images, :registered_on, :datetime
+  end
+end

--- a/db/migrate/20160331111827_add_stat_containerimage_registration_rate_to_metric_rollups.rb
+++ b/db/migrate/20160331111827_add_stat_containerimage_registration_rate_to_metric_rollups.rb
@@ -1,0 +1,5 @@
+class AddStatContainerimageRegistrationRateToMetricRollups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :metric_rollups, :stat_container_image_registration_rate, :integer
+  end
+end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -89,7 +89,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       it "tests '#{ex[:image_name]}'" do
         result_image, result_registry = parser.send(:parse_image_name, ex[:image_name], example_ref)
 
-        expect(result_image).to eq(ex[:image])
+        expect(result_image.except(:registered_on)).to eq(ex[:image])
         expect(result_registry).to eq(ex[:registry])
       end
     end

--- a/spec/models/metric/statistic_spec.rb
+++ b/spec/models/metric/statistic_spec.rb
@@ -17,6 +17,11 @@ describe Metric::Statistic do
     let(:c7) { FactoryGirl.create(:container_group, :deleted_on => hour - 120.minutes) }
     let(:c8) { FactoryGirl.create(:container_group, :deleted_on => hour + 1.minute) }
 
+    let(:c9) { FactoryGirl.create(:container_image, :registered_on => hour - 10.minutes) }
+    let(:c10) { FactoryGirl.create(:container_image, :registered_on => hour - 50.minutes) }
+    let(:c11) { FactoryGirl.create(:container_image, :registered_on => hour - 120.minutes) }
+    let(:c12) { FactoryGirl.create(:container_image, :registered_on => hour + 1.minute) }
+
     it "count created container groups in a provider" do
       ems_openshift.container_groups << [c1, c2, c3, c4, c5, c6, c7, c8]
       derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
@@ -29,6 +34,13 @@ describe Metric::Statistic do
       derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
 
       expect(derived_columns[:stat_container_group_delete_rate]).to eq(2)
+    end
+
+    it "count new registred container images in a provider" do
+      ems_openshift.container_images << [c9, c10, c11, c12]
+      derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
+
+      expect(derived_columns[:stat_container_image_registration_rate]).to eq(2)
     end
   end
 end


### PR DESCRIPTION
Collect how many new container-image records where registered to the db in last hour.
Collect daily rollup (average) of the hourly value.

1. Add _registered_on_ field to _ContainerImage_
2. Add _stat_container_image_registration_rate_ to _metricRollup_