### PR TITLE
update image paths on host, vm, provider and ems screens

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -181,7 +181,6 @@ table.table td {
 }
 
 table.table tbody td img {
-  height: 20px;
   width: 20px;
 }
 

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -6,6 +6,6 @@ class ExtManagementSystemDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/vendor-#{image_name}.png"
+    "svg/vendor-#{image_name}.svg"
   end
 end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -6,6 +6,6 @@ class HostDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/vendor-#{vmm_vendor_display.downcase}.png"
+    "svg/vendor-#{vmm_vendor_display.downcase}.svg"
   end
 end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -6,6 +6,6 @@ class VmOrTemplateDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/vendor-#{vendor.downcase}.png"
+    "svg/vendor-#{vendor.downcase}.svg"
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -60,7 +60,7 @@ module QuadiconHelper
   end
 
   def img_for_vendor(item)
-    "100/vendor-#{h(item.vendor)}.png"
+    "svg/vendor-#{h(item.vendor)}.svg"
   end
 
   def img_for_auth_status(item)
@@ -74,7 +74,7 @@ module QuadiconHelper
   end
 
   def img_for_host_vendor(item)
-    "100/vendor-#{h(item.vmm_vendor_display.downcase)}.png"
+    "svg/vendor-#{h(item.vmm_vendor_display.downcase)}.svg"
   end
 
   def render_quadicon_text(item, row)

--- a/app/views/layouts/quadicon/_ext_management_system.html.haml
+++ b/app/views/layouts/quadicon/_ext_management_system.html.haml
@@ -13,7 +13,7 @@
         = item.total_miq_templates
 
   .flobj{:class => "c#{size}"}
-    %img{:src => image_path("100/vendor-#{h(item.image_name)}.png")}
+    %img{:src => image_path("svg/vendor-#{h(item.image_name)}.svg")}
 
   .flobj{:class => "d#{size}"}
     - case item.authentication_status
@@ -35,7 +35,7 @@
   .flobj
     %img{:src => image_path("#{size}/base-single.png")}
   .flobj{:class => "e#{size}"}
-    %img{:src => image_path("100/vendor-#{h(item.image_name)}.png"), :width => width * 1.8, :height => width * 1.8}
+    %img{:src => image_path("svg/vendor-#{h(item.image_name)}.svg"), :width => width * 1.8, :height => width * 1.8}
 
 - if typ == :listnav
   -# Listnav, no href needed

--- a/app/views/layouts/quadicon/_vm_or_template.html.haml
+++ b/app/views/layouts/quadicon/_vm_or_template.html.haml
@@ -6,7 +6,7 @@
   .flobj{:class => "b#{size}"}
     %img{:src => image_path("72/currentstate-#{h(item.normalized_state.downcase)}.png")}
   .flobj{:class => "c#{size}"}
-    %img{:src => image_path("100/vendor-#{h(item.vendor.downcase)}.png")}
+    %img{:src => image_path("svg/vendor-#{h(item.vendor.downcase)}.svg")}
 
   - if item.get_policies.length > 0
     .flobj{:class => "g#{size}"}


### PR DESCRIPTION
switch vendor images from PNGs to SVGs in list views and quad icons
https://trello.com/c/HjxUnqhd

Old
<img width="1047" alt="screen shot 2016-04-06 at 2 55 14 pm" src="https://cloud.githubusercontent.com/assets/1287144/14328970/3c2e05c8-fc07-11e5-8230-ebc9a6dbabdc.png">
New
<img width="1028" alt="screen shot 2016-04-06 at 2 54 29 pm" src="https://cloud.githubusercontent.com/assets/1287144/14328975/41af777a-fc07-11e5-8a9e-7ba522fdd713.png">
