### PR TITLE
Disable Download button for reports when no records are found

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -11,7 +11,7 @@ class ApplicationHelper::Button::Basic < Hash
   end
 
   def calculate_properties
-    self[:enabled] = !disabled?
+    self[:enabled] = !disabled? if self[:enabled].nil?
   end
 
   def skip?

--- a/app/helpers/application_helper/button/report_download_choice.rb
+++ b/app/helpers/application_helper/button/report_download_choice.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::ReportDownloadChoice < ApplicationHelper::Button::Basic
+  def disabled?
+    MiqReportResult.find(@report_result_id).try(:miq_report_result_details).try(:length).to_i == 0
+  end
+end

--- a/app/helpers/application_helper/toolbar/report_view.rb
+++ b/app/helpers/application_helper/toolbar/report_view.rb
@@ -28,6 +28,7 @@ class ApplicationHelper::Toolbar::ReportView < ApplicationHelper::Toolbar::Basic
       'fa fa-download fa-lg',
       N_('Download'),
       nil,
+      :klass => ApplicationHelper::Button::ReportDownloadChoice,
       :items => [
         button(
           :render_report_txt,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1205023

Download button should be disabled for reports when no records are found.