### PR TITLE
Fix Settings issue where Arrays would merge instead of overwrite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem "rails-controller-testing",        :require => false
 gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",      "~>0.1.2", :require => false
 
-gem "config",                          "~>1.0.0"
+gem "config",                          "~>1.1.0", :git => "git://github.com/Fryguy/config.git", :branch => "overwrite_arrays"
+gem "deep_merge",                      "~>1.0.1", :git => "git://github.com/Fryguy/deep_merge.git", :branch => "overwrite_arrays"
 
 # Local gems
 path "gems/" do

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -8,6 +8,7 @@ module Vmdb
     PASSWORD_FIELDS = %i(bind_pwd password amazon_secret).to_set.freeze
 
     def self.init
+      ::Config.overwrite_arrays = true
       reset_settings_constant(for_resource(my_server))
     end
 


### PR DESCRIPTION
The ability to override Arrays has been made into a PR upstream at
https://github.com/railsconfig/config/pull/137 and
https://github.com/danielsdeleo/deep_merge/pull/21 . However, they
are not yet merged.  When they are merged and released, we can
switch back to a released version.

Supercedes #7656
Paired on this with @carbonin 

@jrafanie Please review.