### PR TITLE
Vim performance scope 7

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -108,7 +108,7 @@ class Chargeback < ActsAsArModel
       if options[:tag] && (report_user.nil? || !report_user.self_service?)
         recs = recs.where(:resource_type => "VmOrTemplate")
                    .where.not(:resource_id => nil)
-                   .where("tag_names like ? ", "%" + options[:tag].split("/")[2..-1].join("/") + "%")
+                   .for_tag_names(options[:tag].split("/")[2..-1])
       else
         recs = recs.where(:resource_type => "VmOrTemplate", :resource_id => vm_owners.keys)
       end

--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -167,6 +167,10 @@ module Metric::Common
   end
 
   class_methods do
+    def for_tag_names(*args)
+      where("tag_names like ?", "%" + args.join("/") + "%")
+    end
+
     def for_time_range(start_time, end_time)
       if start_time.nil?
         none

--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -1,4 +1,8 @@
 module Metric::Helper
+  def self.class_for_interval_name(interval_name, rollup_class = nil)
+    interval_name == "realtime" ? Metric : (rollup_class || MetricRollup)
+  end
+
   def self.class_and_association_for_interval_name(interval_name)
     interval_name == "realtime" ? [Metric, :metrics] : [MetricRollup, :metric_rollups]
   end

--- a/app/models/vim_performance_trend.rb
+++ b/app/models/vim_performance_trend.rb
@@ -23,15 +23,11 @@ class VimPerformanceTrend < ActsAsArModel
 
   def self.vms_by_category(options)
     model, interval = options[:interval_name] == "hourly" ? [MetricRollup, 1.hour] : [VimPerformanceDaily, 1.day]
-    cond = [
-      "timestamp = ? and capture_interval_name = ? and resource_type = ? and tag_names like ?",
-      options[:timestamp],
-      options[:interval_name],
-      "VmOrTemplate",
-      "%" + [options[:group_by_category], options[:group_by_tag]].join("/") + "%"
-    ]
-    rows = model.where(cond).to_a
-    return build(rows, options[:interval_name]), interval
+    rows = model.where(:timestamp             => options[:timestamp],
+                       :capture_interval_name => options[:interval_name],
+                       :resource_type         => "VmOrTemplate")
+                .for_tag_names(options[:group_by_category], options[:group_by_tag])
+    [build(rows.to_a, options), interval]
   end
 
   def self.build(perfs, options)


### PR DESCRIPTION
for VimPerformanceDaily and Rollups, use active record.

Larger goal is to not call VimPerformanceDaily at all and instead call directly into the appropriate metric rollup class.

snuck callbacks in here too.

I was conservative with my tag_names` definition - it doesn't fully qualify the table name (like the original query). if you prefer arel, let me know.