### PR TITLE
Changes to entry point tree for ease of use.

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -365,7 +365,7 @@ class TreeBuilder
                         when IsoDatastore        then x_get_tree_iso_datastore_kids(parent, count_only)
                         when LdapRegion          then x_get_tree_lr_kids(parent, count_only)
                         when MiqAeClass          then x_get_tree_class_kids(parent, count_only, options[:type])
-                        when MiqAeNamespace      then x_get_tree_ns_kids(parent, count_only)
+                        when MiqAeNamespace      then x_get_tree_ns_kids(parent, count_only, options[:type])
                         when MiqGroup            then options[:tree] == :db_tree ?
                                                     x_get_tree_g_kids(parent, count_only) : nil
                         when MiqRegion           then x_get_tree_region_kids(parent, count_only)
@@ -412,6 +412,8 @@ class TreeBuilder
        options[:open_all] ||
        object[:load_children] ||
        node[:expand]
+      node[:expand] = true if options[:type] == :automate &&
+                              Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key])
       kids = x_get_tree_objects(object, options, false, parents).map do |o|
         x_build_node(o, node[:key], options)
       end

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -31,7 +31,18 @@ class TreeBuilderAeClass < TreeBuilder
     end
   end
 
-  def x_get_tree_ns_kids(object, count_only)
+  def x_get_tree_ns_kids(object, count_only, type)
+    if type == :automate
+      if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
+        open_node("aen-#{to_cid(object.id)}")
+        open_node("aen-#{to_cid(object.ae_namespaces.first.id)}")
+      end
+
+      if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
+        open_node("aen-#{to_cid(object.id)}")
+        open_node("aec-#{to_cid(object.ae_classes.first.id)}")
+      end
+    end
     objects = filter_ae_objects(object.ae_namespaces)
     unless MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       ns_classes = filter_ae_objects(object.ae_classes)


### PR DESCRIPTION
Changes to Automate Entrypoint tree to expand Namespace or Class folder nodes by default if they don't have any siblings to save user some extra clicks.

before:
![screenshot from 2016-04-01 13 02 54](https://cloud.githubusercontent.com/assets/3450808/14214253/11740806-f80a-11e5-90b5-dfac65c22c58.png)

after:
![screenshot from 2016-04-01 12 58 31](https://cloud.githubusercontent.com/assets/3450808/14214166/7a62fcce-f809-11e5-8930-5a883dfcf144.png)

@dclarizio please review, this was discussed in one of the SDUI meetings to have tree expand namespace/class nodes by default when user clicks on a domain node to save user from some extra clicks until we have a better control to represent the entrypoint selection process.