### PR TITLE
SSA: Add state of finished into data event in VM scanning.

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -32,7 +32,8 @@ class VmScan < Job
       :data               => {'snapshot_create' => 'scanning',
                               'scanning'        => 'scanning',
                               'snapshot_delete' => 'snapshot_delete',
-                              'synchronizing'   => 'synchronizing'}
+                              'synchronizing'   => 'synchronizing',
+                              'finished'   => 'finished'}
     }
   end
 

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -33,7 +33,7 @@ class VmScan < Job
                               'scanning'        => 'scanning',
                               'snapshot_delete' => 'snapshot_delete',
                               'synchronizing'   => 'synchronizing',
-                              'finished'   => 'finished'}
+                              'finished'        => 'finished'}
     }
   end
 


### PR DESCRIPTION
Add state of 'finished' into data event, so the scanned results can be saved into DB even job state is marked as finished.

https://bugzilla.redhat.com/show_bug.cgi?id=1323724