### PR TITLE
Deleted redundant code in MIQ Policy Controller / Alerts

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -57,8 +57,6 @@ module MiqPolicyController::Alerts
       alerts.push(params[:id])
     end
     process_alerts(alerts, "destroy") unless alerts.empty?
-    add_flash(_("The selected %{models} was deleted") %
-      {:models => ui_lookup(:models => "MiqAlert")}) if @flash_array.nil?
     @new_alert_node = self.x_node = "root"
     get_node_info(x_node)
     replace_right_cell("root", [:alert_profile, :alert])


### PR DESCRIPTION
Check for generated flash messages no longer needed with the code fix in https://github.com/ManageIQ/manageiq/pull/6525
New begin/rescue block in ci_processing/process_elements generates flash messages