### PR TITLE
[api] Service Dialog content query update

### DIFF
--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -168,6 +168,14 @@ class ApiController
       raise UnsupportedMediaTypeError, "Invalid Response Format #{accept} requested"
     end
 
+    #
+    # Method name for optional accessor of virtual attributes
+    #
+    def virtual_attribute_accessor(type, attr)
+      method = "fetch_#{type}_#{attr}"
+      respond_to?(method) ? method : nil
+    end
+
     private
 
     def resource_search(id, type, klass)
@@ -240,9 +248,10 @@ class ApiController
       add_hash json, result
     end
 
-    def fetch_direct_virtual_attribute(_type, resource, attr)
+    def fetch_direct_virtual_attribute(type, resource, attr)
       return unless attr_accessible?(resource, attr)
-      value = resource.public_send(attr)
+      virtattr_accessor = virtual_attribute_accessor(type, attr)
+      value = virtattr_accessor.nil? ? resource.public_send(attr) : send(virtattr_accessor, resource)
       result = {attr => normalize_virtual(nil, attr, value, :ignore_nil => true)}
       # set nil vtype above to "#{type}/#{resource.id}/#{attr}" to support id normalization
       [value, result]

--- a/app/controllers/api_controller/service_dialogs.rb
+++ b/app/controllers/api_controller/service_dialogs.rb
@@ -24,6 +24,25 @@ class ApiController
       end
     end
 
+    #
+    # Virtual attribute accessors
+    #
+    def fetch_service_dialogs_content(resource)
+      case @req[:collection]
+      when "service_templates"
+        service_template = parent_resource_obj
+      when "services"
+        service_template = parent_resource_obj.service_template
+      end
+      return resource.content if service_template.nil?
+      resource_action = service_template.resource_actions.where(:dialog_id => resource.id).first
+      if resource_action.nil?
+        raise BadRequestError,
+              "#{service_dialog_ident(resource)} is not referenced by #{service_template_ident(service_template)}"
+      end
+      resource.content(service_template, resource_action)
+    end
+
     private
 
     def service_dialog_ident(service_dialog)

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -89,8 +89,16 @@ class Dialog < ApplicationRecord
     dialog_field_hash[name.to_s]
   end
 
-  def content
-    DialogSerializer.new.serialize(Array[self])
+  def content(target = nil, resource_action = nil)
+    return DialogSerializer.new.serialize(Array[self]) if target.nil? && resource_action.nil?
+
+    workflow = ResourceActionWorkflow.new({}, @auth_user_obj, resource_action, :target => target)
+
+    workflow.dialog.dialog_fields.each do |dialog_field|
+      # Accessing dialog_field.values forces an update for any values coming from automate
+      dialog_field.values = dialog_field.values
+    end
+    DialogSerializer.new.serialize(Array[workflow.dialog])
   end
 
   private


### PR DESCRIPTION
Update to make sure service dialogs "content" queries are refreshed
by automate via a workflow when queried for a specific service_template
or indirectly for a service.

```
i.e. GET /api/service_templates/:id/service_dialogs/:dialog_id?attributes=content
     GET /api/service_templates/:id/service_dialogs
         ?expand=resources
         &attributes=content
     GET /api/services/:id/service_dialogs/:dialog_id?attributes=content
     GET /api/services/:id/service_dialogs
         ?expand=resources
         &attributes=content
```

https://bugzilla.redhat.com/show_bug.cgi?id=1321352