### PR TITLE
[API] added actions create, delete, edit on chargebacks route

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -144,6 +144,22 @@
       :delete:
       - :name: delete
         :identifier: chargeback_rates_delete
+  :currencies:
+    :description: Currencies
+    :identifier: currency
+    :options:
+    - :collection
+    - :subcollection
+    :methods: *70174834086080
+    :klass: ChargebackRateDetailCurrency
+  :measures:
+    :description: Measures
+    :identifier: measure
+    :options:
+    - :collection
+    - :subcollection
+    :methods: *70174834086080
+    :klass: ChargebackRateDetailMeasure
   :clusters:
     :description: Clusters
     :identifier: ems_cluster

--- a/config/api.yml
+++ b/config/api.yml
@@ -117,7 +117,7 @@
     :identifier: chargeback
     :options:
     - :collection
-    :methods: *70174834086080
+    :methods: *70174834084700
     :klass: ChargebackRate
     :subcollections:
     - :rates
@@ -125,10 +125,25 @@
       :get:
       - :name: read
         :identifier: chargeback
+      :post:
+      - :name: create
+        :identifier: chargeback_rates_new
+      - :name: edit
+        :identifier: chargeback_rates_edit
+      - :name: delete
+        :identifier: chargeback_rates_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: chargeback
+      :post:
+      - :name: edit
+        :identifier: chargeback_rates_edit
+      - :name: delete
+        :identifier: chargeback_rates_delete
+      :delete:
+      - :name: delete
+        :identifier: chargeback_rates_delete
   :clusters:
     :description: Clusters
     :identifier: ems_cluster

--- a/config/api.yml
+++ b/config/api.yml
@@ -149,7 +149,6 @@
     :identifier: currency
     :options:
     - :collection
-    - :subcollection
     :methods: *70174834086080
     :klass: ChargebackRateDetailCurrency
   :measures:
@@ -157,7 +156,6 @@
     :identifier: measure
     :options:
     - :collection
-    - :subcollection
     :methods: *70174834086080
     :klass: ChargebackRateDetailMeasure
   :clusters:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1331,6 +1331,14 @@
     :description: Assignments Accordion
     :feature_type: node
     :identifier: chargeback_assignments
+  - :name: Currencies
+    :description: Chargeback Rate currencies Accordion
+    :feature_type: node
+    :identifier: currency
+  - :name: Measures
+    :description: Chargeback Rate measures Accordion
+    :feature_type: node
+    :identifier: measure
 
 # Timelines
 - :name: Timelines

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1029 }
+  let(:expected_feature_count) { 1031 }
 
   # - container_dashboard
   # - miq_report_widget_editor

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -70,6 +70,80 @@ RSpec.describe "chargebacks API" do
   end
 
   context "with an appropriate role" do
+    it "can create a new chargeback rate" do
+      api_basic_authorize action_identifier(:chargebacks, :create, :collection_actions)
+
+      expect do
+        run_post chargebacks_url,
+                 :description => "chargeback_0",
+                 :rate_type   => "Storage"
+      end.to change(ChargebackRate, :count).by(1)
+      expect_result_to_match_hash(response_hash["results"].first, "description" => "chargeback_0",
+                                                                  "rate_type"   => "Storage",
+                                                                  "default"     => false)
+      expect_request_success
+    end
+
+    it "returns bad request for incomplete chargeback rate" do
+      api_basic_authorize action_identifier(:chargebacks, :create, :collection_actions)
+
+      expect do
+        run_post chargebacks_url,
+                 :rate_type   => "Storage"
+      end.not_to change(ChargebackRate, :count)
+      # expect_bad_request(/description can't be blank/i)
+    end
+
+    it "can edit a chargeback rate through POST" do
+      chargeback_rate = FactoryGirl.build(:chargeback_rate, :description => "chargeback_0")
+      chargeback_rate.save
+
+      api_basic_authorize action_identifier(:chargebacks, :edit)
+      run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
+
+      expect(response_hash["description"]).to eq("chargeback_1")
+      expect_request_success
+      expect(chargeback_rate.reload.description).to eq("chargeback_1")
+    end
+
+    it "can edit a chargeback rate through PATCH" do
+      chargeback_rate = FactoryGirl.build(:chargeback_rate, :description => "chargeback_0")
+      chargeback_rate.save
+
+      api_basic_authorize action_identifier(:chargebacks, :edit)
+      run_patch chargebacks_url(chargeback_rate.id), [{:action => "edit",
+                                                       :path   => "description",
+                                                       :value  => "chargeback_1"}]
+
+      expect(response_hash["description"]).to eq("chargeback_1")
+      expect_request_success
+      expect(chargeback_rate.reload.description).to eq("chargeback_1")
+    end
+
+    it "can delete a chargeback rate" do
+      chargeback_rate = FactoryGirl.build(:chargeback_rate)
+      chargeback_rate.save
+
+      api_basic_authorize action_identifier(:chargebacks, :delete)
+
+      expect do
+        run_delete chargebacks_url(chargeback_rate.id)
+      end.to change(ChargebackRate, :count).by(-1)
+      expect_request_success_with_no_content
+    end
+
+    it "can delete a chargeback rate through POST" do
+      chargeback_rate = FactoryGirl.build(:chargeback_rate)
+      chargeback_rate.save
+
+      api_basic_authorize action_identifier(:chargebacks, :delete)
+
+      expect do
+        run_post chargebacks_url(chargeback_rate.id), :action => "delete"
+      end.to change(ChargebackRate, :count).by(-1)
+      expect_request_success
+    end
+
     it "can create a new chargeback rate detail" do
       api_basic_authorize action_identifier(:rates, :create, :collection_actions)
       chargeback_rate = FactoryGirl.create(:chargeback_rate)
@@ -164,6 +238,38 @@ RSpec.describe "chargebacks API" do
   end
 
   context "without an appropriate role" do
+    it "cannot create a chargeback rate" do
+      api_basic_authorize
+
+      expect { run_post chargebacks_url, :description => "chargeback_0" }.not_to change(ChargebackRate,
+                                                                                        :count)
+      expect_request_forbidden
+    end
+
+    it "cannot edit a chargeback rate" do
+      chargeback_rate = FactoryGirl.build(:chargeback_rate, :description => "chargeback_0")
+      chargeback_rate.save
+
+      api_basic_authorize
+
+      expect do
+        run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
+      end.not_to change { chargeback_rate.reload.description }
+      expect_request_forbidden
+    end
+
+    it "cannot delete a chargeback rate" do
+      chargeback_rate = FactoryGirl.build(:chargeback_rate)
+      chargeback_rate.save
+
+      api_basic_authorize
+
+      expect do
+        run_delete chargebacks_url(chargeback_rate.id)
+      end.not_to change(ChargebackRate, :count)
+      expect_request_forbidden
+    end
+
     it "cannot create a chargeback rate detail" do
       api_basic_authorize
 

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -147,12 +147,11 @@ RSpec.describe "chargebacks API" do
         run_post chargebacks_url,
                  :rate_type   => "Storage"
       end.not_to change(ChargebackRate, :count)
-      # expect_bad_request(/description can't be blank/i)
+      expect_bad_request(/description can't be blank/i)
     end
 
     it "can edit a chargeback rate through POST" do
-      chargeback_rate = FactoryGirl.build(:chargeback_rate, :description => "chargeback_0")
-      chargeback_rate.save
+      chargeback_rate = FactoryGirl.create(:chargeback_rate, :description => "chargeback_0")
 
       api_basic_authorize action_identifier(:chargebacks, :edit)
       run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
@@ -163,8 +162,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can edit a chargeback rate through PATCH" do
-      chargeback_rate = FactoryGirl.build(:chargeback_rate, :description => "chargeback_0")
-      chargeback_rate.save
+      chargeback_rate = FactoryGirl.create(:chargeback_rate, :description => "chargeback_0")
 
       api_basic_authorize action_identifier(:chargebacks, :edit)
       run_patch chargebacks_url(chargeback_rate.id), [{:action => "edit",
@@ -177,8 +175,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can delete a chargeback rate" do
-      chargeback_rate = FactoryGirl.build(:chargeback_rate)
-      chargeback_rate.save
+      chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
       api_basic_authorize action_identifier(:chargebacks, :delete)
 
@@ -189,8 +186,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can delete a chargeback rate through POST" do
-      chargeback_rate = FactoryGirl.build(:chargeback_rate)
-      chargeback_rate.save
+      chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
       api_basic_authorize action_identifier(:chargebacks, :delete)
 
@@ -303,8 +299,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "cannot edit a chargeback rate" do
-      chargeback_rate = FactoryGirl.build(:chargeback_rate, :description => "chargeback_0")
-      chargeback_rate.save
+      chargeback_rate = FactoryGirl.create(:chargeback_rate, :description => "chargeback_0")
 
       api_basic_authorize
 
@@ -315,8 +310,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "cannot delete a chargeback rate" do
-      chargeback_rate = FactoryGirl.build(:chargeback_rate)
-      chargeback_rate.save
+      chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
       api_basic_authorize
 

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -69,6 +69,62 @@ RSpec.describe "chargebacks API" do
     expect_request_success
   end
 
+  it "can list of all currencies" do
+    currency = FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
+
+    api_basic_authorize
+    run_get '/api/currencies'
+
+    expect_result_resources_to_include_hrefs(
+      "resources", ["/api/currencies/#{currency.id}"]
+    )
+    expect_result_to_match_hash(response_hash, "count" => 1)
+    expect_request_success
+  end
+
+  it "can show an individual currency" do
+    currency = FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
+
+    api_basic_authorize
+    run_get "/api/currencies/#{currency.id}"
+
+    expect_result_to_match_hash(
+      response_hash,
+      "name" => currency.name,
+      "id"   => currency.id,
+      "href" => "/api/currencies/#{currency.id}"
+    )
+    expect_request_success
+  end
+
+  it "can list of all measures" do
+    measure = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+
+    api_basic_authorize
+    run_get '/api/measures'
+
+    expect_result_resources_to_include_hrefs(
+      "resources", ["/api/measures/#{measure.id}"]
+    )
+    expect_result_to_match_hash(response_hash, "count" => 1)
+    expect_request_success
+  end
+
+  it "can show an individual measure" do
+    measure = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+
+    api_basic_authorize
+    run_get "/api/measures/#{measure.id}"
+
+    expect_result_to_match_hash(
+      response_hash,
+      "name" => measure.name,
+      "id"   => measure.id,
+      "href" => "/api/measures/#{measure.id}",
+    )
+    expect_request_success
+  end
+
   context "with an appropriate role" do
     it "can create a new chargeback rate" do
       api_basic_authorize action_identifier(:chargebacks, :create, :collection_actions)

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -42,6 +42,16 @@ describe ApiController do
       test_collection_query(:chargebacks, chargebacks_url, ChargebackRate)
     end
 
+    example "query Currencies" do
+      FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
+      test_collection_query(:currencies, "/api/currencies", ChargebackRateDetailCurrency)
+    end
+
+    example "query Measures" do
+      FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+      test_collection_query(:measures, "/api/measures", ChargebackRateDetailMeasure)
+    end
+
     it "query Clusters" do
       FactoryGirl.create(:ems_cluster)
       test_collection_query(:clusters, clusters_url, EmsCluster)


### PR DESCRIPTION
Hi guys !

Just a PR to add actions on ChargebackRate through the api (route */chargebacks*):
* create
* delete
* edit

Hope it is revellent, feel free to tell me if I'm doing something wrong.
Thanks