### PR TITLE
Fix issue with auto-refresh transactions not firing after they should

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -12,11 +12,10 @@ var dialogFieldRefresh = {
     if (selectedValue !== undefined) {
       $('#' + fieldName).selectpicker('val', selectedValue);
     }
-    miqSelectPickerEvent(fieldName, url);
-    $('#' + fieldName).on('change', function() {
+    miqSelectPickerEvent(fieldName, url, {callback: function() {
       dialogFieldRefresh.triggerAutoRefresh(fieldId, triggerAutoRefresh || "true");
       return true;
-    });
+    }});
   },
 
   refreshCheckbox: function(fieldName, fieldId) {
@@ -68,7 +67,7 @@ var dialogFieldRefresh = {
 
       if (data.values.checked_value !== null) {
         if (value[0] !== null) {
-          if (data.values.checked_value.toString() === value[0].toString()) {
+          if (data.values.checked_value.toString() === String(value[0])) {
             option.prop('selected', true);
           }
         }
@@ -107,7 +106,7 @@ var dialogFieldRefresh = {
           .addClass('dynamic-radio-label')
           .text(value[1]);
 
-        if (data.values.checked_value === value[0].toString()) {
+        if (data.values.checked_value === String(value[0])) {
           radio.prop('checked', true);
         }
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1199,7 +1199,7 @@ function miqJqueryRequest(url, options) {
     };
   }
 
-  $.ajax(options.no_encoding ? url : encodeURI(url), ajax_options);
+  return $.ajax(options.no_encoding ? url : encodeURI(url), ajax_options);
 }
 
 function miqDomElementExists(element) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -997,14 +997,16 @@ function miqSendDateRequest(el) {
   //  tack on the id and value to the URL
   var urlstring = url + '?' + el.prop('id') + '=' + el.val();
 
-  if (parms.auto_refresh === true) {
-    dialogFieldRefresh.triggerAutoRefresh(parms.field_id, parms.trigger);
-  }
+  var attemptAutoRefreshTrigger = function() {
+    if (parms.auto_refresh === true) {
+      dialogFieldRefresh.triggerAutoRefresh(parms.field_id, parms.trigger);
+    }
+  };
 
   if (el.attr('data-miq_sparkle_on')) {
-    miqJqueryRequest(urlstring, {beforeSend: true});
+    $.when(miqJqueryRequest(urlstring, {beforeSend: true})).done(attemptAutoRefreshTrigger);
   } else {
-    miqJqueryRequest(urlstring);
+    $.when(miqJqueryRequest(urlstring)).done(attemptAutoRefreshTrigger);
   }
 }
 
@@ -1224,11 +1226,13 @@ function miqInitSelectPicker() {
 function miqSelectPickerEvent(element, url, options){
   $('#' + element).on('change', function(){
     var selected = $('#' + element).val();
-    options =  typeof options !== 'undefined' ? options : {}
-    options['no_encoding'] = true;
+    options =  typeof options !== 'undefined' ? options : {};
+    options.no_encoding = true;
 
     var firstarg = ! _.contains(url, '?');
-    miqJqueryRequest(url + (firstarg ? '?' : '&') + element + '=' + escape(selected), options);
+    $.when(miqJqueryRequest(url + (firstarg ? '?' : '&') + element + '=' + escape(selected), options)).done(function() {
+      options.callback.call();
+    });
     return true;
   });
 }

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -97,17 +97,6 @@ module ApplicationController::DialogRunner
 
     # Use JS to update the display
     render :update do |page|
-      @edit[:wf].dialog.dialog_tabs.each do |tab|
-        tab.dialog_groups.each do |group|
-          group.dialog_fields.each_with_index do |field, _i|
-            params.each do |p|
-              if p[0] == field.name
-                url = url_for(:action => 'dialog_field_changed', :id => "#{@edit[:rec_id] || "new"}")
-              end
-            end
-          end
-        end
-      end
       page << "miqSparkle(false);"
     end
   end

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -113,18 +113,18 @@ describe('dialogFieldRefresh', function() {
 
     it('sets up the select picker event', function() {
       dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
-      expect(window.miqSelectPickerEvent).toHaveBeenCalledWith('fieldName', 'url');
+      expect(window.miqSelectPickerEvent).toHaveBeenCalledWith('fieldName', 'url', {callback: jasmine.any(Function)});
     });
 
-    it('triggers the auto refresh when the drop down changes', function() {
+    it('triggers the auto refresh when the drop down changes', function(done) {
       dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
-      $("#" + fieldName).trigger('change');
+      done();
       expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith(fieldId, 'true');
     });
 
-    it('triggers autorefresh with "false" when triggerAutoRefresh arg is false', function() {
+    it('triggers autorefresh with "false" when triggerAutoRefresh arg is false', function(done) {
       dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url, 'false');
-      $("#" + fieldName).trigger('change');
+      done();
       expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith(fieldId, 'false');
     });
   });


### PR DESCRIPTION
This should fix some issues with any dialog that has auto-refreshing set up on any of the fields. Now that we are using a concurrent web server, when fields change it was immediately kicking off a trigger to auto-refresh, and that transaction was completing before the field change transaction would be completed. Ideally, the field change wouldn't need a transaction and the state of the form would be handled in the javascript, but right now it's all handled server side so the order things were being done was causing problems.

This should solve these, at least:
@gmcculloug https://github.com/ManageIQ/manageiq/issues/7272 (http://talk.manageiq.org/t/reading-dialog-form-values-from-a-refresh-event/1322)
@bzwei http://talk.manageiq.org/t/azure-windows-service-provisioning-failure-basic-information-parameters-virtual-machine-size-is-required/1320