### PR TITLE
form_div should only be replaced for certain type of catalog items.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -171,7 +171,8 @@ class CatalogController < ApplicationController
     render :update do |page|                    # Use JS to update the display
       # for generic/orchestration type tabs do not show up on screen as there is only a single tab when form is initialized
       # when display in catalog is checked, replace div so tabs can be redrawn
-      page.replace("form_div", :partial => "st_form") if params[:st_prov_type] || params[:display]
+      page.replace("form_div", :partial => "st_form") if params[:st_prov_type] ||
+        (params[:display] && @edit[:new][:st_prov_type].starts_with?("generic"))
       page.replace_html("basic_info_div", :partial => "form_basic_info") if params[:display] || params[:template_id] || params[:manager_id]
       if params[:display]
         page << "miq_tabs_show_hide('#details_tab', '#{(params[:display] == "1")}')"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -32,6 +32,35 @@ describe CatalogController do
     end
   end
 
+  context "#atomic_form_field_changed" do
+    before :each do
+      controller.instance_variable_set(:@sb, {})
+      edit = {
+        :key          => "prov_edit__new",
+        :rec_id       => 1,
+        :st_prov_type => "generic",
+        :new          => {
+          :name         => "New Name",
+          :description  => "New Description",
+          :st_prov_type => "generic"
+        }
+      }
+      session[:edit] = edit
+    end
+    # these types do not have tabs on the screen, because we don't show tabs if there is only single tab on screen.
+    it "replaces form_div when generic type catalog item type is being added" do
+      post :atomic_form_field_changed, :params => {:display => "1", :id => "new"}
+      expect(response.body).to include("form_div")
+    end
+
+    # these types already have tabs on the screen so it's only matter of show/hide Details tab for those.
+    it "does not replace form_div when non-generic type catalog item type is being added" do
+      session[:edit][:new][:st_prov_type] = "vmware"
+      post :atomic_form_field_changed, :params => {:display => "1", :id => "new"}
+      expect(response.body).not_to include("form_div")
+    end
+  end
+
   context "#atomic_st_edit" do
     it "Atomic Service Template and it's valid Resource Actions are saved" do
       controller.instance_variable_set(:@sb, {})


### PR DESCRIPTION
Only replace form_div for generic type catalog items because there are no tabs on the screen, if display in catalog is set need to redraw the screen to draw the tabs and show/hide them. Replacing form_div for the types that already have tabs on screen was causing instance variables to be reset in provisioning dialogs.

https://bugzilla.redhat.com/show_bug.cgi?id=1321631
https://bugzilla.redhat.com/show_bug.cgi?id=1322834

@dclarizio please review.