### PR TITLE
config/toolbar_strings.rb doesn't exist

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,6 @@ GlobalVars:
 #
 AllCops:
   Exclude:
-    - config/toolbar_strings.rb
     - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
 ClassAndModuleCamelCase:
   Exclude:
@@ -33,4 +32,3 @@ ClassAndModuleCamelCase:
 FileName:
   Exclude:
     - lib/miq_automation_engine/service_models/*.rb
-    - config/toolbar_strings.rb


### PR DESCRIPTION
Looks like a missed deletion from: [8c4fab1b538a51811c709189707913ac85b57c21](https://github.com/ManageIQ/manageiq/commit/8c4fab1b538a51811c709189707913ac85b57c21) PR #6733