### PR TITLE
Vim performance scope 5

### DIFF
--- a/app/models/metric/long_term_averages.rb
+++ b/app/models/metric/long_term_averages.rb
@@ -53,6 +53,7 @@ module Metric::LongTermAverages
 
         val =  p.send(c) || 0
         vals[c] << val
+        val *= 1.0 unless val.nil?
         Metric::Aggregation::Aggregate.average(c, self, results[:avg], counts, val)
       end
     end

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -78,8 +78,8 @@ class VimPerformanceDaily < MetricRollup
         # over the day.
         Metric::Aggregation::Aggregate.average(c, nil, result[key], counts[key], value)
 
-        Metric::Rollup.rollup_min(c, result[key], perf.send(c))
-        Metric::Rollup.rollup_max(c, result[key], perf.send(c))
+        Metric::Rollup.rollup_min(c, result[key], value)
+        Metric::Rollup.rollup_max(c, result[key], value)
       end
       if rtype == 'VmOrTemplate' && perf.min_max.kind_of?(Hash)
         result[key][:min_max] ||= {}


### PR DESCRIPTION
trivial.

But there seemed no reason to look up these calculated values multiple times.

Also, of the 3 calls into `Metric::Aggregation::Aggregate.average`, 2 of the 3 ensured it was a float going in. Seems like we should ensure it is a float here. (reason: int / int == int. 15/4 = 3 vs 15.0/4 = 3.75)