### PR TITLE
Deleted redundant code in MIQ Policy Controller / Conditions

### DIFF
--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -131,8 +131,6 @@ module MiqPolicyController::Conditions
       @new_condition_node = "xx-#{con.towhat.downcase}"
     end
     process_conditions(conditions, "destroy") unless conditions.empty?
-    add_flash(_("The selected %{models} was deleted") %
-      {:models => ui_lookup(:models => "Condition")}) if @flash_array.nil?
     get_node_info(@new_condition_node)
     replace_right_cell("xx", [:condition])
   end


### PR DESCRIPTION
Check for generated flash messages no longer needed with the code fix in https://github.com/ManageIQ/manageiq/pull/6525
New begin/rescue block in ci_processing/process_elements generates flash messages