### PR TITLE
Enable policy events for Openstack suspend and reboot.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/compute_instance_reboot_end.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/compute_instance_reboot_end.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=ems "
+      value: "/System/event_handlers/event_action_refresh?target=ems"
   - rel5:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_reboot_guest&param="

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/compute_instance_reset_end.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/compute_instance_reset_end.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=ems "
+      value: "/System/event_handlers/event_action_refresh?target=ems"
   - rel5:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_reset&param="

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/compute_instance_suspend.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/compute_instance_suspend.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: compute.instance.suspend.end
+    name: compute.instance.suspend
     inherits: 
     description: 
   fields:


### PR DESCRIPTION
compute.instance.suspend is the name for Openstack suspend event.
Not compute.instance.suspend.start and compute.instance.suspend.end.
   
https://bugzilla.redhat.com/show_bug.cgi?id=1180695