### PR TITLE
Ovirt targeted refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
@@ -2,18 +2,72 @@ class ManageIQ::Providers::Redhat::InfraManager
   class Refresher < ManageIQ::Providers::BaseManager::Refresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
-    def parse_legacy_inventory(ems)
-      rhevm = ems.rhevm_inventory
-      raise "Invalid RHEV server ip address." if rhevm.api.nil?
+    def collect_inventory_for_targets(ems, targets)
+      inventory = ems.rhevm_inventory
+      raise "Invalid RHEV server ip address." if inventory.api.nil?
 
-      raw_ems_data = rhevm.refresh
-      return [] if raw_ems_data.blank?
+      # TODO before iterating over targets it would be good to check whether ExtMgmntSystem is part of it
+      # TODO optimize not to fetch the same objects like clusters for multiple targets
 
-      #TODO cleanup with @ems_data
-      ems.api_version = rhevm.service.version_string
+      targets_with_data = targets.collect do |target|
+        _log.info "Filtering inventory for #{target.class} [#{target.name}] id: [#{target.id}]..."
+
+        case target
+        when Host
+          methods = {
+            :primary => {
+              :host        => target.ems_ref,
+            },
+            :secondary => {
+              :host        => [:statistics, :host_nics],
+            }
+          }
+          data,  = Benchmark.realtime_block(:fetch_host_data) { data = inventory.targeted_refresh(methods) }
+
+        when VmOrTemplate
+          require 'uri'
+
+          vm = target.ems_ref
+          vm_id = URI(vm).path.split('/').last
+
+          methods = {
+            :primary => {
+              :cluster     => target.parent_cluster.ems_ref,
+              :data_center => target.parent_datacenter.ems_ref,
+              :vm          => vm,
+              :template    => "/api/templates?search=vm.id=#{vm_id}"
+            },
+            :secondary => {
+              :vm         => [:disks, :snapshots, :nics],
+              :template   => [:disks]
+            }
+          }
+          data,  = Benchmark.realtime_block(:fetch_vm_data) { inventory.targeted_refresh(methods) }
+
+        else
+          data,  = Benchmark.realtime_block(:fetch_all) { inventory.refresh }
+
+        end
+
+        _log.info "Filtering inventory...Complete"
+        [target, data]
+      end
+
+      ems.api_version = inventory.service.version_string
       ems.save
 
-      RefreshParser.ems_inv_to_hashes(raw_ems_data)
+      targets_with_data
+    end
+
+    def parse_targeted_inventory(ems, _target, inventory)
+      log_header = format_ems_for_logging(ems)
+      _log.debug "#{log_header} Parsing inventory..."
+      hashes, = Benchmark.realtime_block(:parse_inventory) do
+        RefreshParser.ems_inv_to_hashes(inventory)
+      end
+      _log.debug "#{log_header} Parsing inventory...Complete"
+
+      hashes
     end
 
     def post_process_refresh_classes

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -36,7 +36,7 @@ gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=1.1.0",            :require => false
 gem "openscap",                "~>0.4.3",           :require => false
-gem "ovirt",                   "~>0.7.2",           :require => false
+gem "ovirt",                   "~>0.8.0",           :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false


### PR DESCRIPTION
Instead of calling full refresh every time we want to target specific objects when performing refresh of ovirt inventory. This change is dependent on [1]. During refresh we call filter_data and trim set of methods which are used to call ovirt. There are 3 levels of targets:
1. ExtManagementSystem - we use old code to perform full refresh
2. Host - we target specific host without refreshing any other items
3. VmOrTemplate - we target specific vm and we fetch required dependencies such as cluster and data center.

This pull request is waiting on [2] so we could remove duplicates from the code. For now let's progress with the review of the changes.


[1] https://github.com/ManageIQ/ovirt/pull/50
[2] https://github.com/ManageIQ/manageiq/pull/7487