### PR TITLE
Item sorting for tagging: sorted items do not always have non-null names

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -340,7 +340,7 @@ module ApplicationController::Tags
     # Set to first category, if not already set
     @edit[:cat] ||= cats.min_by(&:description)
 
-    @tagitems = @tagging.constantize.find(@object_ids).sort_by { |t| t.name.downcase } unless @object_ids.blank?
+    @tagitems = @tagging.constantize.find(@object_ids).sort_by { |t| t.name.try(:downcase) } unless @object_ids.blank?
 
     @view = get_db_view(@tagging)               # Instantiate the MIQ Report view object
     @view.table = MiqFilter.records2table(@tagitems, @view.cols + ['id'])


### PR DESCRIPTION
This is to fix the following problem for example:

```
INFO -- : Started GET
"/cloud_volume/tagging_edit/1000000000009?db=CloudVolume&escape=false"
INFO -- : Processing by CloudVolumeController#tagging_edit as HTML
INFO -- :   Parameters: {"db"=>"CloudVolume", "escape"=>"false", "id"=>"1000000000009"}
FATAL -- : Error caught: [NoMethodError] undefined method `downcase' for nil:NilClass
app/controllers/application_controller/tags.rb:344:in `block in tag_edit_build_screen'
app/controllers/application_controller/tags.rb:344:in `each'
app/controllers/application_controller/tags.rb:344:in `sort_by'
app/controllers/application_controller/tags.rb:344:in `tag_edit_build_screen'
app/controllers/application_controller/tags.rb:167:in `tagging_tags_set_form_vars'
app/controllers/application_controller/tags.rb:147:in `tagging_edit_tags_reset'
app/controllers/application_controller/tags.rb:15:in `tagging_edit'
```