### PR TITLE
[WIP] Add knockout prefix for removed array elements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rails-controller-testing",        :require => false
 gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",      "~>0.1.2", :require => false
 
-gem "config",                          "~>1.0.0"
+gem "config",                          "~>1.1.0"
 
 # Local gems
 path "gems/" do

--- a/spec/lib/vmdb/settings/hash_differ_spec.rb
+++ b/spec/lib/vmdb/settings/hash_differ_spec.rb
@@ -51,6 +51,7 @@ describe Vmdb::Settings::HashDiffer do
   let(:diff_hash) do
     after_hash.deep_clone.tap do |h|
       h.delete_path(:values, :unchanged)
+      h.store_path(:values, :array, ["new val1", "new val2",])
     end
   end
 

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -106,6 +106,26 @@ describe Vmdb::Settings do
       )
     end
 
+    it "knocksout removed array values" do
+      new_logs = %w(
+        log/*.log
+        log/apache/*.log
+        log/*.txt
+        config/*
+        /var/log/syslog*
+        /var/log/daemon.log*
+        /etc/default/ntp*
+        /var/log/messages*
+        /var/log/cron*
+      )
+      expected = new_logs + %w(--!BUILD --!GUID --!VERSION)
+
+      described_class.save!(miq_server, :log => {:collection => {:current => {:pattern => new_logs}}})
+
+      expect(miq_server.settings_changes.find_by(:key => "/log/collection/current/pattern"))
+        .to have_attributes(:value => expected)
+    end
+
     it "encrypts password fields" do
       password  = "pa$$word"
       encrypted = MiqPassword.encrypt(password)


### PR DESCRIPTION
By default the config gem merges array values in the various config sources.
This means that removing elements from an array value will never take effect.

The knockout prefix tells the gem that the matching elements in other config sources should be removed.

@Fryguy please review