### PR TITLE
Consistent 'Policy' buttons across the UI

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
@@ -5,6 +5,8 @@ class ApplicationHelper::Toolbar::CloudTenantsCenter < ApplicationHelper::Toolba
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
+      :enabled => false,
+      :onwhen  => "1+",
       :items => [
         button(
           :cloud_tenant_tag,

--- a/app/helpers/application_helper/toolbar/configured_systems_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_center.rb
@@ -25,6 +25,8 @@ class ApplicationHelper::Toolbar::ConfiguredSystemsCenter < ApplicationHelper::T
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
+      :enabled => false,
+      :onwhen  => "1+",
       :items => [
         button(
           :provider_foreman_configured_system_tag,

--- a/app/helpers/application_helper/toolbar/miq_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_groups_center.rb
@@ -43,6 +43,8 @@ class ApplicationHelper::Toolbar::MiqGroupsCenter < ApplicationHelper::Toolbar::
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
+      :enabled => false,
+      :onwhen  => "1+",
       :items => [
         button(
           :rbac_group_tags_edit,

--- a/app/helpers/application_helper/toolbar/orchestration_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_templates_center.rb
@@ -47,6 +47,8 @@ class ApplicationHelper::Toolbar::OrchestrationTemplatesCenter < ApplicationHelp
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
+      :enabled => false,
+      :onwhen  => "1+",
       :items => [
         button(
           :orchestration_template_tag,

--- a/app/helpers/application_helper/toolbar/tenants_center.rb
+++ b/app/helpers/application_helper/toolbar/tenants_center.rb
@@ -40,6 +40,8 @@ class ApplicationHelper::Toolbar::TenantsCenter < ApplicationHelper::Toolbar::Ba
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
+      :enabled => false,
+      :onwhen  => "1+",
       :items => [
         button(
           :rbac_tenant_tags_edit,

--- a/app/helpers/application_helper/toolbar/users_center.rb
+++ b/app/helpers/application_helper/toolbar/users_center.rb
@@ -45,6 +45,8 @@ class ApplicationHelper::Toolbar::UsersCenter < ApplicationHelper::Toolbar::Basi
       'fa fa-shield fa-lg',
       t = N_('Policy'),
       t,
+      :enabled => false,
+      :onwhen  => "1+",
       :items => [
         button(
           :rbac_user_tags_edit,


### PR DESCRIPTION
Policy buttons need to behave consistently across the UI: the 'Policy' button needs to become active
only after an item for policy editing has been selected.