### PR TITLE
Miq report sort sortable

### DIFF
--- a/app/models/cim_base_storage_extent.rb
+++ b/app/models/cim_base_storage_extent.rb
@@ -24,8 +24,4 @@ class CimBaseStorageExtent < ActsAsArModel
   def self.table_name
     CimStorageExtent.table_name
   end
-
-  def self.sortable?
-    true
-  end
 end

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -45,7 +45,6 @@ module MiqReport::Search
 
   def get_order_info
     return [] if sortby.nil? # apply limits (note: without order it is non-deterministic)
-    return nil unless db_class.sortable?
     # Convert sort cols from sub-tables from the form of assoc_name.column to the form of table_name.column
     order = Array.wrap(sortby).collect do |c|
       sql_col, sql_type = association_column(c)

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -1,10 +1,6 @@
 module ReportableMixin
   extend ActiveSupport::Concern
   module ClassMethods
-    def sortable?
-      true
-    end
-
     def search(count = :all, options = {})
       conditions = options.delete(:conditions)
       filter = options.delete(:filter)

--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -27,10 +27,6 @@ class VmdbDatabaseConnection < ApplicationRecord
   virtual_column :pid, :type => :integer
   virtual_column :blocked_by, :type => :integer
 
-  def self.sortable?
-    false
-  end
-
   def self.log_statistics(output = $log)
     require 'csv'
 

--- a/app/models/vmdb_database_setting.rb
+++ b/app/models/vmdb_database_setting.rb
@@ -2,10 +2,6 @@ class VmdbDatabaseSetting < ApplicationRecord
   self.table_name = 'pg_catalog.pg_settings'
   self.primary_key = 'name'
 
-  def self.sortable?
-    true
-  end
-
   virtual_belongs_to :vmdb_database
   virtual_column :description,      :type => :string
   virtual_column :minimum_value,    :type => :integer

--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -5,10 +5,6 @@ class ActsAsArModel
     ActiveRecord::Base.connection
   end
 
-  def self.sortable?
-    false
-  end
-
   def connection
     self.class.connection
   end


### PR DESCRIPTION
After introducing #7735, the system is smart enough to properly detect virtual attributes and associations. So there is no need to blanket disable override using the db for sorting.

This allows us to perform more and more searches in the database, rather than applying a blanket statement.

