### PR TITLE
Fix issue where broker_notify_properties changes did not migrate.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,41 +18,41 @@
 :broker_notify_properties:
   :exclude:
     :HostSystem:
-      :config.consoleReservation:
-      :config.dateTimeInfo:
-      :config.network:
-      :config.service:
-      :summary:
-      :summary.overallStatus:
-      :summary.runtime.bootTime:
-      :summary.runtime.healthSystemRuntime.systemHealthInfo.numericSensorInfo:
+    - config.consoleReservation
+    - config.dateTimeInfo
+    - config.network
+    - config.service
+    - summary
+    - summary.overallStatus
+    - summary.runtime.bootTime
+    - summary.runtime.healthSystemRuntime.systemHealthInfo.numericSensorInfo
     :VirtualMachine:
-      :config.locationId:
-      :config.memoryAllocation.overheadLimit:
-      :config.npivWorldWideNameType:
-      :guest.disk:
-      :guest.guestFamily:
-      :guest.guestFullName:
-      :guest.guestId:
-      :guest.ipStack:
-      :guest.net:
-      :guest.screen:
-      :guest.screen.height:
-      :guest.screen.width:
-      :guest.toolsRunningStatus:
-      :guest.toolsStatus:
-      :resourceConfig:
-      :summary:
-      :summary.guest.guestFullName:
-      :summary.guest.guestId:
-      :summary.guest.toolsRunningStatus:
-      :summary.overallStatus:
-      :summary.runtime.bootTime:
-      :summary.runtime.memoryOverhead:
-      :summary.runtime.numMksConnections:
-      :summary.storage:
-      :summary.storage.committed:
-      :summary.storage.unshared:
+    - config.locationId
+    - config.memoryAllocation.overheadLimit
+    - config.npivWorldWideNameType
+    - guest.disk
+    - guest.guestFamily
+    - guest.guestFullName
+    - guest.guestId
+    - guest.ipStack
+    - guest.net
+    - guest.screen
+    - guest.screen.height
+    - guest.screen.width
+    - guest.toolsRunningStatus
+    - guest.toolsStatus
+    - resourceConfig
+    - summary
+    - summary.guest.guestFullName
+    - summary.guest.guestId
+    - summary.guest.toolsRunningStatus
+    - summary.overallStatus
+    - summary.runtime.bootTime
+    - summary.runtime.memoryOverhead
+    - summary.runtime.numMksConnections
+    - summary.storage
+    - summary.storage.committed
+    - summary.storage.unshared
 :capacity:
   :profile:
     :1:

--- a/db/migrate/data/20160127210624_convert_configurations_to_settings_changes/broker_notify_properties.tmpl.yml
+++ b/db/migrate/data/20160127210624_convert_configurations_to_settings_changes/broker_notify_properties.tmpl.yml
@@ -1,38 +1,38 @@
 ---
 exclude:
   HostSystem:
-    config.consoleReservation: 
-    config.dateTimeInfo: 
-    config.network: 
-    config.service: 
-    summary: 
-    summary.overallStatus: 
-    summary.runtime.bootTime: 
-    summary.runtime.healthSystemRuntime.systemHealthInfo.numericSensorInfo: 
+  - config.consoleReservation
+  - config.dateTimeInfo
+  - config.network
+  - config.service
+  - summary
+  - summary.overallStatus
+  - summary.runtime.bootTime
+  - summary.runtime.healthSystemRuntime.systemHealthInfo.numericSensorInfo
   VirtualMachine:
-    config.locationId: 
-    config.memoryAllocation.overheadLimit: 
-    config.npivWorldWideNameType: 
-    guest.disk: 
-    guest.guestFamily: 
-    guest.guestFullName: 
-    guest.guestId: 
-    guest.ipStack: 
-    guest.net: 
-    guest.screen: 
-    guest.screen.height: 
-    guest.screen.width: 
-    guest.toolsRunningStatus: 
-    guest.toolsStatus: 
-    resourceConfig: 
-    summary: 
-    summary.guest.guestFullName: 
-    summary.guest.guestId: 
-    summary.guest.toolsRunningStatus: 
-    summary.overallStatus: 
-    summary.runtime.bootTime: 
-    summary.runtime.memoryOverhead: 
-    summary.runtime.numMksConnections: 
-    summary.storage: 
-    summary.storage.committed: 
-    summary.storage.unshared: 
+  - config.locationId
+  - config.memoryAllocation.overheadLimit
+  - config.npivWorldWideNameType
+  - guest.disk
+  - guest.guestFamily
+  - guest.guestFullName
+  - guest.guestId
+  - guest.ipStack
+  - guest.net
+  - guest.screen
+  - guest.screen.height
+  - guest.screen.width
+  - guest.toolsRunningStatus
+  - guest.toolsStatus
+  - resourceConfig
+  - summary
+  - summary.guest.guestFullName
+  - summary.guest.guestId
+  - summary.guest.toolsRunningStatus
+  - summary.overallStatus
+  - summary.runtime.bootTime
+  - summary.runtime.memoryOverhead
+  - summary.runtime.numMksConnections
+  - summary.storage
+  - summary.storage.committed
+  - summary.storage.unshared

--- a/spec/migrations/20160127210624_convert_configurations_to_settings_changes_spec.rb
+++ b/spec/migrations/20160127210624_convert_configurations_to_settings_changes_spec.rb
@@ -141,6 +141,24 @@ describe ConvertConfigurationsToSettingsChanges do
         :settings      => storage_data
       )
 
+      broker_notify_data = {
+        "exclude" => {
+          "HostSystem" => {
+            "config.property1" => nil,
+            "config.property2" => nil
+          },
+          "VirtualMachine" => {
+            "config.property3" => nil,
+            "config.property4" => nil
+          }
+        },
+      }
+      config_stub.create!(
+        :typ           => "broker_notify_properties",
+        :miq_server_id => 3,
+        :settings      => broker_notify_data
+      )
+
       migrate
 
       deltas = settings_change_stub.where(:resource_id => 1)
@@ -161,6 +179,22 @@ describe ConvertConfigurationsToSettingsChanges do
         :resource_id   => 2,
         :key           => "/storage/alignment/boundary",
         :value         => "1.byte",
+      )
+
+      deltas = settings_change_stub.where(:resource_id => 3).order(:key)
+      expect(deltas.size).to eq(2)
+
+      expect(deltas[0]).to have_attributes(
+        :resource_type => "MiqServer",
+        :resource_id   => 3,
+        :key           => "/broker_notify_properties/exclude/HostSystem",
+        :value         => %w(config.property1 config.property2),
+      )
+      expect(deltas[1]).to have_attributes(
+        :resource_type => "MiqServer",
+        :resource_id   => 3,
+        :key           => "/broker_notify_properties/exclude/VirtualMachine",
+        :value         => %w(config.property3 config.property4),
       )
     end
   end


### PR DESCRIPTION
Because the properties were defined as keys in a Hash, any removals made
by the user would not be properly migrated.  We only ever had them
defined as a Hash in order to be able to do efficient lookups.  Instead,
we can define them in the settings as a simple Array, and just convert
that Array to a Set to get the efficient lookups.  Arrays are properly
handled as expected by the config revamp, so this change leverages that.

Fixes #7677 

@chessbyte Please review.