### PR TITLE
SCVMM retirement - power status bug

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -101,9 +101,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
   end
 
   def vm_destroy(vm, _options = {})
-    if vm.power_state == "on"
-      vm_stop(vm)
-    end
+    vm_stop(vm)
     execute_power_operation("Remove", vm.uid_ems)
   end
 


### PR DESCRIPTION
**Current logic**: 
In SCVMM virtual machines must be stopped before they are deleted. For this reason, we check the power status of a VM before deleting it and turn it off should it be running.

**Problem**:
In SCVMM the power status of a VM in ManageIQ is not always accurate. Without event support we remain uninformed of power status changes until the next EMS refresh takes place which could be up to 15 minutes later.
Given the current logic, if a VM is OFF in ManageIQ but ON in SCVMM we will not power it off before deleting it, causing an exception to be thrown in SCVMM when an attempt is made to delete a running VM.

**Fix**:
Do not check the power status before deleting a VM, stop it regardless of the power status. This requires the -Force parameter, without it an exception is thrown if we try to power off an already stopped VM.  

https://bugzilla.redhat.com/show_bug.cgi?id=1299069