### PR TITLE
Default name to "Copy of XXX" when copying a record

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -597,7 +597,10 @@ class ChargebackController < ApplicationController
       "weekly"  => "Weekly",
       "monthly" => "Monthly"
     }
-    @rate.id = nil if params[:typ] == "copy"
+    if params[:typ] == "copy"
+      @rate.id = nil
+      @edit[:new][:description] = "copy of #{@rate.description}"
+    end
     @edit[:rec_id] = @rate.id || nil
     @edit[:key] = "cbrate_edit__#{@rate.id || "new"}"
     @edit[:current] = copy_hash(@edit[:new])


### PR DESCRIPTION
When a chargeback rate detail record is copied, default name to "Copy of XXX" so Add button is enabled when screen loads. Fixes #2 in the issue #7832

Fixes #7832 

@gtanzillo @lpichler @amaurygonzalez please review.