### PR TITLE
Deleted redundant code in MIQ Policy Controller / Alert Profiles

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -115,8 +115,6 @@ module MiqPolicyController::AlertProfiles
       alert_profiles.push(params[:id])
     end
     process_alert_profiles(alert_profiles, "destroy") unless alert_profiles.empty?
-    add_flash(_("The selected %{model} was deleted") %
-      {:model => ui_lookup(:models => "MiqAlertSet")}) if @flash_array.nil?
     nodes = x_node.split("_")
     nodes.pop
     self.x_node = nodes.join("_")


### PR DESCRIPTION
Check for generated flash messages no longer needed with the code fix in https://github.com/ManageIQ/manageiq/pull/6525
New begin/rescue block in ci_processing/process_elements generates flash messages