### PR TITLE
Set OpenStack cloud instance's cpu_speed

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -377,7 +377,6 @@ module ManageIQ::Providers
       # for connections, delete when not needed.
       private_network = {:ipaddress => server.private_ip_address}.delete_nils
       public_network  = {:ipaddress => server.public_ip_address}.delete_nils
-
       if parent_hosts
         # Find associated host from OpenstackInfra
         filtered_hosts = parent_hosts.select do |x|
@@ -405,6 +404,7 @@ module ManageIQ::Providers
           :cpu_sockets          => flavor[:cpus],
           :cpu_cores_per_socket => 1,
           :cpu_total_cores      => flavor[:cpus],
+          :cpu_speed            => parent_host.try(:hardware).try(:cpu_speed),
           :memory_mb            => flavor[:memory] / 1.megabyte,
           :disk_capacity        => flavor[:root_disk_size] + flavor[:ephemeral_disk_size] + flavor[:swap_disk_size],
           :disks                => [], # Filled in later conditionally on flavor

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_juno_spec.rb
@@ -35,4 +35,31 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
       assert_with_skips
     end
   end
+
+  context "when paired with a infrastructure provider" do
+    # assumes all cloud instances are on single host => dhcp-8-99-202.cloudforms.lab.eng.rdu2.redhat.com
+    before(:each) do
+      @cpu_speed = 2800
+      @hardware = FactoryGirl.create(:hardware, :cpu_speed => @cpu_speed, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
+      @infra_host = FactoryGirl.create(:host_openstack_infra, :hardware => @hardware, :hypervisor_hostname => "dhcp-8-99-202.cloudforms.lab.eng.rdu2.redhat.com")
+      @provider = FactoryGirl.create(:provider_openstack, :name => "undercloud")
+      @infra = FactoryGirl.create(:ems_openstack_infra_with_stack, :name => "undercloud", :provider => @provider)
+      @infra.hosts << @infra_host
+      @ems.provider = @provider
+      @provider.infra_ems = @infra
+      @provider.cloud_ems << @ems
+    end
+
+    it "user instance should inherit cpu_speed of compute host" do
+      with_cassette(@environment, @ems) do
+        EmsRefresh.refresh(@ems)
+        EmsRefresh.refresh(@ems.network_manager)
+      end
+
+      ManageIQ::Providers::Openstack::CloudManager::Vm.all.each do |vm|
+        expect(vm.hardware.cpu_speed).to eq(@cpu_speed)
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
We need to determine an instance's cpu_speed because it is
used in the Right-Size Recommendation page.

Nova API doesn't provide a cpu_speed for user instances. There
is a cpu_speed for the baremetal host and we can use that as a
proxy. We gather this information during the cloud refresh
process.

The cpu_speed will be available when the fog-openstack
introspection provider merges.