### PR TITLE
vmdb_database_settings: use actual db values

### DIFF
--- a/app/models/vmdb_database_setting.rb
+++ b/app/models/vmdb_database_setting.rb
@@ -4,10 +4,7 @@ class VmdbDatabaseSetting < ApplicationRecord
 
   virtual_belongs_to :vmdb_database
   virtual_column :description,      :type => :string
-  virtual_column :minimum_value,    :type => :integer
-  virtual_column :maximum_value,    :type => :integer
   virtual_column :vmdb_database_id, :type => :integer
-  virtual_column :value,            :type => :string
 
   attr_writer :vmdb_database
 
@@ -17,25 +14,13 @@ class VmdbDatabaseSetting < ApplicationRecord
 
   delegate :id, :to => :vmdb_database, :prefix => true
 
-  def minimum_value
-    min_val || ''
-  end
-
-  def maximum_value
-    max_val || ''
-  end
-
-  def value
-    setting || ''
-  end
+  alias_attribute :minimum_value, :min_val
+  alias_attribute :maximum_value, :max_val
+  alias_attribute :value, :setting
 
   def description
     desc = short_desc
     desc += "  #{extra_desc}" unless extra_desc.nil?
     desc
-  end
-
-  def unit
-    super || ''
   end
 end

--- a/spec/models/vmdb_database_setting_spec.rb
+++ b/spec/models/vmdb_database_setting_spec.rb
@@ -52,11 +52,6 @@ describe VmdbDatabaseSetting do
     expect(setting.short_desc).to eq(short_desc)
   end
 
-  it 'defaults unit to a blank string' do
-    setting = VmdbDatabaseSetting.where(:unit => nil).first
-    expect(setting.unit).to eq("")
-  end
-
   [
     :name,
     :description,
@@ -67,8 +62,8 @@ describe VmdbDatabaseSetting do
     :vmdb_database_id
   ].each do |field|
     it "has a #{field}" do
-      setting = VmdbDatabaseSetting.all.first
-      expect(setting.send(field)).to be_truthy
+      setting = VmdbDatabaseSetting.first
+      expect(setting).to respond_to(field)
     end
   end
 end


### PR DESCRIPTION
If a value in the database is nil, use it

While fixing rbac scopes and this model, I wondered why we had these defaults.
@Fryguy any reason to default these strings to '' instead of nil?

Of note `alias_attribute` is a rails construct and `virtual_column` is ours