### PR TITLE
[api] Adding support for /api/settings

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -76,6 +76,7 @@ class ApiController < ApplicationController
   include_concern 'ServiceDialogs'
   include_concern 'ServiceRequests'
   include_concern 'ServiceTemplates'
+  include_concern 'Settings'
   include_concern 'Software'
   include_concern 'Tags'
   include_concern 'Tenants'

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,6 +5,7 @@ class ApiController < ApplicationController
   class AuthenticationError < StandardError; end
   class Forbidden < StandardError; end
   class BadRequestError < StandardError; end
+  class NotFound < StandardError; end
   class UnsupportedMediaTypeError < StandardError; end
 
   def handle_options_request
@@ -30,6 +31,7 @@ class ApiController < ApplicationController
     ApiController::AuthenticationError       => :unauthorized,
     ApiController::Forbidden                 => :forbidden,
     ApiController::BadRequestError           => :bad_request,
+    ApiController::NotFound                  => :not_found,
     ApiController::UnsupportedMediaTypeError => :unsupported_media_type
   }
 

--- a/app/controllers/api_controller/settings.rb
+++ b/app/controllers/api_controller/settings.rb
@@ -1,0 +1,23 @@
+class ApiController
+  module Settings
+    def show_settings
+      validate_api_action
+      selected_sections = if @req[:c_id]
+                            exposed_settings.include?(@req[:c_id]) ? @req[:c_id] : nil
+                          else
+                            exposed_settings
+                          end
+
+      result = Array(selected_sections).each_with_object({}) do |section, hash|
+        hash[section] = ::Settings[section].to_hash
+      end
+      render_resource :settings, result
+    end
+
+    private
+
+    def exposed_settings
+      @exposed_settings ||= YAML.load_file(Rails.root.join("config/api_settings.yml"))[:settings]
+    end
+  end
+end

--- a/app/controllers/api_controller/settings.rb
+++ b/app/controllers/api_controller/settings.rb
@@ -2,16 +2,16 @@ class ApiController
   module Settings
     def show_settings
       validate_api_action
-      selected_sections = if @req[:c_id]
-                            exposed_settings.include?(@req[:c_id]) ? @req[:c_id] : nil
-                          else
-                            exposed_settings
-                          end
+      category = @req[:c_id]
+      selected_sections =
+        if category
+          raise NotFound, "Settings category #{category} not found" unless exposed_settings.include?(category)
+          category
+        else
+          exposed_settings
+        end
 
-      result = Array(selected_sections).each_with_object({}) do |section, hash|
-        hash[section] = ::Settings[section].to_hash
-      end
-      render_resource :settings, result
+      render_resource :settings, ::Settings.to_hash.slice(*Array(selected_sections).collect(&:to_sym))
     end
 
     private

--- a/config/api.yml
+++ b/config/api.yml
@@ -877,6 +877,20 @@
         :identifier: service_tag
       - :name: unassign
         :identifier: service_tag
+  :settings:
+    :description: Settings
+    :identifier: ops_settings
+    :options:
+    - :collection
+    :methods: *70174834086080
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: ops_settings
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: ops_settings
   :software:
     :description: Software
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -883,14 +883,6 @@
     :options:
     - :collection
     :methods: *70174834086080
-    :collection_actions:
-      :get:
-      - :name: read
-        :identifier: ops_settings
-    :resource_actions:
-      :get:
-      - :name: read
-        :identifier: ops_settings
   :software:
     :description: Software
     :options:

--- a/config/api_settings.yml
+++ b/config/api_settings.yml
@@ -1,0 +1,3 @@
+---
+:settings:
+  - product

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -1,0 +1,43 @@
+#
+# REST API Request Tests - /api/settings
+#
+describe ApiController do
+  let(:api_settings_config_file) { Rails.root.join("config/api_settings.yml") }
+  let(:api_settings)             { YAML.load_file(api_settings_config_file)[:settings] }
+
+  context "Settings Queries" do
+    it "tests queries of all exposed settings" do
+      api_basic_authorize
+
+      run_get settings_url
+
+      expect_result_to_have_only_keys(api_settings)
+    end
+
+    it "tests query for a specific setting category" do
+      api_basic_authorize
+
+      category = api_settings.first
+      run_get settings_url(category)
+
+      expect_result_to_have_only_keys(category)
+    end
+
+    it "tests that query for a specific setting category matches the Settings hash" do
+      api_basic_authorize
+
+      category = api_settings.first
+      run_get settings_url(category)
+
+      expect(response_hash[category]).to eq(Settings[category].to_hash.stringify_keys)
+    end
+
+    it "rejects query for an invalid setting category " do
+      api_basic_authorize
+
+      run_get settings_url("invalid_setting")
+
+      expect_resource_not_found
+    end
+  end
+end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -93,7 +93,7 @@ module ApiSpecHelper
                      policy_profiles providers provision_dialogs provision_requests rates
                      reports request_tasks requests resource_pools results roles security_groups
                      servers service_dialogs service_catalogs service_orders service_requests
-                     service_templates services tags tasks templates tenants users vms zones)
+                     service_templates services settings tags tasks templates tenants users vms zones)
 
     define_entrypoint_url_methods
     define_url_methods(collections)


### PR DESCRIPTION
- /api/settings collection
- Expose only desired setting as driven from config/api_settings.yml
- Support GET /api/settings/:section
- Return 404 on un-exposed setting section
- Added rspecs