### PR TITLE
Upgrade puma so we can change the thread count used by rails server.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "high_voltage",                   "~>2.4.0"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "novnc-rails",                    "~>0.2"
 gem "outfielding-jqplot-rails",       "= 1.0.8"
-gem "puma",                           "~>2.13"
+gem "puma",                           "~>3.3.0"
 gem "recursive-open-struct",          "~>1.0.0"
 gem "responders",                     "~>2.0"
 gem "secure_headers",                 "~>3.0.0"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,20 @@
+# We run puma through rails server with options here:
+# https://github.com/ManageIQ/manageiq/blob/2920f76fe609147a6e7c68245a3717d55a7ece7e/app/models/mixins/miq_web_server_worker_mixin.rb#L162-L175
+#
+# Note, Rails::Server and Rack::Server don't expose all puma/thin web server options.
+#
+# As of puma 3.0.0+, puma specific options can be put in config/puma.rb, see:
+# https://github.com/puma/puma/tree/a3136985887d44c79e623b1408a41779b71d8b23#configuration
+#
+#
+# For each rack request, Rails' query cache middleware reserves a database connection
+# for the current thread:
+# https://github.com/rails/rails/blob/fa3537506a12635b51886919589211640ddd3a15/activerecord/lib/active_record/query_cache.rb#L28
+#
+# Puma spins up a thread for each request.
+#
+# Therefore, we should have a database.yml pool greater than or equal to the puma
+# thread count or we risk a ActiveRecord::ConnectionTimeoutError waiting on a
+# connection from the connection pool.
+#
+threads 5, 5


### PR DESCRIPTION
We run puma through rails server with options [here](https://github.com/ManageIQ/manageiq/blob/2920f76fe609147a6e7c68245a3717d55a7ece7e/app/models/mixins/miq_web_server_worker_mixin.rb#L162-L175)

Note, Rails::Server and Rack::Server don't expose all web server options.

As of puma 3.0.0+, puma specific options can be put in config/puma.rb, see [here](https://github.com/puma/puma/tree/a3136985887d44c79e623b1408a41779b71d8b23#configuration)

For each rack request, Rails' query cache middleware reserves a database connection
for the current thread [here](https://github.com/rails/rails/blob/fa3537506a12635b51886919589211640ddd3a15/activerecord/lib/active_record/query_cache.rb#L28).

Puma spins up a thread for each request.

Therefore, we should have a database.yml pool greater than or equal to the puma
thread count or we risk a ActiveRecord::ConnectionTimeoutError waiting on a
connection from the connection pool.