### PR TITLE
Deleted redundant code in MIQ Policy Controller / MIQ Actions

### DIFF
--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -77,8 +77,6 @@ module MiqPolicyController::MiqActions
       actions.push(params[:id])
     end
     process_actions(actions, "destroy") unless actions.empty?
-    add_flash(_("The selected %{models} was deleted") %
-      {:models => ui_lookup(:models => "MiqAction")}) if @flash_array.nil?
     @new_action_node = self.x_node = "root"
     get_node_info(x_node)
     replace_right_cell("root", [:action])


### PR DESCRIPTION
Check for generated flash messages no longer needed with the code fix in https://github.com/ManageIQ/manageiq/pull/6525
New begin/rescue block in ci_processing/process_elements generates flash messages