### PR TITLE
Allow multiple associations in fields

### DIFF
--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -5,8 +5,10 @@ class MiqExpression::Field
 -(?<column>[a-z]+(_[a-z]+)*)
 /x
 
+  ParseError = Class.new(StandardError)
+
   def self.parse(field)
-    match = FIELD_REGEX.match(field)
+    match = FIELD_REGEX.match(field) or raise ParseError, field
     new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:column])
   end
 

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -1,23 +1,21 @@
 class MiqExpression::Field
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
-\.?(?<association>[a-z_]+)?
+\.?(?<associations>[a-z_\.]+)*
 -(?<column>[a-z]+(_[a-z]+)*)
 /x
 
-  ParseError = Class.new(StandardError)
-
   def self.parse(field)
-    match = FIELD_REGEX.match(field) or raise ParseError, field
-    new(match[:model_name].constantize, match[:association], match[:column])
+    match = FIELD_REGEX.match(field)
+    new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:column])
   end
 
-  attr_reader :model, :association, :column
+  attr_reader :model, :associations, :column
   delegate :table_name, :to => :target
 
-  def initialize(model, association, column)
+  def initialize(model, associations, column)
     @model = model
-    @association = association
+    @associations = associations
     @column = column
   end
 
@@ -32,10 +30,10 @@ class MiqExpression::Field
   private
 
   def target
-    if association
-      association.classify.constantize
-    else
+    if associations.none?
       model
+    else
+      associations.last.classify.constantize
     end
   end
 

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -37,59 +37,59 @@ RSpec.describe MiqExpression::Field do
       expect(described_class.parse(field).column).to eq("last_scan_on")
     end
 
-    it "can parse the association when there is none present" do
+    it "can parse the associations when there is none present" do
       field = "Vm-name"
-      expect(described_class.parse(field).association).to be_nil
+      expect(described_class.parse(field).associations).to be_empty
     end
 
-    it "can parse the association when there is one present" do
+    it "can parse the associations when there is one present" do
       field = "Vm.host-name"
-      expect(described_class.parse(field).association).to eq("host")
+      expect(described_class.parse(field).associations).to contain_exactly("host")
     end
 
-    it "will raise a parse error if there are many associations present" do
+    it "can parse the associations when there are many present" do
       field = "Vm.host.hardware-id"
-      expect { described_class.parse(field) }.to raise_error(MiqExpression::Field::ParseError)
+      expect(described_class.parse(field).associations).to contain_exactly("host", "hardware")
     end
   end
 
   describe "#date?" do
     it "returns true for fields of column type :date" do
-      field = described_class.new(Vm, nil, "retires_on")
+      field = described_class.new(Vm, [], "retires_on")
       expect(field).to be_date
     end
 
     it "returns false for fields of column type other than :date" do
-      field = described_class.new(Vm, nil, "name")
+      field = described_class.new(Vm, [], "name")
       expect(field).not_to be_date
     end
   end
 
   describe "#datetime?" do
     it "returns true for fields of column type :datetime" do
-      field = described_class.new(Vm, nil, "created_on")
+      field = described_class.new(Vm, [], "created_on")
       expect(field).to be_datetime
     end
 
     it "returns false for fields of column type other than :datetime" do
-      field = described_class.new(Vm, nil, "name")
+      field = described_class.new(Vm, [], "name")
       expect(field).not_to be_datetime
     end
 
     it "returns true for a :datetime type column on an association" do
-      field = described_class.new(Vm, "guest_applications", "install_time")
+      field = described_class.new(Vm, ["guest_applications"], "install_time")
       expect(field).to be_datetime
     end
   end
 
   describe "#table_name" do
-    it "returns the table name of the model when there is no association" do
-      field = described_class.new(Vm, nil, "name")
+    it "returns the table name of the model when there are no associations" do
+      field = described_class.new(Vm, [], "name")
       expect(field.table_name).to eq("vms")
     end
 
-    it "returns the table name of the target association if there is an association" do
-      field = described_class.new(Vm, "guest_applications", "name")
+    it "returns the table name of the target association if there are associations" do
+      field = described_class.new(Vm, ["guest_applications"], "name")
       expect(field.table_name).to eq("guest_applications")
     end
   end

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe MiqExpression::Field do
 
     it "can parse the associations when there is one present" do
       field = "Vm.host-name"
-      expect(described_class.parse(field).associations).to contain_exactly("host")
+      expect(described_class.parse(field).associations).to eq(["host"])
     end
 
     it "can parse the associations when there are many present" do
       field = "Vm.host.hardware-id"
-      expect(described_class.parse(field).associations).to contain_exactly("host", "hardware")
+      expect(described_class.parse(field).associations).to eq(%w(host hardware))
     end
   end
 

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe MiqExpression::Field do
       field = "Vm.host.hardware-id"
       expect(described_class.parse(field).associations).to eq(%w(host hardware))
     end
+
+    it "will raise a parse error when given a field with unsupported syntax" do
+      field = "Vm,host+name"
+      expect { described_class.parse(field) }.to raise_error(MiqExpression::Field::ParseError)
+    end
   end
 
   describe "#date?" do


### PR DESCRIPTION
Looks like my assumptions were wrong in https://github.com/ManageIQ/manageiq/commit/a0f5c9ace5a04c239dfdc1385e812b7666c4ae10 - lack of specs for `MiqExpression.get_sqltable` and my trying to inspect the source code to see what it supported (never a good idea) led me to believe we didn't officially support expressions with fields with more than one association. I stumbled across https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_alerts.yml#L167-L169 which proved me wrong.

Here I'm reverting the above commit, but also re-adding error handling for poorly formed expressions, and changing a couple of specs to be order dependent, because associations are.

/cc @gtanzillo @yrudman