### PR TITLE
Puma 3.0.0+ resets our proctitle, so use it's proctitle tag option.

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -18,3 +18,4 @@
 # connection from the connection pool.
 #
 threads 5, 5
+tag "MIQ: Web Server Worker"

--- a/gems/pending/util/miq-process.rb
+++ b/gems/pending/util/miq-process.rb
@@ -145,7 +145,7 @@ class MiqProcess
 
   def self.is_worker?(pid)
     command_line = self.command_line(pid)
-    command_line.start_with?(MiqWorker::PROCESS_TITLE_PREFIX)
+    command_line.include?(MiqWorker::PROCESS_TITLE_PREFIX)
   end
 
   LINUX_STATES = {


### PR DESCRIPTION
We generically set a proctitle for all of our workers [here](https://github.com/ManageIQ/manageiq/blob/3c0b760039cc0efbb96880b0034ab3be03628c0d/app/models/miq_worker/runner.rb#L484).
This is done before we run the Rails::Server, which loads puma and resets
the proctitle.

So, instead of looking like this:
```
MIQ: MiqUiWorker id: 509000000000012, uri: http://0.0.0.0:3000
```

It looks like this with puma 3.3.0:
```
puma 3.3.0 (tcp://0.0.0.0:3000) [...]
```

We can use the supported --tag puma option to get most of what we need.

The benefit is we aren't fighting with puma on each upgrade as it does have the
right to set a proctitle for itself.  We also gain the puma version.

Note: We have to hardcode the value in config/puma.rb so we lose which worker
it is (MiqUiWorker or a MiqWebServiceWorker), but this is easily known by looking
at the binding port: 3000s (UI), 4000s (WS).

ps output with puma 2.14.0:

```
503 91747 91721   0 12:22PM ttys001    0:01.83 MIQ: MiqGenericWorker id: 509000000000011, queue: generic
503 91749 91721   0 12:22PM ttys001    0:00.71 MIQ: MiqUiWorker id: 509000000000012, uri: http://0.0.0.0:3000
```

ps output with puma 3.3.0 and this change:

```
503 92363 92335   0 12:29PM ttys004    0:01.72 MIQ: MiqGenericWorker id: 509000000000013, queue: generic
503 92366 92335   0 12:29PM ttys004    0:00.65 puma 3.3.0 (tcp://0.0.0.0:3000) [MIQ: Web Server Worker]
```