### PR TITLE
Rescue the error when connection timed-out

### DIFF
--- a/gems/pending/appliance_console/key_configuration.rb
+++ b/gems/pending/appliance_console/key_configuration.rb
@@ -83,7 +83,7 @@ module ApplianceConsole
         scp.download!(key_path, KEY_FILE)
       end
       File.exist?(KEY_FILE)
-    rescue Net::SSH::AuthenticationFailed, SocketError => e
+    rescue => e
       say("Failed to fetch key: #{e.message}")
       false
     end


### PR DESCRIPTION
Addressing:
net/ssh/transport/session.rb:70:in `initialize': Connection timed out - connect(2) (Errno::ETIMEDOUT)

Auditing the SCP gem and dependencies, I see a lot of potential
exceptions that may occur: Net::SCP::Error, Net::SSH::Exception,
SystemCallError, SocketError and perhaps more. They all have one common
superclass that is StandardError.

https://bugzilla.redhat.com/show_bug.cgi?id=1321107

Similar to https://github.com/ManageIQ/manageiq/pull/5788