### PR TITLE
Optimize GCE provisioning do_clone_task_check

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
   def do_clone_task_check(clone_task_ref)
     source.with_provider_connection do |google|
-      instance = google.servers.all.detect { |s| s.id == clone_task_ref }
+      instance = google.servers.get(dest_name, dest_availability_zone.ems_ref)
 
       return true if instance.ready?
       return false, instance.status_message


### PR DESCRIPTION
Instead of listing all instances and detecting the one we are looking for, call google.servers.get with the new instance name and zone.