### PR TITLE
Fix gtl view toolbar in */show_list

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -996,7 +996,7 @@ module ApplicationController::CiProcessing
     session["#{self.class.session_key_prefix}_display".to_sym] = nil
     @display  = nil
     @lastaction  = "show_list"
-    @gtl_url = "/#{self.class.table_name}/show_list/?"
+    @gtl_url = "/show_list"
 
     model = options.delete(:model) # Get passed in model override
     @view, @pages = get_view(model || self.class.model, options)  # Get the records (into a view) and the paginator


### PR DESCRIPTION
the value in @gtl_url is prepended by `ManageIQ.controller` in the toolbar js code

therefore, we need only the action name (prefixed by a slash) in order for these buttons to work, not including the controller name or a trailing question mark

This prevents exceptions like `No route matches [GET] "/resource_pool/resource_pool/show_list"` when switching to a different gtl view.

Closes #7648