### PR TITLE
[WIP] API - support PUT and DELETE for service_requests

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -25,6 +25,10 @@
     :gp: &70174834085860
     - :get
     - :post
+    :gud: &70174834085621
+    - :get
+    - :put
+    - :delete
     :gpd: &70174834085620
     - :get
     - :post
@@ -767,11 +771,17 @@
     :options:
     - :collection
     - :subcollection
-    :methods: *70174834086080
+    :methods: *70174834085621
     :klass: ServiceTemplateProvisionRequest
     :subcollections:
     - :request_tasks
     - :tasks
+    :resource_actions:
+      :post:
+      - :name: edit
+        :identifier: catalogitem_edit
+      - :name: delete
+        :identifier: catalogitem_delete
   :service_templates:
     :description: Service Templates
     :identifier: catalog_items_accord


### PR DESCRIPTION
We need something like this to support the [shopping cart](https://github.com/ManageIQ/manageiq-ui-self_service/pull/33):

   * we use PUT with { "process": true }, to mark an item as ordered (when the user clicks Order on the whole shopping cart
   * we use DELETE to remove an item from the shopping cart


@abellotti can you review please? Or is there already a way to achieve it that I have missed?

One possible concert.. this allows deletion of service_requests even with `process: true`, which *may* not be a good thing - but we do need to be able to delete at least those with `process: false`.