### PR TITLE
Add pglogical subscription dsn update

### DIFF
--- a/spec/replication/ar_pglogical_spec.rb
+++ b/spec/replication/ar_pglogical_spec.rb
@@ -71,6 +71,23 @@ describe "ar_pglogical extension" do
         end
       end
 
+      describe "#node_dsn_update" do
+        let(:new_dsn) { "host='newhost.example.com' dbname='vmdb_test' user='root'" }
+
+        it "sets the dsn" do
+          expect(connection.pglogical.node_dsn_update(node_name, new_dsn)).to be true
+          dsn = connection.exec_query(<<-SQL).first["if_dsn"]
+            SELECT if_dsn
+            FROM pglogical.node_interface if
+            JOIN pglogical.node node ON
+              if.if_nodeid = node.node_id
+            WHERE node.node_name = '#{node_name}'
+          SQL
+
+          expect(dsn).to eq(new_dsn)
+        end
+      end
+
       describe "#replication_set_create" do
         it "creates a replication set" do
           rep_insert = true

--- a/spec/replication/miq_pglogical_spec.rb
+++ b/spec/replication/miq_pglogical_spec.rb
@@ -71,4 +71,16 @@ describe MiqPglogical do
       expect(subject.included_tables).to include(table)
     end
   end
+
+  describe ".region_to_node_name" do
+    it "returns the correct name" do
+      expect(described_class.region_to_node_name(4)).to eq("region_4")
+    end
+  end
+
+  describe ".node_name_to_region" do
+    it "returns the correct region" do
+      expect(described_class.node_name_to_region("region_5")).to eq(5)
+    end
+  end
 end


### PR DESCRIPTION
Add a method to update the connection string for an active node.

This will allow people to change how we connect to subscribed nodes without removing all of the data from that node and re-running the initial sync.

~~This change also required passing the password (encrypted) back to the UI when retrieving subscriptions from the database.  That way we will not blank the password on update if the user provided one when the subscription was created.~~

NOTE: This assumes that we are connecting to the *same database* after the dsn change. pglogical tracks changes using the transaction id, not triggers, so if the transactions don't match what the subscription is expecting the behavior is undefined (and likely bad).

@gtanzillo @h-kataria @Fryguy please review.