### PR TITLE
UI for orderable orchestration templates

### DIFF
--- a/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
+++ b/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
@@ -1,0 +1,44 @@
+ManageIQ.angular.app.controller('orchestrationTemplateCopyController', ['$http', '$scope', '$timeout', 'stackId', 'miqService', function($http, $scope, $timeout, stackId, miqService) {
+  $scope.stackId = stackId;
+  $scope.templateInfo = {
+    templateId: null,
+    templateName: null,
+    templateDescription: null,
+    templateDraft: null,
+    templateContent: null
+  };
+  $scope.modelCopy = _.extend({}, $scope.templateInfo);
+  $scope.model = 'templateInfo';
+  $scope.newRecord = true;
+  $scope.saveable = miqService.saveable;
+
+  var otinfoUrl = '/orchestration_stack/stacks_ot_info';
+  var submitUrl = '/orchestration_stack/stacks_ot_copy';
+
+  $http.get(otinfoUrl + '/' + stackId).success(function(response) {
+    $scope.templateInfo.templateId = response.template_id;
+    $scope.templateInfo.templateName = "Copy of " + response.template_name;
+    $scope.templateInfo.templateDescription = response.template_description;
+    $scope.templateInfo.templateDraft = response.template_draft;
+    $scope.templateInfo.templateContent = response.template_content;
+    $scope.modelCopy = _.extend({}, $scope.templateInfo);
+  });
+
+  $scope.$watch('templateInfo.templateContent', function() {
+    if ($scope.templateInfo.templateContent != null) {
+      var cursor = ManageIQ.editor.getDoc().getCursor();
+      ManageIQ.editor.getDoc().setValue($scope.templateInfo.templateContent);
+      ManageIQ.editor.getDoc().setCursor(cursor);
+    }
+  });
+
+  $scope.cancelClicked = function() {
+    miqService.sparkleOn();
+    miqService.miqAjaxButton(submitUrl + '?button=cancel&id=' + $scope.stackId);
+  };
+
+  $scope.addClicked = function() {
+    miqService.sparkleOn();
+    miqService.miqAjaxButton(submitUrl + '?button=add', $scope.templateInfo);
+  };
+}]);

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -831,6 +831,7 @@ class CatalogController < ApplicationController
     x_tree[:open_nodes].push("xx-#{ot_type}") unless x_tree[:open_nodes].include?("xx-#{ot_type}")
     self.x_node = "ot-#{to_cid(ot.id)}"
     x_tree[:open_nodes].push(x_node)
+    add_flash(params[:flash_message]) if params.key?(:flash_message)
     explorer
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1692,13 +1692,18 @@ class CatalogController < ApplicationController
             condition = ["display=? and service_template_catalog_id IS NOT NULL", true]
             service_template_list(condition, :no_checkboxes => true)
           else
-            process_show_list(:model => typ.constantize)
+            options = {:model => typ.constantize}
+            options[:where_clause] = ["orderable=?", true] if x_active_tree == :ot_tree
+            process_show_list(options)
           end
           @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => typ)}
         elsif ["xx-otcfn", "xx-othot", "xx-otazu"].include?(x_node)
           typ = node_name_to_template_name(x_node)
           @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => typ)}
-          process_show_list(:model => typ.constantize, :gtl_dbname => :orchestrationtemplate)
+          options = {:model        => typ.constantize,
+                     :gtl_dbname   => :orchestrationtemplate,
+                     :where_clause => ["orderable=?", true]}
+          process_show_list(options)
         else
           if x_active_tree == :stcat_tree
             @record = ServiceTemplateCatalog.find_by_id(from_cid(id))

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -43,6 +43,9 @@ class OrchestrationStackController < ApplicationController
       @view, @pages = get_view(kls, :parent => @orchestration_stack)  # Get the records (into a view) and the paginator
       @showtype = @display
       notify_about_unauthorized_items(title, ui_lookup(:tables => 'orchestration_stack'))
+    when "stack_orchestration_template"
+      drop_breadcrumb(:name => "%{name} (Orchestration Template)" % {:name => @orchestration_stack.name},
+                      :url  => "/orchestration_stack/show/#{@orchestration_stack.id}?display=#{@display}")
     end
 
     # Came in from outside show_list partial

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -104,6 +104,9 @@ class OrchestrationStackController < ApplicationController
     elsif params[:pressed] == "orchestration_template_copy"
       orchestration_template_copy
       return
+    elsif params[:pressed] == "orchestration_templates_view"
+      orchestration_templates_view
+      return
     else
       params[:page] = @current_page if @current_page.nil?                     # Save current page for list refresh
       @refresh_div = "main_div" # Default div for button.rjs to refresh
@@ -257,6 +260,14 @@ class OrchestrationStackController < ApplicationController
                            :flash_message => flash_message)
         end
       end
+    end
+  end
+
+  def orchestration_templates_view
+    template = find_by_id_filtered(OrchestrationStack, params[:id]).orchestration_template
+    render :update do |page|
+      page << javascript_prologue
+      page.redirect_to(:controller => 'catalog', :action => 'ot_show', :id => template.id)
     end
   end
 

--- a/app/helpers/application_helper/button/orchestration_template_copy_orderable.rb
+++ b/app/helpers/application_helper/button/orchestration_template_copy_orderable.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::OrchestrationTemplateCopyOrderable < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self[:title] = N_("This Template is already orderable") if disabled?
+  end
+
+  def disabled?
+    @record.orchestration_template.orderable?
+  end
+end

--- a/app/helpers/application_helper/button/orchestration_template_make_orderable.rb
+++ b/app/helpers/application_helper/button/orchestration_template_make_orderable.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::OrchestrationTemplateMakeOrderable < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self[:title] = N_("This Template is already orderable") if disabled?
+  end
+
+  def disabled?
+    @record.orchestration_template.orderable?
+  end
+end

--- a/app/helpers/application_helper/button/orchestration_template_view_in_catalog.rb
+++ b/app/helpers/application_helper/button/orchestration_template_view_in_catalog.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::OrchestrationTemplateViewInCatalog < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self[:title] = N_("This Template is not orderable") unless @record.orchestration_template.orderable?
+  end
+
+  def disabled?
+    !@record.orchestration_template.orderable?
+  end
+end

--- a/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
+++ b/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
@@ -18,6 +18,12 @@ class ApplicationHelper::Toolbar::StackOrchestrationTemplateCenter < Application
           t = N_('Copy this Orchestration Template as orderable'),
           t,
           :klass => ApplicationHelper::Button::OrchestrationTemplateCopyOrderable),
+        button(
+          :orchestration_templates_view,
+          'fa pficon-info fa-lg',
+          t = N_('View this Orchestration Template in Catalogs'),
+          t,
+          :klass => ApplicationHelper::Button::OrchestrationTemplateViewInCatalog),
       ]
     )
   ])

--- a/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
+++ b/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
@@ -16,7 +16,8 @@ class ApplicationHelper::Toolbar::StackOrchestrationTemplateCenter < Application
           :orchestration_template_copy,
           'fa fa-files-o fa-lg',
           t = N_('Copy this Orchestration Template as orderable'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::OrchestrationTemplateCopyOrderable),
       ]
     )
   ])

--- a/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
+++ b/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
@@ -1,0 +1,23 @@
+class ApplicationHelper::Toolbar::StackOrchestrationTemplateCenter < ApplicationHelper::Toolbar::Basic
+  button_group('stack_orchestration_template_vmdb', [
+    select(
+      :stack_orchestration_template_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :make_ot_orderable,
+          'pficon pficon-edit fa-lg',
+          t = N_('Make the Orchestration Template orderable'),
+          t,
+          :klass => ApplicationHelper::Button::OrchestrationTemplateMakeOrderable),
+        button(
+          :orchestration_template_copy,
+          'fa fa-files-o fa-lg',
+          t = N_('Copy this Orchestration Template as orderable'),
+          t),
+      ]
+    )
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -429,6 +429,8 @@ class ApplicationHelper::ToolbarChooser
         return "resource_pools_center_tb"
       elsif @display == "storages"
         return "storages_center_tb"
+      elsif @display == "stack_orchestration_template"
+        return "stack_orchestration_template_center"
       elsif (@layout == "vm" || @layout == "host") && @display == "performance"
         return "#{@explorer ? "x_" : ""}vm_performance_tb"
       elsif @display == "dashboard"

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -56,7 +56,6 @@ module OrchestrationStackHelper::TextualSummary
   def textual_orchestration_template
     template = @record.orchestration_template
     return nil if template.nil?
-    return nil unless template.orderable
     label = ui_lookup(:table => "orchestration_template")
     h = {:label => label, :image => "orchestration_template", :value => template.name}
     if role_allows(:feature => "orchestration_templates_view")

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -56,6 +56,7 @@ module OrchestrationStackHelper::TextualSummary
   def textual_orchestration_template
     template = @record.orchestration_template
     return nil if template.nil?
+    return nil unless template.orderable
     label = ui_lookup(:table => "orchestration_template")
     h = {:label => label, :image => "orchestration_template", :value => template.name}
     if role_allows(:feature => "orchestration_templates_view")

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -61,7 +61,7 @@ module OrchestrationStackHelper::TextualSummary
     h = {:label => label, :image => "orchestration_template", :value => template.name}
     if role_allows(:feature => "orchestration_templates_view")
       h[:title] = _("Show this Orchestration Template")
-      h[:link] = url_for(:controller => 'catalog', :action => 'ot_show', :id => template.id)
+      h[:link] = url_for(:action => 'show', :id => @orchestration_stack, :display => 'stack_orchestration_template')
     end
     h
   end

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -41,7 +41,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
       "othot" => OrchestrationTemplateHot,
       "otazu" => OrchestrationTemplateAzure
     }
-    objects = rbac_filtered_objects(classes[object[:id]].all).sort_by { |o| o.name.downcase }
+    objects = rbac_filtered_objects(classes[object[:id]].where(["orderable=?", true])).sort_by { |o| o.name.downcase }
     count_only_or_objects(count_only, objects, nil)
   end
 end

--- a/app/views/layouts/_my_code_mirror.html.haml
+++ b/app/views/layouts/_my_code_mirror.html.haml
@@ -6,6 +6,7 @@
 - width ||= "auto"
 - read_only ||= false
 - no_focus ||= false
+- angular ||= false
 
 :javascript
   if (miqDomElementExists('#{text_area_id}')) {
@@ -18,7 +19,12 @@
       readOnly:      #{read_only ? "'nocursor'".html_safe : false}
     });
     ManageIQ.editor.on('change', function (cm, change) {
-      miqSendOneTrans('#{url}');
+      if (#{angular}) {
+        ManageIQ.editor.save();
+        $(textarea).trigger("change");
+      } else {
+        miqSendOneTrans('#{url}');
+      }
     });
     ManageIQ.editor.on('blur', function (cm, change) {
       ManageIQ.editor.save();

--- a/app/views/orchestration_stack/_copy_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_copy_orchestration_template.html.haml
@@ -1,0 +1,48 @@
+%form#form_div.form-horizontal{:name => 'angularForm', 'ng-controller' => 'orchestrationTemplateCopyController'}
+  = render :partial => 'layouts/flash_msg'
+  %h3
+    = _('New Orchestration Template Information')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Name')
+      .col-md-8
+        %input.form-control{:type          => 'text',
+                            :name          => 'ot_name',
+                            'ng-model'     => 'templateInfo.templateName',
+                            'ng-maxlength' => 255,
+                            :miqrequired   => true,
+                            :checkchange   => true}
+    .form-group
+      %label.col-md-2.control-label
+        = _('Description')
+      .col-md-8
+        %textarea.form-control{:name         => 'ot_description',
+                               :rows         => 8,
+                               'ng-model'    => 'templateInfo.templateDescription',
+                               'miqrequired' => true,
+                               :checkchange  => true}
+    .form-group
+      %label.col-md-2.control-label
+        = _('Draft')
+      .col-md-10
+        %input{:type         => 'checkbox',
+               :name         => 'ot_draft',
+               'ng-model'    => 'templateInfo.templateDraft'}
+
+  %hr
+
+  = text_area_tag("template_content", '', 'ng-model' => 'templateInfo.templateContent', :style => "display:none;")
+  = render :partial => "/layouts/my_code_mirror",
+  :locals       => {:text_area_id => "template_content",
+    :mode         => "yaml",
+    :line_numbers => true,
+    :read_only    => false,
+    :angular      => true}
+
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
+
+:javascript
+  ManageIQ.editor.refresh();
+  ManageIQ.angular.app.value('stackId', #{@record.id});
+  miq_bootstrap('#form_div');

--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -1,0 +1,35 @@
+%table.table.table-bordered.table-striped
+  %thead
+    %tr
+      %th{:colspan => "2"}= _('Details')
+  %tbody
+    - {:name        => _("Name"),
+       :description => _("Description"),
+       :draft       => _("Draft"),
+       :read_only   => _("Read Only"),
+       :orderable?  => _("Orderable"),
+       :created_at  => _("Created On"),
+       :updated_at  => _("Updated On")}.each do |sym, label|
+      %tr
+        %td.label
+          = label
+        %td
+          - case sym
+          - when :draft, :orderable?
+            = @record.orchestration_template.send(sym) ? _("True") : _("False")
+          - when :read_only
+            = @record.orchestration_template.stacks.empty? ? _("False") : _("True")
+          - else
+            = @record.orchestration_template.send(sym)
+
+- if @record.orchestration_template.content
+  %hr
+  #form_div
+    = text_area_tag("template_content", @record.orchestration_template.content, :style => "display:none;")
+    = render :partial => "/layouts/my_code_mirror",
+      :locals => {:text_area_id => "template_content",
+                  :mode         => "yaml",
+                  :line_numbers => true,
+                  :read_only    => true}
+    :javascript
+      ManageIQ.editor.refresh();

--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -1,35 +1,38 @@
-%table.table.table-bordered.table-striped
-  %thead
-    %tr
-      %th{:colspan => "2"}= _('Details')
-  %tbody
-    - {:name        => _("Name"),
-       :description => _("Description"),
-       :draft       => _("Draft"),
-       :read_only   => _("Read Only"),
-       :orderable?  => _("Orderable"),
-       :created_at  => _("Created On"),
-       :updated_at  => _("Updated On")}.each do |sym, label|
+#form_div
+  #basic_info_div
+  = render :partial => "layouts/flash_msg"
+  %table.table.table-bordered.table-striped
+    %thead
       %tr
-        %td.label
-          = label
-        %td
-          - case sym
-          - when :draft, :orderable?
-            = @record.orchestration_template.send(sym) ? _("True") : _("False")
-          - when :read_only
-            = @record.orchestration_template.stacks.empty? ? _("False") : _("True")
-          - else
-            = @record.orchestration_template.send(sym)
+        %th{:colspan => "2"}= _('Details')
+    %tbody
+      - {:name        => _("Name"),
+         :description => _("Description"),
+         :draft       => _("Draft"),
+         :read_only   => _("Read Only"),
+         :orderable?  => _("Orderable"),
+         :created_at  => _("Created On"),
+         :updated_at  => _("Updated On")}.each do |sym, label|
+        %tr
+          %td.label
+            = label
+          %td
+            - case sym
+            - when :draft, :orderable?
+              = @record.orchestration_template.send(sym) ? _("True") : _("False")
+            - when :read_only
+              = @record.orchestration_template.stacks.empty? ? _("False") : _("True")
+            - else
+              = @record.orchestration_template.send(sym)
 
-- if @record.orchestration_template.content
-  %hr
-  #form_div
-    = text_area_tag("template_content", @record.orchestration_template.content, :style => "display:none;")
-    = render :partial => "/layouts/my_code_mirror",
-      :locals => {:text_area_id => "template_content",
-                  :mode         => "yaml",
-                  :line_numbers => true,
-                  :read_only    => true}
-    :javascript
-      ManageIQ.editor.refresh();
+  - if @record.orchestration_template.content
+    %hr
+    #form_div
+      = text_area_tag("template_content", @record.orchestration_template.content, :style => "display:none;")
+      = render :partial => "/layouts/my_code_mirror",
+        :locals => {:text_area_id => "template_content",
+                    :mode         => "yaml",
+                    :line_numbers => true,
+                    :read_only    => true}
+      :javascript
+        ManageIQ.editor.refresh();

--- a/app/views/orchestration_stack/show.html.haml
+++ b/app/views/orchestration_stack/show.html.haml
@@ -7,5 +7,7 @@
   - else
     - if %w(instances security_groups).include?(@display)
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@orchestration_stack.id}"}
+    - elsif @display == 'stack_orchestration_template'
+      = render :partial => "stack_orchestration_template"
     - elsif @showtype == 'main'
       = render :partial => 'main'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1915,6 +1915,7 @@ Vmdb::Application.routes.draw do
         retire
         show
         show_list
+        stacks_ot_info
         tagging_edit
         protect
       ),
@@ -1931,6 +1932,7 @@ Vmdb::Application.routes.draw do
         sections_field_changed
         show
         show_list
+        stacks_ot_copy
         protect
         tagging_edit
         tag_edit_form_field_changed

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -256,6 +256,11 @@
         :description: Edit Orchestration Templates Tags
         :feature_type: control
         :identifier: orchestration_template_tag
+      - :name: Make Template Orderable
+        :description: Make Orchestration Template orderable
+        :feature_type: control
+        :identifier: make_ot_orderable
+
     - :name: Create Service Dialog from Orchestration Template
       :description: Create Service Dialog from Orchestration Template
       :identifier: service_dialog_from_ot

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -9,23 +9,46 @@ describe OrchestrationStackController do
   render_views
 
   describe '#show' do
-    let(:record) { FactoryGirl.create(:orchestration_stack_cloud) }
+    context "instances" do
+      let(:record) { FactoryGirl.create(:orchestration_stack_cloud) }
 
-    before do
-      session[:settings] = {
-        :views => {:manageiq_providers_cloudmanager_vm => "grid"}
-      }
-      get :show, :params => {:id => record.id, :display => "instances"}
+      before do
+        session[:settings] = {
+          :views => {:manageiq_providers_cloudmanager_vm => "grid"}
+        }
+        get :show, :params => {:id => record.id, :display => "instances"}
+      end
+
+      it 'does not render compliance check and comparison buttons' do
+        expect(response.body).not_to include('instance_check_compliance')
+        expect(response.body).not_to include('instance_compare')
+      end
+
+      it "renders the listnav" do
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_orchestration_stack")
+      end
     end
 
-    it 'does not render compliance check and comparison buttons' do
-      expect(response.body).not_to include('instance_check_compliance')
-      expect(response.body).not_to include('instance_compare')
-    end
+    context "orchestration templates" do
+      let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template) }
 
-    it "renders the listnav" do
-      expect(response.status).to eq(200)
-      expect(response.status).to render_template(:partial => "layouts/listnav/_orchestration_stack")
+      before do
+        session[:settings] = {
+          :views => {:manageiq_providers_cloudmanager_vm => "grid"}
+        }
+        get :show, :params => {:id => record.id, :display => "stack_orchestration_template"}
+      end
+
+      it "renders the listnav" do
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_orchestration_stack")
+      end
+
+      it "renders the orchestration template details" do
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "orchestration_stack/_stack_orchestration_template")
+      end
     end
   end
 end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -130,5 +130,15 @@ describe OrchestrationStackController do
         expect(response).to render_template(:partial => "orchestration_stack/_copy_orchestration_template")
       end
     end
+
+    context "view stack's orchestration template in catalog" do
+      it "redirects to catalog controller" do
+        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+        post :button, :params => {:id => record.id, :pressed => "orchestration_templates_view"}
+        expect(response.status).to eq(200)
+        expect(response.body).to include("window.location.href")
+        expect(response.body).to include("/catalog/ot_show/")
+      end
+    end
   end
 end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -52,6 +52,45 @@ describe OrchestrationStackController do
     end
   end
 
+  describe "#stacks_ot_info" do
+    it "returns all the orchestration template attributes" do
+      stack = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+      get :stacks_ot_info, :id => stack.id
+      expect(response.status).to eq(200)
+      ret = JSON.parse(response.body)
+      expect(ret).to have_key('template_id')
+      expect(ret).to have_key('template_name')
+      expect(ret).to have_key('template_description')
+      expect(ret).to have_key('template_draft')
+      expect(ret).to have_key('template_content')
+    end
+  end
+
+  describe "#stacks_ot_copy" do
+    let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template) }
+
+    it "correctly cancels the orchestration template copying form" do
+      post :stacks_ot_copy, :params => {:id => record.id, :button => "cancel"}
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:partial => "layouts/_flash_msg")
+      expect(assigns(:flash_array).first[:message]).to include('was cancelled')
+      expect(response).to render_template(:partial => "orchestration_stack/_stack_orchestration_template")
+    end
+
+    it "correctly redirects to catalog controller after template copy submission" do
+      post :stacks_ot_copy, :params => {
+        :button              => "add",
+        :templateId          => record.orchestration_template.id,
+        :templateName        => "new name",
+        :templateDescription => "new description",
+        :templateDraft       => "true",
+        :templateContent     => File.read('spec/fixtures/orchestration_templates/cfn_parameters.json')}
+      expect(response.status).to eq(200)
+      expect(response.body).to include("window.location.href")
+      expect(response.body).to include("/catalog/ot_show/")
+    end
+  end
+
   describe "#button" do
     context "make stack's orchestration template orderable" do
       it "won't allow making stack's orchestration template orderable when already orderable" do
@@ -70,6 +109,25 @@ describe OrchestrationStackController do
         expect(response.status).to eq(200)
         expect(response).to render_template(:partial => "layouts/_flash_msg")
         expect(assigns(:flash_array).first[:message]).to include('is now orderable')
+      end
+    end
+
+    context "copy stack's orchestration template as orderable" do
+      it "won't allow copying stack's orchestration template orderable when already orderable" do
+        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+        post :button, :params => {:id => record.id, :pressed => "orchestration_template_copy"}
+        expect(record.orchestration_template.orderable?).to be_truthy
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/_flash_msg")
+        expect(assigns(:flash_array).first[:message]).to include('is already orderable')
+      end
+
+      it "renders orchestration template copying form" do
+        record = FactoryGirl.create(:orchestration_stack_amazon_with_non_orderable_template)
+        post :button, :params => {:id => record.id, :pressed => "orchestration_template_copy"}
+        expect(record.orchestration_template.orderable?).to be_falsey
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "orchestration_stack/_copy_orchestration_template")
       end
     end
   end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -51,4 +51,26 @@ describe OrchestrationStackController do
       end
     end
   end
+
+  describe "#button" do
+    context "make stack's orchestration template orderable" do
+      it "won't allow making stack's orchestration template orderable when already orderable" do
+        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+        post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
+        expect(record.orchestration_template.orderable?).to be_truthy
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/_flash_msg")
+        expect(assigns(:flash_array).first[:message]).to include('is already orderable')
+      end
+
+      it "makes stack's orchestration template orderable" do
+        record = FactoryGirl.create(:orchestration_stack_amazon_with_non_orderable_template)
+        post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
+        expect(record.orchestration_template.orderable?).to be_falsey
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/_flash_msg")
+        expect(assigns(:flash_array).first[:message]).to include('is now orderable')
+      end
+    end
+  end
 end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -6,6 +6,10 @@ FactoryGirl.define do
   factory :orchestration_stack_cloud, :parent => :orchestration_stack, :class => "ManageIQ::Providers::CloudManager::OrchestrationStack" do
   end
 
+  factory :orchestration_stack_cloud_with_template, :parent => :orchestration_stack, :class => "ManageIQ::Providers::CloudManager::OrchestrationStack" do
+    orchestration_template { FactoryGirl.create(:orchestration_template) }
+  end
+
   factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
   end
 

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -13,6 +13,10 @@ FactoryGirl.define do
   factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
   end
 
+  factory :orchestration_stack_amazon_with_non_orderable_template, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
+    orchestration_template { FactoryGirl.create(:orchestration_template_cfn, :orderable => false) }
+  end
+
   factory :orchestration_stack_azure, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Azure::CloudManager::OrchestrationStack" do
   end
 

--- a/spec/javascripts/controllers/orchestration_template/orchestration_template_copy_controller_spec.js
+++ b/spec/javascripts/controllers/orchestration_template/orchestration_template_copy_controller_spec.js
@@ -1,0 +1,107 @@
+describe('orchestrationTemplateCopyController', function() {
+  var $scope, $controller, $httpBackend, miqService;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function($rootScope, _$controller_, _$httpBackend_, _miqService_) {
+    miqService = _miqService_;
+    spyOn(miqService, 'miqFlash');
+    spyOn(miqService, 'miqAjaxButton');
+    spyOn(miqService, 'sparkleOn');
+    spyOn(miqService, 'sparkleOff');
+    $scope = $rootScope.$new();
+    $scope.templateInfo = {
+      templateId: null,
+      templateName: null,
+      templateDescription: null,
+      templateDraft: null,
+      templateContent: null
+    };
+    $httpBackend = _$httpBackend_;
+
+    setFixtures('<html><head></head><body></body></html>');
+    ManageIQ.editor = CodeMirror(document.body);
+
+    $controller = _$controller_('orchestrationTemplateCopyController', {
+      $scope: $scope,
+      stackId: 1000000000001,
+      miqService: miqService
+    });
+  }));
+
+  beforeEach(inject(function(_$controller_) {
+    var retirementFormResponse = {
+      template_id: 1000000000001,
+      template_name: 'template_name',
+      template_description: 'template_description',
+      template_draft: 'true',
+      template_content: 'template_content',
+    };
+    $httpBackend.whenGET('/orchestration_stack/stacks_ot_info/1000000000001').respond(retirementFormResponse);
+    $httpBackend.flush();
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('initialization', function() {
+    it('sets the templateInfo to the values returned with http request', function() {
+      expect($scope.templateInfo.templateId).toEqual(1000000000001);
+      expect($scope.templateInfo.templateName).toEqual('Copy of template_name');
+      expect($scope.templateInfo.templateDescription).toEqual('template_description');
+      expect($scope.templateInfo.templateDraft).toEqual('true');
+      expect($scope.templateInfo.templateContent).toEqual('template_content');
+    });
+  });
+
+  describe('#cancelClicked', function() {
+    beforeEach(function() {
+      $scope.angularForm = {
+        $setPristine: function(value) {}
+      };
+      $scope.cancelClicked();
+    });
+
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
+    });
+
+    it('turns the spinner on once', function() {
+      expect(miqService.sparkleOn.calls.count()).toBe(1);
+    });
+
+    it('delegates to miqService.miqAjaxButton', function() {
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/orchestration_stack/stacks_ot_copy?button=cancel&id=' + $scope.stackId);
+    });
+  });
+
+  describe('#addClicked', function() {
+    beforeEach(function() {
+      $scope.angularForm = {
+        $setPristine: function (value){}
+      };
+      $scope.addClicked();
+    });
+
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
+    });
+
+    it('turns the spinner on once', function() {
+      expect(miqService.sparkleOn.calls.count()).toBe(1);
+    });
+
+    it('delegates to miqService.miqAjaxButton', function() {
+      var addContent = {
+        templateId: $scope.templateInfo.templateId,
+        templateName: $scope.templateInfo.templateName,
+        templateDescription: $scope.templateInfo.templateDescription,
+        templateDraft: $scope.templateInfo.templateDraft,
+        templateContent: $scope.templateInfo.templateContent
+      };
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/orchestration_stack/stacks_ot_copy?button=add', addContent);
+    });
+  });
+});

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1006 }
+  let(:expected_feature_count) { 1007 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
Implemented:

* don't display non-orderable orchestration templates in orch. templates catalogs view
* new read-only screen showing stack's orchestration template + spec
* new button to make a template orderable + spec
* new button to copy a template as orderable + spec
* button to take the user from the stack's orch. template page to the orch. template view in catalog controller

Fixes: #6600

https://bugzilla.redhat.com/show_bug.cgi?id=1302810