### PR TITLE
Fix for triggering automate value updates on dialog field sorted items.

### DIFF
--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -54,6 +54,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def trigger_automate_value_updates
+    @raw_values = @default_value = nil
     raw_values
   end
 

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -187,4 +187,59 @@ describe DialogFieldDropDownList do
       end
     end
   end
+
+  describe "#trigger_automate_value_updates" do
+    let(:dialog_field) { described_class.new(:dynamic => dynamic) }
+
+    context "when the dialog_field is dynamic" do
+      let(:dynamic) { true }
+
+      before do
+        allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(
+          %w(automate values)
+        )
+      end
+
+      context "when the raw values are already set" do
+        before do
+          dialog_field.instance_variable_set(:@raw_values, %w(potato potato))
+        end
+
+        it "updates with the values from automate" do
+          expect(dialog_field.trigger_automate_value_updates).to eq(%w(automate values))
+        end
+      end
+
+      context "when the raw values are not already set" do
+        it "returns the values from automate" do
+          expect(dialog_field.trigger_automate_value_updates).to eq(%w(automate values))
+        end
+      end
+    end
+
+    context "when the dialog_field is not dynamic" do
+      let(:dynamic) { false }
+
+      context "when the raw values are already set" do
+        before do
+          dialog_field.instance_variable_set(:@raw_values, %w(potato potato))
+          dialog_field.values = %w(original values)
+        end
+
+        it "returns the raw values" do
+          expect(dialog_field.trigger_automate_value_updates).to eq(%w(original values))
+        end
+      end
+
+      context "when the raw values are not already set" do
+        before do
+          dialog_field.values = %w(original values)
+        end
+
+        it "returns the values" do
+          expect(dialog_field.trigger_automate_value_updates).to eq(%w(original values))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This will ensure that raw values and default values get reset on a refresh for sorted items, similar to how the other dialog fields behave.

