### PR TITLE
Pods Creation Trend should use creationTimestamp

### DIFF
--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -7,7 +7,7 @@ module Metric::Statistic
     container_groups = ContainerGroup.where(:ems_id => obj.id).or(ContainerGroup.where(:old_ems_id => obj.id))
 
     {
-      :stat_container_group_create_rate       => container_groups.where(:created_on => capture_interval).count,
+      :stat_container_group_create_rate       => container_groups.where(:ems_created_on => capture_interval).count,
       :stat_container_group_delete_rate       => container_groups.where(:deleted_on => capture_interval).count,
       :stat_container_image_registration_rate => obj.container_images.where(:registered_on => capture_interval).count
     }

--- a/spec/models/metric/statistic_spec.rb
+++ b/spec/models/metric/statistic_spec.rb
@@ -7,10 +7,10 @@ describe Metric::Statistic do
 
     hour = Time.parse(Metric::Helper.nearest_hourly_timestamp(Time.now)).utc
 
-    let(:c1) { FactoryGirl.create(:container_group, :created_on => hour - 10.minutes) }
-    let(:c2) { FactoryGirl.create(:container_group, :created_on => hour - 50.minutes) }
-    let(:c3) { FactoryGirl.create(:container_group, :created_on => hour - 120.minutes) }
-    let(:c4) { FactoryGirl.create(:container_group, :created_on => hour + 1.minute) }
+    let(:c1) { FactoryGirl.create(:container_group, :ems_created_on => hour - 10.minutes) }
+    let(:c2) { FactoryGirl.create(:container_group, :ems_created_on => hour - 50.minutes) }
+    let(:c3) { FactoryGirl.create(:container_group, :ems_created_on => hour - 120.minutes) }
+    let(:c4) { FactoryGirl.create(:container_group, :ems_created_on => hour + 1.minute) }
 
     let(:c5) { FactoryGirl.create(:container_group, :deleted_on => hour - 10.minutes) }
     let(:c6) { FactoryGirl.create(:container_group, :deleted_on => hour - 50.minutes) }


### PR DESCRIPTION
Pods Creation Trend should use creationTimestamp
Fix Issue: https://github.com/ManageIQ/manageiq/issues/7772

When adding a new OpenShift provider to ManageIQ all the pods are going to have the same `created_on` timestamp, generating a big spike of Pods Creation in the Trend added in #6759.

We should use the real pod `creationTimestamp` for the Pods Creation statistics, in manageIQ db it is `ems_created_on`, it's already converted to utc.