### PR TITLE
Google: Fix bug when firewall rules do not have a `source_range`

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
@@ -192,7 +192,7 @@ module ManageIQ::Providers
         ret = []
 
         name            = fw.name
-        source_ip_range = fw.source_ranges.first
+        source_ip_range = fw.source_ranges.nil? ? "0.0.0.0/0" : fw.source_ranges.first
 
         fw.allowed.each do |fw_allowed|
           protocol      = fw_allowed["IPProtocol"].upcase


### PR DESCRIPTION
Per docs[1], set default to "0.0.0.0/0" unless otherwise specified.

[1] https://cloud.google.com/compute/docs/networking#firewalls

Closes #7672 
