### PR TITLE
Toolbar buttons: properly handle situations when the :enabled property is a string, not a boolean

### DIFF
--- a/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::T
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -39,7 +39,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::T
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"auth_key_pair_cloud\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"auth_key_pair_cloud\")}"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/availability_zones_center.rb
+++ b/app/helpers/application_helper/toolbar/availability_zones_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::AvailabilityZonesCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::AvailabilityZonesCenter < ApplicationHelper::T
           N_('Edit Tags for the selected Availability Zones'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/blank_view.rb
+++ b/app/helpers/application_helper/toolbar/blank_view.rb
@@ -5,6 +5,6 @@ class ApplicationHelper::Toolbar::BlankView < ApplicationHelper::Toolbar::Basic
       nil,
       nil,
       nil,
-      :enabled => "false"),
+      :enabled => false),
   ])
 end

--- a/app/helpers/application_helper/toolbar/chargebacks_center.rb
+++ b/app/helpers/application_helper/toolbar/chargebacks_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           t = N_('Edit the selected Chargeback Rate'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :chargeback_rates_copy,
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           t = N_('Copy the selected Chargeback Rate to a new Chargeback Rate'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :chargeback_rates_delete,
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Chargeback Rate will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Chargeback Rates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_containers_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainersCenter < Application
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::CloudObjectStoreContainersCenter < Application
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+")
       ]
     )

--- a/app/helpers/application_helper/toolbar/cloud_object_store_objects_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_object_store_objects_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::CloudObjectStoreObjectsCenter < ApplicationHel
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::CloudObjectStoreObjectsCenter < ApplicationHel
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+")
       ]
     )

--- a/app/helpers/application_helper/toolbar/cloud_subnets_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_subnets_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::CloudSubnetsCenter < ApplicationHelper::Toolba
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::CloudSubnetsCenter < ApplicationHelper::Toolba
           N_('Edit Tags for the selected Floating IPs'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Toolbar::CloudTenantsCenter < ApplicationHelper::Toolba
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/cloud_volume_snapshots_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_snapshots_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::CloudVolumeSnapshotsCenter < ApplicationHelper
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::CloudVolumeSnapshotsCenter < ApplicationHelper
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ConfigurationProfileForemanCenter < Applicatio
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :provider_foreman_refresh_provider,

--- a/app/helpers/application_helper/toolbar/configured_system_ansibletower_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_ansibletower_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemAnsibletowerCenter < Applicati
           N_('Edit Tags'),
           :url       => "tagging",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemCenter < ApplicationHelper::To
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :configured_system_provision,
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemCenter < ApplicationHelper::To
           t,
           :url       => "provision",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemCenter < ApplicationHelper::To
           N_('Edit Tags'),
           :url       => "tagging",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/configured_system_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_foreman_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemForemanCenter < ApplicationHel
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :configured_system_provision,
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemForemanCenter < ApplicationHel
           t,
           :url       => "provision",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemForemanCenter < ApplicationHel
           N_('Edit Tags'),
           :url       => "tagging",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/configured_systems_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemsCenter < ApplicationHelper::T
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :provider_foreman_configured_system_provision,
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemsCenter < ApplicationHelper::T
           t,
           :url       => "provision",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemsCenter < ApplicationHelper::T
           N_('Edit Tags'),
           :url       => "tagging",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemsForemanCenter < ApplicationHe
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :provider_foreman_configured_system_provision,
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemsForemanCenter < ApplicationHe
           t,
           :url       => "provision",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemsForemanCenter < ApplicationHe
           N_('Edit Tags'),
           :url       => "tagging",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_builds_center.rb
+++ b/app/helpers/application_helper/toolbar/container_builds_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::ContainerBuildsCenter < ApplicationHelper::Too
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::ContainerBuildsCenter < ApplicationHelper::Too
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::ContainerBuildsCenter < ApplicationHelper::Too
           N_('Edit Tags for this #{ui_lookup(:table=>"container_builds")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/container_groups_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainerGroupsCenter < ApplicationHelper::Too
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainerGroupsCenter < ApplicationHelper::Too
           N_('Edit Tags for this #{ui_lookup(:table=>"container_groups")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_image_registries_center.rb
+++ b/app/helpers/application_helper/toolbar/container_image_registries_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainerImageRegistriesCenter < ApplicationHe
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainerImageRegistriesCenter < ApplicationHe
           N_('Edit Tags for this #{ui_lookup(:table=>"container_image_registries")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_images_center.rb
+++ b/app/helpers/application_helper/toolbar/container_images_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::ContainerImagesCenter < ApplicationHelper::Too
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::ContainerImagesCenter < ApplicationHelper::Too
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::ContainerImagesCenter < ApplicationHelper::Too
           N_('Edit Tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_nodes_center.rb
+++ b/app/helpers/application_helper/toolbar/container_nodes_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainerNodesCenter < ApplicationHelper::Tool
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainerNodesCenter < ApplicationHelper::Tool
           N_('Edit Tags for this #{ui_lookup(:table=>"container_nodes")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_projects_center.rb
+++ b/app/helpers/application_helper/toolbar/container_projects_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainerProjectsCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainerProjectsCenter < ApplicationHelper::T
           N_('Edit Tags for this #{ui_lookup(:table=>"container_projects")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_replicators_center.rb
+++ b/app/helpers/application_helper/toolbar/container_replicators_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainerReplicatorsCenter < ApplicationHelper
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainerReplicatorsCenter < ApplicationHelper
           N_('Edit Tags for this #{ui_lookup(:table=>"container_replicators")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_routes_center.rb
+++ b/app/helpers/application_helper/toolbar/container_routes_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainerRoutesCenter < ApplicationHelper::Too
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainerRoutesCenter < ApplicationHelper::Too
           N_('Edit Tags for this #{ui_lookup(:table=>"container_routes")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_services_center.rb
+++ b/app/helpers/application_helper/toolbar/container_services_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainerServicesCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainerServicesCenter < ApplicationHelper::T
           N_('Edit Tags for this #{ui_lookup(:table=>"container_services")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/containers_center.rb
+++ b/app/helpers/application_helper/toolbar/containers_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::ContainersCenter < ApplicationHelper::Toolbar:
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::ContainersCenter < ApplicationHelper::Toolbar:
           N_('Edit Tags for selected #{ui_lookup(:tables=>"container")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/customization_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/customization_templates_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
           N_('Select a single Customization Templates to copy'),
           N_('Copy Selected Customization Templates'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :customization_template_edit,
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
           N_('Select a single Customization Templates to edit'),
           N_('Edit Selected Customization Templates'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :customization_template_delete,
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
           N_('Remove Customization Templates from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Customization Templates will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Customization Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/dialog_center.rb
+++ b/app/helpers/application_helper/toolbar/dialog_center.rb
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::DialogCenter < ApplicationHelper::Toolbar::Bas
       'pficon pficon-add-circle-o fa-lg',
       N_('Add'),
       nil,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :dialog_add_tab,

--- a/app/helpers/application_helper/toolbar/dialogs_center.rb
+++ b/app/helpers/application_helper/toolbar/dialogs_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::DialogsCenter < ApplicationHelper::Toolbar::Ba
           t = N_('Edit the selected Dialog'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :dialog_copy,
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::DialogsCenter < ApplicationHelper::Toolbar::Ba
           t = N_('Copy the selected Dialog to a new Dialog'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :dialog_delete,
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::DialogsCenter < ApplicationHelper::Toolbar::Ba
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Dialog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Dialogs?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/drifts_center.rb
+++ b/app/helpers/application_helper/toolbar/drifts_center.rb
@@ -6,7 +6,7 @@ class ApplicationHelper::Toolbar::DriftsCenter < ApplicationHelper::Toolbar::Bas
       N_('Select up to 10 timestamps for Drift Analysis'),
       nil,
       :url_parms => "main_div",
-      :enabled   => "false",
+      :enabled   => false,
       :onwhen    => "2+"),
   ])
 end

--- a/app/helpers/application_helper/toolbar/ems_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clouds_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected \#{ui_lookup(:tables=>\"ems_clouds\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :ems_cloud_discover,
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
           N_('Select a single #{ui_lookup(:table=>"ems_cloud")} to edit'),
           N_('Edit Selected #{ui_lookup(:table=>"ems_cloud")}'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ems_cloud_delete,
@@ -44,7 +44,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
           N_('Remove #{ui_lookup(:tables=>"ems_clouds")} from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"ems_clouds\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"ems_clouds\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -55,7 +55,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -64,7 +64,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
           N_('Manage Policies for the selected #{ui_lookup(:tables=>"ems_clouds")}'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :ems_cloud_tag,
@@ -72,7 +72,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
           N_('Edit Tags for the selected #{ui_lookup(:tables=>"ems_clouds")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_clusters_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clusters_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :ems_cluster_compare,
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
           N_('Select two or more items to compare'),
           N_('Compare Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         separator,
         button(
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -44,7 +44,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -53,7 +53,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
           N_('Manage Policies for the selected items'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :ems_cluster_tag,
@@ -61,7 +61,7 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
           N_('Edit Tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           N_('Refresh Items and Relationships for all #{ui_lookup(:table=>"ems_containers")}'),
           N_('Refresh Items and Relationships'),
           :confirm   => N_("Refresh Items and Relationships related to  \#{ui_lookup(:table=>\"ems_containers\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :url_parms => "main_div",
           :onwhen    => "1+"),
         separator,
@@ -28,7 +28,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           N_('Select a single #{ui_lookup(:table=>"ems_container")} to edit'),
           N_('Edit Selected #{ui_lookup(:table=>"ems_container")}'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ems_container_delete,
@@ -37,7 +37,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           N_('Remove #{ui_lookup(:tables=>"ems_containers")} from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"ems_containers\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"ems_containers\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -48,7 +48,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -57,7 +57,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           N_('Edit Tags for this #{ui_lookup(:table=>"ems_container")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infras_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected \#{ui_lookup(:tables=>\"ems_infras\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :ems_infra_discover,
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
           N_('Select a single #{ui_lookup(:table=>"ems_infra")} to edit'),
           N_('Edit Selected #{ui_lookup(:table=>"ems_infra")}'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ems_infra_delete,
@@ -44,7 +44,7 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
           N_('Remove #{ui_lookup(:tables=>"ems_infras")} from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"ems_infras\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"ems_infras\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -55,7 +55,7 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -64,7 +64,7 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
           N_('Manage Policies for the selected #{ui_lookup(:tables=>"ems_infras")}'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :ems_infra_tag,
@@ -72,7 +72,7 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
           N_('Edit Tags for the selected #{ui_lookup(:tables=>"ems_infras")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewaresCenter < ApplicationHelper::Tool
           N_('Select a single #{ui_lookup(:table=>"ems_middleware")} to edit'),
           N_('Edit Selected #{ui_lookup(:table=>"ems_middleware")}'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ems_middleware_delete,
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewaresCenter < ApplicationHelper::Tool
           N_('Remove #{ui_lookup(:tables=>"ems_middlewares")} from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"ems_middlewares\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"ems_middlewares\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -38,7 +38,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewaresCenter < ApplicationHelper::Tool
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -47,7 +47,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewaresCenter < ApplicationHelper::Tool
           N_('Edit Tags for this #{ui_lookup(:table=>"ems_middleware")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_networks_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected \#{ui_lookup(:tables=>\"ems_networks\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -28,7 +28,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           N_('Select a single #{ui_lookup(:table=>"ems_network")} to edit'),
           N_('Edit Selected #{ui_lookup(:table=>"ems_network")}'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ems_network_delete,
@@ -37,7 +37,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           N_('Remove #{ui_lookup(:tables=>"ems_networks")} from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"ems_networks\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"ems_networks\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -48,7 +48,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -57,7 +57,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           N_('Manage Policies for the selected #{ui_lookup(:tables=>"ems_networks")}'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :ems_network_tag,
@@ -65,7 +65,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           N_('Edit Tags for the selected #{ui_lookup(:tables=>"ems_networks")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/flavors_center.rb
+++ b/app/helpers/application_helper/toolbar/flavors_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::FlavorsCenter < ApplicationHelper::Toolbar::Ba
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::FlavorsCenter < ApplicationHelper::Toolbar::Ba
           N_('Edit Tags for the selected Flavors'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/floating_ips_center.rb
+++ b/app/helpers/application_helper/toolbar/floating_ips_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::FloatingIpsCenter < ApplicationHelper::Toolbar
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::FloatingIpsCenter < ApplicationHelper::Toolbar
           N_('Edit Tags for the selected Floating IPs'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/hosts_center.rb
+++ b/app/helpers/application_helper/toolbar/hosts_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_scan,
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_compare,
@@ -30,7 +30,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Select two or more items to compare'),
           N_('Compare Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         button(
           :host_discover,
@@ -52,7 +52,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           t = N_('Edit Selected items'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_delete,
@@ -61,7 +61,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Remove items from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -72,7 +72,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -81,7 +81,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Manage Policies for the selected items'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_tag,
@@ -89,7 +89,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Edit Tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_check_compliance,
@@ -98,7 +98,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Check Compliance of Last Known Configuration'),
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_analyze_check_compliance,
@@ -107,7 +107,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Analyze then Check Compliance'),
           :url_parms => "main_div",
           :confirm   => N_("Analyze then Check Compliance for the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -125,7 +125,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Request to Provision items'),
           N_('Provision items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -136,7 +136,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
       'fa fa-power-off fa-lg',
       N_('Power Operations'),
       N_('Power'),
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -147,7 +147,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :image     => "standby",
           :confirm   => N_("Shutdown the selected items to Standy Mode?"),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_shutdown,
@@ -157,7 +157,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :image     => "guest_shutdown",
           :url_parms => "main_div",
           :confirm   => N_("Shutdown the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :host_reboot,
@@ -167,7 +167,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :image     => "guest_restart",
           :url_parms => "main_div",
           :confirm   => N_("Restart the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(

--- a/app/helpers/application_helper/toolbar/iso_datastores_center.rb
+++ b/app/helpers/application_helper/toolbar/iso_datastores_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::IsoDatastoresCenter < ApplicationHelper::Toolb
           N_('Remove ISO Datastores from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected ISO Datastores and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected ISO Datastores?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -28,7 +28,7 @@ class ApplicationHelper::Toolbar::IsoDatastoresCenter < ApplicationHelper::Toolb
           N_('Refresh Relationships'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh Relationships for selected ISO Datastores?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ldap_regions_center.rb
+++ b/app/helpers/application_helper/toolbar/ldap_regions_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::LdapRegionsCenter < ApplicationHelper::Toolbar
           N_('Select a single LDAP Region to edit'),
           N_('Edit the selected LDAP Region'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ldap_region_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::LdapRegionsCenter < ApplicationHelper::Toolbar
           N_('Delete selected LDAP Regions'),
           :url_parms => "main_div",
           :confirm   => N_("Delete all selected LDAP Regions?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/middleware_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_servers_center.rb
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::MiddlewareServersCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::MiddlewareServersCenter < ApplicationHelper::T
           N_('Edit Tags for this #{ui_lookup(:table=>"middleware_servers")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_ae_domain_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_domain_center.rb
@@ -39,7 +39,7 @@ class ApplicationHelper::Toolbar::MiqAeDomainCenter < ApplicationHelper::Toolbar
           N_('Select a single Namespace to edit'),
           N_('Edit Selected Namespace'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_ae_namespace_delete,
@@ -48,7 +48,7 @@ class ApplicationHelper::Toolbar::MiqAeDomainCenter < ApplicationHelper::Toolbar
           N_('Remove Namespaces'),
           :url_parms => "main_div",
           :confirm   => N_("Are you sure you want to remove the selected Namespaces?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_ae_domains_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_domains_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::MiqAeDomainsCenter < ApplicationHelper::Toolba
           N_('Select a single Domains to edit'),
           N_('Edit Selected Domains'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_ae_domain_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::MiqAeDomainsCenter < ApplicationHelper::Toolba
           N_('Remove Domains'),
           :url_parms => "main_div",
           :confirm   => N_("Are you sure you want to remove the selected Domains?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(

--- a/app/helpers/application_helper/toolbar/miq_ae_instances_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_instances_center.rb
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::MiqAeInstancesCenter < ApplicationHelper::Tool
           N_('Select a single Instance to edit'),
           N_('Edit Selected Instance'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_ae_instance_copy,
@@ -43,7 +43,7 @@ class ApplicationHelper::Toolbar::MiqAeInstancesCenter < ApplicationHelper::Tool
           N_('Select Instances to copy'),
           N_('Copy selected Instances'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_ae_instance_delete,
@@ -52,7 +52,7 @@ class ApplicationHelper::Toolbar::MiqAeInstancesCenter < ApplicationHelper::Tool
           N_('Remove Instances'),
           :url_parms => "main_div",
           :confirm   => N_("Are you sure you want to remove the selected Instances?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_ae_methods_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_methods_center.rb
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::MiqAeMethodsCenter < ApplicationHelper::Toolba
           N_('Select a single Method to edit'),
           N_('Edit Selected Method'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_ae_method_copy,
@@ -43,7 +43,7 @@ class ApplicationHelper::Toolbar::MiqAeMethodsCenter < ApplicationHelper::Toolba
           N_('Select Methods to copy'),
           N_('Copy selected Methods'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_ae_method_delete,
@@ -52,7 +52,7 @@ class ApplicationHelper::Toolbar::MiqAeMethodsCenter < ApplicationHelper::Toolba
           N_('Remove Methods'),
           :url_parms => "main_div",
           :confirm   => N_("Are you sure you want to remove the selected Methods?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::MiqAeNamespaceCenter < ApplicationHelper::Tool
           t = N_('Edit Selected Item'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_ae_class_copy,
@@ -42,7 +42,7 @@ class ApplicationHelper::Toolbar::MiqAeNamespaceCenter < ApplicationHelper::Tool
           N_('Select Classes to copy'),
           N_('Copy selected Classes'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_ae_namespace_delete,
@@ -51,7 +51,7 @@ class ApplicationHelper::Toolbar::MiqAeNamespaceCenter < ApplicationHelper::Tool
           t,
           :url_parms => "main_div",
           :confirm   => N_("Are you sure you want to remove selected Items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_dialogs_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_dialogs_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::MiqDialogsCenter < ApplicationHelper::Toolbar:
           t,
           :klass     => ApplicationHelper::Button::OldDialogsEditDelete,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :old_dialogs_copy,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::MiqDialogsCenter < ApplicationHelper::Toolbar:
           t = N_('Copy the selected Dialog to a new Dialog'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :old_dialogs_delete,
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::MiqDialogsCenter < ApplicationHelper::Toolbar:
           :klass     => ApplicationHelper::Button::OldDialogsEditDelete,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Dialog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Dialogs?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_groups_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::MiqGroupsCenter < ApplicationHelper::Toolbar::
           N_('Select a single Group to edit'),
           N_('Edit the selected Group'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :rbac_group_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::MiqGroupsCenter < ApplicationHelper::Toolbar::
           N_('Delete selected Groups'),
           :url_parms => "main_div",
           :confirm   => N_("Delete all selected Groups?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -50,7 +50,7 @@ class ApplicationHelper::Toolbar::MiqGroupsCenter < ApplicationHelper::Toolbar::
           t = N_('Edit \'#{session[:customer_name]}\' Tags for the selected Groups'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_report_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_center.rb
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::MiqReportCenter < ApplicationHelper::Toolbar::
           t = N_('Delete this Saved Report from the Database'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+",
           :confirm   => N_("The selected Saved Reports will be permanently removed from the database. Are you sure you want to delete this saved Report?")),
         button(

--- a/app/helpers/application_helper/toolbar/miq_report_schedules_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_schedules_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::MiqReportSchedulesCenter < ApplicationHelper::
           t = N_('Edit the selected Schedule'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_report_schedule_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::MiqReportSchedulesCenter < ApplicationHelper::
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Schedules and ALL of their components will be permanently removed from the VMDB.  Are you sure you want to delete the selected Schedules?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_report_schedule_enable,
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::MiqReportSchedulesCenter < ApplicationHelper::
           t = N_('Enable the selected Schedules'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_report_schedule_disable,
@@ -42,7 +42,7 @@ class ApplicationHelper::Toolbar::MiqReportSchedulesCenter < ApplicationHelper::
           t = N_('Disable the selected Schedules'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -51,7 +51,7 @@ class ApplicationHelper::Toolbar::MiqReportSchedulesCenter < ApplicationHelper::
           t = N_('Queue up selected Schedules to run now'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_schedules_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_schedules_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::MiqSchedulesCenter < ApplicationHelper::Toolba
           t = N_('Edit the selected Schedule'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :schedule_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::MiqSchedulesCenter < ApplicationHelper::Toolba
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Schedules and ALL of their components will be permanently removed from the VMDB.  Are you sure you want to delete the selected Schedules?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :schedule_enable,
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::MiqSchedulesCenter < ApplicationHelper::Toolba
           t = N_('Enable the selected Schedules'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :schedule_disable,
@@ -42,7 +42,7 @@ class ApplicationHelper::Toolbar::MiqSchedulesCenter < ApplicationHelper::Toolba
           t = N_('Disable the selected Schedules'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -51,7 +51,7 @@ class ApplicationHelper::Toolbar::MiqSchedulesCenter < ApplicationHelper::Toolba
           t = N_('Queue up selected Schedules to run now'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_template_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_template_center.rb
@@ -160,7 +160,7 @@ class ApplicationHelper::Toolbar::MiqTemplateCenter < ApplicationHelper::Toolbar
       N_('Compare selected Templates'),
       nil,
       :url_parms => "main_div",
-      :enabled   => "false",
+      :enabled   => false,
       :onwhen    => "2+"),
   ])
 end

--- a/app/helpers/application_helper/toolbar/miq_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_templates_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_compare,
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Select two or more Templates to compare'),
           N_('Compare Selected Templates'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         separator,
         button(
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Select a single Template to edit'),
           N_('Edit Selected Template'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_template_ownership,
@@ -40,7 +40,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Set Ownership for the selected Templates'),
           N_('Set Ownership'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_delete,
@@ -49,7 +49,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Remove Templates from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -60,7 +60,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -69,7 +69,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Manage Policies for the selected Templates'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_policy_sim,
@@ -77,7 +77,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('View Policy Simulation for the selected Templates'),
           N_('Policy Simulation'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_tag,
@@ -85,7 +85,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Edit tags for the selected Templates'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_check_compliance,
@@ -94,7 +94,7 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           N_('Check Compliance of Last Known Configuration'),
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/network_routers_center.rb
+++ b/app/helpers/application_helper/toolbar/network_routers_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::NetworkRoutersCenter < ApplicationHelper::Tool
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::NetworkRoutersCenter < ApplicationHelper::Tool
           N_('Edit Tags for the selected Floating IPs'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ontap_file_shares_center.rb
+++ b/app/helpers/application_helper/toolbar/ontap_file_shares_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::OntapFileSharesCenter < ApplicationHelper::Too
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::OntapFileSharesCenter < ApplicationHelper::Too
           N_('Edit tags for the selected File Shares'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb
+++ b/app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::OntapLogicalDisksCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::OntapLogicalDisksCenter < ApplicationHelper::T
           N_('Edit tags for the selected Logical Disks'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb
+++ b/app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::OntapStorageSystemsCenter < ApplicationHelper:
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::OntapStorageSystemsCenter < ApplicationHelper:
           N_('Edit tags for the selected Systems'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::OntapStorageVolumesCenter < ApplicationHelper:
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::OntapStorageVolumesCenter < ApplicationHelper:
           N_('Edit tags for the selected Volumes'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
           N_('Remove #{ui_lookup(:tables=>"orchestration_stack")} from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"orchestration_stack\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"orchestration_stack\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
           N_('Edit Tags for the selected #{ui_lookup(:tables=>"orchestration_stack")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -44,7 +44,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -52,7 +52,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for the selected #{ui_lookup(:tables=>"orchestration_stack")}'),
           N_('Set Retirement Dates'),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+",
           :url_parms => "main_div"),
         button(
@@ -61,7 +61,7 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
           t = N_('Retire selected #{ui_lookup(:tables => "orchestration_stack")}'),
           t,
           :confirm   => N_("Retire the selected \#{ui_lookup(:tables => \"orchestration_stack\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+",
           :url_parms => "main_div"),
       ]

--- a/app/helpers/application_helper/toolbar/orchestration_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_templates_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::OrchestrationTemplatesCenter < ApplicationHelp
           t,
           :klass     => ApplicationHelper::Button::OrchestrationTemplateEditRemove,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :orchestration_template_copy,
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::OrchestrationTemplatesCenter < ApplicationHelp
           t,
           :klass     => ApplicationHelper::Button::OrchestrationTemplateEditRemove,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :orchestration_template_remove,
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::OrchestrationTemplatesCenter < ApplicationHelp
           t,
           :confirm   => N_("Remove selected Orchestration Templates?"),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -54,7 +54,7 @@ class ApplicationHelper::Toolbar::OrchestrationTemplatesCenter < ApplicationHelp
           N_('Edit tags for the selected Items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/persistent_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/persistent_volumes_center.rb
@@ -41,7 +41,7 @@ class ApplicationHelper::Toolbar::PersistentVolumesCenter < ApplicationHelper::T
       t = N_('Policy'),
       t,
       :image   => "policy",
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -51,7 +51,7 @@ class ApplicationHelper::Toolbar::PersistentVolumesCenter < ApplicationHelper::T
           N_('Edit Tags'),
           :image     => "tag",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/provider_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/provider_foreman_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ProviderForemanCenter < ApplicationHelper::Too
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :provider_foreman_refresh_provider,
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::ProviderForemanCenter < ApplicationHelper::Too
           :url       => "refresh",
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships for all items related to the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::ProviderForemanCenter < ApplicationHelper::Too
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Provider'),
           t,
-          :enabled => "true",
+          :enabled => true,
           :url     => "new"),
         button(
           :provider_foreman_edit_provider,
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::ProviderForemanCenter < ApplicationHelper::Too
           N_('Edit Selected item'),
           :url       => "edit",
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :provider_foreman_delete_provider,
@@ -42,7 +42,7 @@ class ApplicationHelper::Toolbar::ProviderForemanCenter < ApplicationHelper::Too
           :url       => "delete",
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
       ]

--- a/app/helpers/application_helper/toolbar/pxe_image_types_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_image_types_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::PxeImageTypesCenter < ApplicationHelper::Toolb
           N_('Select a single System Image Type to edit'),
           N_('Edit the selected System Image Type'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :pxe_image_type_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::PxeImageTypesCenter < ApplicationHelper::Toolb
           N_('Remove System Image Types from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected System Image Types will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected System Image Types?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/pxe_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_servers_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::PxeServersCenter < ApplicationHelper::Toolbar:
           N_('Select a single PXE Servers to edit'),
           N_('Edit Selected PXE Servers'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :pxe_server_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::PxeServersCenter < ApplicationHelper::Toolbar:
           N_('Remove PXE Servers from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected PXE Servers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected PXE Servers?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -36,7 +36,7 @@ class ApplicationHelper::Toolbar::PxeServersCenter < ApplicationHelper::Toolbar:
           N_('Refresh Relationships'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh Relationships for selected PXE Servers?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/repositories_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::RepositoriesCenter < ApplicationHelper::Toolba
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected Repositories?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -28,7 +28,7 @@ class ApplicationHelper::Toolbar::RepositoriesCenter < ApplicationHelper::Toolba
           N_('Select a single Repository to edit'),
           N_('Edit the Selected Repository'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :repository_delete,
@@ -37,7 +37,7 @@ class ApplicationHelper::Toolbar::RepositoriesCenter < ApplicationHelper::Toolba
           N_('Remove Repositories from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Repositories and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Repositories?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -48,7 +48,7 @@ class ApplicationHelper::Toolbar::RepositoriesCenter < ApplicationHelper::Toolba
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -57,7 +57,7 @@ class ApplicationHelper::Toolbar::RepositoriesCenter < ApplicationHelper::Toolba
           N_('Manage Policies for the selected Repositories'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :repository_tag,
@@ -65,7 +65,7 @@ class ApplicationHelper::Toolbar::RepositoriesCenter < ApplicationHelper::Toolba
           N_('Edit Tags for the selected Repositories'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/resource_pools_center.rb
+++ b/app/helpers/application_helper/toolbar/resource_pools_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ResourcePoolsCenter < ApplicationHelper::Toolb
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::ResourcePoolsCenter < ApplicationHelper::Toolb
           N_('Remove Resource Pools from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Resource Pools and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Resource Pools?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::ResourcePoolsCenter < ApplicationHelper::Toolb
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::ResourcePoolsCenter < ApplicationHelper::Toolb
           N_('Manage Policies for the selected Resource Pools'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :resource_pool_tag,
@@ -43,7 +43,7 @@ class ApplicationHelper::Toolbar::ResourcePoolsCenter < ApplicationHelper::Toolb
           N_('Edit Tags for the selected Resource Pools'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/saved_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_reports_center.rb
@@ -19,7 +19,7 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
           'product product-report fa-lg',
           t = N_('Show full screen Report'),
           t,
-          :enabled => "false",
+          :enabled => false,
           :onwhen  => "1",
           :url     => "/report_only",
           :popup   => true,
@@ -31,7 +31,7 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
           t,
           :url_parms => "main_div",
           :confirm   => N_("The selected Saved Reports will be permanently removed from the database. Are you sure you want to delete the selected Saved Reports?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/scan_profiles_center.rb
+++ b/app/helpers/application_helper/toolbar/scan_profiles_center.rb
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::ScanProfilesCenter < ApplicationHelper::Toolba
           t = N_('Edit the selected Analysis Profiles'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ap_copy,
@@ -30,7 +30,7 @@ class ApplicationHelper::Toolbar::ScanProfilesCenter < ApplicationHelper::Toolba
           t = N_('Copy the selected Analysis Profiles'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :ap_delete,
@@ -39,7 +39,7 @@ class ApplicationHelper::Toolbar::ScanProfilesCenter < ApplicationHelper::Toolba
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Analysis Profiles and ALL of their components will be permanently removed from the VMDB.  Are you sure you want to delete the selected Analysis Profiles?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/security_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/security_groups_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::SecurityGroupsCenter < ApplicationHelper::Tool
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::SecurityGroupsCenter < ApplicationHelper::Tool
           N_('Edit Tags for the selected Security Groups'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/services_center.rb
+++ b/app/helpers/application_helper/toolbar/services_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
           N_('Select a single service to edit'),
           N_('Edit Selected Service'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :service_delete,
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
           N_('Remove Services from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Services?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
           N_('Set Ownership for the selected Services'),
           N_('Set Ownership'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -43,7 +43,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -52,7 +52,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
           N_('Edit tags for the selected Items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -63,7 +63,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -72,7 +72,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
           N_('Set Retirement Dates for the selected items'),
           N_('Set Retirement Dates'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :service_retire_now,
@@ -81,7 +81,7 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
           N_('Retire selected items'),
           :url_parms => "main_div",
           :confirm   => N_("Retire the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogsCenter < ApplicationHel
           N_('Select a single Item to edit'),
           N_('Edit Selected Item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :st_catalog_delete,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogsCenter < ApplicationHel
           N_('Remove Items from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Items will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/servicetemplates_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplates_center.rb
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
           N_('Select a single Item to edit'),
           N_('Edit Selected Item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :catalogitem_delete,
@@ -31,7 +31,7 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
           N_('Remove Items from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -42,7 +42,7 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -51,7 +51,7 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
           N_('Edit tags for the selected Items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/storage_managers_center.rb
+++ b/app/helpers/application_helper/toolbar/storage_managers_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::StorageManagersCenter < ApplicationHelper::Too
           N_('Refresh Inventory'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh Inventory for all Storage CIs known to the selected Storage Managers?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :storage_manager_refresh_status,
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::StorageManagersCenter < ApplicationHelper::Too
           N_('Refresh Status'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh Status for all Storage CIs known to the selected Storage Managers?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -37,7 +37,7 @@ class ApplicationHelper::Toolbar::StorageManagersCenter < ApplicationHelper::Too
           N_('Select a single Storage Manager to edit'),
           N_('Edit Selected Storage Manager'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :storage_manager_delete,
@@ -46,7 +46,7 @@ class ApplicationHelper::Toolbar::StorageManagersCenter < ApplicationHelper::Too
           N_('Remove Storage Managers from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Storage Managers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Storage Managers?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/storages_center.rb
+++ b/app/helpers/application_helper/toolbar/storages_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::StoragesCenter < ApplicationHelper::Toolbar::B
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::StoragesCenter < ApplicationHelper::Toolbar::B
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected \#{ui_lookup(:tables=>\"storages\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :storage_delete,
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::StoragesCenter < ApplicationHelper::Toolbar::B
           N_('Remove #{ui_lookup(:tables=>"storages")} from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"storages\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"storages\")}?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::StoragesCenter < ApplicationHelper::Toolbar::B
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -44,7 +44,7 @@ class ApplicationHelper::Toolbar::StoragesCenter < ApplicationHelper::Toolbar::B
           N_('Edit Tags for the selected #{ui_lookup(:tables=>"storages")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/tasks_center.rb
+++ b/app/helpers/application_helper/toolbar/tasks_center.rb
@@ -13,7 +13,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
       'pficon pficon-delete fa-lg',
       N_('Delete Tasks'),
       nil,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :miq_task_delete,
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           N_('Delete'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected tasks will be permanently removed from the database. Are you sure you want to delete the selected tasks?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_task_deleteolder,
@@ -31,7 +31,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           N_('Delete Older'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: Tasks that are older than selected task will be permanently removed from the database. Are you sure you want to delete older tasks?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_task_deleteall,
@@ -40,7 +40,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           N_('Delete All'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: Finished tasks will be permanently removed from the database. Are you sure you want to delete all finished tasks?"),
-          :enabled   => "true"),
+          :enabled   => true),
       ]
     ),
   ])
@@ -52,7 +52,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
       N_('Cancel Job'),
       :url_parms => "main_div",
       :confirm   => N_("Warning: The selected task will be cancelled. Are you sure you want to cancel the task?"),
-      :enabled   => "false",
+      :enabled   => false,
       :onwhen    => "1"),
   ])
 end

--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :image_scan,
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :image_compare,
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Select two or more items to compare'),
           N_('Compare Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         separator,
         button(
@@ -41,7 +41,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Select a single item to edit'),
           N_('Edit Selected item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :image_ownership,
@@ -49,7 +49,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Set Ownership for the selected items'),
           N_('Set Ownership'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :image_delete,
@@ -58,7 +58,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -67,7 +67,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('CPU/Memory Recommendations of selected item'),
           N_('Right-Size Recommendations'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :image_reconfigure,
@@ -75,7 +75,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Reconfigure the Memory/CPUs of selected items'),
           N_('Reconfigure Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -86,7 +86,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -95,7 +95,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Manage Policies for the selected items'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :image_policy_sim,
@@ -103,7 +103,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('View Policy Simulation for the selected items'),
           N_('Policy Simulation'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :image_tag,
@@ -111,7 +111,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :image_check_compliance,
@@ -120,7 +120,7 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           N_('Check Compliance of Last Known Configuration'),
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_scan,
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_compare,
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Select two or more Templates to compare'),
           N_('Compare Selected Templates'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         separator,
         button(
@@ -41,7 +41,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Select a single Template to edit'),
           N_('Edit Selected Template'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :miq_template_ownership,
@@ -49,7 +49,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Set Ownership for the selected Templates'),
           N_('Set Ownership'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_delete,
@@ -58,7 +58,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Remove Templates from the VMDB'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -69,7 +69,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -78,7 +78,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Manage Policies for the selected Templates'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_policy_sim,
@@ -86,7 +86,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('View Policy Simulation for the selected Templates'),
           N_('Policy Simulation'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_tag,
@@ -94,7 +94,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Edit tags for the selected Templates'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :miq_template_check_compliance,
@@ -103,7 +103,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Check Compliance of Last Known Configuration'),
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected Templates?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -121,7 +121,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           N_('Clone this Template'),
           N_('Clone selected Template'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/tenants_center.rb
+++ b/app/helpers/application_helper/toolbar/tenants_center.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Toolbar::TenantsCenter < ApplicationHelper::Toolbar::Ba
           N_('Select a single item to edit'),
           N_('Edit the selected item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :rbac_tenant_delete,
@@ -21,7 +21,7 @@ class ApplicationHelper::Toolbar::TenantsCenter < ApplicationHelper::Toolbar::Ba
           N_('Delete selected items'),
           :url_parms => "main_div",
           :confirm   => N_("Delete all selected items and all of their children?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :rbac_tenant_manage_quotas,
@@ -29,7 +29,7 @@ class ApplicationHelper::Toolbar::TenantsCenter < ApplicationHelper::Toolbar::Ba
           N_('Select a single item to manage quotas'),
           N_('Manage Quotas for the Selected Item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
       ]
     ),
@@ -47,7 +47,7 @@ class ApplicationHelper::Toolbar::TenantsCenter < ApplicationHelper::Toolbar::Ba
           t = N_('Edit \'#{session[:customer_name]}\' Tags for the selected Tenant'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/time_profiles_center.rb
+++ b/app/helpers/application_helper/toolbar/time_profiles_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::TimeProfilesCenter < ApplicationHelper::Toolba
           N_('Select a single Time Profile to edit'),
           N_('Edit selected Time Profile'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :tp_copy,
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::TimeProfilesCenter < ApplicationHelper::Toolba
           N_('Select a single Time Profile to copy'),
           N_('Copy selected Time Profile'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :tp_delete,
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::TimeProfilesCenter < ApplicationHelper::Toolba
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Time Profiles will be permanently removed from the VMDB. Are you sure you want to delete the selected Time Profiles?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/user_roles_center.rb
+++ b/app/helpers/application_helper/toolbar/user_roles_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::UserRolesCenter < ApplicationHelper::Toolbar::
           N_('Select a single Role to edit'),
           N_('Edit the selected Role'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :rbac_role_copy,
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::UserRolesCenter < ApplicationHelper::Toolbar::
           N_('Select a single Role to copy'),
           N_('Copy the selected Role to a new Role'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :rbac_role_delete,
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::UserRolesCenter < ApplicationHelper::Toolbar::
           N_('Delete selected Roles'),
           :url_parms => "main_div",
           :confirm   => N_("Delete all selected Roles?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/users_center.rb
+++ b/app/helpers/application_helper/toolbar/users_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::UsersCenter < ApplicationHelper::Toolbar::Basi
           N_('Select a single User to edit'),
           N_('Edit the selected User'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :rbac_user_copy,
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::UsersCenter < ApplicationHelper::Toolbar::Basi
           N_('Select a single User to copy'),
           N_('Copy the selected User to a new User'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :rbac_user_delete,
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::UsersCenter < ApplicationHelper::Toolbar::Basi
           N_('Delete selected Users'),
           :url_parms => "main_div",
           :confirm   => N_("Delete all selected Users?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -52,7 +52,7 @@ class ApplicationHelper::Toolbar::UsersCenter < ApplicationHelper::Toolbar::Basi
           t = N_('Edit \'#{session[:customer_name]}\' Tags for the selected Users'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/vm_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_center.rb
@@ -280,7 +280,7 @@ class ApplicationHelper::Toolbar::VmCenter < ApplicationHelper::Toolbar::Basic
       N_('Compare selected VMs'),
       nil,
       :url_parms => "main_div",
-      :enabled   => "false",
+      :enabled   => false,
       :onwhen    => "2+"),
   ])
 end

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_scan,
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_compare,
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Select two or more items to compare'),
           N_('Compare Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         separator,
         button(
@@ -41,7 +41,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Select a single item to edit'),
           N_('Edit Selected item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :instance_ownership,
@@ -49,7 +49,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Set Ownership for the selected items'),
           N_('Set Ownership'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_delete,
@@ -58,7 +58,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -67,7 +67,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           t = N_('Reconfigure selected Instance'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1")
       ]
     ),
@@ -78,7 +78,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -87,7 +87,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Manage Policies for the selected items'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_policy_sim,
@@ -95,7 +95,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('View Policy Simulation for the selected items'),
           N_('Policy Simulation'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_tag,
@@ -103,7 +103,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_check_compliance,
@@ -112,7 +112,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Check Compliance of Last Known Configuration'),
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -136,7 +136,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Set Retirement Dates for the selected items'),
           N_('Set Retirement Dates'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_retire_now,
@@ -145,7 +145,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Retire selected items'),
           :url_parms => "main_div",
           :confirm   => N_("Retire the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -156,7 +156,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
       'fa fa-power-off fa-lg',
       N_('Power Operations'),
       N_('Power'),
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -167,7 +167,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "guest_shutdown",
           :url_parms => "main_div",
           :confirm   => N_("Stop the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_start,
@@ -177,7 +177,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "power_on",
           :url_parms => "main_div",
           :confirm   => N_("Start the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_pause,
@@ -187,7 +187,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "power_pause",
           :url_parms => "main_div",
           :confirm   => N_("Pause the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_suspend,
@@ -197,7 +197,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "suspend",
           :url_parms => "main_div",
           :confirm   => N_("Suspend the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_shelve,
@@ -207,7 +207,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "power_shelve",
           :url_parms => "main_div",
           :confirm   => N_("Shelve the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_shelve_offload,
@@ -217,7 +217,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "power_shelve_offload",
           :url_parms => "main_div",
           :confirm   => N_("Shelve Offload the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_resume,
@@ -227,7 +227,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "power_resume",
           :url_parms => "main_div",
           :confirm   => N_("Resume the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -238,7 +238,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "power_reset",
           :url_parms => "main_div",
           :confirm   => N_("Soft Reboot the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_reset,
@@ -248,7 +248,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "guest_restart",
           :url_parms => "main_div",
           :confirm   => N_("Hard Reboot the Guest OS on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :instance_terminate,
@@ -258,7 +258,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :image     => "power_off",
           :url_parms => "main_div",
           :confirm   => N_("Terminate the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_scan,
@@ -24,7 +24,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Perform SmartState Analysis'),
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_collect_running_processes,
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Extract Running Processes'),
           :confirm   => N_("Extract Running Processes for the selected items?"),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_compare,
@@ -41,7 +41,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Select two or more items to compare'),
           N_('Compare Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         separator,
         button(
@@ -50,7 +50,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Select a single item to edit'),
           N_('Edit Selected item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :vm_ownership,
@@ -58,7 +58,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Set Ownership for the selected items'),
           N_('Set Ownership'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_delete,
@@ -67,7 +67,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -76,7 +76,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('CPU/Memory Recommendations of selected item'),
           N_('Right-Size Recommendations'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :vm_reconfigure,
@@ -84,7 +84,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Reconfigure the Memory/CPUs of selected items'),
           N_('Reconfigure Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -95,7 +95,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -104,7 +104,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Manage Policies for the selected items'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_policy_sim,
@@ -112,7 +112,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('View Policy Simulation for the selected items'),
           N_('Policy Simulation'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_tag,
@@ -120,7 +120,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_check_compliance,
@@ -129,7 +129,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Check Compliance of Last Known Configuration'),
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -153,7 +153,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Clone this item'),
           N_('Clone selected item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :vm_publish,
@@ -161,7 +161,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           t = N_('Publish selected VM to a Template'),
           t,
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :vm_migrate,
@@ -169,7 +169,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Migrate selected items to another Host/Datastore'),
           N_('Migrate selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_retire,
@@ -177,7 +177,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Set Retirement Dates for the selected items'),
           N_('Set Retirement Dates'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_retire_now,
@@ -186,7 +186,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Retire selected items'),
           :url_parms => "main_div",
           :confirm   => N_("Retire the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),
@@ -197,7 +197,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
       'fa fa-power-off fa-lg',
       N_('Power Operations'),
       N_('Power'),
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -208,7 +208,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :image     => "guest_shutdown",
           :url_parms => "main_div",
           :confirm   => N_("Shutdown the Guest OS on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_guest_restart,
@@ -218,7 +218,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :image     => "guest_restart",
           :url_parms => "main_div",
           :confirm   => N_("Restart the Guest OS on the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
@@ -229,7 +229,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :image     => "power_on",
           :url_parms => "main_div",
           :confirm   => N_("Power On the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_stop,
@@ -239,7 +239,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :image     => "power_off",
           :url_parms => "main_div",
           :confirm   => N_("Power Off the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_suspend,
@@ -249,7 +249,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :image     => "power_suspend",
           :url_parms => "main_div",
           :confirm   => N_("Suspend the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_reset,
@@ -259,7 +259,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :image     => "power_reset",
           :url_parms => "main_div",
           :confirm   => N_("Reset the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/vms_center.rb
+++ b/app/helpers/application_helper/toolbar/vms_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
           :confirm   => N_("Refresh relationships and power states for all items related to the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_compare,
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('Select two or more items to compare'),
           N_('Compare Selected items'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "2+"),
         separator,
         button(
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('Select a single item to edit'),
           N_('Edit Selected item'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1"),
         button(
           :vm_ownership,
@@ -40,7 +40,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('Set Ownership for the selected items'),
           N_('Set Ownership'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_delete,
@@ -49,7 +49,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         separator,
       ]
@@ -61,7 +61,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "false",
+      :enabled => false,
       :onwhen  => "1+",
       :items   => [
         button(
@@ -70,7 +70,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('Manage Policies for the selected items'),
           N_('Manage Policies'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_policy_sim,
@@ -78,7 +78,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('View Policy Simulation for the selected items'),
           N_('Policy Simulation'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_tag,
@@ -86,7 +86,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('Edit tags for the selected items'),
           N_('Edit Tags'),
           :url_parms => "main_div",
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
         button(
           :vm_check_compliance,
@@ -95,7 +95,7 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           N_('Check Compliance of Last Known Configuration'),
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled   => "false",
+          :enabled   => false,
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/x_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/x_configured_system_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::XConfiguredSystemCenter < ApplicationHelper::T
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :configured_system_provision,
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::XConfiguredSystemCenter < ApplicationHelper::T
           t,
           :url       => "provision",
           :url_parms => "main_div",
-          :enabled   => "true"),
+          :enabled   => true),
       ]
     ),
     select(
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::XConfiguredSystemCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :configured_system_tag,
@@ -31,7 +31,7 @@ class ApplicationHelper::Toolbar::XConfiguredSystemCenter < ApplicationHelper::T
           N_('Edit Tags'),
           :url       => "tagging",
           :url_parms => "main_div",
-          :enabled   => "true"),
+          :enabled   => true),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_miq_template_center.rb
+++ b/app/helpers/application_helper/toolbar/x_miq_template_center.rb
@@ -156,7 +156,7 @@ class ApplicationHelper::Toolbar::XMiqTemplateCenter < ApplicationHelper::Toolba
       N_('Compare selected Templates'),
       nil,
       :url_parms => "main_div",
-      :enabled   => "false",
+      :enabled   => false,
       :onwhen    => "2+"),
   ])
 end

--- a/app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Toolbar::XProviderForemanConfiguredSystemCenter < Appli
       'fa fa-recycle fa-lg',
       t = N_('Lifecycle'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :provider_foreman_configured_system_provision,
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::XProviderForemanConfiguredSystemCenter < Appli
           t,
           :url       => "provision",
           :url_parms => "main_div",
-          :enabled   => "true"),
+          :enabled   => true),
       ]
     ),
     select(
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::XProviderForemanConfiguredSystemCenter < Appli
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
-      :enabled => "true",
+      :enabled => true,
       :items   => [
         button(
           :provider_foreman_configured_system_tag,
@@ -31,7 +31,7 @@ class ApplicationHelper::Toolbar::XProviderForemanConfiguredSystemCenter < Appli
           N_('Edit Tags'),
           :url       => "tagging",
           :url_parms => "main_div",
-          :enabled   => "true"),
+          :enabled   => true),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -273,7 +273,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
       N_('Compare selected VMs'),
       nil,
       :url_parms => "main_div",
-      :enabled   => "false",
+      :enabled   => false,
       :onwhen    => "2+"),
   ])
 end


### PR DESCRIPTION
Commit ad12dbfc76df326ffe259e18a650c07b7841113f (pull request #7562) changed the `:enabled` property into a boolean in the toolbar processing logic, but did not actually convert the toolbar definition files so that the `:enabled` property
is an actual boolean, not a string.

This caused some buttons (the ones that are disabled by default, e.g. policy buttons) not to function
as expected: these buttons were enabled by default, no `onwhen` functionality took effect.

This PR converts all the `:enabled` properties in the toolbar definition files into a boolean
to be consistent with the internal logic of the toolbar builder.