### PR TITLE
Support for rendering human readable model name in reports

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -259,4 +259,8 @@ module MiqReport::Formatting
     return val if val.to_f < 1.0e+15
     val.to_f.to_s
   end
+
+  def format_model_name(val, _options = {})
+    ui_lookup(:model => val)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -753,6 +753,10 @@ en:
       ManageIQ::Providers::Amazon::CloudManager::FloatingIp:                Floating IP (Amazon)
       ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet:          Cloud Subnet (OpenStack)
       ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter:        Network Router (OpenStack)
+      ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack:     Orchestration Stack (OpenStack)
+      ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack:     Orchestration Stack (OpenStack)
+      ManageIQ::Providers::Azure::CloudManager::OrchestrationStack:         Orchestration Stack (Azure)
+      ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack:        Orchestration Stack (Amazon)
       MiddlewareDeployment:     Middleware Deployment
       MiddlewareServer:         Middleware Server
       MiqAction:                Action

--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -833,3 +833,10 @@
     :function:
       :name: large_number_to_exponential_form
       :length: 50
+
+  :model_name:
+    :description: Human readable model name
+    :data_types:
+      - :string
+    :function:
+      :name: model_name

--- a/product/views/OrchestrationStack.yaml
+++ b/product/views/OrchestrationStack.yaml
@@ -88,3 +88,13 @@ graph:
 # Dimensions of graph (1 or 2)
 #   Note: specifying 2 for a single dimension graph may not return expected results
 dims: 
+
+col_formats:
+-
+-
+- :model_name
+-
+-
+-
+-
+-

--- a/product/views/OrchestrationTemplate.yaml
+++ b/product/views/OrchestrationTemplate.yaml
@@ -49,7 +49,7 @@ headers:
 
 col_formats:
 -
--
+- :model_name
 - :boolean_yes_no
 -
 -

--- a/product/views/OrchestrationTemplateAzure.yaml
+++ b/product/views/OrchestrationTemplateAzure.yaml
@@ -49,7 +49,7 @@ headers:
 
 col_formats:
 -
--
+- :model_name
 - :boolean_yes_no
 -
 -

--- a/product/views/OrchestrationTemplateCfn.yaml
+++ b/product/views/OrchestrationTemplateCfn.yaml
@@ -49,7 +49,7 @@ headers:
 
 col_formats:
 -
--
+- :model_name
 - :boolean_yes_no
 -
 -

--- a/product/views/OrchestrationTemplateHot.yaml
+++ b/product/views/OrchestrationTemplateHot.yaml
@@ -49,7 +49,7 @@ headers:
 
 col_formats:
 -
--
+- :model_name
 - :boolean_yes_no
 -
 -

--- a/spec/models/miq_report/formatting_spec.rb
+++ b/spec/models/miq_report/formatting_spec.rb
@@ -28,4 +28,10 @@ describe MiqReport, "::Formatting" do
         .to eq("Front 123 Bytes Back")
     end
   end
+
+  describe "#format_model_name" do
+    it "finds human readable name for given model" do
+      expect(subject.format_model_name("MiqAction")).to eq("Action")
+    end
+  end
 end


### PR DESCRIPTION
Before:
![model-names-before](https://cloud.githubusercontent.com/assets/6648365/14209498/ad28945a-f824-11e5-95bf-2c2f59a25f76.jpg)

After:
![model-names-after](https://cloud.githubusercontent.com/assets/6648365/14209504/b36f7f0e-f824-11e5-8aa4-9f1cbebcdaee.jpg)
