### PR TITLE
Correct the format of options passed to job template

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job < ::Orchestra
   end
 
   def self.raw_create_stack(template, options = {})
-    template.run(options[:extra_vars] || {})
+    template.run(options)
   rescue => err
     _log.error "Failed to create job from template(#{name}), error: #{err}"
     raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace


### PR DESCRIPTION
AnsibleTower job launching:

`:extra_vars` is used to be extracted from options and passed to job template at job launching. Now the `run` method accepts a full Hash with key `:extra_vars`. Therefore the whole options need to be passed on. 