### PR TITLE
Vim performance scope 2 b

### DIFF
--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -151,22 +151,26 @@ module Metric::Helper
     counts.values.max rescue 0
   end
 
-  def self.get_time_zone(options)
+  def self.get_time_zone(options = nil)
     return TimeProfile::DEFAULT_TZ if options.nil?
     return options[:time_profile].tz if options[:time_profile] && options[:time_profile].tz
     options[:tz] || TimeProfile::DEFAULT_TZ
   end
 
-  def self.get_time_range_from_offset(start_offset, end_offset = nil, options = {})
-    # Get yesterday at 23:00 in specified TZ. Then convert that to UTC. Then subtract offsets
-    tz = Metric::Helper.get_time_zone(options)
+  # interval_name of daily:
+  #   Get yesterday at 23:00 in specified TZ. Then convert that to UTC. Then subtract offsets
+  # @param start_offset [Fixnum]
+  # @param end_offset [Fixnum|nil]
+  # @return [Range<Datetime,Datetime>] timestamp range for offsets
+  def self.time_range_from_offset(interval_name, start_offset, end_offset, tz = nil)
+    tz ||= Metric::Helper.get_time_zone
     time_in_tz = Time.now.in_time_zone(tz)
     now = time_in_tz.hour == 23 ? time_in_tz.utc : (time_in_tz.midnight - 1.hour).utc
 
     start_time = now - start_offset.seconds
     end_time   = end_offset.nil? ? now : now - end_offset.seconds
 
-    return start_time, end_time
+    start_time..end_time
   end
 
   def self.get_time_interval(obj, timestamp)

--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -159,13 +159,20 @@ module Metric::Helper
 
   # interval_name of daily:
   #   Get yesterday at 23:00 in specified TZ. Then convert that to UTC. Then subtract offsets
+  # interval_name of hourly (and others)
+  #   Just your typical x.seconds.ago
+  #
   # @param start_offset [Fixnum]
   # @param end_offset [Fixnum|nil]
   # @return [Range<Datetime,Datetime>] timestamp range for offsets
   def self.time_range_from_offset(interval_name, start_offset, end_offset, tz = nil)
-    tz ||= Metric::Helper.get_time_zone
-    time_in_tz = Time.now.in_time_zone(tz)
-    now = time_in_tz.hour == 23 ? time_in_tz.utc : (time_in_tz.midnight - 1.hour).utc
+    if interval_name == "daily"
+      tz ||= Metric::Helper.get_time_zone
+      time_in_tz = Time.now.in_time_zone(tz)
+      now = time_in_tz.hour == 23 ? time_in_tz.utc : (time_in_tz.midnight - 1.hour).utc
+    else
+      now = Time.now.utc
+    end
 
     start_time = now - start_offset.seconds
     end_time   = end_offset.nil? ? now : now - end_offset.seconds

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -250,12 +250,12 @@ module MiqReport::Generator
         # only_cols += conditions.columns_for_sql # Add cols references in expression to ensure they are present for evaluation
       end
 
-      start_time, end_time = Metric::Helper.get_time_range_from_offset(db_options[:start_offset], db_options[:end_offset], :tz => tz)
+      time_range = Metric::Helper.time_range_from_offset("daily", db_options[:start_offset], db_options[:end_offset], tz)
       # TODO: add .select(only_cols)
       results = VimPerformanceDaily
                 .find_entries(ext_options.merge(:class => klass))
                 .where(where_clause)
-                .where(:timestamp => start_time..end_time)
+                .where(:timestamp => time_range)
                 .includes(includes)
                 .references(includes)
                 .limit(options[:limit])

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -29,11 +29,11 @@ module MiqReport::Generator::Trend
 
       includes = include.blank? ? [] : include.keys
 
-      start_time, end_time = Metric::Helper.get_time_range_from_offset(db_options[:start_offset], db_options[:end_offset], :tz => tz)
+      time_range = Metric::Helper.time_range_from_offset("daily", db_options[:start_offset], db_options[:end_offset], tz)
       trend_klass = db_options[:trend_db].kind_of?(Class) ? db_options[:trend_db] : Object.const_get(db_options[:trend_db])
 
       recs = VimPerformanceDaily.find_entries(:class => trend_klass, :tz => tz, :time_profile => time_profile)
-             .where(where_clause).where(:timestamp => start_time..end_time).includes(includes)
+                                .where(where_clause).where(:timestamp => time_range).includes(includes)
       results = Rbac.filtered(recs, :class        => db_options[:trend_db],
                                     :filter       => db_options[:trend_filter],
                                     :userid       => options[:userid],

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -39,12 +39,11 @@ module MiqReport::Generator::Trend
                                     :userid       => options[:userid],
                                     :miq_group_id => options[:miq_group_id])
     else
-      start_time = Time.now.utc - db_options[:start_offset].seconds
-      end_time   =  db_options[:end_offset].nil? ? Time.now.utc : Time.now.utc - db_options[:end_offset].seconds
+      time_range = Metric::Helper.time_range_from_offset('hourly', db_options[:start_offset], db_options[:end_offset])
 
       # Search and filter performance data
       trend_klass = db_options[:trend_db].kind_of?(Class) ? db_options[:trend_db] : Object.const_get(db_options[:trend_db])
-      recs = trend_klass.with_interval_and_time_range('hourly', start_time..end_time).where(where_clause)
+      recs = trend_klass.with_interval_and_time_range('hourly', time_range).where(where_clause)
       results = Rbac.filtered(recs, :class        => db_options[:trend_db],
                                     :filter       => db_options[:trend_filter],
                                     :userid       => options[:userid],


### PR DESCRIPTION
Consolidate common logic that parses offset date ranges.
This is the other side of #7767 and has been pulled out of #7284 

Higher level goal (although not necessary for my current set of PRs) is to have the daily vs hourly processing as similar as possible.

This is part of teasing logic out of `VimPerformanceDaily` and using scopes with `Rbac`