### PR TITLE
Fix URLs for GTL buttons

### DIFF
--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -171,7 +171,7 @@ class AuthKeyPairCloudController < ApplicationController
     @auth_key_pair_cloud = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@auth_key_pair_cloud)
 
-    @gtl_url = "/auth_key_pair_cloud/show/#{@auth_key_pair_cloud.id}?"
+    @gtl_url = "/show"
     drop_breadcrumb(
       {:name => _("Key Pairs"), :url => "/auth_key_pair_cloud/show_list?page=#{@current_page}&refresh=y"},
       true

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -18,7 +18,7 @@ class AvailabilityZoneController < ApplicationController
     @availability_zone = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@availability_zone)
 
-    @gtl_url = "/availability_zone/show/" << @availability_zone.id.to_s << "?"
+    @gtl_url = "/show"
     drop_breadcrumb({:name => _("Availabilty Zones"),
                      :url  => "/availability_zones/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display

--- a/app/controllers/cim_instance_controller.rb
+++ b/app/controllers/cim_instance_controller.rb
@@ -112,7 +112,7 @@ class CimInstanceController < ApplicationController
     @record = identify_record(params[:id])
     return if record_no_longer_exists?(@record)
 
-    @gtl_url = "/#{self.class.table_name}/show/#{@record.id}?"
+    @gtl_url = "/show"
 
     case @display
     when "download_pdf", "main", "summary_only"

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -27,7 +27,7 @@ class CloudObjectStoreContainerController < ApplicationController
     @cloud_object_store_container = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@record)
 
-    @gtl_url = "/cloud_object_store_container/show/#{@record.id}?"
+    @gtl_url = "/show"
     drop_breadcrumb(
       {
         :name => ui_lookup(:tables => "cloud_object_stores"),

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -25,7 +25,7 @@ class CloudObjectStoreObjectController < ApplicationController
     @object_store_object = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@object_store_object)
 
-    @gtl_url = "/cloud_object_store_object/show#{@object_store_object.id}?"
+    @gtl_url = "/show"
     drop_breadcrumb(
       {
         :name => ui_lookup(:tables => "cloud_objects"),

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -46,7 +46,7 @@ class CloudTenantController < ApplicationController
     @cloud_tenant = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@cloud_tenant)
 
-    @gtl_url = "/cloud_tenant/show/" << @cloud_tenant.id.to_s << "?"
+    @gtl_url = "/show"
     drop_breadcrumb({:name => _("Cloud Tenants"), :url => "/cloud_tenant/show_list?page=#{@current_page}&refresh=y"}, true)
 
     case @display

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -25,7 +25,7 @@ class CloudVolumeController < ApplicationController
     @volume = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@volume)
 
-    @gtl_url = "/cloud_volume/show/" << @volume.id.to_s << "?"
+    @gtl_url = "/show"
     drop_breadcrumb({:name => _("Cloud Volumes"), :url => "/cloud_volume/show_list?page=#{@current_page}&refresh=y"}, true)
 
     case @display

--- a/app/controllers/cloud_volume_snapshot_controller.rb
+++ b/app/controllers/cloud_volume_snapshot_controller.rb
@@ -29,7 +29,7 @@ class CloudVolumeSnapshotController < ApplicationController
     @snapshot = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@snapshot)
 
-    @gtl_url = "/cloud_volume_snapshot/show/#{@snapshot.id}?"
+    @gtl_url = "/show"
     drop_breadcrumb(
       {
         :name => ui_lookup(:tables => 'cloud_volume_snapshot'),

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -24,7 +24,7 @@ class EmsClusterController < ApplicationController
     @ems_cluster = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@ems_cluster)
 
-    @gtl_url = "/ems_cluster/show/" << @ems_cluster.id.to_s << "?"
+    @gtl_url = "/ems_cluster"
 
     case @display
     when "download_pdf", "main", "summary_only"

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -10,7 +10,7 @@ module EmsCommon
     @ems = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@ems)
 
-    @gtl_url = show_link(@ems) << "?"
+    @gtl_url = "/show"
     @showtype = "config"
     drop_breadcrumb({:name => ui_lookup(:tables => @table_name), :url => "/#{@table_name}/show_list?page=#{@current_page}&refresh=y"}, true)
 

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -16,7 +16,7 @@ class FlavorController < ApplicationController
     @showtype   = "config"
     @flavor     = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@flavor)
-    @gtl_url = "/flavor/show/#{@flavor.id}?"
+    @gtl_url = "/show"
 
     case @display
     when "download_pdf", "main", "summary_only"

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -26,7 +26,7 @@ class HostController < ApplicationController
     @host = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@host, 'Host')
 
-    @gtl_url = "/host/show/" << @host.id.to_s << "?"
+    @gtl_url = "/show"
     @showtype = "config"
     set_config(@host)
     case @display

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -116,7 +116,7 @@ class MiqRequestController < ApplicationController
 
     drop_breadcrumb(:name => bc_name, :url => "/miq_request/show_list?typ=#{@request_tab}")
     @lastaction = "show_list"
-    @gtl_url = "/miq_request/show_list/?"
+    @gtl_url = "/show_list"
 
     @settings[:views][:miqrequest] = params[:type] if params[:type]   # new gtl type came in, set it
     @gtl_type = @settings[:views][:miqrequest]                        # set the var for the UI to use

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -55,7 +55,7 @@ module ContainersCommonMixin
   def show_container(record, controller_name, display_name)
     return if record_no_longer_exists?(record)
 
-    @gtl_url = "/#{controller_name}/show/" << record.id.to_s << "?"
+    @gtl_url = "/show"
     drop_breadcrumb({:name => display_name,
                      :url  => "/#{controller_name}/show_list?page=#{@current_page}&refresh=y"},
                     true)

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -8,7 +8,7 @@ module Mixins
       @record     = identify_record(params[:id])
       return if record_no_longer_exists?(@record)
 
-      @gtl_url = "/#{self.class.table_name}/show/" << @record.id.to_s << "?"
+      @gtl_url = "/show"
       case @display
       when "download_pdf", "main", "summary_only"
         get_tagdata(@record)

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -17,7 +17,7 @@ class OrchestrationStackController < ApplicationController
     @orchestration_stack = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@orchestration_stack)
 
-    @gtl_url = "/orchestration_stack/show/" << @orchestration_stack.id.to_s << "?"
+    @gtl_url = "/show"
     drop_breadcrumb({:name => _("Orchestration Stacks"),
                      :url  => "/orchestration_stack/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -248,7 +248,7 @@ class ProviderForemanController < ApplicationController
 
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
-    @gtl_url = "/provider_foreman/show/#{@record.id}?"
+    @gtl_url = "/show"
     set_summary_pdf_data if "download_pdf" == @display
   end
 

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -250,10 +250,10 @@ module ReportController::Reports::Editor
     @in_a_form = true
     if ["new", "copy", "create"].include?(request.parameters["action"])
       # drop_breadcrumb( {:name=>"Add Report", :url=>"/report/new"} )
-      @gtl_url = "/report/new/?"
+      @gtl_url = "/new"
     else
       # drop_breadcrumb( {:name=>"Edit Report", :url=>"/report/edit"} )
-      @gtl_url = "/report/edit/?"
+      @gtl_url = "/edit"
     end
   end
 

--- a/app/controllers/repository_controller.rb
+++ b/app/controllers/repository_controller.rb
@@ -23,7 +23,7 @@ class RepositoryController < ApplicationController
                       :url  => "/repository/show/#{@repo.id}?display=#{@display}")
       @view, @pages = get_view(kls, :parent => @repo) # Get the records (into a view) and the paginator
       @showtype = @display
-      @gtl_url = "/repository/show/" << @repo.id.to_s << "?"
+      @gtl_url = "/show"
       notify_about_unauthorized_items(title, _('Repository'))
 
     when "download_pdf", "main", "summary_only"

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -17,7 +17,7 @@ class ResourcePoolController < ApplicationController
     @record = identify_record(params[:id])
     return if record_no_longer_exists?(@record)
 
-    @gtl_url = "/resource_pool/show/" << @record.id.to_s << "?"
+    @gtl_url = "/show"
     drop_breadcrumb({:name => _("Resource Pools"),
                      :url  => "/resource_pool/show_list?page=#{@current_page}&refresh=y"}, true)
 

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -17,7 +17,7 @@ class StorageController < ApplicationController
     @storage = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@storage)
 
-    @gtl_url = "/storage/show/" << @storage.id.to_s << "?"
+    @gtl_url = "/show"
     #   drop_breadcrumb({:name=>ui_lookup(:tables=>"storages"), :url=>"/storage/show_list?page=#{@current_page}&refresh=y"}, true)
 
     case @display

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -243,7 +243,7 @@ class StorageManagerController < ApplicationController
     @sm = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@sm)
 
-    @gtl_url = "/storage_manager/show/" << @sm.id.to_s << "?"
+    @gtl_url = "/show"
     @showtype = "config"
     drop_breadcrumb({:name => ui_lookup(:tables => "storage_managers"), :url => "/storage_manager/show_list?page=#{@current_page}&refresh=y"}, true)
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -231,7 +231,7 @@ module VmCommon
     else
       rec_cls = "vm"
     end
-    @gtl_url = "/#{rec_cls}/show/" << @record.id.to_s << "?"
+    @gtl_url = "/show"
     if ["download_pdf", "main", "summary_only"].include?(@display)
       get_tagdata(@record)
       drop_breadcrumb({:name => _("Virtual Machines"),
@@ -355,7 +355,7 @@ module VmCommon
 
     @button_group = "vm"
 
-    @gtl_url = "/#{@button_group}/show/" << @record.id.to_s << "?"
+    @gtl_url = "/show"
     get_tagdata(@record)
     drop_breadcrumb({:name => _("Virtual Machines"),
                      :url  => "/#{@button_group}/show_list?page=#{@current_page}&refresh=y"}, true)
@@ -1215,7 +1215,7 @@ module VmCommon
     @listicon = "scan_history"
     @showtype = "scan_history"
     @lastaction = "scan_history"
-    @gtl_url = "/vm/scan_history/?"
+    @gtl_url = "/scan_history"
     @no_checkboxes = true
     @showlinks = true
 

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1369,21 +1369,16 @@ class ApplicationHelper::ToolbarBuilder
   def url_for_save_button(name, url_tpl, controller_restful)
     url = safer_eval(url_tpl)
 
-    if %w(view_grid view_tile view_list).include?(name)
-      # blows up in sub screens for CI's, need to get rid of first directory and anything after last slash in @gtl_url, that's being manipulated in JS function
-      url.gsub!(/^\/[a-z|A-Z|0-9|_|-]+/, "")
-      ridx = url.rindex('/')
-      url = url.slice(0..ridx - 1) if ridx
-
+    if %w(view_grid view_tile view_list).include?(name) && controller_restful && url =~ %r{^\/(\d+|\d+r\d+)\?$}
       # handle restful routes - we want just / if the url is just an id
-      url = '/' if controller_restful && url =~ %r{^\/(\d+|\d+r\d+)\?$}
+      url = '/'
     end
 
     url
   end
 
   def build_toolbar_save_button(item, props)
-    props[:url] = url_for_save_button(props['id'], item[:url], controller_restful?) if item[:url]
+    props[:url] = url_for_save_button(props[:id], item[:url], controller_restful?) if item[:url]
     props[:explorer] = true if @explorer && !item[:url] # Add explorer = true if ajax button
     props
   end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1366,7 +1366,7 @@ class ApplicationHelper::ToolbarBuilder
     )
   end
 
-  def url_for_save_button(name, url_tpl, controller_restful)
+  def url_for_button(name, url_tpl, controller_restful)
     url = safer_eval(url_tpl)
 
     if %w(view_grid view_tile view_list).include?(name) && controller_restful && url =~ %r{^\/(\d+|\d+r\d+)\?$}
@@ -1378,7 +1378,7 @@ class ApplicationHelper::ToolbarBuilder
   end
 
   def build_toolbar_save_button(item, props)
-    props[:url] = url_for_save_button(props[:id], item[:url], controller_restful?) if item[:url]
+    props[:url] = url_for_button(props[:id], item[:url], controller_restful?) if item[:url]
     props[:explorer] = true if @explorer && !item[:url] # Add explorer = true if ajax button
     props
   end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2829,12 +2829,6 @@ describe ApplicationHelper do
         build_toolbar_save_button(@item, @item_out)
       end
 
-      it "gets rid of first directory and anything after last slash when button is 'view_grid', 'view_tile' or 'view_list'" do
-        @item = {:url => '/some/path/to/the/testing/code'}
-        @item_out = {'id' => 'view_list'}
-        expect(subject).to include(:url => '/path/to/the/testing')
-      end
-
       it "saves the value as it is otherwise" do
         expect(subject).to have_key(:url)
       end
@@ -2854,24 +2848,13 @@ describe ApplicationHelper do
       end
 
       it "returns / when button is 'view_grid', 'view_tile' or 'view_list'" do
-        result = url_for_save_button('view_list', '/ems_cloud/1r2?', true)
+        result = url_for_save_button('view_list', '/1r2?', true)
         expect(result).to eq('/')
       end
 
       it "supports compressed ids" do
-        result = url_for_save_button('view_list', '/ems_cloud/1?', true)
+        result = url_for_save_button('view_list', '/1?', true)
         expect(result).to eq('/')
-      end
-    end
-
-    context "when restless routes" do
-      before do
-        allow(controller).to receive(:restful?) { false }
-      end
-
-      it "gets rid of first directory and anything after last slash when button is 'view_grid', 'view_tile' or 'view_list'" do
-        result = url_for_save_button('view_list', '/some/path/to/the/testing/code', false)
-        expect(result).to eq('/path/to/the/testing')
       end
     end
   end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2833,27 +2833,27 @@ describe ApplicationHelper do
         expect(subject).to have_key(:url)
       end
 
-      it "calls url_for_save_button" do
+      it "calls url_for_button" do
         b = _toolbar_builder
-        expect(b).to receive(:url_for_save_button).and_call_original
+        expect(b).to receive(:url_for_button).and_call_original
         b.send(:build_toolbar_save_button, @item, @item_out)
       end
     end
   end
 
-  describe "url_for_save_button" do
+  describe "url_for_button" do
     context "when restful routes" do
       before do
         allow(controller).to receive(:restful?) { true }
       end
 
       it "returns / when button is 'view_grid', 'view_tile' or 'view_list'" do
-        result = url_for_save_button('view_list', '/1r2?', true)
+        result = url_for_button('view_list', '/1r2?', true)
         expect(result).to eq('/')
       end
 
       it "supports compressed ids" do
-        result = url_for_save_button('view_list', '/1?', true)
+        result = url_for_button('view_list', '/1?', true)
         expect(result).to eq('/')
       end
     end


### PR DESCRIPTION
JavaScript code for toolbars will prepend correct controller name and append record id
when constructing the button's url.

Same instance of this problem has been fixed in pull request #7649 (for a different controller).

Additionally, I removed url transformation done in `url_for_save_button()`, which would:
1. set url from controller: /controller/action/id?parameters
2. in url_for_save_button(), we transformed the url to: /action
3. in javascript, we added the controller, id and parameters back
   
Now, we will just set the /action url in controller and have javascript add the rest.
