### PR TITLE
MiqExpression#to_ruby specs housekeeping

### DIFF
--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -339,10 +339,9 @@ describe MiqExpression do
   end
 
   describe ".to_ruby" do
-    # Based on FogBugz 6181: something INCLUDES []
     it "detects value empty array" do
-      exp = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "/[]/"})
-      expect(exp.to_ruby).to eq("<value ref=vm, type=string>/virtual/name</value> =~ /\\/\\[\\]\\//")
+      exp = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "[]"})
+      expect(exp.to_ruby).to eq("<value ref=vm, type=string>/virtual/name</value> =~ /\\[\\]/")
     end
 
     it "raises error if expression contains ruby script" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -650,16 +650,6 @@ describe MiqExpression do
     end
   end
 
-  it "supports yaml" do
-    exp = YAML.load '--- !ruby/object:MiqExpression
-    exp:
-      "=":
-        field: Host-enabled_inbound_ports
-        value: "22,427,5988,5989"
-    '
-    expect(exp.to_ruby).to eq('<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> == [22,427,5988,5989]')
-  end
-
   it "tests numeric set expressions" do
     exp = MiqExpression.new("=" => {"field" => "Host-enabled_inbound_ports", "value" => "22,427,5988,5989"})
     expect(exp.to_ruby).to eq('<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> == [22,427,5988,5989]')

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -347,7 +347,7 @@ describe MiqExpression do
 
     it "raises error if expression contains ruby script" do
       exp = MiqExpression.new("RUBY" => {"field" => "Host-name", "value" => "puts 'Hello world!'"})
-      expect { exp.to_ruby }.to raise_error(RuntimeError, "Ruby scripts in expressions are no longer supported. Please use the regular expression feature of conditions instead.")
+      expect { exp.to_ruby }.to raise_error(/Ruby scripts in expressions are no longer supported/)
     end
 
     context "date/time support" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -338,7 +338,7 @@ describe MiqExpression do
     end
   end
 
-  describe ".to_ruby" do
+  describe "#to_ruby" do
     it "detects value empty array" do
       exp = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "[]"})
       expect(exp.to_ruby).to eq("<value ref=vm, type=string>/virtual/name</value> =~ /\\[\\]/")


### PR DESCRIPTION
Bundling together a few changes to the `MiqExpression#to_ruby` specs. I'll happily break these out if there's too much going on  here. But in summary:

* Get all the remaining specs under the `#to_ruby` context
* Delete a test in https://github.com/ManageIQ/manageiq/commit/af198fa21e1ca10f56889290b7bb36d95a6ecf32 I didn't consider necessary
* Make a couple of changes to the two specs that were there originally

Perhaps best reviewed as individual commits.

Part of ongoing work to improve and expand these specs for MiqExpression

/cc @gtanzillo @yrudman @jrafanie 
@miq-bot add-label test, refactoring