### PR TITLE
Render human readable orchestration stack type in summary screen

### DIFF
--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module OrchestrationStackHelper::TextualSummary
   end
 
   def textual_type
-    @record.type
+    ui_lookup(:model => @record.type)
   end
 
   def textual_status


### PR DESCRIPTION
Before:

![os-before](https://cloud.githubusercontent.com/assets/6648365/14278552/9877bf8e-fb28-11e5-962e-0dd33d02e63b.jpg)

After:

![os-after](https://cloud.githubusercontent.com/assets/6648365/14278565/a3a00074-fb28-11e5-9826-3512425011fe.jpg)
