### PR TITLE
Expose 'ManageIQ' in the User-Agent for GCE

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -79,6 +79,8 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
       :provider               => "Google",
       :google_project         => google_project,
       :google_json_key_string => google_json_key,
+      :app_name               => I18n.t("product.name"),
+      :app_version            => Vmdb::Appliance.VERSION,
     )
   end
 


### PR DESCRIPTION
This results in a User-Agent similar to: "ManageIQ/0.0.0 fog".

Note that I'd like to add version in as well, but I couldn't find a constant containing this - possible improvement?

cc @blomquisg @agrare 