### PR TITLE
Add psych dependency to resolve test issues on RHSCL ruby

### DIFF
--- a/gems/manageiq_foreman/manageiq_foreman.gemspec
+++ b/gems/manageiq_foreman/manageiq_foreman.gemspec
@@ -19,13 +19,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "apipie-bindings", "= 0.0.15"
+  spec.add_runtime_dependency "psych"
   spec.add_runtime_dependency "rest-client",     "~> 2.0.0.rc1"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "vcr", "~> 2.6"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "rspec"
 
   spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
/opt/rh/rh-ruby22/root/usr/share/ruby/yaml.rb:4:in `<top (required)>':
It seems your ruby installation is missing psych (for YAML output).
To eliminate this warning, please install libyaml and reinstall your ruby.
/opt/rh/rh-ruby22/root/usr/share/ruby/yaml.rb:5:in `require': cannot load such file -- psych (LoadError)
	from /opt/rh/rh-ruby22/root/usr/share/ruby/yaml.rb:5:in `<top (required)>'