### PR TITLE
Remove setting timestamp for existing MiqEvent instances during migration.

### DIFF
--- a/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
+++ b/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
@@ -33,10 +33,6 @@ class FixEventClassForEvmAlertEvent < ActiveRecord::Migration
         event.update_attributes(attrs)
       end
     end
-
-    say_with_time("Setting timestamp for MiqEvent") do
-      MiqEvent.where(:timestamp => nil).each { |e| e.update_attributes(:timestamp => e.created_on) }
-    end
   end
 
   def down
@@ -44,10 +40,6 @@ class FixEventClassForEvmAlertEvent < ActiveRecord::Migration
       EventStream.where(:type => 'MiqEvent', :event_type => 'EVMAlertEvent').update_all(
         :type => 'EmsEvent', :target_id => nil, :target_type => nil
       )
-    end
-
-    say_with_time("Deleting timestamp for MiqEvent") do
-      MiqEvent.update_all(:timestamp => nil)
     end
   end
 end

--- a/spec/migrations/20160307205816_fix_event_class_for_evm_alert_event_spec.rb
+++ b/spec/migrations/20160307205816_fix_event_class_for_evm_alert_event_spec.rb
@@ -70,14 +70,6 @@ describe FixEventClassForEvmAlertEvent do
         :vm_location       => 'test_vm/test_vm.vmx'
       )
     end
-
-    it "sets timestamp for MiqEvent" do
-      now = Time.now.utc
-      event = event_stream_stub.create!(:type => 'MiqEvent', :event_type => 'test', :created_on => now)
-
-      migrate
-      expect(event.reload).to have_attributes(:timestamp => now)
-    end
   end
 
   migration_context :down do


### PR DESCRIPTION
The class of EVMAlertEvent has been converted from EmsEvent to MiqEvent along with the timestamp column set.
Timeline which looks for events' timestamp checks for MiqEvent only for EVMAlertEvent.
So there is no need to set timestamp for existing MiqEvent instances that are not EVMAlertEvent.