### PR TITLE
Use 'preferred' when referencing Google region in providers

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -25,7 +25,8 @@ module EmsCloudHelper::TextualSummary
   #
   def textual_provider_region
     return nil if @ems.provider_region.nil?
-    {:label => _("Region"), :value => @ems.description}
+    label_val = (@ems.type.include? "Google") ? _("Preferred Region") : _("Region")
+    {:label => label_val, :value => @ems.description}
   end
 
   def textual_hostname

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -62,7 +62,7 @@
 
     .form-group{"ng-class" => "{'has-error': angularForm.provider_region.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
-        = _('Region')
+        = _('Preferred Region')
       .col-md-8
         = select_tag('provider_region',
                      options_for_select([["<#{_('Choose')}>", nil]] + Array(@google_regions.invert).sort_by { |desc, _name| desc }, disabled: ["<#{_('Choose')}>", nil]),


### PR DESCRIPTION
Tested this out in the UI and it seems to resolve the issue of treating the Google region as a preferred value versus a connection value as found in other cloud providers.

@dajohnso @agrare 

Closes #6974