### PR TITLE
change containergroup to container group

### DIFF
--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -1,6 +1,6 @@
 module Metric::Rollup
   ROLLUP_COLS  = Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float || c[0, 7] == "derived" }.compact +
-                 [:stat_containergroup_create_rate, :stat_containergroup_delete_rate]
+                 [:stat_container_group_create_rate, :stat_container_group_delete_rate]
   STORAGE_COLS = Metric.columns_hash.collect { |c, _h| c.to_sym if c.starts_with?("derived_storage_") }.compact
 
   NON_STORAGE_ROLLUP_COLS = (ROLLUP_COLS - STORAGE_COLS)

--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -6,8 +6,8 @@ module Metric::Statistic
     container_groups = ContainerGroup.where(:ems_id => obj.id).or(ContainerGroup.where(:old_ems_id => obj.id))
 
     {
-      :stat_containergroup_create_rate => container_groups.where(:created_on => capture_interval).count,
-      :stat_containergroup_delete_rate => container_groups.where(:deleted_on => capture_interval).count
+      :stat_container_group_create_rate => container_groups.where(:created_on => capture_interval).count,
+      :stat_container_group_delete_rate => container_groups.where(:deleted_on => capture_interval).count
     }
   end
 end

--- a/db/migrate/20160405074214_change_container_group_metric_field_name.rb
+++ b/db/migrate/20160405074214_change_container_group_metric_field_name.rb
@@ -1,0 +1,6 @@
+class ChangeContainerGroupMetricFieldName < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :metric_rollups, :stat_containergroup_create_rate, :stat_container_group_create_rate
+    rename_column :metric_rollups, :stat_containergroup_delete_rate, :stat_container_group_delete_rate
+  end
+end

--- a/spec/models/metric/statistic_spec.rb
+++ b/spec/models/metric/statistic_spec.rb
@@ -21,14 +21,14 @@ describe Metric::Statistic do
       ems_openshift.container_groups << [c1, c2, c3, c4, c5, c6, c7, c8]
       derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
 
-      expect(derived_columns[:stat_containergroup_create_rate]).to eq(2)
+      expect(derived_columns[:stat_container_group_create_rate]).to eq(2)
     end
 
     it "count deleted container groups in a provider" do
       ems_openshift.container_groups << [c1, c2, c3, c4, c5, c6, c7, c8]
       derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
 
-      expect(derived_columns[:stat_containergroup_delete_rate]).to eq(2)
+      expect(derived_columns[:stat_container_group_delete_rate]).to eq(2)
     end
   end
 end


### PR DESCRIPTION
Change stat-containergroup to stat-container-group

`stat_[class-name]_[action]_[rollup]` -> `stat_[class-family]_[class-name]_[action]_[rollup]`

https://github.com/ManageIQ/manageiq/pull/7624 will use this convention.