### PR TITLE
Add specs for non-date/time comparisons with MiqExpression#to_sql

### DIFF
--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -17,6 +17,26 @@ describe MiqExpression do
       expect(sql).to eq("\"vms\".\"name\" = 'foo'")
     end
 
+    it "generates the SQL for a < expression" do
+      sql, * = described_class.new("<" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
+      expect(sql).to eq("hardwares.cpu_sockets < 2")
+    end
+
+    it "generates the SQL for a <= expression" do
+      sql, * = described_class.new("<=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
+      expect(sql).to eq("hardwares.cpu_sockets <= 2")
+    end
+
+    it "generates the SQL for a > expression" do
+      sql, * = described_class.new(">" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
+      expect(sql).to eq("hardwares.cpu_sockets > 2")
+    end
+
+    it "generates the SQL for a >= expression" do
+      sql, * = described_class.new(">=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
+      expect(sql).to eq("hardwares.cpu_sockets >= 2")
+    end
+
     it "generates the SQL for a LIKE expression" do
       sql, * = MiqExpression.new("LIKE" => {"field" => "Vm-name", "value" => "foo"}).to_sql
       expect(sql).to eq("vms.name LIKE '%foo%'")


### PR DESCRIPTION
I'm about to start refactoring these, but realized there's no test coverage for these operators when we're not dealing with date/time values. The output might change in the way we quote these values after I've refactored, so I'm submitting this PR first to better highlight what changes in a future PR

@gtanzillo please review, thanks!
@miq-bot add-label test