### PR TITLE
Improve UI in assignment rate to tenant

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -741,8 +741,13 @@ class ChargebackController < ApplicationController
       else
         klass.classify.constantize
       end
+    @edit[:cb_assign][:hierarchy] ||= {}
     classtype.all.each do |instance|
       @edit[:cb_assign][:cis][instance.id] = instance.name
+      next unless klass == "tenant" && instance.root?
+      @edit[:cb_assign][:hierarchy][instance.id] = {}
+      @edit[:cb_assign][:hierarchy][instance.id][:name] = instance.name
+      @edit[:cb_assign][:hierarchy][instance.id][:subtenant] = instance.build_tenant_tree
     end
   end
 
@@ -754,6 +759,7 @@ class ChargebackController < ApplicationController
       @edit[:new][key] = params[key].to_s if params[key]
     end
   end
+
 
   # Get variables from edit form
   def cb_assign_get_form_vars

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -465,7 +465,7 @@ module UiConstants
     "enterprise"   => _("The Enterprise"),
     "storage"      => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "storage")},
     "storage-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "storage")},
-    "tenant"       => _("Tenant")
+    "tenant"       => _("Tenants")
   }
   ASSIGN_TOS["MiqServer"] = {
     "miq_server" => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "miq_server")},
@@ -478,7 +478,7 @@ module UiConstants
     "ext_management_system" => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ext_management_systems")},
     "ems_cluster"           => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ems_cluster")},
     "vm-tags"               => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "vm")},
-    "tenant"		            => _("Tenant")
+    "tenant"                => _("Tenants")
   }
 
   EXP_COUNT_TYPE = [_("Count of"), "count"].freeze  # Selection for count based filters

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -287,6 +287,28 @@ class Tenant < ApplicationRecord
     end
   end
 
+  #   Tenant
+  #      Tenant A
+  #      Tenant B
+  #
+  # @return [Array(JSON({name => String, id => Numeric, parent => Numeric}))] all subtenants of a tenant
+  # e.g.:
+  #   [
+  #     {name=>"Tenant A",id=>2,parent=>1},
+  #     {name=>"Tenant B",id=>3,parent=>1}
+  #   ]
+  def build_tenant_tree
+    data_tenant = []
+    all_subtenants.each do |subtenant|
+      next unless subtenant.parent_name == name
+      data_tenant.push(:name => subtenant.name, :id => subtenant.id, :parent => id)
+      if subtenant.all_subtenants.count > 0
+        data_tenant.concat(subtenant.build_tenant_tree)
+      end
+    end
+    data_tenant
+  end
+
   private
 
   # when a root tenant has an attribute with a nil value,

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -15,7 +15,6 @@
       :javascript
         miqInitSelectPicker();
         miqSelectPickerEvent("cbshow_typ", "#{url}")
-
     - if !@edit[:new][:cbshow_typ].blank? && @edit[:new][:cbshow_typ].ends_with?("-tags")
       .form-group
         %label.col-md-2.control-label
@@ -27,19 +26,51 @@
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("cbtag_cat", "#{url}")
-
   - unless @edit[:new][:cbshow_typ].nil? || @edit[:new][:cbshow_typ] == "nil"
     - if !@edit[:new][:cbshow_typ].ends_with?("-tags") || @edit[:new][:cbtag_cat].present?
       %hr
       %h3
         = _('Selections')
-      %table.table.table-bordered.table-striped
-        %thead
-          %tr
-            %th= _('Name')
-            %th= _('Rate')
-        %tbody
-          - if @edit[:new][:cbshow_typ].ends_with?("-tags")
+      - if @edit[:new][:cbshow_typ] == "tenant"
+        %table.table.table-bordered.table-hover.table-treegrid
+          %thead
+            %tr
+              %th= _('Name')
+              %th= _('Rate')
+          %tbody
+            - @edit[:cb_assign][:hierarchy].sort_by(&:first).each do |id, data|
+              %tr.collapsed{:id => "tenant_#{id}"}
+                %td.treegrid-node
+                  = h(data[:name])
+                %td
+                  - options = @edit[:cb_rates].invert.sort
+                  = select_tag("#{@edit[:new][:cbshow_typ]}__#{id}",
+                              options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{id}".to_sym].to_s),
+                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class => "selectpicker")
+                :javascript
+                  miqInitSelectPicker();
+                  miqSelectPickerEvent("#{@edit[:new][:cbshow_typ]}__#{id}", "#{url}")
+              - data[:subtenant].each do |tenant|
+                %tr{:id => "tenant_#{tenant[:id]}", :'data-parent' => "#tenant_#{tenant[:parent]}"}
+                  %td.treegrid-node
+                    = h(tenant[:name])
+                  %td
+                    - options = @edit[:cb_rates].invert.sort
+                    = select_tag("#{@edit[:new][:cbshow_typ]}__#{tenant[:id]}",
+                                options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{tenant[:id]}".to_sym].to_s),
+                                "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class => "selectpicker")
+                  :javascript
+                    miqInitSelectPicker();
+                    miqSelectPickerEvent("#{@edit[:new][:cbshow_typ]}__#{tenant[:id]}", "#{url}")
+        :javascript
+           $('.table-treegrid').treegrid({})
+      - elsif @edit[:new][:cbshow_typ].ends_with?("-tags")
+        %table.table.table-bordered.table-striped
+          %thead
+            %tr
+              %th= _('Name')
+              %th= _('Rate')
+          %tbody
             - @edit[:cb_assign][:tags].invert.sort_by { |a| a.first.downcase }.each do |tag, id|
               %tr
                 %td
@@ -48,11 +79,17 @@
                   - options = @edit[:cb_rates].invert.sort
                   = select_tag("#{@edit[:new][:cbshow_typ]}__#{id}",
                               options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{id}".to_sym].to_s),
-                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
+                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class => "selectpicker")
                 :javascript
                   miqInitSelectPicker();
                   miqSelectPickerEvent("#{@edit[:new][:cbshow_typ]}__#{id}", "#{url}")
-          - else
+      - else
+        %table.table.table-bordered.table-striped
+          %thead
+            %tr
+              %th= _('Name')
+              %th= _('Rate')
+          %tbody
             - @edit[:cb_assign][:cis].invert.sort_by { |a| a.first.downcase }.each do |ci, id|
               %tr#new_tr
                 %td
@@ -61,7 +98,7 @@
                   - options = @edit[:cb_rates].invert.sort
                   = select_tag("#{@edit[:new][:cbshow_typ]}__#{id}",
                               options_for_select([[nothing, "nil"]] + options, @edit[:new]["#{@edit[:new][:cbshow_typ]}__#{id}".to_sym].to_s),
-                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
+                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class => "selectpicker")
                 :javascript
                   miqInitSelectPicker();
                   miqSelectPickerEvent("#{@edit[:new][:cbshow_typ]}__#{id}", "#{url}")

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -856,4 +856,20 @@ describe Tenant do
       expect(projects.map(&:first)).to eq(%w(root.proj3 root.ten1.proj1 root.ten2.proj2))
     end
   end
+
+  describe ".build_tenant_tree" do
+    let!(:tenant)   { FactoryGirl.create(:tenant) }
+    let!(:tenantA)  { FactoryGirl.create(:tenant, :parent => tenant) }
+    let!(:tenantA1) { FactoryGirl.create(:tenant, :parent => tenantA) }
+
+    it "returns subtenants of a tenant" do
+      expected_array = [{:name => tenantA.name, :id => tenantA.id, :parent => tenant.id},
+                        {:name => tenantA1.name, :id => tenantA1.id, :parent => tenantA.id}]
+      expect(tenant.build_tenant_tree).to match_array(expected_array)
+    end
+
+    it "returns [] of a tenant without subtenants" do
+      expect(tenantA1.build_tenant_tree).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
**Improve the UI assignment rate to tenant**, now that show which tenant is a subtenant of other.

That uses [Patterfly treegrid-table](https://www.patternfly.org/widgets/#treegrid-table) and we can expand tenants.

## In action
![](https://media.taiga.io/attachments/0/c/c/9/50d738e5164d3d833fc67955236b89fe4b03181739ca095b281e84892ff8/assign.gif)

## Before
![GitHub Logo](https://media.taiga.io/attachments/c/5/4/9/4798f9ea65a7f1f6e9e819e7f3c55d0b8284b0c9516b8391d9613f058c3f/captura-de-pantalla-2016-04-02-a-las-214018.png)

## Now
![GitHub Logo](https://media.taiga.io/attachments/c/e/c/2/6d4167a35f15b9b5196f2905ba97c9e20764cb401fadb555a4513270ff63/captura-de-pantalla-2016-04-01-a-las-142935.png)

TAIGA LINK : [Task 64] (https://tree.taiga.io/project/sergioocon-charging-in-manageiq/task/64)

Thanks to @lpichler forsupport and @skateman for support wit treegrid-table