### PR TITLE
Callback before automation starts

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -96,6 +96,7 @@ module MiqAeEngine
       if object_type
         vmdb_object = object_type.constantize.find_by_id(object_id)
         automate_attrs[create_automation_attribute_key(vmdb_object)] = object_id
+        vmdb_object.before_ae_starts(options) if vmdb_object.respond_to?(:before_ae_starts)
       end
 
       automate_attrs['User::user']      = user_id            unless user_id.nil?

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -766,4 +766,29 @@ module MiqAeEngineSpec
       expect(ws.root['_missing_instance']).to eq('FRED')
     end
   end
+
+  describe MiqAeEngine do
+    before do
+      TestClass = Class.new do
+        def before_ae_starts(_options)
+        end
+      end
+    end
+
+    context "deliver to automate" do
+      let(:test_class) { TestClass.new }
+      let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
+      let(:user) { FactoryGirl.create(:user_with_group) }
+      let(:options) { {:user_id => user.id, :object_type => "MiqAeEngineSpec::TestClass"} }
+
+      it "#before_ae_starts" do
+        allow(MiqAeEngine).to receive(:create_automation_object).with(any_args).and_return(nil)
+        allow(TestClass).to receive(:find_by_id).with(any_args).and_return(test_class)
+        allow(MiqAeEngine).to receive(:resolve_automation_object).with(any_args).and_return(workspace)
+        allow(MiqAeEngine).to receive(:create_automation_attribute_key).with(any_args).and_return("abc")
+        expect(test_class).to receive(:before_ae_starts).once.with(options)
+        MiqAeEngine.deliver(options)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If some of the provision objects implement a before_ae_starts
automate engine will call it before it starts the Automate Engine.
This is the bookend for the 'after_ae_delivery' which is run after
automation ends. It passes in the options hash that it was called with.
The object getting the options can analyze for retries.