### PR TITLE
Display labels for ContainerProject, ContainerRoute

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -314,8 +314,10 @@ module ManageIQ::Providers::Kubernetes
       new_result
     end
 
-    def parse_namespaces(container_projects)
-      parse_base_item(container_projects).except(:namespace)
+    def parse_namespaces(namespace)
+      new_result = parse_base_item(namespace).except(:namespace)
+      new_result[:labels] = parse_labels(namespace)
+      new_result
     end
 
     def parse_persistent_volume(persistent_volume)

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -81,7 +81,7 @@ module ManageIQ::Providers::Kubernetes
     end
 
     def get_namespaces(inventory)
-      process_collection(inventory["namespace"], :container_projects) { |n| parse_namespaces(n) }
+      process_collection(inventory["namespace"], :container_projects) { |n| parse_namespace(n) }
 
       @data[:container_projects].each do |ns|
         @data_index.store_path(:container_projects, :by_name, ns[:name], ns)
@@ -314,7 +314,7 @@ module ManageIQ::Providers::Kubernetes
       new_result
     end
 
-    def parse_namespaces(namespace)
+    def parse_namespace(namespace)
       new_result = parse_base_item(namespace).except(:namespace)
       new_result[:labels] = parse_labels(namespace)
       new_result

--- a/app/views/container_project/_main.html.haml
+++ b/app/views/container_project/_main.html.haml
@@ -6,8 +6,8 @@
                                                                           :items => textual_quota}
     = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Limit Ranges"),
                                                                           :items => textual_limits}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Labels"),
+                                                               :items => textual_group_container_labels}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
-
-

--- a/app/views/container_route/_main.html.haml
+++ b/app/views/container_route/_main.html.haml
@@ -4,6 +4,9 @@
     = render :partial => "shared/summary/textual",
              :locals => {:title => _("Properties"),
                          :items => textual_group_properties}
+    = render :partial => "shared/summary/textual",
+             :locals => {:title => _("Labels"),
+                         :items => textual_group_container_labels}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual",
              :locals => {:title => _("Relationships"),

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -3,6 +3,38 @@ require 'recursive-open-struct'
 describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
   let(:parser)  { described_class.new }
 
+  describe "parse_namespaces" do
+    it "handles simple data" do
+      expect(parser.send(:parse_namespaces,
+                         RecursiveOpenStruct.new(
+                           :metadata => {
+                             :name              => "proj2",
+                             :selfLink          => "/api/v1/namespaces/proj2",
+                             :uid               => "554c1eaa-f4f6-11e5-b943-525400c7c086",
+                             :resourceVersion   => "150569",
+                             :creationTimestamp => "2016-03-28T15:04:13Z",
+                             :labels            => {:department => "Warp-drive"},
+                             :annotations       => {:"openshift.io/description"  => "",
+                                                    :"openshift.io/display-name" => "Project 2"}
+                           },
+                           :spec     => {:finalizers => ["openshift.io/origin", "kubernetes"]},
+                           :status   => {:phase => "Active"}
+                         )
+                        )).to eq(:ems_ref          => "554c1eaa-f4f6-11e5-b943-525400c7c086",
+                                 :name             => "proj2",
+                                 :ems_created_on   => "2016-03-28T15:04:13Z",
+                                 :resource_version => "150569",
+                                 :labels           => [
+                                   {
+                                     :section => "labels",
+                                     :name    => "department",
+                                     :value   => "Warp-drive",
+                                     :source  => "kubernetes"
+                                   }
+                                 ])
+    end
+  end
+
   describe "parse_image_name" do
     example_ref = "docker://abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     example_images = [{:image_name => "example",

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -3,9 +3,9 @@ require 'recursive-open-struct'
 describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
   let(:parser)  { described_class.new }
 
-  describe "parse_namespaces" do
+  describe "parse_namespace" do
     it "handles simple data" do
-      expect(parser.send(:parse_namespaces,
+      expect(parser.send(:parse_namespace,
                          RecursiveOpenStruct.new(
                            :metadata => {
                              :name              => "proj2",


### PR DESCRIPTION
Addresses points (1), (2) of #7744.

ContainerProject labels now refreshed correctly and displayed:
![screenshot-localhost 3000 2016-04-06 22-25-28](https://cloud.githubusercontent.com/assets/273688/14344337/b678b7ee-fcaf-11e5-8f26-961860ea7a1e.png)
ContainerRoute labels now displayed:
![screenshot-localhost 3000 2016-04-06 22-40-33](https://cloud.githubusercontent.com/assets/273688/14344341/bb719270-fcaf-11e5-9d3c-0f4ecb2d1b79.png)
(ignore the tag called "Kubernetes label 'app'" on the right side of the last screenshot, it was in my DB from unrelated work.  the point here is just displaying the labels.)