### PR TITLE
x_settings_changed - remove unused method, routes and specs

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -30,26 +30,6 @@ module ApplicationController::Explorer
     end
   end
 
-  # Capture explorer settings changes and save them for a user
-  def x_settings_changed
-    @edit = session[:edit]  # Set @edit so it is preserved in the session object
-    @keep_compare = true if session[:miq_compare] # if explorer was resized when on compare screen, keep compare object in session
-
-    if params.key?(:width)
-      # Store the new settings in the user record and in @settings (session)
-      if current_user
-        user_settings = current_user.settings || {}
-        user_settings[:explorer] ||= {}
-        user_settings[:explorer][params[:controller]] ||= {}
-        user_settings[:explorer][params[:controller]][:width] = params['width']
-        @settings[:explorer] = user_settings[:explorer]
-        current_user.update_attributes(:settings => user_settings)
-      end
-    end
-
-    render :js => ''
-  end
-
   # FIXME: the code below has to be converted into proper actions called though
   # proper routes, this is just a small step to fix the current situation
   X_BUTTON_ALLOWED_ACTIONS = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,7 +111,6 @@ Vmdb::Application.routes.draw do
     x_button
     x_history
     x_search_by_name
-    x_settings_changed
     x_show
   )
 
@@ -236,7 +235,6 @@ Vmdb::Application.routes.draw do
         tree_select
         x_button
         x_history
-        x_settings_changed
         x_show
       ) +
                button_post +
@@ -1387,7 +1385,6 @@ Vmdb::Application.routes.draw do
         validate_method_data
         x_button
         x_history
-        x_settings_changed
         x_show
       )
     },
@@ -1431,7 +1428,6 @@ Vmdb::Application.routes.draw do
         upload_import_file
         x_button
         x_history
-        x_settings_changed
         x_show
       ) +
                button_post
@@ -1834,7 +1830,6 @@ Vmdb::Application.routes.draw do
         wait_for_task
         x_button
         x_show
-        x_settings_changed
         zone_edit
         zone_field_changed
         ldap_region_add
@@ -1957,7 +1952,6 @@ Vmdb::Application.routes.draw do
         tree_select
         x_button
         x_history
-        x_settings_changed
       )
     },
 
@@ -2019,7 +2013,6 @@ Vmdb::Application.routes.draw do
         widget_shortcut_reset
         x_button
         x_history
-        x_settings_changed
         x_show
       ) +
                exp_post
@@ -2110,7 +2103,6 @@ Vmdb::Application.routes.draw do
         tree_select
         x_button
         x_history
-        x_settings_changed
         x_show
       ) +
                dialog_runner_post

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -47,26 +47,6 @@ describe VmInfraController do
       end
     end
 
-    context "#x_settings_changed" do
-      let(:user) { FactoryGirl.create(:user, :userid => 'wilma', :settings => {}) }
-      before(:each) do
-        set_user_privileges user
-      end
-
-      it "sets the width of left pane for session's user" do
-        session[:settings] = {}
-        allow(User).to receive(:find_by_userid).and_return(user)
-
-        controller.instance_variable_set(:@settings,  {})
-        expect(user).to receive(:save)
-        width = '100'
-        get :x_settings_changed, :params => { :width => width }
-
-        expect(user.settings[:explorer][controller.controller_name][:width]).to eq(width)
-        expect(session[:settings][:explorer][controller.controller_name][:width]).to eq(width)
-      end
-    end
-
     context '#x_history_add_item' do
       def make_item(i)
         {

--- a/spec/routing/catalog_routing_spec.rb
+++ b/spec/routing/catalog_routing_spec.rb
@@ -70,7 +70,6 @@ describe 'routes for CatalogController' do
     tree_select
     x_button
     x_history
-    x_settings_changed
     x_show
   ).each do |path|
     describe "##{path}" do

--- a/spec/routing/miq_ae_class_routing_spec.rb
+++ b/spec/routing/miq_ae_class_routing_spec.rb
@@ -188,10 +188,4 @@ describe MiqAeClassController do
       expect(post("/miq_ae_class/x_history")).to route_to("miq_ae_class#x_history")
     end
   end
-
-  describe "#x_settings_changed" do
-    it "routes with POST" do
-      expect(post("/miq_ae_class/x_settings_changed")).to route_to("miq_ae_class#x_settings_changed")
-    end
-  end
 end

--- a/spec/routing/miq_ae_customization_routing_spec.rb
+++ b/spec/routing/miq_ae_customization_routing_spec.rb
@@ -51,7 +51,6 @@ describe MiqAeCustomizationController do
     upload_import_file
     x_button
     x_history
-    x_settings_changed
     x_show
   ).each do |path|
     describe "##{path}" do

--- a/spec/routing/ops_routing_spec.rb
+++ b/spec/routing/ops_routing_spec.rb
@@ -107,7 +107,6 @@ describe "routing for OpsController" do
     wait_for_task
     x_button
     x_show
-    x_settings_changed
     zone_edit
     zone_field_changed
   ).each do |task|

--- a/spec/routing/provider_foreman_routing_spec.rb
+++ b/spec/routing/provider_foreman_routing_spec.rb
@@ -51,7 +51,6 @@ describe 'routes for ProviderForeman' do
     x_button
     x_history
     x_search_by_name
-    x_settings_changed
     x_show
   ).each do |task|
     describe "##{task}" do

--- a/spec/routing/pxe_routing_spec.rb
+++ b/spec/routing/pxe_routing_spec.rb
@@ -158,10 +158,4 @@ describe PxeController do
       expect(post("/pxe/x_history")).to route_to("pxe#x_history")
     end
   end
-
-  describe "#x_settings_changed" do
-    it "routes with POST" do
-      expect(post("/pxe/x_settings_changed")).to route_to("pxe#x_settings_changed")
-    end
-  end
 end

--- a/spec/routing/report_routing_spec.rb
+++ b/spec/routing/report_routing_spec.rb
@@ -336,12 +336,6 @@ describe "routes for ReportController" do
     end
   end
 
-  describe "#x_settings_changed" do
-    it "routes with POST" do
-      expect(post("/report/x_settings_changed")).to route_to("report#x_settings_changed")
-    end
-  end
-
   describe "#x_show" do
     it "routes with POST" do
       expect(post("/report/x_show")).to route_to("report#x_show")

--- a/spec/routing/service_routing_spec.rb
+++ b/spec/routing/service_routing_spec.rb
@@ -109,10 +109,4 @@ describe 'routes for ServiceController' do
       expect(post("/service/x_show")).to route_to("service#x_show")
     end
   end
-
-  describe "#x_settings_changed" do
-    it "routes with POST" do
-      expect(post("/service/x_settings_changed")).to route_to("service#x_settings_changed")
-    end
-  end
 end

--- a/spec/routing/shared_examples/explorer_examples.rb
+++ b/spec/routing/shared_examples/explorer_examples.rb
@@ -24,10 +24,4 @@ shared_examples_for "A controller that has explorer routes" do
       expect(post("/#{controller_name}/tree_select")).to route_to("#{controller_name}#tree_select")
     end
   end
-
-  describe '#x_settings_changed' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/x_settings_changed")).to route_to("#{controller_name}#x_settings_changed")
-    end
-  end
 end

--- a/spec/routing/shared_examples/vm_common_examples.rb
+++ b/spec/routing/shared_examples/vm_common_examples.rb
@@ -305,12 +305,6 @@ shared_examples_for 'A controller that has vm_common routes' do
     end
   end
 
-  describe '#x_settings_changed' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/x_settings_changed")).to route_to("#{controller_name}#x_settings_changed")
-    end
-  end
-
   describe '#x_show' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/x_show")).to route_to("#{controller_name}#x_show")


### PR DESCRIPTION
Seems like there's no remaining users of `x_settings_changed` (previously used by explorer, I suspect last before the dhtmlx refactor) - removing :).

@kbrock you seem to have been the last one to [touch](https://github.com/ManageIQ/manageiq/commit/9fe28591) it, so if you know anything more..