### PR TITLE
Handle max winrm requests

### DIFF
--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -2,6 +2,7 @@ require 'winrm'
 require 'winrm-elevated'
 
 class MiqWinRM
+  WMI_RETRIES = 2
   attr_reader :uri, :username, :password, :hostname, :port, :connection, :executor
 
   def initialize
@@ -29,44 +30,54 @@ class MiqWinRM
   end
 
   def run_powershell_script(script)
-    execute if @executor.nil?
-    $log.debug "Running powershell script on #{hostname} as #{username}:\n#{script}" unless $log.nil?
-    @executor.run_powershell_script(script)
-  rescue WinRM::WinRMAuthorizationError
-    $log.info "Error Logging In to #{hostname} using user \"#{username}\"" unless $log.nil?
-    raise
-  rescue WinRM::WinRMWMIError => error
-    $log.debug "Error Running Powershell on #{hostname} using user \"#{username}\": #{error}" unless $log.nil?
-    if error.to_s.include? "This user is allowed a maximum number of "
-      $log.debug "Re-opening connection and retrying" unless $log.nil?
-      @executor.close
-      @executor        = nil 
-      @connection      = raw_connect(@username, @password, @uri) if @elevated_runner
-      @elevated_runner = nil
-      retry
-    else
+    wmi_error_retries = 0
+    begin
+      execute if @executor.nil?
+      $log.debug "Running powershell script on #{hostname} as #{username}:\n#{script}" if $log
+      @executor.run_powershell_script(script)
+    rescue WinRM::WinRMAuthorizationError
+      $log.info "Error Logging In to #{hostname} using user \"#{username}\"" if $log
       raise
+    rescue WinRM::WinRMWMIError => error
+      $log.debug "Error Running Powershell on #{hostname} using user \"#{username}\": #{error}" if $log
+      raise if wmi_error_retries > WMI_RETRIES
+      wmi_error_retries += 1
+      if error.to_s.include? "This user is allowed a maximum number of "
+        $log.debug "Re-opening connection and retrying" if $log
+        @executor.close
+        @executor        = nil
+        @connection      = raw_connect(@username, @password, @uri) if @elevated_runner
+        @elevated_runner = nil
+        retry
+      else
+        raise
+      end
     end
   end
 
   def run_elevated_powershell_script(script)
-    elevate if @elevated_runner.nil?
-    $log.debug "Running powershell script elevated on #{hostname} as #{username}:\n#{script}" unless $log.nil?
-    @elevated_runner.powershell_elevated(script, @username, @password)
-  rescue WinRM::WinRMAuthorizationError
-    $log.info "Error Logging In to #{hostname} using user \"#{username}\"" unless $log.nil?
-    raise
-  rescue WinRM::WinRMWMIError => error
-    $log.debug "Error Running Powershell on #{hostname} using user \"#{username}\": #{error}" unless $log.nil?
-    if error.to_s.include? "This user is allowed a maximum number of "
-      $log.debug "Re-opening connection and retrying" unless $log.nil?
-      @connection      = raw_connect(@username, @password, @uri)
-      @elevated_runner = nil
-      @executor.close if @executor
-      @executor = nil 
-      retry
-    else
+    wmi_error_retries = 0
+    begin
+      elevate if @elevated_runner.nil?
+      $log.debug "Running powershell script elevated on #{hostname} as #{username}:\n#{script}" if $log
+      @elevated_runner.powershell_elevated(script, @username, @password)
+    rescue WinRM::WinRMAuthorizationError
+      $log.info "Error Logging In to #{hostname} using user \"#{username}\"" if $log
       raise
+    rescue WinRM::WinRMWMIError => error
+      $log.debug "Error Running Powershell on #{hostname} using user \"#{username}\": #{error}" if $log
+      raise if wmi_error_retries > WMI_RETRIES
+      wmi_error_retries += 1
+      if error.to_s.include? "This user is allowed a maximum number of "
+        $log.debug "Re-opening connection and retrying" if $log
+        @connection      = raw_connect(@username, @password, @uri)
+        @elevated_runner = nil
+        @executor.close if @executor
+        @executor = nil
+        retry
+      else
+        raise
+      end
     end
   end
 


### PR DESCRIPTION
The WinRM gem currently assumes that a Windows server allows 1500
operations per connection, and resets the connection just before hitting
the limit.

Unfortunately, this limit is configurable and a WMI error may be returned
by any operation.  Issue /WinRb/WinRM#197
tracks this problem.  The gem owner will eventually fix this issue by watching
for the error and simply resetting the connection when it occurs, but he
won't be doing so until version 2 of the gem - which is a while off.

We are propagating the fix up a level to the MiqWinRM wrapper class here.
When the error is returned either while running a command_executor or an elevated_runner
we do the right thing and retry the last command issued.

@djberg96 @roliveri @Fryguy @jrafanie @chessbyte please review, comment, and merge when
appropriate.  Thanks much.