### PR TITLE
Handle all BEFORE/AFTER expressions as date/time

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -665,11 +665,7 @@ class MiqExpression
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
       clause = field.not_eq(exp[operator]["value"]).to_sql
     when "before", "after"
-      col_type = self.class.get_col_type(exp[operator]["field"]) if exp[operator]["field"]
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if col_type == :date || col_type == :datetime
-
-      operands = self.class.operands2sqlvalue(operator, exp[operator])
-      clause = operands.join(" #{self.class.normalize_sql_operator(operator)} ")
+      return _to_sql({"date_time_with_logical_operator" => exp}, tz)
     when "like", "includes"
       field = Field.parse(exp[operator]["field"])
       clause = field.matches("%#{exp[operator]["value"]}%").to_sql


### PR DESCRIPTION
All BEFORE/AFTER expressions should be date/times, so just recur with
the date_time_with_logical_operator operator for now. I'd like for this
to go away in a future revision, but this should clarify the only path
through this case as it stands.

Probably makes more sense to merge https://github.com/ManageIQ/manageiq/pull/7837 first (there will be a conflict) but it's not essential. I'll have to rebase whichever one doesn't get merged, but I wanted to keep this separate.

/cc @gtanzillo @yrudman 
@miq-bot add-label refactoring, core