### PR TITLE
[WIP] Move filters from miq_groups to entitlements

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -1,4 +1,11 @@
 class Entitlement < ApplicationRecord
   belongs_to :miq_group
   belongs_to :miq_user_role
+
+  def self.remove_tag_filters_by_name!(tag_name)
+    find_each do |entitlement|
+      entitlement.tag_filters.reject! { |t| t == tag_name }
+      entitlement.save
+    end
+  end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -65,9 +65,11 @@ class MiqGroup < ApplicationRecord
       end
       group.miq_user_role = user_role
       group.sequence      = index + 1
-      group.filters       = ldap_to_filters[group_name]
       group.group_type    = SYSTEM_GROUP
       group.tenant        = root_tenant
+
+      group.set_managed_filters(ldap_to_filters.fetch_path(group_name, "managed"))
+      group.set_belongsto_filters(ldap_to_filters.fetch_path(group_name, "belongsto"))
 
       if group.changed?
         mode = group.new_record? ? "Created" : "Updated"

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -4,7 +4,7 @@ class MiqGroup < ApplicationRecord
   TENANT_GROUP = "tenant"
 
   belongs_to :tenant
-  has_one    :entitlement
+  has_one    :entitlement,   :autosave => true
   has_one    :miq_user_role, :through => :entitlement
   has_and_belongs_to_many :users
   has_many   :vms,         :dependent => :nullify
@@ -149,11 +149,6 @@ class MiqGroup < ApplicationRecord
     get_filters("belongsto")
   end
 
-  def set_filters(type, filter)
-    self.filters ||= {}
-    self.filters[type.to_s] = filter
-  end
-
   def self.remove_tag_from_all_managed_filters(tag)
     all.each do |miq_group|
       miq_group.remove_tag_from_managed_filter(tag)
@@ -174,12 +169,16 @@ class MiqGroup < ApplicationRecord
     end
   end
 
+  # TODO: Mark for deprecation or remove (pending multiple entitlements)
   def set_managed_filters(filter)
-    set_filters("managed", filter)
+    self.entitlement ||= Entitlement.new
+    entitlement.tag_filters = filter
   end
 
+  # TODO: Mark for deprecation or remove (pending multiple entitlements)
   def set_belongsto_filters(filter)
-    set_filters("belongsto", filter)
+    self.entitlement ||= Entitlement.new
+    entitlement.resource_filters = filter
   end
 
   def miq_user_role_name

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -149,26 +149,6 @@ class MiqGroup < ApplicationRecord
     get_filters("belongsto")
   end
 
-  def self.remove_tag_from_all_managed_filters(tag)
-    all.each do |miq_group|
-      miq_group.remove_tag_from_managed_filter(tag)
-      miq_group.save if miq_group.filters_changed?
-    end
-  end
-
-  def remove_tag_from_managed_filter(filter_to_remove)
-    if get_managed_filters.present?
-      *category, _tag = filter_to_remove.split("/")
-      category = category.join("/")
-      self.filters["managed"].each do |filter|
-        next unless filter.first.starts_with?(category)
-        next unless filter.include?(filter_to_remove)
-        filter.delete(filter_to_remove)
-      end
-      self.filters["managed"].reject!(&:empty?)
-    end
-  end
-
   # TODO: Mark for deprecation or remove (pending multiple entitlements)
   def set_managed_filters(filter)
     self.entitlement ||= Entitlement.new

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,7 +4,7 @@ class Tag < ApplicationRecord
   virtual_has_one :category,       :class_name => "Classification"
   virtual_has_one :categorization, :class_name => "Hash"
 
-  before_destroy :remove_from_managed_filters
+  after_destroy :remove_from_managed_filters
 
   def self.to_tag(name, options = {})
     File.join(Tag.get_namespace(options), name)
@@ -149,7 +149,7 @@ class Tag < ApplicationRecord
   private
 
   def remove_from_managed_filters
-    MiqGroup.remove_tag_from_all_managed_filters(name)
+    Entitlement.remove_tag_filters_by_name!(name)
   end
 
   def name_path

--- a/db/migrate/20160401201704_add_filters_to_entitlements.rb
+++ b/db/migrate/20160401201704_add_filters_to_entitlements.rb
@@ -1,0 +1,6 @@
+class AddFiltersToEntitlements < ActiveRecord::Migration[5.0]
+  def change
+    add_column :entitlements, :tag_filters,      :text, :array => true, :default => []
+    add_column :entitlements, :resource_filters, :text, :array => true, :default => []
+  end
+end

--- a/db/migrate/20160405171818_move_filters_to_entitlements.rb
+++ b/db/migrate/20160405171818_move_filters_to_entitlements.rb
@@ -1,0 +1,46 @@
+class MoveFiltersToEntitlements < ActiveRecord::Migration[5.0]
+  class Entitlement < ActiveRecord::Base
+    belongs_to :miq_group, :class_name => "MoveFiltersToEntitlements::MiqGroup"
+  end
+
+  class MiqGroup < ActiveRecord::Base
+    has_one :entitlement, :class_name => "MoveFiltersToEntitlements::Entitlement"
+
+    serialize :filters
+  end
+
+  def up
+    MiqGroup.find_each do |group|
+      if group.filters.present?
+        if group.filters["managed"].present?
+          group.entitlement ||= Entitlement.new
+          group.entitlement.tag_filters = group.filters["managed"]
+        end
+
+        if group.filters["belongsto"].present?
+          group.entitlement ||= Entitlement.new
+          group.entitlement.resource_filters = group.filters["belongsto"]
+        end
+
+        group.filters = nil
+        group.entitlement.save!
+        group.save!
+      end
+    end
+  end
+
+  def down
+    Entitlement.find_each do |entitlement|
+      if entitlement.miq_group && (entitlement.tag_filters.present? || entitlement.resource_filters.present?)
+        group = entitlement.miq_group
+
+        group.filters = {"managed" => entitlement.tag_filters, "belongsto" => entitlement.resource_filters}
+        group.save!
+
+        entitlement.tag_filters      = []
+        entitlement.resource_filters = []
+        entitlement.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20160405191955_remove_filters_from_miq_groups.rb
+++ b/db/migrate/20160405191955_remove_filters_from_miq_groups.rb
@@ -1,0 +1,5 @@
+class RemoveFiltersFromMiqGroups < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :miq_groups, :filters, :text
+  end
+end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -16,12 +16,14 @@ FactoryGirl.define do
     description { |g| g.role ? "EvmGroup-#{g.role}" : generate(:miq_group_description) }
 
     after :build do |g, e|
-      if e.role || e.features || e.miq_user_role_id || e.miq_user_role
-        g.entitlement = FactoryGirl.create(:entitlement,
-                                           :features => e.features,
-                                           :role => e.role,
-                                           :miq_user_role_id => e.miq_user_role_id,
-                                           :miq_user_role => e.miq_user_role)
+      unless g.entitlement
+        if e.role || e.features || e.miq_user_role_id || e.miq_user_role
+          g.entitlement = FactoryGirl.create(:entitlement,
+                                             :features => e.features,
+                                             :role => e.role,
+                                             :miq_user_role_id => e.miq_user_role_id,
+                                             :miq_user_role => e.miq_user_role)
+        end
       end
     end
 

--- a/spec/migrations/20160405171818_move_filters_to_entitlements_spec.rb
+++ b/spec/migrations/20160405171818_move_filters_to_entitlements_spec.rb
@@ -1,0 +1,73 @@
+require_migration
+
+describe MoveFiltersToEntitlements do
+  let(:miq_group_stub)   { migration_stub(:MiqGroup) }
+  let(:entitlement_stub) { migration_stub(:Entitlement) }
+
+  let(:filters1) do
+    {"managed"   => ["/managed/operations/analysis_failed"],
+     "belongsto" => ["/belongsto/ExtManagementSystem|RHEVM"]}
+  end
+
+  let(:filters2) do
+    {"managed"   => [],
+     "invalid"   => [":trollface:"],
+     "belongsto" => ["/belongsto/ExtManagementSystem|RHEVM"]}
+  end
+
+  let(:filters3) { nil }
+
+  migration_context :up do
+    1.upto(3) do |n|
+      let!("miq_group#{n}") do
+        miq_group_stub.create!(:filters => send("filters#{n}"))
+      end
+    end
+
+    before do
+      migrate
+      1.upto(3) { |n| send("miq_group#{n}").reload }
+    end
+
+    it "sets the filters on the entitlement appropriately and clears the group filters" do
+      expect(miq_group1.filters).to be_nil
+      expect(miq_group2.filters).to be_nil
+      expect(miq_group3.filters).to be_nil
+
+      expect(miq_group1.entitlement.tag_filters).to eq(filters1["managed"])
+      expect(miq_group1.entitlement.resource_filters).to eq(filters1["belongsto"])
+
+      expect(miq_group2.entitlement.tag_filters).to eq(filters2["managed"])
+      expect(miq_group2.entitlement.resource_filters).to eq(filters2["belongsto"])
+
+      expect(miq_group3.entitlement).to be_nil
+    end
+  end
+
+  migration_context :down do
+    1.upto(2) do |n|
+      let!("miq_group#{n}") do
+        miq_group_stub.create!(:entitlement => entitlement_stub.create!(:tag_filters      => send("filters#{n}")["managed"],
+                                                                        :resource_filters => send("filters#{n}")["belongsto"]))
+      end
+    end
+    let!(:miq_group3) { miq_group_stub.create!(:entitlement => nil) }
+
+    before do
+      migrate
+      1.upto(3) { |n| send("miq_group#{n}").reload }
+    end
+
+    it "sets the filters back on miq_group and clears the entitlement filters" do
+      expect(miq_group1.entitlement.tag_filters).to be_empty
+      expect(miq_group1.entitlement.resource_filters).to be_empty
+      expect(miq_group2.entitlement.tag_filters).to be_empty
+      expect(miq_group2.entitlement.resource_filters).to be_empty
+      expect(miq_group3.entitlement).not_to be_present
+
+      expect(miq_group1.filters).to eq(filters1)
+      expect(miq_group2.filters).to eq(filters2.slice("belongsto", "managed"))
+      expect(miq_group3.filters).to eq(filters3)
+    end
+  end
+end

--- a/spec/models/entitlement_spec.rb
+++ b/spec/models/entitlement_spec.rb
@@ -1,4 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe Entitlement, :type => :model do
+describe Entitlement do
+  describe ".remove_tag_filters_by_name!" do
+    let!(:e1) do
+      filters = %w(/managed/operations/analysis_failed /managed/here_be_dragons /managed/lolfilter)
+      Entitlement.create!(:tag_filters => filters)
+    end
+    let!(:e2) do
+      filters = %w(/managed/operations/analysis_passed /managed/filterz)
+      Entitlement.create!(:tag_filters => filters)
+    end
+
+    before { Entitlement.remove_tag_filters_by_name!("/managed/here_be_dragons") }
+
+    it "removes the filter without ruining the others" do
+      expect(e1.reload.tag_filters).to eq(%w(/managed/operations/analysis_failed /managed/lolfilter))
+      expect(e2.reload.tag_filters).to eq(%w(/managed/operations/analysis_passed /managed/filterz))
+    end
+  end
 end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -4,26 +4,6 @@ describe MiqGroup do
       @miq_group = FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator")
     end
 
-    describe ".remove_tag_from_all_managed_filters" do
-      let(:other_miq_group) { FactoryGirl.create(:miq_group) }
-      let(:filters) { [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"], ["/managed/my_name/test"]] }
-
-      before do
-        @miq_group.set_managed_filters(filters)
-        other_miq_group.set_managed_filters(filters)
-        [@miq_group, other_miq_group].each(&:save)
-      end
-
-      it "removes managed filter from all groups" do
-        MiqGroup.all.each { |group| expect(group.get_managed_filters).to match_array(filters) }
-
-        MiqGroup.remove_tag_from_all_managed_filters("/managed/my_name/test")
-
-        expected_filters = [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"]]
-        MiqGroup.all.each { |group| expect(group.get_managed_filters).to match_array(expected_filters) }
-      end
-    end
-
     context "#get_filters" do
       it "normal" do
         expected = {:test => "test filter"}

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -220,7 +220,8 @@ describe MiqReport do
       user  = FactoryGirl.create(:user_with_group)
       group = user.current_group
       allow(User).to receive_messages(:server_timezone => "UTC")
-      group.update_attributes(:filters => {"managed" => [["/managed/environment/prod"]], "belongsto" => []})
+      group.set_managed_filters([["/managed/environment/prod"]])
+      group.save!
 
       report = MiqReport.new(:db => "Vm")
       results, attrs = report.paged_view_search(
@@ -243,7 +244,8 @@ describe MiqReport do
       vm1 = FactoryGirl.create(:vm_vmware, :name => "VA", :storage => FactoryGirl.create(:storage, :name => "SA"))
       vm2 = FactoryGirl.create(:vm_vmware, :name => "VB", :storage => FactoryGirl.create(:storage, :name => "SB"))
       tag = "/managed/environment/prod"
-      group.update_attributes(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.set_managed_filters([[tag]])
+      group.save!
       vm1.tag_with(tag, :ns => "*")
       vm2.tag_with(tag, :ns => "*")
 
@@ -310,7 +312,8 @@ describe MiqReport do
       vm2 =  FactoryGirl.create(:vm_vmware, :name => "VB",  :host => FactoryGirl.create(:host, :name => "HB"))
       vm3 =  FactoryGirl.create(:vm_vmware, :name => "VAA", :host => FactoryGirl.create(:host, :name => "HAA"))
       tag =  "/managed/environment/prod"
-      group.update_attributes(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.set_managed_filters([[tag]])
+      group.save!
 
       # vm1's host.name starts with HA but isn't tagged
       vm2.tag_with(tag, :ns => "*")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,8 +46,8 @@ describe User do
 
   context "filter methods" do
     let(:user) { FactoryGirl.create(:user, :miq_groups => [miq_group]) }
-    let(:mfilters) { {"managed"   => "m"} }
-    let(:bfilters) { {"belongsto" => "b"} }
+    let(:mfilters) { ["m"] }
+    let(:bfilters) { ["b"] }
     let(:miq_group) { FactoryGirl.create(:miq_group) }
 
     before do


### PR DESCRIPTION
This PR moves the `miq_groups.filters` column, which contains "belongsto" and "managed" filters in a serialized hash, to an MiqGroup's Entitlement with `resource_filters` and `tag_filters`.

Here, I'll help. ^_^

* **"managed" filters are now "tag_filters"**
* **"belongsto" filters are now "resource_filters"**

Note that the actual internal format of the filters remains the same (`/belongsto/*` and `/managed/*`), as we don't want to take on that sort of large change at this time.

There are lots of methods on MiqGroup that have been marked for removal or deprecation. Some of them will likely be _required_ to be removed without deprecation due to multiple entitlements being a feature we want for the next release (some methods can't be implemented backwards-compatible).
I've simply added comments for now as ultimately the work done for multiple entitlements will determine those methods' fate.

@miq-bot add_label core, tenancy

r? @jrafanie