### PR TITLE
update company categories and tags action button styling

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -400,3 +400,19 @@ iframe, .iframe {
 .icon-red {
   color: red;
 }
+
+/* Action cell */
+
+.action-cell {
+    position: relative;
+    width: 100px;
+}
+
+.action-cell .btn {
+    border: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}

--- a/app/views/ops/_classification_entries.html.haml
+++ b/app/views/ops/_classification_entries.html.haml
@@ -4,9 +4,9 @@
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr
-        %th.narrow
         %th= _("Name")
         %th= _("Description")
+        %th.action-cell= _("Actions")
     %tbody
       - if entry != nil && entry == "new"
         = render :partial => "classification_entry", :locals => {:entry => "new", :edit => true}

--- a/app/views/ops/_classification_entry.html.haml
+++ b/app/views/ops/_classification_entry.html.haml
@@ -3,27 +3,19 @@
   - if entry == "new"
     %tr#new_tr{:class => cycle('row0', 'row1')}
       %td
-        %button.btn.btn-default{:title => _("Add this entry"),
-          "data-submit"         => 'classification_entries_div',
-          "data-miq_sparkle_on" => true,
-          :remote               => true,
-          "data-method"         => :post,
-          'data-click_url'      => {:url => "#{url}"}.to_json}
-          %i.fa.fa-plus.fa-lg
-      %td
         = text_field("entry", "name", :maxlength => MAX_NAME_LEN, :style => "width: 100%;")
       %td
         = text_field("entry", "description", :maxlength => MAX_DESC_LEN, :style => "width: 100%;")
-  - else
-    %tr{:class => cycle('row0', 'row1'), :id => "#{entry.id}_tr"}
-      %td
-        %button.btn.btn-default{:title => _("Update this entry"),
+      %td.action-cell
+        %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
           "data-submit"         => 'classification_entries_div',
           "data-miq_sparkle_on" => true,
           :remote               => true,
           "data-method"         => :post,
           'data-click_url'      => {:url => "#{url}"}.to_json}
-          %i.fa.fa-save.fa-lg
+          = _("Add")
+  - else
+    %tr{:class => cycle('row0', 'row1'), :id => "#{entry.id}_tr"}
       %td
         = text_field("entry", "name",
           :maxlength => MAX_NAME_LEN,
@@ -34,24 +26,32 @@
           :maxlength => MAX_DESC_LEN,
           "value"    => entry.description,
           :style     => "width: 100%;")
+      %td.action-cell
+        %button.btn.btn-default.btn-block.btn-sm{:title => _("Update this entry"),
+          "data-submit"         => 'classification_entries_div',
+          "data-miq_sparkle_on" => true,
+          :remote               => true,
+          "data-method"         => :post,
+          'data-click_url'      => {:url => "#{url}"}.to_json}
+          = _("Save")
 - else
   - if entry == "new"
     %tr#new_tr{:class => cycle('row0', 'row1'), :onclick => remote_function(:url => {:action => 'ce_select', :id => 'new'}), :title => _("Click to add a new entry")}
       %td
-        %button.btn.btn-default
-          %i.fa.fa-plus.fa-lg
-      %td
         = _("<New Entry>")
       %td= _("<Click on this row to create a new entry>")
+      %td.action-cell
+        %button.btn.btn-default.btn-block.btn-sm
+          = _("Add")
   - else
     %tr{:class => cycle('row0', 'row1'), :id => "#{entry.id}_tr"}
-      %td
-        %button.btn.btn-default{:onclick => remote_function(:url => {:action => 'ce_delete',
-                                                    :id     => entry.id},
-                                           :confirm => _("Deleting the '%s' entry will also unassign it from all items, are you sure?") % entry.name),
-                                           :title => _("Click to delete this entry")}
-          %i.fa.fa-minus.fa-lg
       %td{:onclick => remote_function(:url => {:action => 'ce_select', :id => entry.id, :field => "name"}), :title => _("Click to update this entry")}
         = entry.name
       %td{:onclick => remote_function(:url => {:action => 'ce_select', :id => entry.id, :field => "description"}), :title => _("Click to update this entry")}
         = entry.description
+      %td.action-cell
+        %button.btn.btn-default.btn-block.btn-sm{:onclick => remote_function(:url => {:action => 'ce_delete',
+                                                    :id     => entry.id},
+                                           :confirm => _("Deleting the '%s' entry will also unassign it from all items, are you sure?") % entry.name),
+                                           :title => _("Click to delete this entry")}
+          = _("Delete")

--- a/app/views/ops/_settings_co_categories_tab.html.haml
+++ b/app/views/ops/_settings_co_categories_tab.html.haml
@@ -3,19 +3,15 @@
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr
-        %th.narrow
         %th= _("Name")
         %th= _("Description")
         %th= _("Show in Console")
         %th= _("Single Value")
         %th= _("Capture C & U Data")
         %th= _("Default")
+        %th= _("Actions")
     %tbody
       %tr#new_tr{:onclick => remote_function(:url => {:action => 'category_edit', :id => nil}), :title => _("Click to add a new category")}
-        %td.narrow
-          %ul.icons.list-unstyled
-            %li
-              %span.glyphicon.glyphicon-plus
         %td
           = _("<Click on this row to create a new category>")
         %td
@@ -23,21 +19,11 @@
         %td
         %td
         %td
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
       - @categories.each do |cat|
         %tr
-          - if cat[:default] == "t" || cat[:default].to_s == "1"
-            %td.narrow{:title => _("Category '%s' cannot be deleted") % cat[:name]}
-              %ul.icons.list-unstyled
-                %li
-                  %span.pficon.pficon-delete
-          - else
-            %td.narrow{:onclick => remote_function(:url => {:action => 'category_delete',
-              :id      => cat[:id]},
-              :confirm => _("Are you sure you want to delete category '%s'?") % cat[:name]),
-              :title   => _("Click to delete this category")}
-              %ul.icons.list-unstyled
-                %li
-                  %span.pficon.pficon-delete
           - t = _("Click to edit this category")
           %td{:onclick => remote_function(:url => {:action => 'category_edit', :id => cat[:id]}), :title => t}
             = h(cat[:name])
@@ -52,3 +38,15 @@
           %td{:onclick => remote_function(:url => {:action => 'category_edit', :id => cat[:id]}), :title => t}
             - default = cat[:default] ? true : false
             = h(default)
+
+          - if cat[:default] == "t" || cat[:default].to_s == "1"
+            %td.action-cell{:title => _("Category '%s' cannot be deleted") % cat[:name]}
+              %button.btn.btn-default.btn-block.btn-sm
+                = _("Delete")
+          - else
+            %td.action-cell{:onclick => remote_function(:url => {:action => 'category_delete',
+              :id      => cat[:id]},
+              :confirm => _("Are you sure you want to delete category '%s'?") % cat[:name]),
+              :title   => _("Click to delete this category")}
+              %button.btn.btn-default.btn-block.btn-sm
+                = _("Delete")


### PR DESCRIPTION
Update with new Patternfly Table View action button styling: 

Old
<img width="1118" alt="screen shot 2016-04-05 at 4 38 29 pm" src="https://cloud.githubusercontent.com/assets/1287144/14297418/a012906a-fb4c-11e5-9d3c-455f8d30616a.png">
New
<img width="1119" alt="screen shot 2016-04-05 at 4 40 28 pm" src="https://cloud.githubusercontent.com/assets/1287144/14297439/b97a962e-fb4c-11e5-96db-10743aa09f4f.png">

Old
<img width="1061" alt="screen shot 2016-04-06 at 10 18 34 am" src="https://cloud.githubusercontent.com/assets/1287144/14319792/93896f0a-fbe0-11e5-9636-207c43783851.png">
New
<img width="1059" alt="screen shot 2016-04-06 at 10 17 51 am" src="https://cloud.githubusercontent.com/assets/1287144/14319798/98935452-fbe0-11e5-9afe-d8f1a900f249.png">

