### PR TITLE
Rewrite migrations to using ActiveRecord

### DIFF
--- a/db/migrate/20151021093644_set_correct_sti_type_on_cloud_network.rb
+++ b/db/migrate/20151021093644_set_correct_sti_type_on_cloud_network.rb
@@ -1,31 +1,38 @@
 class SetCorrectStiTypeOnCloudNetwork < ActiveRecord::Migration
+  CLOUD_TEMPLATE_CLASS = "ManageIQ::Providers::Openstack::CloudManager::Template".freeze
+  CLOUD_PUBLIC_CLASS   = "ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Public".freeze
+  CLOUD_PRIVATE_CLASS  = "ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Private".freeze
+
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class BaseManager < ExtManagementSystem; end
+
+  class CloudManager < BaseManager; end
+
+  class CloudNetwork < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system,
+               :foreign_key => :ems_id, :class_name => SetCorrectStiTypeOnCloudNetwork::BaseManager
+  end
+
   def up
-    connection.execute <<-SQL
-      UPDATE cloud_networks
-      SET type = 'CloudNetwork'
-    SQL
+    CloudNetwork.update_all(:type => CLOUD_TEMPLATE_CLASS)
 
-    # Set OpenStack specific STI types for Public network
-    connection.execute <<-SQL
-      UPDATE cloud_networks c
-      SET type = 'ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Public'
-      FROM ext_management_systems e
-      WHERE c.ems_id = e.id AND c.external_facing AND e.type = 'ManageIQ::Providers::Openstack::CloudManager'
-    SQL
+    CloudNetwork.joins(:ext_management_system)
+                .where(:cloud_networks => {:external_facing => true},
+                       :ext_management_systems => {:type => 'ManageIQ::Providers::Openstack::CloudManager'})
+                .update_all(:type => CLOUD_PUBLIC_CLASS)
 
-    # Set OpenStack specific STI types for Private network
-    connection.execute <<-SQL
-      UPDATE cloud_networks c
-      SET type = 'ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Private'
-      FROM ext_management_systems e
-      WHERE c.ems_id = e.id AND NOT c.external_facing AND e.type = 'ManageIQ::Providers::Openstack::CloudManager'
-    SQL
+    CloudNetwork.joins(:ext_management_system)
+                .where.not(:cloud_networks => {:external_facing => true})
+                .where(:ext_management_systems => {:type => 'ManageIQ::Providers::Openstack::InfraManager'})
+                .update_all(:type => CLOUD_PRIVATE_CLASS)
   end
 
   def down
-    connection.execute <<-SQL
-      UPDATE cloud_networks
-      SET type = NULL
-    SQL
+    CloudNetwork.update_all(:type => nil)
   end
 end

--- a/spec/migrations/20151021093644_set_correct_sti_type_on_cloud_network_spec.rb
+++ b/spec/migrations/20151021093644_set_correct_sti_type_on_cloud_network_spec.rb
@@ -1,0 +1,39 @@
+require_migration
+
+describe SetCorrectStiTypeOnCloudNetwork do
+  let(:cloud_manager_stub)   { migration_stub(:CloudManager) }
+  let(:cloud_network_stub)   { migration_stub(:CloudNetwork) }
+
+  let!(:empty_cloud_network) { cloud_network_stub.create! }
+
+  let!(:ems_cloud)           { cloud_manager_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager") }
+  let!(:cloud_cloud_network) { cloud_network_stub.create!(:external_facing => true, :ems_id => ems_cloud.id) }
+
+  let!(:ems_infra)           { cloud_manager_stub.create!(:type => "ManageIQ::Providers::Openstack::InfraManager") }
+  let!(:infra_cloud_network) { cloud_network_stub.create!(:external_facing => false, :ems_id => ems_infra.id) }
+
+  migration_context :up do
+    it "sets correct type to cloud_network objects according to cloud_manager" do
+      migrate
+
+      expect(empty_cloud_network.reload.type).to eq(described_class::CLOUD_TEMPLATE_CLASS)
+      expect(cloud_cloud_network.reload.type).to eq(described_class::CLOUD_PUBLIC_CLASS)
+      expect(infra_cloud_network.reload.type).to eq(described_class::CLOUD_PRIVATE_CLASS)
+    end
+  end
+
+  migration_context :down do
+    it "sets type = nil for all cloud_networks" do
+      cloud_cloud_network.type = described_class::CLOUD_PUBLIC_CLASS
+      cloud_cloud_network.save!
+
+      infra_cloud_network.type = described_class::CLOUD_PRIVATE_CLASS
+      infra_cloud_network.save!
+
+      migrate
+
+      expect(cloud_cloud_network.reload.type).to be_nil
+      expect(infra_cloud_network.reload.type).to be_nil
+    end
+  end
+end

--- a/spec/migrations/20151021095831_set_correct_sti_type_on_cloud_subnet_spec.rb
+++ b/spec/migrations/20151021095831_set_correct_sti_type_on_cloud_subnet_spec.rb
@@ -1,0 +1,39 @@
+require_migration
+
+describe SetCorrectStiTypeOnCloudSubnet do
+  let(:cloud_subnet_stub)      { migration_stub(:CloudSubnet) }
+  let(:cloud_network_stub)     { migration_stub(:CloudNetwork) }
+
+  let!(:empty_cloud_subnet)    { cloud_subnet_stub.create! }
+
+  let!(:private_cloud_network) { cloud_network_stub.create!(:type => described_class::CLOUD_PRIVATE_CLASS) }
+  let!(:private_cloud_subnet)  { cloud_subnet_stub.create!(:cloud_network_id => private_cloud_network.id) }
+
+  let!(:public_cloud_network)  { cloud_network_stub.create!(:type => described_class::CLOUD_PUBLIC_CLASS) }
+  let!(:public_cloud_subnet)   { cloud_subnet_stub.create!(:cloud_network_id => public_cloud_network.id) }
+
+  migration_context :up do
+    it "migrates a series of representative row" do
+      migrate
+
+      expect(empty_cloud_subnet.reload.type).to eq("CloudSubnet")
+      expect(private_cloud_subnet.reload.type).to eq(described_class::CLOUD_SUBNET)
+      expect(public_cloud_subnet.reload.type).to eq(described_class::CLOUD_SUBNET)
+    end
+  end
+
+  migration_context :down do
+    it "migrates a series of representative row" do
+      private_cloud_subnet.type = described_class::CLOUD_SUBNET
+      private_cloud_subnet.save!
+
+      public_cloud_subnet.type = described_class::CLOUD_SUBNET
+      public_cloud_subnet.save!
+
+      migrate
+
+      expect(private_cloud_subnet.reload.type).to be_nil
+      expect(public_cloud_subnet.reload.type).to be_nil
+    end
+  end
+end


### PR DESCRIPTION

https://github.com/ManageIQ/manageiq/issues/6739

rewrite these migrations to using ActiveRecord and added specs

https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20151021093644_set_correct_sti_type_on_cloud_network.rb
https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20151021095831_set_correct_sti_type_on_cloud_subnet.rb 

@Ladas there were your migrations 

@Fryguy @jrafanie 