### PR TITLE
Rbac simplify scope 1

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -506,9 +506,7 @@ module Rbac
   end
 
   def self.method_with_scope(ar_scope, options)
-    if ar_scope == VmdbDatabaseConnection
-      ar_scope.all
-    elsif ar_scope < ActsAsArModel || (ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?)
+    if ar_scope < ActsAsArModel || (ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?)
       ar_scope.all(options)
     else
       ar_scope.apply_legacy_finder_options(options)

--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -1,6 +1,7 @@
 class VmdbDatabaseConnection < ApplicationRecord
   self.table_name = 'pg_stat_activity'
-  self.primary_key = nil
+  # a little wierd since the self.pid != self["pid"] ( self.spid == self["pid"])
+  self.primary_key = 'pid'
 
   has_many :vmdb_database_locks, :primary_key => 'pid', :foreign_key => 'pid'
 
@@ -25,8 +26,6 @@ class VmdbDatabaseConnection < ApplicationRecord
 
   virtual_column :pid, :type => :integer
   virtual_column :blocked_by, :type => :integer
-
-  attr_reader :vmdb_database_id
 
   def self.sortable?
     false


### PR DESCRIPTION
`Rbac.method_with_scope` has specialized code for `ActAsActiveRecord` (another pr) and classes like `VmdbDatabaseSettings`. If we can remove this code, it will simplify the flow through rbac. It will also remove `klass` from most method signatures.

Classes like `VmdbDatabaseSettings` are not very rails friendly, and require us to jump through a few hoops to use them. But it does seem like most of these classes do have a primary id. I'm not sure why we have `pid` which maps to a different field to link to `VmdbDatabase`, but for the most part, much of the code that manipulates columns seems no longer necessary.

What do you think about removing some of this custom logic?

**UPDATE:** I scaled this back to just change the necessary Rbac code. I've put in other PRs that can be discussed separately for these 2 models.

Thanks

/cc @tenderlove  @GregP you two had added this rbac code. Not sure if you can provide any information in reproducing the base cases for them
/cc @Fryguy you seem to have fingerprints over here. Not sure if you have anything special to say.
/cc @gtanzillo FYI, this will fall under your umbrella