### PR TITLE
metric_rollups: only load recent performance state

### DIFF
--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -246,7 +246,7 @@ module Metric::Rollup
     #   the current hour too because the capture in vim_performance_state_for_ts,
     #   if not found for the perf timestamp, will return a state for the current
     #   hour only.
-    MiqPreloader.preload(recs, :vim_performance_states, :conditions => {'vim_performance_states.timestamp' => [ts, Metric::Helper.nearest_hourly_timestamp(Time.now.utc)]}) unless recs.empty?
+    MiqPreloader.preload(recs, :vim_performance_states, VimPerformanceState.where(:timestamp => [ts, Metric::Helper.nearest_hourly_timestamp(Time.now.utc)])) unless recs.empty?
 
     recs.each do |rec|
       perf = perf_recs.fetch_path(rec.class.base_class.name, rec.id, interval_name, ts)

--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -1,7 +1,7 @@
 module MiqPreloader
-  def self.preload(records, associations, _options = {})
+  def self.preload(records, associations, preload_scope = nil)
     preloader = ActiveRecord::Associations::Preloader.new
-    preloader.preload(records, associations)
+    preloader.preload(records, associations, preload_scope)
   end
 
   # it will load records and their associations, and return the children


### PR DESCRIPTION
Leverage the where clause so we only load the recent performance state records instead of loading all of them.

introduced by 387640c2a9456e0a3f3

https://bugzilla.redhat.com/show_bug.cgi?id=1322485