### PR TITLE
Miq report sort

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -63,6 +63,23 @@ module MiqReport::Generator
     "#{table2class(table)}-#{col}"
   end
 
+  # this is different from col_to_expression_col. It includes the base reporting table
+  # so virtual relations can be properly detected.
+  # col_to_expression should probably be deprecated, but that may introduce quirks with
+  # string comparisons that I'm not ready to debug. sorry. kb
+  # @return [String] A column to pass into MiqExpression of the form: report_table.association-column
+  def col_to_complete_expression_col(col)
+    parts = col.split(".")
+    column = parts.pop
+    parts.unshift(table2class(db))
+    "#{parts.join(".")}-#{column}"
+  end
+
+  # there is also a miq_report#get_col_info defined, but it is not the same as MiqEpression.get_col_info
+  def col_to_col_info(col)
+    MiqExpression.get_col_info col_to_complete_expression_col(col)
+  end
+
   def table2class(table)
     @table2class ||= {}
 

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -41,8 +41,7 @@ module MiqReport::Search
 
       if c.include?(".")
         assoc, col = c.split(".")
-        t = get_sqltable(assoc)
-        sql_col = [t, col].join(".")
+        sql_col = [get_sqltable(assoc), col].join(".")
       else
         sql_col = [db_class.table_name, c].join(".")
       end

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -32,12 +32,12 @@ module MiqReport::Search
   end
 
   def get_order_info
-    apply_sortby_in_search = db_class.sortable?
-    return [apply_sortby_in_search, nil] if sortby.nil? || !apply_sortby_in_search
+    return [true, nil] if sortby.nil? # apply limits (note: without order it is non-deterministic)
+    return [false, nil] unless db_class.sortable?
     # Convert sort cols from sub-tables from the form of assoc_name.column to the form of table_name.column
     order = sortby.to_miq_a.collect do |c|
       info = col_to_col_info(c)
-      apply_sortby_in_search = false if info[:virtual_reflection] || info[:virtual_column]
+      return [false, nil] if info[:virtual_reflection] || info[:virtual_column]
 
       if c.include?(".")
         assoc, col = c.split(".")
@@ -57,7 +57,7 @@ module MiqReport::Search
       end
     end
 
-    return apply_sortby_in_search, order
+    [true, order]
   end
 
   def get_parent_targets(parent, assoc)

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -37,8 +37,7 @@ module MiqReport::Search
     if apply_sortby_in_search && !sortby.nil?
       # Convert sort cols from sub-tables from the form of assoc_name.column to the form of table_name.column
       order = sortby.to_miq_a.collect do |c|
-        col  = col_to_expression_col(c)
-        info = MiqExpression.get_col_info(col)
+        info = col_to_col_info(c)
         apply_sortby_in_search = false if info[:virtual_reflection] || info[:virtual_column]
 
         if c.include?(".")

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -32,30 +32,28 @@ module MiqReport::Search
   end
 
   def get_order_info
-    order = nil
     apply_sortby_in_search = db_class.sortable?
-    if apply_sortby_in_search && !sortby.nil?
-      # Convert sort cols from sub-tables from the form of assoc_name.column to the form of table_name.column
-      order = sortby.to_miq_a.collect do |c|
-        info = col_to_col_info(c)
-        apply_sortby_in_search = false if info[:virtual_reflection] || info[:virtual_column]
+    return [apply_sortby_in_search, nil] if sortby.nil? || !apply_sortby_in_search
+    # Convert sort cols from sub-tables from the form of assoc_name.column to the form of table_name.column
+    order = sortby.to_miq_a.collect do |c|
+      info = col_to_col_info(c)
+      apply_sortby_in_search = false if info[:virtual_reflection] || info[:virtual_column]
 
-        if c.include?(".")
-          assoc, col = c.split(".")
-          t = get_sqltable(assoc)
-          sql_col = [t, col].join(".")
-        else
-          sql_col = [db_class.table_name, c].join(".")
-        end
-        sql_col = "LOWER(#{sql_col})" if [:string, :text].include?(info[:data_type])
-        sql_col
-      end.join(",")
+      if c.include?(".")
+        assoc, col = c.split(".")
+        t = get_sqltable(assoc)
+        sql_col = [t, col].join(".")
+      else
+        sql_col = [db_class.table_name, c].join(".")
+      end
+      sql_col = "LOWER(#{sql_col})" if [:string, :text].include?(info[:data_type])
+      sql_col
+    end.join(",")
 
-      unless self.order.nil?
-        case self.order.downcase
-        when "ascending"  then order += " asc"
-        when "descending" then order += " desc"
-        end
+    unless self.order.nil?
+      case self.order.downcase
+      when "ascending"  then order += " asc"
+      when "descending" then order += " desc"
       end
     end
 

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -25,6 +25,24 @@ describe MiqReport do
         expect(order).to eq("LOWER(vms.name)")
       end
 
+      it "detects a virtual association (and that it can't be sorted)" do
+        @miq_report.sortby = ["miq_provision_template.name"]
+        apply_sortby_in_search, _order = @miq_report.get_order_info
+        expect(apply_sortby_in_search).to be_falsy
+      end
+
+      it "detects a virtual column (and that it can't be sorted)" do
+        @miq_report.sortby = ["active"]
+        apply_sortby_in_search, _order = @miq_report.get_order_info
+        expect(apply_sortby_in_search).to be_falsy
+      end
+
+      it "detects a virtual column when any of the fields are a virtual column (and that it can't be sorted)" do
+        @miq_report.sortby = %w(name active id)
+        apply_sortby_in_search, _order = @miq_report.get_order_info
+        expect(apply_sortby_in_search).to be_falsy
+      end
+
       context "works when there are columns from other tables specified in sortby" do
         it "works with association where table_name can be guessed at" do
           @miq_report.sortby = ["name", "operating_system.product_name"]


### PR DESCRIPTION
If you sort by a column on a virtual association, the report generation will not detect that it is virtual and attempt to put it in the sql. It will blow up. Added specs to show issue.

Some models like `VmdbDatabaseConnection` are defined with `def self.sortable? ; false ; end` - which turns off all db sorting. So this bug will not rear it's head.

But for a model like `VmOrTemplate`, sorting by a column on a virtual attribute will cause a 500 / backtrace.

There is a followup PR #7736 which questions if we can just remove `sortable?`, which no longer seems necessary.

/cc @Fryguy @jrafanie FYI This is the bug I reported in chat.