### PR TITLE
Fix GCE refresh exception when there are no disks

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
@@ -113,7 +113,8 @@ module ManageIQ::Providers
       end
 
       def process_collection(collection, key)
-        @data[key] ||= []
+        @data[key]       ||= []
+        @data_index[key] ||= {}
 
         collection.each do |item|
           uid, new_result = yield(item)
@@ -466,7 +467,7 @@ module ManageIQ::Providers
       end
 
       def link_volumes_to_base_snapshots
-        @data_index[:cloud_volumes].each do |_, volume|
+        @data_index.fetch_path(:cloud_volumes).each do |_, volume|
           base_snapshot = volume[:base_snapshot]
           next if base_snapshot.nil?
 


### PR DESCRIPTION
When running a refresh on a GCE provider with no disks the following exception is seen

```
[----] I, [2016-04-05T09:53:45.341874 #8544:efd0e4]  INFO -- : MIQ(ManageIQ::Providers::Google::CloudManager::RefreshParser#ems_inv_to_hashes) Collecting data for EMS : [GCE Project 1] id: [1]...Complete
[----] E, [2016-04-05T09:53:45.341972 #8544:efd0e4] ERROR -- : MIQ(ManageIQ::Providers::Google::CloudManager::Refresher#refresh) EMS: [GCE Project 1], id: [1] Refresh failed
[----] E, [2016-04-05T09:53:45.344066 #8544:efd0e4] ERROR -- : [NoMethodError]: undefined method `each' for nil:NilClass  Method:[rescue in block in refresh]
[----] E, [2016-04-05T09:53:45.344303 #8544:efd0e4] ERROR -- : /home/grare/adam/workspace/manageiq/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb:469:in `link_volumes_to_base_snapshots'
/home/grare/adam/workspace/manageiq/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb:38:in `ems_inv_to_hashes'
/home/grare/adam/workspace/manageiq/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb:9:in `ems_inv_to_hashes'
/home/grare/adam/workspace/manageiq/app/models/manageiq/providers/google/cloud_manager/refresher.rb:6:in `parse_inventory'
```