### PR TITLE
Extract with_time_profile_or_tz

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -182,5 +182,15 @@ module Metric::Common
         where(:timestamp => start_time..end_time)
       end
     end
+
+    # @param :time_profile_or_tz [TimeProfile|Timezone] (default: DEFAULT_TIMEZONE)
+    def with_time_profile_or_tz(time_profile_or_tz = nil)
+      if (time_profile = TimeProfile.default_time_profile(time_profile_or_tz))
+        tp_ids = time_profile.profile_for_each_region.pluck(:id)
+        where(:time_profile_id => tp_ids)
+      else
+        none
+      end
+    end
   end
 end

--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -186,8 +186,8 @@ module Metric::Common
     # @param :time_profile_or_tz [TimeProfile|Timezone] (default: DEFAULT_TIMEZONE)
     def with_time_profile_or_tz(time_profile_or_tz = nil)
       if (time_profile = TimeProfile.default_time_profile(time_profile_or_tz))
-        tp_ids = time_profile.profile_for_each_region.pluck(:id)
-        where(:time_profile_id => tp_ids)
+        tp_ids = time_profile.profile_for_each_region
+        where(:time_profile => tp_ids)
       else
         none
       end

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -183,7 +183,10 @@ class TimeProfile < ApplicationRecord
     TimeProfile.rollup_daily_metrics.detect { |tp| tp.match_user_tz?(user_id, user_tz) }
   end
 
+  # @param tz [nil|TimeProfile|TimeZone] (default timezone "UTC")
+  # @return [TimeProfile] time profile that uses this time zone
   def self.default_time_profile(tz = DEFAULT_TZ)
+    return tz if tz.kind_of?(TimeProfile)
     tz ||= DEFAULT_TZ
     rollup_daily_metrics.find_all_with_entire_tz.detect { |tp| tp.tz_or_default == tz }
   end

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -22,15 +22,15 @@ class VimPerformanceDaily < MetricRollup
 
   # @param ext_options [Hash] search options
   # @opts ext_options :klass [Class] class for metrics (default: MetricRollup)
-  # @opts ext_options :tp [TimeProfile]
+  # @opts ext_options :time_profile [TimeProfile]
   # @opts ext_options :tz [Timezone] (default: DEFAULT_TIMEZONE)
   def self.find_entries(ext_options)
     ext_options ||= {}
+    # TODO: remove changing ext_options once this side effect is no longer needed:
     time_profile = ext_options[:time_profile] ||= TimeProfile.default_time_profile(ext_options[:tz])
-    klass = ext_options[:class] || MetricRollup
+    klass = Metric::Helper::class_for_interval_name("daily", ext_options[:class])
 
-    tp_ids = time_profile ? time_profile.profile_for_each_region.collect(&:id) : []
-    klass.where(:time_profile_id => tp_ids, :capture_interval_name => 'daily')
+    klass.with_time_profile_or_tz(time_profile || ext_options[:tz]).where(:capture_interval_name => 'daily')
   end
 
   def self.process_hourly_for_one_day(recs, options = {})


### PR DESCRIPTION
Big goal: Simplify timezone and time profile passing, so `ext_options` and `VimPerformanceDaily.find_entries` can be banished. And rbac scopes is easier.

merging time_profile and timezone into a single variable. `time_profile_or_tz` is passed around instead of `ext_options` with `:tz` or `:time_profile`. This avoids the dubious hash that is passing who knows what. It also makes `ext_options` less pervasive.
