### PR TITLE
Add another stub for Entitlement for preventing to load from app folder in migration

### DIFF
--- a/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
+++ b/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
@@ -1,15 +1,15 @@
 class RemoveMiqUserRoleFromMiqGroups < ActiveRecord::Migration[5.0]
   class MiqGroup < ActiveRecord::Base
-    has_one :entitlement, :class_name => RemoveMiqUserRoleFromMiqGroups::Entitlement
+    has_one :entitlement, :class_name => 'RemoveMiqUserRoleFromMiqGroups::Entitlement'
   end
 
   class Entitlement < ActiveRecord::Base
-    belongs_to :miq_group,     :class_name => RemoveMiqUserRoleFromMiqGroups::MiqGroup
-    belongs_to :miq_user_role, :class_name => RemoveMiqUserRoleFromMiqGroups::MiqUserRole
+    belongs_to :miq_group,     :class_name => 'RemoveMiqUserRoleFromMiqGroups::MiqGroup'
+    belongs_to :miq_user_role, :class_name => 'RemoveMiqUserRoleFromMiqGroups::MiqUserRole'
   end
 
   class MiqUserRole < ActiveRecord::Base
-    has_many :entitlements, :class_name => RemoveMiqUserRoleFromMiqGroups::Entitlement
+    has_many :entitlements, :class_name => 'RemoveMiqUserRoleFromMiqGroups::Entitlement'
   end
 
   def up


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/6739

this change is allowing to use https://github.com/testdouble/good-migrations
and prevents to load Entitlement model from app folder

@jrafanie @Fryguy @chrisarcand 