### PR TITLE
Removed not used parameter 'inputs' from _subst() and _subst_find() in condition.rb

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -90,7 +90,7 @@ class Condition < ApplicationRecord
     eval(expr) ? true : false
   end
 
-  def self.subst(expr, rec, _inputs)
+  def self.subst(expr, rec, _inputs = nil)
     findexp = /<find>(.+?)<\/find>/im
     if expr =~ findexp
       expr = expr.gsub!(findexp) { |_s| _subst_find(rec, $1.strip) }


### PR DESCRIPTION
Refactoring MiqExpression  - #7751

There is no used parameter 'inputs' in several methods. This is first PR to remove not used parameter from _subst() and _subst_find(). Next step would be -  remove not used 'inputs' parameter from subst() method which is used in many classes and change related rspecs  

@gtanzillo @jrafanie 
@miq-bot add-label core, refactoring