### PR TITLE
Put the initializers sequentially so they're run in the right order.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -92,10 +92,6 @@ module Vmdb
     config.logger = Vmdb.rails_logger
     config.colorize_logging = false
 
-    initializer :prepare_productization, :after => :append_asset_paths do
-      Vmdb::Productization.new.prepare
-    end
-
     config.before_initialize do
       require_relative 'environments/patches/database_configuration'
 
@@ -106,9 +102,16 @@ module Vmdb
       require 'vmdb_helper'
     end
 
+    # Note: If an initializer doesn't have an after, Rails will add one based
+    # on the top to bottom order of initializer calls in the file.
+    # Because this is easy to mess up, keep your initializers in order.
     initializer :load_vmdb_settings, :before => :load_config_initializers do
       Vmdb::Settings.init
       Vmdb::Loggers.apply_config(::Settings.log)
+    end
+
+    initializer :prepare_productization, :after => :append_asset_paths do
+      Vmdb::Productization.new.prepare
     end
 
     config.after_initialize do


### PR DESCRIPTION
This was introduced in #7432.

Rails goes through the initializers top to bottom and adds
an "after" if it doesn't exist. See [here](https://github.com/rails/rails/blob/863d385012824ac9a792b0c337f06c562914149f/railties/lib/rails/initializable.rb#L84).

When the initializers are in this order top to bottom:
* prepare_productization (after append_asset_paths)
* load_vmdb_settings     (before load_config_initializers)

Rails ends up altering load_vmdb_settings (adding an after):
* prepare_productization (after append_asset_paths)
* load_vmdb_settings     (before load_config_initializers, after prepare_productization)

When evaluating the initializers in this way, load_vmdb_settings needs to run
before load_config_initializers and after prepare_productization.

Therefore prepare_productization is forced to run early, BEFORE append_asset_paths,
thereby ignoring our after => append_asset_paths.

This causes productization to break because assets paths prepended by prepare_productization
end up coming after the normal asset paths.

Making prepare_productization follow append_asset_paths fixes this.

On Master, public/assets contains copies from app/assets instead of productization:

```
RAILS_ENV=production be rake assets:clobber assets:precompile
...

$ ls -l public/assets/bg-login*.png app/assets/images/bg-login.png productization/assets/images/bg-login.png
39807 Mar 18 13:54 app/assets/images/bg-login.png
 5040 Sep  8  2015 productization/assets/images/bg-login.png
39807 Mar 18 13:54 public/assets/bg-login-034ab86f5006293d2c1f776dbb532e16fe16dcc446256b387750348b7dbd0b20.png
34693 Mar 18 13:54 public/assets/bg-login-2-2cfdb45832ff4770b7aa71a49fe8e488bf5acee84b334683d19b15008c805cae.png
```

After this patch, public/assets contains copies from productization/assets:

```
RAILS_ENV=production be rake assets:clobber assets:precompile
...

ls -l public/assets/bg-login*.png app/assets/images/bg-login.png productization/assets/images/bg-login.png
39807 Mar 18 13:54 app/assets/images/bg-login.png
 5040 Sep  8  2015 productization/assets/images/bg-login.png
 3428 Sep  8  2015 public/assets/bg-login-2-1991f4c5dfc4e55b0e293a7e29860caea53e2dcbed53d999fe5a1a9f605b29db.png
 5040 Sep  8  2015 public/assets/bg-login-6d6e23c3b3abe1321ed612a89b6b737e4d34cf239358f845d2cbb4e59fc7f06b.png
```