### PR TITLE
Deleted redundant code in MIQ AE Controller

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1879,8 +1879,6 @@ class MiqAeClassController < ApplicationController
     end
 
     process_aeinstances(aeinstances, "destroy") unless aeinstances.empty?
-    add_flash(_("The selected %{record} were deleted") %
-      {:record => ui_lookup(:models => "MiqAeInstance")}) if @flash_array.nil?
     replace_right_cell([:ae])
   end
 
@@ -1907,8 +1905,6 @@ class MiqAeClassController < ApplicationController
     end
 
     process_aemethods(aemethods, "destroy") unless aemethods.empty?
-    add_flash(_("The selected %{record} were deleted") %
-      {:record => ui_lookup(:models => "MiqAeMethod")}) if @flash_array.nil?
     replace_right_cell([:ae])
   end
 


### PR DESCRIPTION
Check for generated flash messages no longer needed with the code fix in https://github.com/ManageIQ/manageiq/pull/6525
New begin/rescue block in ci_processing/process_elements generates flash messages