### PR TITLE
Fix issue where VMDB::Config#stale? did not work as expected.

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -302,43 +302,43 @@ class MiqServer < ApplicationRecord
   end
 
   def monitor_poll
-    ((@vmdb_config && @vmdb_config.config[:server][:monitor_poll]) || 5.seconds).to_i_with_method
+    (::Settings.server.monitor_poll || 5.seconds).to_i_with_method
   end
 
   def stop_poll
-    ((@vmdb_config && @vmdb_config.config[:server][:stop_poll]) || 10.seconds).to_i_with_method
+    (::Settings.server.stop_poll || 10.seconds).to_i_with_method
   end
 
   def heartbeat_frequency
-    ((@vmdb_config && @vmdb_config.config[:server][:heartbeat_frequency]) || 30.seconds).to_i_with_method
+    (::Settings.server.heartbeat_frequency || 30.seconds).to_i_with_method
   end
 
   def server_dequeue_frequency
-    ((@vmdb_config && @vmdb_config.config[:server][:server_dequeue_frequency]) || 5.seconds).to_i_with_method
+    (::Settings.server.server_dequeue_frequency || 5.seconds).to_i_with_method
   end
 
   def server_monitor_frequency
-    ((@vmdb_config && @vmdb_config.config[:server][:server_monitor_frequency]) || 60.seconds).to_i_with_method
+    (::Settings.server.server_monitor_frequency || 60.seconds).to_i_with_method
   end
 
   def server_log_frequency
-    ((@vmdb_config && @vmdb_config.config[:server][:server_log_frequency]) || 5.minutes).to_i_with_method
+    (::Settings.server.server_log_frequency || 5.minutes).to_i_with_method
   end
 
   def server_log_timings_threshold
-    ((@vmdb_config && @vmdb_config.config[:server][:server_log_timings_threshold]) || 1.second).to_i_with_method
+    (::Settings.server.server_log_timings_threshold || 1.second).to_i_with_method
   end
 
   def worker_dequeue_frequency
-    ((@vmdb_config && @vmdb_config.config[:server][:worker_dequeue_frequency]) || 3.seconds).to_i_with_method
+    (::Settings.server.worker_dequeue_frequency || 3.seconds).to_i_with_method
   end
 
   def worker_messaging_frequency
-    ((@vmdb_config && @vmdb_config.config[:server][:worker_messaging_frequency]) || 5.seconds).to_i_with_method
+    (::Settings.server.worker_messaging_frequency || 5.seconds).to_i_with_method
   end
 
   def worker_monitor_frequency
-    ((@vmdb_config && @vmdb_config.config[:server][:worker_monitor_frequency]) || 15.seconds).to_i_with_method
+    (::Settings.server.worker_monitor_frequency || 15.seconds).to_i_with_method
   end
 
   def threshold_exceeded?(name, now = Time.now.utc)

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -133,7 +133,6 @@ class MiqServer < ApplicationRecord
     _log.info("#{msg}")
     puts "** #{msg}"
 
-    @vmdb_config = VMDB::Config.new("vmdb")
     starting_server_record
 
     #############################################################

--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -75,6 +75,7 @@ module MiqServer::ConfigurationManagement
   end
 
   def sync_log_level
-    Vmdb::Loggers.apply_config(@vmdb_config.config[:log])
+    # TODO: Can this be removed since the VMDB::Config::Activator will do this anyway?
+    Vmdb::Loggers.apply_config(::Settings.log)
   end
 end

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -117,8 +117,7 @@ module MiqServer::EnvironmentManagement
   end
 
   def disk_usage_threshold
-    @vmdb_config = VMDB::Config.new("vmdb")
-    @vmdb_config.config.fetch_path(:server, :events, :disk_usage_gt_percent) || 80
+    ::Settings.server.events.disk_usage_gt_percent || 80
   end
 
   def check_disk_usage(disks)

--- a/app/models/miq_server/server_monitor.rb
+++ b/app/models/miq_server/server_monitor.rb
@@ -39,7 +39,7 @@ module MiqServer::ServerMonitor
   end
 
   def miq_server_time_threshold
-    ((@vmdb_config && @vmdb_config.config[:server][:heartbeat_timeout]) || 2.minutes).to_i_with_method
+    (::Settings.server.heartbeat_timeout || 2.minutes).to_i_with_method
   end
 
   def monitor_servers_as_master

--- a/app/models/miq_server/worker_management/dequeue.rb
+++ b/app/models/miq_server/worker_management/dequeue.rb
@@ -56,15 +56,15 @@ module MiqServer::WorkerManagement::Dequeue
   end
 
   def prefetch_max_per_worker
-    @vmdb_config.config[:server][:prefetch_max_per_worker] || 100
+    ::Settings.server.prefetch_max_per_worker || 100
   end
 
   def prefetch_min_per_worker
-    @vmdb_config.config[:server][:prefetch_min_per_worker] || 10
+    ::Settings.server.prefetch_min_per_worker || 10
   end
 
   def prefetch_stale_threshold
-    (@vmdb_config.config[:server][:prefetch_stale_threshold] || 30.seconds).to_i_with_method
+    (::Settings.server.prefetch_stale_threshold || 30.seconds).to_i_with_method
   end
 
   def prefetch_below_threshold?(queue_name, wcount)

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -34,10 +34,8 @@ module MiqServer::WorkerManagement::Heartbeat
     # Special process the sync_ messages to send the current values of what to synchronize
     messages.collect do |message, *args|
       case message
-      when "sync_config"
-        [message, {:config => @vmdb_config}]
       when "sync_active_roles"
-        [message, {:roles  => @active_role_names}]
+        [message, {:roles => @active_role_names}]
       else
         [message, *args]
       end

--- a/app/models/miq_server/worker_management/monitor/settings.rb
+++ b/app/models/miq_server/worker_management/monitor/settings.rb
@@ -16,7 +16,7 @@ module MiqServer::WorkerManagement::Monitor::Settings
   end
 
   def sync_worker_monitor_settings
-    @worker_monitor_settings = @vmdb_config.config[:server][:worker_monitor]
+    @worker_monitor_settings = ::Settings.server.worker_monitor.to_hash
     @worker_monitor_settings.keys.each do |k|
       @worker_monitor_settings[k] = @worker_monitor_settings[k].to_i_with_method if @worker_monitor_settings[k].respond_to?(:to_i_with_method)
     end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -8,7 +8,6 @@ class MiqWorker::Runner
   include Vmdb::Logging
   attr_accessor :last_hb, :worker, :worker_settings
   attr_reader   :active_roles, :server
-  attr_writer   :vmdb_config
 
   INTERRUPT_SIGNALS = ["SIGINT", "SIGTERM"]
 
@@ -20,10 +19,6 @@ class MiqWorker::Runner
 
   def self.start_worker(*args)
     new(*args).start
-  end
-
-  def vmdb_config
-    @vmdb_config ||= VMDB::Config.new("vmdb")
   end
 
   def poll_method
@@ -278,15 +273,14 @@ class MiqWorker::Runner
     _log.info("#{log_prefix} Synchronizing active roles complete...")
   end
 
-  def message_sync_config(*args)
+  def message_sync_config(*_args)
     _log.info("#{log_prefix} Synchronizing configuration...")
-    opts = args.extract_options!
-    sync_config(opts[:config])
+    sync_config
     _log.info("#{log_prefix} Synchronizing configuration complete...")
   end
 
-  def sync_config(config = nil)
-    self.vmdb_config = config
+  def sync_config
+    Vmdb::Settings.reload!
     @my_zone ||= MiqServer.my_zone
     sync_log_level
     sync_worker_settings

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -300,11 +300,12 @@ class MiqWorker::Runner
   end
 
   def sync_log_level
-    Vmdb::Loggers.apply_config(vmdb_config.config[:log])
+    # TODO: Can this be removed since the VMDB::Config::Activator will do this anyway?
+    Vmdb::Loggers.apply_config(::Settings.log)
   end
 
   def sync_worker_settings
-    @worker_settings = self.class.corresponding_model.worker_settings(:config => vmdb_config)
+    @worker_settings = self.class.corresponding_model.worker_settings(:config => ::Settings.to_hash)
     @poll = @worker_settings[:poll]
     poll_method
   end

--- a/lib/patches/config_patch.rb
+++ b/lib/patches/config_patch.rb
@@ -1,6 +1,10 @@
 module ConfigDecryptPasswords
   def reload!
-    Vmdb::Settings.decrypt_passwords!(super)
+    Vmdb::Settings.decrypt_passwords!(super).tap do
+      # Do not set the last_loaded when accessing a remote server's settings. It
+      #   should only be set when reloading the current process' Settings.
+      Vmdb::Settings.last_loaded = Time.now.utc if equal?(::Settings)
+    end
   end
 
   alias load! reload!

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -56,10 +56,6 @@ module VMDB
       MiqServer.my_server.set_config(config)
     end
 
-    def stale?
-      full_config != ::Settings.to_hash
-    end
-
     # NOTE: Used by Configuration -> Advanced
     def self.get_file
       Vmdb::Settings.encrypt_passwords!(::Settings.to_hash).to_yaml
@@ -84,18 +80,6 @@ module VMDB
     # protected
     def self.filter_settings_by_name(settings, name)
       name == "vmdb" ? settings : settings[name.to_sym]
-    end
-
-    private
-
-    def full_config
-      if name == "vmdb"
-        config
-      else
-        ::Settings.to_hash.tap do |settings|
-          settings[name.to_sym] = config
-        end
-      end
     end
   end
 end

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -7,9 +7,17 @@ module Vmdb
   class Settings
     PASSWORD_FIELDS = %i(bind_pwd password amazon_secret).to_set.freeze
 
+    cattr_accessor :last_loaded
+
     def self.init
       ::Config.overwrite_arrays = true
       reset_settings_constant(for_resource(my_server))
+      self.last_loaded = Time.now.utc
+    end
+
+    def self.reload!
+      ::Settings.reload!
+      activate
     end
 
     def self.walk(settings = ::Settings, path = [], &block)

--- a/spec/factories/miq_ems_refresh_worker.rb
+++ b/spec/factories/miq_ems_refresh_worker.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :miq_ems_refresh_worker do
-    pid { Process.pid }
-  end
-end

--- a/spec/factories/miq_worker.rb
+++ b/spec/factories/miq_worker.rb
@@ -7,4 +7,12 @@ FactoryGirl.define do
   factory :miq_ui_worker, :class => "MiqUiWorker", :parent => :miq_worker
 
   factory :miq_ems_metrics_processor_worker, :class => "MiqEmsMetricsProcessorWorker", :parent => :miq_worker
+
+  factory :miq_ems_refresh_worker,
+          :parent => :miq_worker,
+          :class  => "ManageIQ::Providers::BaseManager::RefreshWorker"
+
+  factory :ems_refresh_worker_amazon,
+          :parent => :miq_ems_refresh_worker,
+          :class  => "ManageIQ::Providers::Amazon::CloudManager::RefreshWorker"
 end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -306,7 +306,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "should return proper message on heartbeat via drb" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_config', {:config => nil}]])
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_config']])
           end
         end
 
@@ -327,7 +327,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "exit message followed by active_roles and config" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['exit'], ['sync_active_roles', {:roles => nil}], ['sync_config', {:config => nil}]])
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['exit'], ['sync_active_roles', {:roles => nil}], ['sync_config']])
           end
         end
 
@@ -337,7 +337,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "should return proper message on heartbeat via drb" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_active_roles', {:roles => nil}], ['sync_config', {:config => nil}]])
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_active_roles', {:roles => nil}], ['sync_config']])
           end
         end
 

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -143,7 +143,6 @@ describe MiqServer do
     end
 
     context "#ntp_reload" do
-      let(:config)     { @miq_server.get_config("vmdb") }
       let(:server_ntp) { {:server => ["server.pool.com"]} }
       let(:zone_ntp)   { {:server => ["zone.pool.com"]} }
       let(:chrony)     { double }
@@ -155,8 +154,7 @@ describe MiqServer do
 
         it "syncs with server settings with zone and server configured" do
           @zone.update_attribute(:settings, :ntp => zone_ntp)
-          config.config = {:ntp => server_ntp}
-          config.save
+          stub_settings(:ntp => server_ntp)
 
           expect(LinuxAdmin::Chrony).to receive(:new).and_return(chrony)
           expect(chrony).to receive(:clear_servers)
@@ -166,8 +164,7 @@ describe MiqServer do
 
         it "syncs with zone settings if server not configured" do
           @zone.update_attribute(:settings, :ntp => zone_ntp)
-          config.config = {}
-          config.save
+          stub_settings({})
 
           expect(LinuxAdmin::Chrony).to receive(:new).and_return(chrony)
           expect(chrony).to receive(:clear_servers)
@@ -177,8 +174,7 @@ describe MiqServer do
 
         it "syncs with default zone settings if server and zone not configured" do
           @zone.update_attribute(:settings, {})
-          config.config = {}
-          config.save
+          stub_settings({})
 
           expect(LinuxAdmin::Chrony).to receive(:new).and_return(chrony)
           expect(chrony).to receive(:clear_servers)


### PR DESCRIPTION
Because `stale?` did not work as expected, the effect is that the server
would constantly tell its workers to `sync_config`.  The fix is that we
can just replace the usage of `VMDB::Config` completely with a simple time
check on the current `::Settings` object.

Fixes #7585 and fixes #7604 

@jrafanie @chessbyte Please review
cc @abellotti