### PR TITLE
Only provision VMs to datastores which can be written to

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1100,7 +1100,7 @@ class MiqRequestWorkflow
     MiqPreloader.preload(hosts, :storages)
 
     storages = hosts.each_with_object({}) do |host, hash|
-      host.storages.each { |s| hash[s.id] = s }
+      host.writable_storages.each { |s| hash[s.id] = s }
     end.values
 
     allowed_storages_cache = process_filter(:ds_filter, Storage, storages).collect do |s|

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
@@ -19,7 +19,7 @@ prov.eligible_hosts.each do |h|
   nvms = h.vms.length
 
   if min_registered_vms.nil? || nvms < min_registered_vms
-    s = h.storages.max_by(&:free_space)
+    s = h.writable_storages.max_by(&:free_space)
     unless s.nil?
       host    = h
       storage = s

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_best_fit_least_utilized.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_best_fit_least_utilized.rb
@@ -19,7 +19,7 @@ prov.eligible_hosts.each do |h|
   next unless h.power_state == "on"
   nvms = h.vms.length
   if min_registered_vms.nil? || nvms < min_registered_vms
-    s = h.storages.sort { |a, b| a.free_space <=> b.free_space }.last
+    s = h.writable_storages.sort { |a, b| a.free_space <=> b.free_space }.last
     unless s.nil?
       host    = h
       storage = s

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -54,7 +54,7 @@ module MiqAeEngine
         next unless h.power_state == "on"
         nvms = h.vms.collect { |v| v if v.power_state == "on" }.compact.length
         if min_running_vms.nil? || nvms < min_running_vms
-          storages = h.storages.find_all { |s| s.free_space > vm.provisioned_storage } # Filter out storages that do not have enough free space for the Vm
+          storages = h.writable_storages.find_all { |s| s.free_space > vm.provisioned_storage } # Filter out storages that do not have enough free space for the Vm
           s = storages.sort { |a, b| a.free_space <=> b.free_space }.last
           unless s.nil?
             result["host"]    = h

--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -1,6 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceHost < MiqAeServiceModelBase
     expose :storages,              :association => true
+    expose :read_only_storages
+    expose :writable_storages
     expose :vms,                   :association => true
     expose :ext_management_system, :association => true
     expose :hardware,              :association => true

--- a/spec/automation/unit/method_validation/vmware_best_fit_least_utilized_spec.rb
+++ b/spec/automation/unit/method_validation/vmware_best_fit_least_utilized_spec.rb
@@ -23,12 +23,16 @@ describe "Vmware_best_fit_least_utilized" do
   context "Auto placement" do
     let(:storages) { 4.times.collect { |r| FactoryGirl.create(:storage, :free_space => 1000 * (r + 1)) } }
 
+    let(:ro_storage) { FactoryGirl.create(:storage, :free_space => 10000) }
+
     let(:vms) { 5.times.collect { FactoryGirl.create(:vm_vmware) } }
 
     # host1 has two small  storages and 2 vms
     # host2 has two larger storages and 3 vms
+    # host3 has one larger read-only datastore and one smaller writable datastore
     let(:host1) { FactoryGirl.create(:host_vmware, :storages => storages[0..1], :vms => vms[2..3], :ext_management_system => ems) }
     let(:host2) { FactoryGirl.create(:host_vmware, :storages => storages[0..1], :vms => vms[2..4], :ext_management_system => ems) }
+    let(:host3) { FactoryGirl.create(:host_vmware, :storages => [ro_storage, storages[2]], :vms => vms[2..4], :ext_management_system => ems) }
 
     let(:host_struct) do
       [MiqHashStruct.new(:id => host1.id, :evm_object_class => host1.class.base_class.name.to_sym),
@@ -40,6 +44,7 @@ describe "Vmware_best_fit_least_utilized" do
         host1.ems_cluster = ems_cluster
         host2.ems_cluster = ems_cluster
         datacenter.with_relationship_type("ems_metadata") { datacenter.add_child(ems_cluster) }
+        HostStorage.where(:host_id => host3.id, :storage_id => ro_storage.id).update(:read_only => true)
       end
 
       it "selects a host with fewer vms and a storage with more free space" do
@@ -50,6 +55,17 @@ describe "Vmware_best_fit_least_utilized" do
         miq_provision.reload
         expect(miq_provision.options[:placement_host_name]).to eq([host1.id, host1.name])
         expect(miq_provision.options[:placement_ds_name]).to   eq([host1.storages[1].id, host1.storages[1].name])
+      end
+
+      it "selects largest storage that is writable" do
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_hosts).and_return([host3])
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_storages).and_return(host3.storages)
+
+        ws.root
+        miq_provision.reload
+
+        # host3.storages[0] is larger but read-only, so it should select host3.storages[1]
+        expect(miq_provision.options[:placement_ds_name]).to eq([host3.storages[1].id, host3.storages[1].name])
       end
     end
 


### PR DESCRIPTION
Use the `:read_only` property of `HostStorage` to ensure that VMs will only be provisioned to a datastore that the host has write access to.

https://bugzilla.redhat.com/show_bug.cgi?id=1187819