### PR TITLE
rename get_time_zone to default_time_zone

### DIFF
--- a/app/models/miq_report/formatters/csv.rb
+++ b/app/models/miq_report/formatters/csv.rb
@@ -8,9 +8,9 @@ module MiqReport::Formatters::Csv
     csv_table.data.each do |key|
       key.data.each do |k|
         if k[0] == "v_date"
-          key.data[k[0]] = k[1].in_time_zone(get_time_zone("UTC")).strftime("%m/%d/%Y %Z")
+          key.data[k[0]] = k[1].in_time_zone(default_time_zone).strftime("%m/%d/%Y %Z")
         elsif k[0] == "v_time"
-          key.data[k[0]] = k[1].in_time_zone(get_time_zone("UTC")).strftime("%H:%M %Z")
+          key.data[k[0]] = k[1].in_time_zone(default_time_zone).strftime("%H:%M %Z")
         elsif k[1].kind_of?(Time)
           key.data[k[0]] = format_timezone(k[1], Time.zone, "gtl")
         end

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -192,7 +192,7 @@ module MiqReport::Formatting
     col = options[:column]
     col, sfx = col.to_s.split("__") # The suffix (month, quarter, year) defines the range
 
-    val = val.in_time_zone(get_time_zone("UTC"))
+    val = val.in_time_zone(default_time_zone)
     if val.respond_to?("beginning_of_#{sfx}")
       stime = val.send("beginning_of_#{sfx}")
       etime = val.send("end_of_#{sfx}")

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -837,7 +837,7 @@ module MiqReport::Generator
     self.append_to_title!(" (filtered for #{user.name})")
   end
 
-  def get_time_zone(default_tz = nil)
-    time_profile ? time_profile.tz || tz || default_tz : tz || default_tz
+  def default_time_zone(default_tz = nil)
+    time_profile.try!(:tz) || tz || default_tz || TimeProfile::DEFAULT_TZ
   end
 end

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -1,6 +1,6 @@
 module MiqReport::Generator::Html
   def build_html_rows(clickable_rows = false)
-    tz = get_time_zone(Time.zone.name) if Time.zone
+    tz = default_time_zone(Time.zone.try(:name))
     html_rows = []
     counter = 0
     group_counter = 0

--- a/app/models/miq_report/generator/sorting.rb
+++ b/app/models/miq_report/generator/sorting.rb
@@ -68,7 +68,7 @@ module MiqReport::Generator::Sorting
   end
 
   def build_value_for_sort_suffix(value, suffix)
-    value = value.in_time_zone(get_time_zone("UTC")) if value && value.kind_of?(Time)
+    value = value.in_time_zone(default_time_zone) if value && value.kind_of?(Time)
     value = value.to_time.utc.beginning_of_day            if value && value.kind_of?(Date)
     suffix = suffix.to_sym if suffix
 

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -161,7 +161,7 @@ module MiqReport::Generator::Trend
           if Time.at(result).utc <= Time.now.utc
             return Time.at(result).utc.strftime("%m/%d/%Y")
           else
-            return "#{((Time.at(result).utc - Time.now.utc) / 1.day).round} days, on #{Time.at(result).utc.strftime("%m/%d/%Y")} (#{get_time_zone("UTC")})"
+            return "#{((Time.at(result).utc - Time.now.utc) / 1.day).round} days, on #{Time.at(result).utc.strftime("%m/%d/%Y")} (#{default_time_zone})"
           end
         else
           return "after 1 year"

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -64,7 +64,7 @@ module ReportFormatter
 
     # C&U performance charts (Cluster, Host, VM based)
     def build_performance_chart_area(maxcols, divider)
-      tz = mri.get_time_zone(Time.zone.name)
+      tz = mri.default_time_zone(Time.zone.name)
       nils2zero = false # Allow gaps in charts for nil values
 
       #### To do - Uncomment to handle long term averages

--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -26,7 +26,7 @@ module ReportFormatter
 
     def build_document_body
       mri = options.mri
-      tz = mri.get_time_zone(Time.zone.name)
+      tz = mri.default_time_zone(Time.zone.name)
       output << "<table class='table table-striped table-bordered'>"
       output << "<thead>"
       output << "<tr>"

--- a/lib/report_formatter/text.rb
+++ b/lib/report_formatter/text.rb
@@ -7,7 +7,7 @@ module ReportFormatter
       mri = options.mri
       # allow override
       #     return if max_col_width
-      tz = mri.get_time_zone(Time.zone.name)
+      tz = mri.default_time_zone(Time.zone.name)
 
       @max_col_width = []
       unless mri.headers.empty?
@@ -89,7 +89,7 @@ module ReportFormatter
     # Uses fit_to_width to truncate table if necessary
     def build_document_body
       mri = options.mri
-      tz = mri.get_time_zone(Time.zone.name)
+      tz = mri.default_time_zone(Time.zone.name)
       s = @hr
 
       save_val = nil
@@ -165,7 +165,7 @@ module ReportFormatter
 
     def build_document_footer
       mri = options.mri
-      tz = mri.get_time_zone(Time.zone.name)
+      tz = mri.default_time_zone(Time.zone.name)
       if !mri.user_categories.blank? || !mri.categories.blank? || !mri.conditions.nil? || !mri.display_filter.nil?
         output << @hr
         unless mri.user_categories.blank?

--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -12,7 +12,7 @@ module ReportFormatter
     # Generates the body of the timeline
     def build_document_body
       mri = options.mri
-      tz = mri.get_time_zone(Time.zone.name)
+      tz = mri.default_time_zone(Time.zone.name)
       # Calculate the earliest time of events to show
       unless mri.timeline[:last_unit].nil?
         #       START of TIMELINE TIMEZONE Code
@@ -54,7 +54,7 @@ module ReportFormatter
 
     def tl_event(tl_xml, row, col)
       mri = options.mri
-      tz = mri.get_time_zone(Time.zone.name)
+      tz = mri.default_time_zone(Time.zone.name)
       etime = row[col]
       return if etime.nil?                              # Skip nil dates - Sprint 41
       return if !@start_time.nil? && etime < @start_time # Skip if before start time limit


### PR DESCRIPTION
Bigger goal: simplify `time_profile` and `tz` - getting away from `ext_options`. `ext_options` is making VimPerformanceDaily and friends really hard to pull into scopes, and therefor a bain to converting Rbac to scopes.

In this case, there are 2 definitions of `get_time_zone`. This was renamed (as the other will be as well) to avoid confusion and better state what is happening.

1. renamed to be rubocop friendly and to distinguish from the other
   method with the same name but takes different parameters.
2. use no parameters to use default rather than passing in everywhere
   Only 1 spot uses non "UTC" - it uses Time.zone. In that case it uses
   nil as default, only to have "UTC" swapped in further down the chain.

/cc @gtanzillo I'm more concerned with the naming of `Metrics::Helper.get_time_zone`, but wanted to clean this up so I didn't mess this stuff up while changing that.