### PR TITLE
Hardcode the assets manifest file name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,9 @@ module Vmdb
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
+    # Set the manifest file name so that we are sure it gets overwritten on updates
+    config.assets.manifest = Rails.root.join("public/assets/.sprockets-manifest.json").to_s
+
     # Customize any additional options below...
 
     # HACK: By default, Rails.configuration.eager_load_paths contains all of the directories


### PR DESCRIPTION
This will allow us to update the assets without concern for
what the previous manifest file was named.

Before, when `rake evm:compile_assets` was run in the kickstart the
manifest would be regenerated, creating a new filename.
Updating leads to multiple manifest files being present which
in some cases causes the asset pipeline to use the incorrect
manifest.

https://bugzilla.redhat.com/show_bug.cgi?id=1324202

@jrafanie @simaishi 