### PR TITLE
Replication Configuration screen in Configure/Configuration.

### DIFF
--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -48,7 +48,7 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController',['$http', '
   $scope.saveClicked = function() {
     // remove existing subscriptions that have not changed before sending them up for save
     $scope.pglogicalReplicationModel.subscriptions.forEach(function(subscription, index, object) {
-      if (typeof subscription.id !== 'undefined' && !subscriptionChanged(subscription, $scope.modelCopy.subscriptions[index])) {
+      if (typeof subscription.id !== 'undefined' && subscription["remove"] !== true &&  !subscriptionChanged(subscription, $scope.modelCopy.subscriptions[index])) {
         object.splice(index, 1);
       }
     });
@@ -121,7 +121,7 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController',['$http', '
       $scope.pglogicalReplicationModel.dbname        = subscription.dbname;
       $scope.pglogicalReplicationModel.host          = subscription.host;
       $scope.pglogicalReplicationModel.user          = subscription.user;
-      $scope.pglogicalReplicationModel.password      = subscription.password;
+      $scope.pglogicalReplicationModel.password      = miqService.storedPasswordPlaceholder;
       $scope.pglogicalReplicationModel.port          = subscription.port;
     }
   };
@@ -142,7 +142,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController',['$http', '
       subscription.dbname   = $scope.pglogicalReplicationModel.dbname;
       subscription.host     = $scope.pglogicalReplicationModel.host;
       subscription.user     = $scope.pglogicalReplicationModel.user;
-      subscription.password = $scope.pglogicalReplicationModel.password;
       subscription.port     = $scope.pglogicalReplicationModel.port;
     }
     $scope.pglogicalReplicationModel.addEnabled = false;
@@ -259,9 +258,9 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController',['$http', '
     // if updating a record use form fields to compare
     if ($scope.pglogicalReplicationModel.updateEnabled) {
       var subscription = {};
-      subscription["dbname"] = $scope.pglogicalReplicationModel.dbname;
+      subscription["dbname"]  = $scope.pglogicalReplicationModel.dbname;
       subscription["host"]     = $scope.pglogicalReplicationModel.host;
-      subscription["user"] = $scope.pglogicalReplicationModel.user;
+      subscription["user"]     = $scope.pglogicalReplicationModel.user;
       subscription["password"] = $scope.pglogicalReplicationModel.password;
       subscription["port"]     = $scope.pglogicalReplicationModel.port;
     } else

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -1,0 +1,282 @@
+ManageIQ.angular.app.controller('pglogicalReplicationFormController',['$http', '$scope', 'pglogicalReplicationFormId', 'miqService', function($http, $scope, pglogicalReplicationFormId, miqService) {
+  var init = function() {
+    $scope.pglogicalReplicationModel = {
+      replication_type:'none',
+      subscriptions:[],
+      addEnabled: false,
+      updateEnabled: false
+    };
+    $scope.formId = pglogicalReplicationFormId;
+    $scope.afterGet = false;
+    $scope.modelCopy = angular.copy( $scope.pglogicalReplicationModel );
+
+    ManageIQ.angular.scope = $scope;
+    $scope.newRecord = false;
+    miqService.sparkleOn();
+    $http.get('/ops/pglogical_subscriptions_form_fields/' + pglogicalReplicationFormId).success(function(data) {
+      $scope.pglogicalReplicationModel.replication_type = data.replication_type;
+      $scope.pglogicalReplicationModel.subscriptions = data.subscriptions;
+
+      if ($scope.pglogicalReplicationModel.replication_type == "none")
+        miqService.miqFlash("warn", __("No replication role has been set"));
+
+      $scope.afterGet = true;
+      $scope.modelCopy = angular.copy( $scope.pglogicalReplicationModel );
+      miqService.sparkleOff();
+    });
+
+    $scope.$watch("pglogicalReplicationModel.replication_type", function() {
+      $scope.form = $scope.angularForm;
+      $scope.model = "pglogicalReplicationModel";
+    });
+  };
+
+  var pglogicalManageSubscriptionsButtonClicked = function(buttonName, serializeFields) {
+    miqService.sparkleOn();
+    var url = '/ops/pglogical_save_subscriptions/' + pglogicalReplicationFormId + '?button=' + buttonName;
+    miqService.miqAjaxButton(url, serializeFields);
+  };
+
+  $scope.resetClicked = function() {
+    $scope.pglogicalReplicationModel = angular.copy( $scope.modelCopy );
+    $scope.angularForm.$setUntouched(true);
+    $scope.angularForm.$setPristine(true);
+    miqService.miqFlash("warn", __("All changes have been reset"));
+  };
+
+  $scope.saveClicked = function() {
+    // remove existing subscriptions marked for deletetion before sending them up for save
+    $scope.pglogicalReplicationModel.subscriptions.forEach(function(subscription, index, object) {
+      // remove subscription from list if they were not updatedin the form
+      if (subscription.remove === true || (typeof subscription.id !== 'undefined' && !subscriptionChanged(subscription, $scope.modelCopy.subscriptions[index]))) {
+        object.splice(index, 1);
+      }
+    });
+    pglogicalManageSubscriptionsButtonClicked('save', {
+      'replication_type': $scope.pglogicalReplicationModel.replication_type,
+      'subscriptions' : $scope.pglogicalReplicationModel.subscriptions
+    });
+    $scope.angularForm.$setPristine(true);
+  };
+
+  // check if subscription values have been changed
+  var subscriptionChanged = function(new_subscription, original_subscription) {
+    if (new_subscription.database  === original_subscription.database &&
+        new_subscription.host      === original_subscription.host &&
+        new_subscription.username  === original_subscription.username &&
+        new_subscription.password  === original_subscription.password &&
+        new_subscription.port      === original_subscription.port)
+      return false;
+    else
+      return true;
+  }
+
+  $scope.toggleValueForWatch =   function(watchValue, initialValue) {
+    if($scope[watchValue] == initialValue)
+      $scope[watchValue] = "NO-OP";
+    else if($scope[watchValue] == "NO-OP")
+      $scope[watchValue] = initialValue;
+  };
+
+  // replication type changed, show appropriate flash message
+  $scope.replicationTypeChanged = function() {
+    miqService.miqFlashClear();
+    var original_value = $scope.modelCopy.replication_type;
+    var new_value      = $scope.pglogicalReplicationModel.replication_type;
+    if ((original_value == "none" && new_value == "none") || (original_value == "remote" && new_value == 'none'))
+      miqService.miqFlash("warn", __("No replication role has been set"));
+    else if (original_value == "global" && new_value == 'none')
+      miqService.miqFlash("warn", __("All current subscriptions will be removed"));
+    else if (original_value == "global" && new_value == 'remote')
+      miqService.miqFlash("warn", __("Changing to remote replication role will remove all current subscriptions"));
+
+    if (new_value != "global")
+      $scope.pglogicalReplicationModel.subscriptions = []
+  };
+
+  // add new subscription button pressed
+  $scope.enableSubscriptionAdd = function(){
+    $scope.pglogicalReplicationModel.updateEnabled = false;
+    $scope.pglogicalReplicationModel.addEnabled    = true;
+    $scope.pglogicalReplicationModel.database      = '';
+    $scope.pglogicalReplicationModel.host          = '';
+    $scope.pglogicalReplicationModel.username      = '';
+    $scope.pglogicalReplicationModel.password      = '';
+    $scope.pglogicalReplicationModel.port          = '5432';
+  };
+
+  // update existing subscription button pressed
+  $scope.enableSubscriptionUpdate = function(idx){
+    var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
+    if (subscription.newRecord === true) {
+      $scope.pglogicalReplicationModel.s_index       = idx;
+      $scope.pglogicalReplicationModel.updateEnabled = true;
+      $scope.pglogicalReplicationModel.database      = subscription.database;
+      $scope.pglogicalReplicationModel.host          = subscription.host;
+      $scope.pglogicalReplicationModel.username      = subscription.username;
+      $scope.pglogicalReplicationModel.password      = subscription.password;
+      $scope.pglogicalReplicationModel.port          = subscription.port;
+    }
+    else if (confirm("An updated subscription must point to the same database with which it was originally created. Failure to do so will result in undefined behavior. Do you want to continue?")) {
+      $scope.pglogicalReplicationModel.s_index       = idx;
+      $scope.pglogicalReplicationModel.updateEnabled = true;
+      $scope.pglogicalReplicationModel.database      = subscription.database;
+      $scope.pglogicalReplicationModel.host          = subscription.host;
+      $scope.pglogicalReplicationModel.username      = subscription.username;
+      $scope.pglogicalReplicationModel.password      = subscription.password;
+      $scope.pglogicalReplicationModel.port          = subscription.port;
+    }
+  };
+
+  // add new subscription
+  $scope.addSubscription = function(idx) {
+    if (typeof idx == 'undefined') {
+      $scope.pglogicalReplicationModel.subscriptions.push({
+        database: $scope.pglogicalReplicationModel.database,
+        host: $scope.pglogicalReplicationModel.host,
+        username: $scope.pglogicalReplicationModel.username,
+        password: $scope.pglogicalReplicationModel.password,
+        port: $scope.pglogicalReplicationModel.port,
+        newRecord: true
+      });
+    } else {
+      var subscription      = $scope.pglogicalReplicationModel.subscriptions[idx];
+      subscription.database = $scope.pglogicalReplicationModel.database;
+      subscription.host     = $scope.pglogicalReplicationModel.host;
+      subscription.username = $scope.pglogicalReplicationModel.username;
+      subscription.password = $scope.pglogicalReplicationModel.password;
+      subscription.port     = $scope.pglogicalReplicationModel.port;
+    }
+    $scope.pglogicalReplicationModel.addEnabled = false;
+    $scope.pglogicalReplicationModel.updateEnabled = false;
+  };
+
+  //delete an existing subscription
+  $scope.removeSubscription = function(idx) {
+    var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
+    if (subscription.newRecord === true)
+      $scope.pglogicalReplicationModel.subscriptions.splice(idx, 1);
+    else if (confirm("Deleting a subscription will remove all replicated data which originated in the selected region. Do you want to continue?"))
+      subscription.remove = true;
+  };
+
+  // discard new subscription add
+  $scope.discardSubscription = function(idx) {
+    if (typeof idx == 'undefined') {
+      $scope.pglogicalReplicationModel.database   = '';
+      $scope.pglogicalReplicationModel.host       = '';
+      $scope.pglogicalReplicationModel.username   = '';
+      $scope.pglogicalReplicationModel.password   = '';
+      $scope.pglogicalReplicationModel.port       = '';
+      $scope.pglogicalReplicationModel.addEnabled = false;
+    } else {
+      var original_values = $scope.modelCopy.subscriptions[idx];
+      var subscription    = $scope.pglogicalReplicationModel.subscriptions[idx];
+      $scope.pglogicalReplicationModel.updateEnabled = false;
+      subscription.database = original_values.database;
+      subscription.host     = original_values.host;
+      subscription.username = original_values.username;
+      subscription.password = original_values.password;
+      subscription.port     = original_values.port;
+    }
+  };
+
+  // validate subscription, all required fields should have data
+  $scope.subscriptionValid = function() {
+    if (typeof $scope.pglogicalReplicationModel.database != 'undefined' && $scope.pglogicalReplicationModel.database !== '' &&
+        typeof $scope.pglogicalReplicationModel.host     != 'undefined' && $scope.pglogicalReplicationModel.host     !== '' &&
+        typeof $scope.pglogicalReplicationModel.username != 'undefined' && $scope.pglogicalReplicationModel.username !== '' &&
+        typeof $scope.pglogicalReplicationModel.password != 'undefined' && $scope.pglogicalReplicationModel.password !== ''
+      )
+      return true;
+    else
+      return false;
+  }
+
+  $scope.saveEnabled = function() {
+    saveable = $scope.angularForm.$dirty && $scope.angularForm.$valid
+    if (saveable &&
+      $scope.pglogicalReplicationModel.replication_type === "global" &&
+      $scope.pglogicalReplicationModel.subscriptions.length >= 1)
+      return true;
+    else  if (saveable &&
+      $scope.pglogicalReplicationModel.replication_type !== "global" &&
+      $scope.pglogicalReplicationModel.subscriptions.length == 0)
+      return true;
+    else
+      return false;
+  }
+
+  // method to set flag to disable certain buttons when add of subscription in progress
+  $scope.addInProgress = function() {
+    return $scope.pglogicalReplicationModel.addEnabled == true;
+  }
+
+  // validate new/existing subscription
+  $scope.validateSubscription = function(idx) {
+    var data = {};
+    if (typeof idx == 'undefined') {
+      data["database"] = $scope.pglogicalReplicationModel.database;
+      data["host"]     = $scope.pglogicalReplicationModel.host;
+      data["username"] = $scope.pglogicalReplicationModel.username;
+      data["password"] = $scope.pglogicalReplicationModel.password;
+      data["port"]     = $scope.pglogicalReplicationModel.port;
+    } else {
+      var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
+      data["database"] = subscription.database;
+      data["host"]     = subscription.host;
+      data["username"] = subscription.username;
+      data["password"] = subscription.password;
+      data["port"]     = subscription.port;
+    }
+    miqService.sparkleOn();
+    var url = '/ops/pglogical_validate_subscription/' + pglogicalReplicationFormId;
+    miqService.miqAjaxButton(url, data);
+  };
+
+  // cancel delete button should be displayed only if existing saved subscriptions were deleted
+  $scope.showCancelDelete = function(idx) {
+    var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
+    // only show subscriptions in red if they were saved subscriptions and deleted in current edit session
+    if (subscription.remove === true)
+      return true;
+    else
+      return false;
+  }
+
+  // put back subscription that was deleted into new subscriptions array
+  $scope.cancelDelete = function(idx) {
+    var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
+    subscription.remove = false;
+  }
+
+  $scope.showChanged = function(idx, fieldName) {
+    var original_values = $scope.modelCopy.subscriptions[idx];
+    // if updating a record use form fields to compare
+    if ($scope.pglogicalReplicationModel.updateEnabled) {
+      var subscription = {};
+      subscription["database"] = $scope.pglogicalReplicationModel.database;
+      subscription["host"]     = $scope.pglogicalReplicationModel.host;
+      subscription["username"] = $scope.pglogicalReplicationModel.username;
+      subscription["password"] = $scope.pglogicalReplicationModel.password;
+      subscription["port"]     = $scope.pglogicalReplicationModel.port;
+    } else
+      var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
+
+    if (typeof original_values != 'undefined' && original_values[fieldName] != subscription[fieldName])
+      return true;
+    else
+     return false;
+  }
+
+  $scope.subscriptionInValidMessage = function(){
+    if ($scope.pglogicalReplicationModel.replication_type == 'global' &&
+      ($scope.pglogicalReplicationModel.subscriptions.length === 0 ||
+      ($scope.pglogicalReplicationModel.subscriptions.length == 1 && $scope.pglogicalReplicationModel.subscriptions[0].remove === true)))
+      return true;
+    else
+      return false;
+  }
+
+  init();
+}]);

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -193,9 +193,9 @@ module OpsController::Settings::Common
         sub.dbname   = subscription['dbname']
         sub.host     = subscription['host']
         sub.user     = subscription['user']
-        sub.password = subscription['password']
+        sub.password = subscription['password'] == '●●●●●●●●' ? nil : subscription['password']
         sub.port     = subscription['port']
-        if sub.id && sub.remove == "true"
+        if sub.id && subscription['remove'] == "true"
           sub.delete
         else
           subscriptions_to_save.push(sub)
@@ -254,7 +254,7 @@ module OpsController::Settings::Common
        :host     => sub.host,
        :id       => sub.id,
        :user     => sub.user,
-       :password => sub.password,
+       :password => '●●●●●●●●',
        :port     => sub.port
       }
     }

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -62,6 +62,8 @@
             = _("Import")
           = miq_tab_header("settings_rhn", @sb[:active_tab]) do
             = _("Red Hat Updates")
+          = miq_tab_header("settings_replication", @sb[:active_tab]) do
+            = _("Replication")
         .tab-content
           = miq_tab_content("settings_details", @sb[:active_tab]) do
             = render :partial => "settings_details_tab"
@@ -77,6 +79,8 @@
             = render :partial => "settings_import_tab"
           = miq_tab_content("settings_rhn", @sb[:active_tab]) do
             = render :partial => "settings_rhn_tab"
+          = miq_tab_content("settings_replication", @sb[:active_tab]) do
+            = render :partial => "settings_replication_tab"
     -# Diagnostics
   - when :diagnostics_tree
     - if x_node.split("-")[0] == "z"

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -38,32 +38,36 @@
           %th= _('Port')
           %th{:colspan => 2}=_('Actions')
         %tbody
-          %tr{"ng-show" => "pglogicalReplicationModel.addEnabled"}
+          %tr{"ng-if" => "pglogicalReplicationModel.addEnabled"}
             %td
               %input.form-control{"type"        => "text",
                                   "id"          => "host",
                                   "name"        => "host",
-                                  "ng-model"    => "pglogicalReplicationModel.database",
-                                  "ng-required" => true}
+                                  "ng-model"    => "pglogicalReplicationModel.dbname",
+                                  "miqrequired" => "",
+                                  "checkchange" => ""}
             %td
               %input.form-control{"type"        => "text",
                                   "id"          => "host",
                                   "name"        => "host",
                                   "ng-model"    => "pglogicalReplicationModel.host",
-                                  "ng-required" => true}
+                                  "miqrequired" => "",
+                                  "checkchange" => ""}
             %td
               %input.form-control{"type"        => "text",
                                   "id"          => "userid",
                                   "name"        => "userid",
-                                  "ng-model"    => "pglogicalReplicationModel.username",
-                                  "ng-required" => true}
+                                  "ng-model"    => "pglogicalReplicationModel.user",
+                                  "miqrequired" => "",
+                                  "checkchange" => ""}
             %td
               %input.form-control{"type"        => "password",
                                   "id"          => "password",
                                   "name"        => "password",
                                   "ng-model"    => "pglogicalReplicationModel.password",
                                   "placeholder" => placeholder_if_present("pglogicalReplicationModel.password"),
-                                  "ng-required" => true}
+                                  "miqrequired" => "",
+                                  "checkchange" => ""}
             %td
               %input.form-control{"type"        => "text",
                                   "id"          => "port",
@@ -88,59 +92,54 @@
                       %a{"ng-click" => "discardSubscription()"}
                         = _('Discard')
 
-          %tr{"ng-repeat" => "subscription in pglogicalReplicationModel.subscriptions", "ng-form" => "rowForm", "ng-class" => "{'danger': showCancelDelete($index)}"}
-            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
-                "ng-class"=>"{'active': showChanged($index, 'database')}"}
-              {{subscription.database}}
-            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
-                "ng-class"=>"{'active': showChanged($index, 'database')}"}
+          %tr{"ng-repeat" => "subscription in pglogicalReplicationModel.subscriptions track by $index", "ng-form" => "rowForm", "ng-class" => "{'danger': showCancelDelete($index)}"}
+            %td{"ng-if" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+                "ng-class"=>"{'active': showChanged($index, 'dbname')}"}
+              {{subscription.dbname}}
+            %td{"ng-if" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+                "ng-class"=>"{'active': showChanged($index, 'dbname')}"}
               %input.form-control{"type"        => "text",
-                                  "id"          => "database",
-                                  "name"        => "database",
-                                  "ng-model"    => "pglogicalReplicationModel.database",
-                                  "ng-change"   => "showChanged($index, 'database')",
-                                  "ng-required" => true}
+                                  "name"        => "dbname",
+                                  "ng-model"    => "pglogicalReplicationModel.dbname",
+                                  "ng-change"   => "showChanged($index, 'dbname')",
+                                  "miqrequired" => ""}
 
-            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+            %td{"ng-if" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
                 "ng-class"=>"{'active': showChanged($index, 'host')}"}
               {{subscription.host}}
-            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+            %td{"ng-if" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
                 "ng-class"=>"{'active': showChanged($index, 'host')}"}
               %input.form-control{"type"        => "text",
-                                  "id"          => "host",
                                   "name"        => "host",
                                   "ng-model"    => "pglogicalReplicationModel.host",
-                                  "ng-required" => true}
+                                  "miqrequired" => ""}
 
-            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
-                "ng-class"=>"{'active': showChanged($index, 'username')}"}
-              {{subscription.username}}
-            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
-                "ng-class"=>"{'active': showChanged($index, 'username')}"}
+            %td{"ng-if" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+                "ng-class"=>"{'active': showChanged($index, 'user')}"}
+              {{subscription.user}}
+            %td{"ng-if" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+                "ng-class"=>"{'active': showChanged($index, 'user')}"}
               %input.form-control{"type"        => "text",
-                                  "id"          => "username",
-                                  "name"        => "username",
-                                  "ng-model"    => "pglogicalReplicationModel.username",
-                                  "ng-required" => true}
+                                  "name"        => "user",
+                                  "ng-model"    => "pglogicalReplicationModel.user",
+                                  "miqrequired" => ""}
 
-            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+            %td{"ng-if" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
                 "ng-class"=>"{'active': showChanged($index, 'password')}"}
               ●●●●●●●●
-            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+            %td{"ng-if" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
                 "ng-class"=>"{'active': showChanged($index, 'password')}"}
               %input.form-control{"type"        => "password",
-                                  "id"          => "password",
                                   "name"        => "password",
                                   "ng-model"    => "pglogicalReplicationModel.password",
-                                  "ng-required" => true}
+                                  "miqrequired" => ""}
 
-            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+            %td{"ng-if" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
                 "ng-class"=>"{'active': showChanged($index, 'port')}"}
               {{subscription.port}}
-            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+            %td{"ng-if" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
                 "ng-class"=>"{'active': showChanged($index, 'port')}"}
               %input.form-control{"type"        => "text",
-                                  "id"          => "port",
                                   "name"        => "port",
                                   "ng-model"    => "pglogicalReplicationModel.port"}
 
@@ -187,21 +186,23 @@
                    :alt       => _("Save"),
                    :style     => "cursor:not-allowed",
                    "ng-click" => "disabledClick($event)",
-                   "ng-show"  => "!saveEnabled()")
+                   "ng-show"  => "!saveEnabled(angularForm)")
       = button_tag(_("Save"),
                    :class     => "btn btn-primary",
                    :alt       => _("Save"),
                    "ng-click" => "saveClicked()",
-                   "ng-show"  => "saveEnabled()")
-      = button_tag("Reset",
-           :class        => "btn btn-default btn-disabled",
-           :alt          => "Reset changes",
-           :title        => "Reset changes",
-           "ng-class"    => "{'btn-disabled': angularForm.$pristine}",
-           "ng-click"    => "resetClicked()",
-           "ng-disabled" => "angularForm.$pristine",
-           "ng-hide"     => "newRecord")
-
+                   "ng-show"  => "saveEnabled(angularForm)")
+      = button_tag(_("Reset"),
+                   :class     => "btn btn-default btn-disabled",
+                   :alt       => _("Reset changes"),
+                   :style     => "cursor:not-allowed",
+                   "ng-click" => "disabledClick($event)",
+                   "ng-show"  => "!saveEnabled(angularForm)")
+      = button_tag(_("Reset"),
+                   :class     => "btn btn-default",
+                   :alt       => _("Reset changes"),
+                   "ng-click" => "resetClicked()",
+                   "ng-show"  => "saveEnabled(angularForm)")
   :javascript
     ManageIQ.angular.app.value('pglogicalReplicationFormId', 'new');
     miq_bootstrap('#form_div');

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -132,7 +132,7 @@
               %input.form-control{"type"        => "password",
                                   "name"        => "password",
                                   "ng-model"    => "pglogicalReplicationModel.password",
-                                  "miqrequired" => ""}
+                                  "ng-disabled" => "!subscription.newRecord"}
 
             %td{"ng-if" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
                 "ng-class"=>"{'active': showChanged($index, 'port')}"}

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -1,0 +1,193 @@
+- if @sb[:active_tab] == "settings_replication"
+  - @angular_form = true
+
+  %form.form-horizontal#form_div{"name"          => "angularForm",
+                                 "ng-controller" => "pglogicalReplicationFormController",
+                                 "ng-show"       => "afterGet"}
+    = render :partial => "layouts/flash_msg"
+    .form-group{"ng-class" => "{'has-error': angularForm.subscriptions.$invalid}"}
+      %label.col-md-2.control-label
+        = _('Type')
+      .col-md-2
+        = select_tag('replication_type',
+                          options_for_select([["<#{_('None')}>", 'none'], ["Global", 'global'], ["Remote", 'remote']]),
+                          "ng-model"                    => "pglogicalReplicationModel.replication_type",
+                          "ng-change"                   => "replicationTypeChanged()",
+                          "miqrequired"                 => "",
+                          "checkchange"                 => "",
+                          "selectpicker-for-select-tag" => "")
+
+    .subscriptions_div{"ng-if" => "pglogicalReplicationModel.replication_type == 'global'"}
+      %h3
+        = _('Subscriptions')
+      %br
+        %span{"style"=>"color:red", "ng-show" => "subscriptionInValidMessage()"}
+          = _("At least 1 subscription must be added to save server replication type")
+      %table{:width => "100%", :align => "bottom"}
+        %tr
+          %td#buttons_on{:align => "right"}
+            %button.btn.btn-primary.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionAdd()",  :align => "left"}= _('Add Subscription')
+      %table.table.table-striped.table-hover.table-condensed.table-bordered
+        %thead
+          %th= _('Database')
+          %th= _('Host')
+          %th= _('Username')
+          %th= _('Password')
+          %th= _('Port')
+          %th=_('Actions')
+        %tbody
+          %tr{"ng-show" => "pglogicalReplicationModel.addEnabled"}
+            %td
+              %input.form-control{"type"        => "text",
+                                  "id"          => "host",
+                                  "name"        => "host",
+                                  "ng-model"    => "pglogicalReplicationModel.database",
+                                  "ng-required" => true}
+            %td
+              %input.form-control{"type"        => "text",
+                                  "id"          => "host",
+                                  "name"        => "host",
+                                  "ng-model"    => "pglogicalReplicationModel.host",
+                                  "ng-required" => true}
+            %td
+              %input.form-control{"type"        => "text",
+                                  "id"          => "userid",
+                                  "name"        => "userid",
+                                  "ng-model"    => "pglogicalReplicationModel.username",
+                                  "ng-required" => true}
+            %td
+              %input.form-control{"type"        => "password",
+                                  "id"          => "password",
+                                  "name"        => "password",
+                                  "ng-model"    => "pglogicalReplicationModel.password",
+                                  "placeholder" => placeholder_if_present("pglogicalReplicationModel.password"),
+                                  "ng-required" => true}
+            %td
+              %input.form-control{"type"        => "text",
+                                  "id"          => "port",
+                                  "name"        => "port",
+                                  "ng-model"    => "pglogicalReplicationModel.port"}
+            %td.action-cell
+              %button.btn.btn-default.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()",  "ng-click" => "addSubscription()"}= _('Accept')
+              %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
+                %i.fa.fa-ellipsis-v.pull-right
+              %ul.dropdown-menu.pull-right
+                %li
+                  %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
+                    = _('Validate')
+                %li
+                  %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription()"}
+                    = _('Validate')
+                %li
+                  %a{"ng-click" => "discardSubscription()"}
+                    = _('Discard')
+
+          %tr{"ng-repeat" => "subscription in pglogicalReplicationModel.subscriptions", "ng-form" => "rowForm", "ng-class" => "{'danger': showCancelDelete($index)}"}
+            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+                "ng-class"=>"{'active': showChanged($index, 'database')}"}
+              {{subscription.database}}
+            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+                "ng-class"=>"{'active': showChanged($index, 'database')}"}
+              %input.form-control{"type"        => "text",
+                                  "id"          => "database",
+                                  "name"        => "database",
+                                  "ng-model"    => "pglogicalReplicationModel.database",
+                                  "ng-change"   => "showChanged($index, 'database')",
+                                  "ng-required" => true}
+
+            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+                "ng-class"=>"{'active': showChanged($index, 'host')}"}
+              {{subscription.host}}
+            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+                "ng-class"=>"{'active': showChanged($index, 'host')}"}
+              %input.form-control{"type"        => "text",
+                                  "id"          => "host",
+                                  "name"        => "host",
+                                  "ng-model"    => "pglogicalReplicationModel.host",
+                                  "ng-required" => true}
+
+            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+                "ng-class"=>"{'active': showChanged($index, 'username')}"}
+              {{subscription.username}}
+            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+                "ng-class"=>"{'active': showChanged($index, 'username')}"}
+              %input.form-control{"type"        => "text",
+                                  "id"          => "username",
+                                  "name"        => "username",
+                                  "ng-model"    => "pglogicalReplicationModel.username",
+                                  "ng-required" => true}
+
+            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+                "ng-class"=>"{'active': showChanged($index, 'password')}"}
+              ●●●●●●●●
+            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+                "ng-class"=>"{'active': showChanged($index, 'password')}"}
+              %input.form-control{"type"        => "password",
+                                  "id"          => "password",
+                                  "name"        => "password",
+                                  "ng-model"    => "pglogicalReplicationModel.password",
+                                  "ng-required" => true}
+
+            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
+                "ng-class"=>"{'active': showChanged($index, 'port')}"}
+              {{subscription.port}}
+            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index",
+                "ng-class"=>"{'active': showChanged($index, 'port')}"}
+              %input.form-control{"type"        => "text",
+                                  "id"          => "port",
+                                  "name"        => "port",
+                                  "ng-model"    => "pglogicalReplicationModel.port"}
+
+            %td{:class => "action-cell", "ng-show" => "showCancelDelete($index)"}
+              %button.btn.btn-default.btn-sm{:type => "button", "ng-click" => "cancelDelete($index)"}= _('Cancel Delete')
+
+            %td{:class => "action-cell", "ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
+              %button.btn.btn-default.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionUpdate($index)"}= _('Update')
+              %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
+                %i.fa.fa-ellipsis-v.pull-right
+              %ul.dropdown-menu.pull-right
+                %li
+                  %a{"ng-click" => "removeSubscription($index)"}
+                    = _('Delete')
+                %li
+                  %a{"ng-click" => "validateSubscription($index)"}
+                    = _('Validate')
+            %td{:class => "action-cell", "ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
+              %button.btn.btn-default.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()", "ng-click" => "addSubscription($index)"}= _('Accept')
+              %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
+                %i.fa.fa-ellipsis-v.pull-right
+              %ul.dropdown-menu.pull-right
+                %li
+                  %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
+                    = _('Validate')
+                %li
+                  %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription($index)"}
+                    = _('Validate')
+                %li
+                  %a{"ng-click" => "discardSubscription($index)"}
+                    = _('Discard')
+
+    .button-group{:align => "right"}
+      = button_tag(_("Save"),
+                   :class     => "btn btn-primary btn-disabled",
+                   :alt       => _("Save"),
+                   :style     => "cursor:not-allowed",
+                   "ng-click" => "disabledClick($event)",
+                   "ng-show"  => "!saveEnabled()")
+      = button_tag(_("Save"),
+                   :class     => "btn btn-primary",
+                   :alt       => _("Save"),
+                   "ng-click" => "saveClicked()",
+                   "ng-show"  => "saveEnabled()")
+      = button_tag("Reset",
+           :class        => "btn btn-default btn-disabled",
+           :alt          => "Reset changes",
+           :title        => "Reset changes",
+           "ng-class"    => "{'btn-disabled': angularForm.$pristine}",
+           "ng-click"    => "resetClicked()",
+           "ng-disabled" => "angularForm.$pristine",
+           "ng-hide"     => "newRecord")
+
+  :javascript
+    ManageIQ.angular.app.value('pglogicalReplicationFormId', 'new');
+    miq_bootstrap('#form_div');

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -26,7 +26,9 @@
       %table{:width => "100%", :align => "bottom"}
         %tr
           %td#buttons_on{:align => "right"}
-            %button.btn.btn-primary.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionAdd()",  :align => "left"}= _('Add Subscription')
+            %button.btn.btn-primary{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionAdd()",  :align => "left"}= _('Add Subscription')
+            %br
+            %br
       %table.table.table-striped.table-hover.table-condensed.table-bordered
         %thead
           %th= _('Database')
@@ -34,7 +36,7 @@
           %th= _('Username')
           %th= _('Password')
           %th= _('Port')
-          %th=_('Actions')
+          %th{:colspan => 2}=_('Actions')
         %tbody
           %tr{"ng-show" => "pglogicalReplicationModel.addEnabled"}
             %td
@@ -67,20 +69,24 @@
                                   "id"          => "port",
                                   "name"        => "port",
                                   "ng-model"    => "pglogicalReplicationModel.port"}
-            %td.action-cell
-              %button.btn.btn-default.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()",  "ng-click" => "addSubscription()"}= _('Accept')
+            %td{:class => "action-cell"}
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()",  "ng-click" => "addSubscription()"}= _('Accept')
+
+            %td{:class => "action-cell", :style => "width: 5px"}
               %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
-                %i.fa.fa-ellipsis-v.pull-right
-              %ul.dropdown-menu.pull-right
-                %li
-                  %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
-                    = _('Validate')
-                %li
-                  %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription()"}
-                    = _('Validate')
-                %li
-                  %a{"ng-click" => "discardSubscription()"}
-                    = _('Discard')
+                .dropdown.pull-right.dropdown-kebab-pf
+                  .btn.btn-link.btn-block.dropdown-toggle
+                    %span.fa.fa-ellipsis-v
+                  %ul.dropdown-menu.dropdown-menu-right.3
+                    %li
+                      %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
+                        = _('Validate')
+                    %li
+                      %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription()"}
+                        = _('Validate')
+                    %li
+                      %a{"ng-click" => "discardSubscription()"}
+                        = _('Discard')
 
           %tr{"ng-repeat" => "subscription in pglogicalReplicationModel.subscriptions", "ng-form" => "rowForm", "ng-class" => "{'danger': showCancelDelete($index)}"}
             %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)",
@@ -141,31 +147,39 @@
             %td{:class => "action-cell", "ng-show" => "showCancelDelete($index)"}
               %button.btn.btn-default.btn-sm{:type => "button", "ng-click" => "cancelDelete($index)"}= _('Cancel Delete')
 
-            %td{:class => "action-cell", "ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
-              %button.btn.btn-default.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionUpdate($index)"}= _('Update')
+            %td{:class => "action-cell","ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionUpdate($index)"}= _('Update')
+
+            %td{:class => "action-cell", :style => "width: 5px", "ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
               %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
-                %i.fa.fa-ellipsis-v.pull-right
-              %ul.dropdown-menu.pull-right
-                %li
-                  %a{"ng-click" => "removeSubscription($index)"}
-                    = _('Delete')
-                %li
-                  %a{"ng-click" => "validateSubscription($index)"}
-                    = _('Validate')
+                .dropdown.pull-right.dropdown-kebab-pf
+                  .btn.btn-link.btn-block.dropdown-toggle
+                    %span.fa.fa-ellipsis-v
+                  %ul.dropdown-menu.dropdown-menu-right.3
+                    %li
+                      %a{"ng-click" => "removeSubscription($index)"}
+                        = _('Delete')
+                    %li
+                      %a{"ng-click" => "validateSubscription($index)"}
+                        = _('Validate')
             %td{:class => "action-cell", "ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
-              %button.btn.btn-default.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()", "ng-click" => "addSubscription($index)"}= _('Accept')
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()", "ng-click" => "addSubscription($index)"}= _('Accept')
+
+            %td{:class => "action-cell", :style => "width: 5px", "ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
               %a{:class => "dropdown-toggle", "data-toggle" => "dropdown", :style => "cursor: pointer; cursor: hand;"}
-                %i.fa.fa-ellipsis-v.pull-right
-              %ul.dropdown-menu.pull-right
-                %li
-                  %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
-                    = _('Validate')
-                %li
-                  %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription($index)"}
-                    = _('Validate')
-                %li
-                  %a{"ng-click" => "discardSubscription($index)"}
-                    = _('Discard')
+                .dropdown.pull-right.dropdown-kebab-pf
+                  .btn.btn-link.btn-block.dropdown-toggle
+                    %span.fa.fa-ellipsis-v
+                  %ul.dropdown-menu.dropdown-menu-right.3
+                    %li
+                      %a{:class => "disabled", "ng-show" => "!subscriptionValid()"}
+                        = _('Validate')
+                    %li
+                      %a{"ng-show" => "subscriptionValid()", "ng-click" => "validateSubscription($index)"}
+                        = _('Validate')
+                    %li
+                      %a{"ng-click" => "discardSubscription($index)"}
+                        = _('Discard')
 
     .button-group{:align => "right"}
       = button_tag(_("Save"),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1794,6 +1794,7 @@ Vmdb::Application.routes.draw do
         fetch_production_log
         log_collection_form_fields
         log_protocol_changed
+        pglogical_subscriptions_form_fields
         schedule_form_fields
         show_product_update
         tenant_quotas_form_fields
@@ -1842,6 +1843,8 @@ Vmdb::Application.routes.draw do
         log_depot_validate
         orphaned_records_delete
         perf_chart_chooser
+        pglogical_save_subscriptions
+        pglogical_validate_subscription
         product_updates_list
         rbac_group_edit
         rbac_group_field_changed

--- a/spec/javascripts/controllers/ops/pglogical_replication_form_controller_spec.js
+++ b/spec/javascripts/controllers/ops/pglogical_replication_form_controller_spec.js
@@ -1,0 +1,81 @@
+describe('pglogicalReplicationFormController', function() {
+  var $scope, $controller, $httpBackend, miqService;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function($rootScope, _$controller_, _$httpBackend_, _miqService_) {
+    miqService = _miqService_;
+    spyOn(miqService, 'miqFlash');
+    spyOn(miqService, 'miqAjaxButton');
+    spyOn(miqService, 'sparkleOn');
+    spyOn(miqService, 'sparkleOff');
+    $scope = $rootScope.$new();
+    $scope.pglogicalReplicationModel = {
+      replication_type: 'none',
+      subscriptions   : []};
+    $httpBackend = _$httpBackend_;
+    $controller = _$controller_('pglogicalReplicationFormController', {
+      $scope: $scope,
+      pglogicalReplicationFormId: 'new',
+      miqService: miqService
+    });
+  }));
+
+  beforeEach(inject(function(_$controller_) {
+    var pglogicalReplicationFormResponse = {
+      replication_type: 'none',
+      subscriptions   : []};
+    $httpBackend.whenGET('/ops/pglogical_subscriptions_form_fields/new').respond(pglogicalReplicationFormResponse);
+    $httpBackend.flush();
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('initialization', function() {
+    it('sets the replication type returned with http request', function() {
+      expect($scope.pglogicalReplicationModel.replication_type).toEqual('none');
+    });
+
+    it('sets the subscriptions value returned with http request', function() {
+      expect($scope.pglogicalReplicationModel.subscriptions).toEqual([]);
+    });
+  });
+
+  describe('#resetClicked', function() {
+    beforeEach(function() {
+      $scope.angularForm = {
+        $setPristine: function (value){},
+        $setUntouched: function (value){}
+      };
+      $scope.resetClicked();
+    });
+
+    it('sets total spinner count to be 1', function() {
+      expect(miqService.sparkleOn.calls.count()).toBe(1);
+    });
+  });
+
+  describe('#saveClicked', function() {
+    beforeEach(function() {
+      $scope.angularForm = {
+        $setPristine: function (value){}
+      };
+      $scope.saveClicked();
+    });
+
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
+    });
+
+    it('delegates to miqService.miqAjaxButton', function() {
+      var submitContent = {
+        replication_type: $scope.pglogicalReplicationModel.replication_type,
+        subscriptions:    $scope.pglogicalReplicationModel.subscriptions};
+
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/pglogical_save_subscriptions/new?button=save', submitContent);
+    });
+  });
+});


### PR DESCRIPTION
Added a new "Replication" tab under Configure/Configuration in Settings accordion under Region. That allows user to set replication type to none/remote/global. IF user selects replication type to global, table to add/remove subscriptions will be presented to user. At least 1 subscription must be added to save replication type as global.

screenshots:
![screenshot from 2016-04-07 16 17 53](https://cloud.githubusercontent.com/assets/3450808/14365585/9fe4b79e-fcdc-11e5-9165-38b7585dcf89.png)

![screenshot from 2016-04-07 16 18 12](https://cloud.githubusercontent.com/assets/3450808/14365591/a53eef7a-fcdc-11e5-931d-520197266be5.png)

![screenshot from 2016-04-07 16 18 24](https://cloud.githubusercontent.com/assets/3450808/14365595/a95dddb4-fcdc-11e5-9d95-cfe2731216e5.png)

![screenshot from 2016-04-07 16 18 34](https://cloud.githubusercontent.com/assets/3450808/14365597/ad0c72c2-fcdc-11e5-8b19-fe50791b4505.png)

![screenshot from 2016-04-07 16 19 11](https://cloud.githubusercontent.com/assets/3450808/14365605/b316c83e-fcdc-11e5-99b8-2fabdc374786.png)

![screenshot from 2016-04-07 16 19 59](https://cloud.githubusercontent.com/assets/3450808/14365610/b7416fcc-fcdc-11e5-9db0-223fabba1c49.png)
