### PR TITLE
Convert matching expressions to use Arel

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -665,18 +665,18 @@ class MiqExpression
 
       operands = self.class.operands2sqlvalue(operator, exp[operator])
       clause = operands.join(" #{self.class.normalize_sql_operator(operator)} ")
-    when "like", "not like", "starts with", "ends with", "includes"
-      operands = self.class.operands2sqlvalue(operator, exp[operator])
-      case operator.downcase
-      when "starts with"
-        operands[1] = "'" + operands[1].to_s + "%'"
-      when "ends with"
-        operands[1] = "'%" + operands[1].to_s + "'"
-      when "like", "not like", "includes"
-        operands[1] = "'%" + operands[1].to_s + "%'"
-      end
-      clause = operands.join(" #{self.class.normalize_sql_operator(operator)} ")
-      clause = "!(" + clause + ")" if operator.downcase == "not like"
+    when "like", "includes"
+      field = Field.parse(exp[operator]["field"])
+      clause = field.matches("%#{exp[operator]["value"]}%").to_sql
+    when "starts with"
+      field = Field.parse(exp[operator]["field"])
+      clause = field.matches("#{exp[operator]["value"]}%").to_sql
+    when "ends with"
+      field = Field.parse(exp[operator]["field"])
+      clause = field.matches("%#{exp[operator]["value"]}").to_sql
+    when "not like"
+      field = Field.parse(exp[operator]["field"])
+      clause = field.does_not_match("%#{exp[operator]["value"]}%").to_sql
     when "and", "or"
       operands = exp[operator].collect do|operand|
         o = _to_sql(operand, tz) if operand.present?

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -37,6 +37,18 @@ class MiqExpression::Field
     end
   end
 
+  def matches(other)
+    escape = nil
+    case_sensitive = true
+    arel_attribute.matches(other, escape, case_sensitive)
+  end
+
+  def does_not_match(other)
+    escape = nil
+    case_sensitive = true
+    arel_attribute.does_not_match(other, escape, case_sensitive)
+  end
+
   private
 
   def arel_attribute

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -39,41 +39,41 @@ describe MiqExpression do
 
     it "generates the SQL for a LIKE expression" do
       sql, * = MiqExpression.new("LIKE" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("vms.name LIKE '%foo%'")
+      expect(sql).to eq("\"vms\".\"name\" LIKE '%foo%'")
     end
 
     it "generates the SQL for a NOT LIKE expression" do
       sql, * = MiqExpression.new("NOT LIKE" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("!(vms.name LIKE '%foo%')")
+      expect(sql).to eq("\"vms\".\"name\" NOT LIKE '%foo%'")
     end
 
     it "generates the SQL for a STARTS WITH expression " do
       sql, * = MiqExpression.new("STARTS WITH" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("vms.name LIKE 'foo%'")
+      expect(sql).to eq("\"vms\".\"name\" LIKE 'foo%'")
     end
 
     it "generates the SQL for an ENDS WITH expression" do
       sql, * = MiqExpression.new("ENDS WITH" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("vms.name LIKE '%foo'")
+      expect(sql).to eq("\"vms\".\"name\" LIKE '%foo'")
     end
 
     it "generates the SQL for an INCLUDES" do
       sql, * = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("vms.name LIKE '%foo%'")
+      expect(sql).to eq("\"vms\".\"name\" LIKE '%foo%'")
     end
 
     it "generates the SQL for an AND expression" do
       exp1 = {"STARTS WITH" => {"field" => "Vm-name", "value" => "foo"}}
       exp2 = {"ENDS WITH" => {"field" => "Vm-name", "value" => "bar"}}
       sql, * = MiqExpression.new("AND" => [exp1, exp2]).to_sql
-      expect(sql).to eq("(vms.name LIKE 'foo%' AND vms.name LIKE '%bar')")
+      expect(sql).to eq("(\"vms\".\"name\" LIKE 'foo%' AND \"vms\".\"name\" LIKE '%bar')")
     end
 
     it "generates the SQL for an AND expression where only one is supported by SQL" do
       exp1 = {"STARTS WITH" => {"field" => "Vm-name", "value" => "foo"}}
       exp2 = {"ENDS WITH" => {"field" => "Vm-platform", "value" => "bar"}}
       sql, * = MiqExpression.new("AND" => [exp1, exp2]).to_sql
-      expect(sql).to eq("(vms.name LIKE 'foo%')")
+      expect(sql).to eq("(\"vms\".\"name\" LIKE 'foo%')")
     end
 
     it "returns nil for an AND expression where none is supported by SQL" do
@@ -87,7 +87,7 @@ describe MiqExpression do
       exp1 = {"STARTS WITH" => {"field" => "Vm-name", "value" => "foo"}}
       exp2 = {"ENDS WITH" => {"field" => "Vm-name", "value" => "bar"}}
       sql, * = MiqExpression.new("OR" => [exp1, exp2]).to_sql
-      expect(sql).to eq("(vms.name LIKE 'foo%' OR vms.name LIKE '%bar')")
+      expect(sql).to eq("(\"vms\".\"name\" LIKE 'foo%' OR \"vms\".\"name\" LIKE '%bar')")
     end
 
     it "returns nil for an OR expression where one is not supported by SQL" do


### PR DESCRIPTION
This converts the matching expressions (LIKE, NOT LIKE, etc..) to use Arel.  Couple of things to note:

* Introducing a bit more duplication here, but I plan to deal with this later
* Arel gives us ILIKE out of the box

While the ILIKE support is great, I'm not sure this is the right time to bring this out (especially as the `#to_ruby` stuff doesn't support case insensitive matching, and should be done together). @kbrock do you know if there's a way to fall back on using LIKE for now so there's no behavioral change in this PR?

/cc @gtanzillo @yrudman 
@miq-bot add-label refactoring, core