### PR TITLE
Fix empty datacenter selection in vm provision

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -910,7 +910,7 @@ class MiqRequestWorkflow
   def get_ems_folders(folder, dh = {}, full_path = "")
     if folder.evm_object_class == :EmsFolder && !EmsFolder::NON_DISPLAY_FOLDERS.include?(folder.name)
       full_path += full_path.blank? ? "#{folder.name}" : " / #{folder.name}"
-      dh[folder.id] = full_path unless folder.kind_of?(Datacenter)
+      dh[folder.id] = full_path unless folder.type == "Datacenter"
     end
 
     # Process child folders
@@ -961,7 +961,7 @@ class MiqRequestWorkflow
     # Walk the xml document parents to find the requested class
     while node.kind_of?(XmlHash::Element)
       ci = node.attributes[:object]
-      if node.name == klass_name && (datacenter == false || datacenter == true && ci.kind_of?(Datacenter))
+      if node.name == klass_name && (datacenter == false || datacenter == true && ci.type == "Datacenter")
         result = ci
         break
       end

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -3,6 +3,7 @@ describe MiqRequestWorkflow do
   let(:ems) { FactoryGirl.create(:ext_management_system) }
   let(:resource_pool) { FactoryGirl.create(:resource_pool) }
   let(:ems_folder) { FactoryGirl.create(:ems_folder) }
+  let(:datacenter) { FactoryGirl.create(:ems_folder, :type => "Datacenter") }
 
   context "#validate" do
     let(:dialog) { workflow.instance_variable_get(:@dialogs) }
@@ -338,6 +339,21 @@ describe MiqRequestWorkflow do
     it "returns an empty hash if no resource pools are found" do
       src = {:ems =>  ems, :folder => ems_folder}
       expect(workflow.folder_to_respool(src)).to be_empty
+    end
+  end
+
+  context "#folder_to_datacenter" do
+    before do
+      datacenter.ext_management_system = ems
+      attrs = datacenter.attributes.merge(:object => datacenter, :ems => ems)
+      xml_hash = XmlHash::Element.new('EmsFolder', attrs)
+      hash = {"EmsFolder_#{datacenter.id}" => xml_hash}
+      workflow.instance_variable_set("@ems_xml_nodes", hash)
+    end
+
+    it "returns a datacenter" do
+      src = {:ems => ems, :folder => datacenter}
+      expect(workflow.folder_to_datacenter(src)).to eql(datacenter.id => datacenter.name)
     end
   end
 


### PR DESCRIPTION
`build_ci_hash_struct` sets the class to the base_class, this means that a Datacenter has class EmsFolder.  This causes no Datacenters to be shown in the provision workflow.

Introduced when removing is_datacenter here https://github.com/ManageIQ/manageiq/pull/7070.