### PR TITLE
keys should be symbolized while accessing settings in Configuration

### DIFF
--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -21,7 +21,7 @@ class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
 
     say_with_time("Adding tables to replication worker exclude list") do
       Configuration.where(:typ => "vmdb").each do |c|
-        c.settings[:workers][:worker_base][:replication_worker][:replication][:exclude_tables] << MiqEventDefinition.table_name << ScanItem.table_name
+        c.settings.deep_symbolize_keys[:workers][:worker_base][:replication_worker][:replication][:exclude_tables] << MiqEventDefinition.table_name << ScanItem.table_name
         c.save!
       end
     end

--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -21,7 +21,7 @@ class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
 
     say_with_time("Adding tables to replication worker exclude list") do
       Configuration.where(:typ => "vmdb").each do |c|
-        c.settings.deep_symbolize_keys[:workers][:worker_base][:replication_worker][:replication][:exclude_tables] <<
+        c.settings.deep_symbolize_keys![:workers][:worker_base][:replication_worker][:replication][:exclude_tables] <<
           MiqEventDefinition.table_name << ScanItem.table_name
         c.save!
       end

--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -21,7 +21,8 @@ class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
 
     say_with_time("Adding tables to replication worker exclude list") do
       Configuration.where(:typ => "vmdb").each do |c|
-        c.settings.deep_symbolize_keys[:workers][:worker_base][:replication_worker][:replication][:exclude_tables] << MiqEventDefinition.table_name << ScanItem.table_name
+        c.settings.deep_symbolize_keys[:workers][:worker_base][:replication_worker][:replication][:exclude_tables] <<
+          MiqEventDefinition.table_name << ScanItem.table_name
         c.save!
       end
     end

--- a/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
+++ b/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
@@ -52,15 +52,15 @@ describe RemoveReplicatedRowsFromNewlyExcludedTables do
 
     it "adds newly excluded tables with datatype of keys as string " do
       empty_settings = {
-          "workers" => {
-              "worker_base" => {
-                  :replication_worker => {
-                      :replication => {
-                          :exclude_tables => []
-                      }
-                  }
+        "workers" => {
+          "worker_base" => {
+            :replication_worker => {
+              :replication => {
+                :exclude_tables => []
               }
+            }
           }
+        }
       }
       config = conf_stub.create!(:typ => "vmdb", :settings => empty_settings)
 
@@ -71,6 +71,5 @@ describe RemoveReplicatedRowsFromNewlyExcludedTables do
       expect(excludes).to include(event_def_stub.table_name)
       expect(excludes).to include(scan_item_stub.table_name)
     end
-
   end
 end

--- a/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
+++ b/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
@@ -49,5 +49,28 @@ describe RemoveReplicatedRowsFromNewlyExcludedTables do
       expect(excludes).to include(event_def_stub.table_name)
       expect(excludes).to include(scan_item_stub.table_name)
     end
+
+    it "adds newly excluded tables with datatype of keys as string " do
+      empty_settings = {
+          "workers" => {
+              "worker_base" => {
+                  :replication_worker => {
+                      :replication => {
+                          :exclude_tables => []
+                      }
+                  }
+              }
+          }
+      }
+      config = conf_stub.create!(:typ => "vmdb", :settings => empty_settings)
+
+      migrate
+
+      config.reload
+      excludes = config.settings[:workers][:worker_base][:replication_worker][:replication][:exclude_tables]
+      expect(excludes).to include(event_def_stub.table_name)
+      expect(excludes).to include(scan_item_stub.table_name)
+    end
+
   end
 end


### PR DESCRIPTION
Migration was throwing an error on copy of production DB. 
applying .deep_symbolize_keys to settings fixed the issue.
Thank you Nick for fixing it.

@carbonin @gtanzillo  