### PR TITLE
[WIP] spec supports timeout pid file

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -99,8 +99,10 @@ describe "MiqAeMethodDispatch" do
     send_ae_request_via_queue(@automate_args, 2)
     status, _msg, _ws = deliver_ae_request_from_queue
     expect(status).to eql 'timeout'
-    pid = File.read(@pidfile).to_i
-    expect { Process.getpgid(pid) }.to raise_error(Errno::ESRCH)
+    if File.exist?(@pidfile)
+      pid = File.read(@pidfile).to_i
+      expect { Process.getpgid(pid) }.to raise_error(Errno::ESRCH)
+    end
   end
 
   it "run method that writes to stderr and stdout" do


### PR DESCRIPTION
If a process is terminated, let the pid file be cleaned up

```
  1) MiqAeMethodDispatch long running method
     Failure/Error: pid = File.read(@pidfile).to_i
     
     Errno::ENOENT:
       No such file or directory @ rb_sysopen - /tmp/d20160402-6207-1x9l659/rip_van_winkle.pid
     # ./spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb:102:in `read'
     # ./spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb:102:in `block (2 levels) in <top (required)>'
```

I've gotten this blowing up my build quite a few times.  [ref](https://travis-ci.org/ManageIQ/manageiq/jobs/120224876#L634)
/cc @gmcculloug I think this is the solution here - not sure. Maybe it is glazing over the real solution