### PR TITLE
remove special rbac for VmdbDatabaseSettings

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -506,7 +506,7 @@ module Rbac
   end
 
   def self.method_with_scope(ar_scope, options)
-    if ar_scope == VmdbDatabaseConnection || ar_scope == VmdbDatabaseSetting
+    if ar_scope == VmdbDatabaseConnection
       ar_scope.all
     elsif ar_scope < ActsAsArModel || (ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?)
       ar_scope.all(options)

--- a/app/models/vmdb_database_setting.rb
+++ b/app/models/vmdb_database_setting.rb
@@ -1,9 +1,9 @@
 class VmdbDatabaseSetting < ApplicationRecord
   self.table_name = 'pg_catalog.pg_settings'
-  self.primary_key = nil
+  self.primary_key = 'name'
 
   def self.sortable?
-    false
+    true
   end
 
   virtual_belongs_to :vmdb_database

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -44,6 +44,7 @@ describe MiqReport do
   end
 
   context "paged_view_search" do
+    # is this still needed?
     it "should not call get_cached_page to load cached results if target class does not respond to id" do
       report = MiqReport.new(
         :name      => "VmdbDatabaseSetting",


### PR DESCRIPTION
This model has migrated from acts as active record type model to rails slowly.

I am submitting this pr to remove the special rbac handling. (done less aggressively in #7674).
This line was introduced in https://github.com/ManageIQ/manageiq/pull/3862 for rails4 support. This line doesn't seem necessary anymore.

The other PR would meet our needs, but I feel we are best served by simply converting `database_settings.rb` to a simple rails compliant model.

/cc @chessbyte 
