### PR TITLE
Allow snapshots to be used as templates

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision.rb
@@ -1,3 +1,5 @@
 class ManageIQ::Providers::Google::CloudManager::Provision < ::MiqProvisionCloud
   include_concern 'Cloning'
+  include_concern 'Disk'
+  include_concern 'StateMachine'
 end

--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -8,59 +8,15 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
     end
   end
 
-  def initial_disk
-    # Check if the source is a snapshot; if it is, we can't use a single
-    # request to make the instance and have to create the disk first
-    resource = ManageIQ::Providers::Google::Resource.new(source.location)
-
-    if resource.snapshot?
-      # Unfortunately we have to provision the disk first, then provision the
-      # instance.
-      return create_initial_disk_from_snapshot.get_as_boot_disk(true, true)
-    elsif resource.image?
-      # We can provision the instance in the same request; just return the hash
-      return initial_disk_hash
-    else
-      # Unknown type!
-      _log.error("Unknown resource location to provision from: #{source.location}")
-      raise MiqException::MiqProvisionError, _("Unsupported source: #{source.location}")
-    end
-  end
-
-  def initial_disk_hash
-    {
-      :boot             => true,
-      :autoDelete       => true,
-      :initializeParams => {
-        :name        => dest_name,
-        :diskSizeGb  => get_option(:boot_disk_size).to_i,
-        :sourceImage => source.location,
-      },
-    }
-  end
-
-  def create_initial_disk_from_snapshot
-    disk = source.with_provider_connection do |google|
-      google.disks.create(
-        :name            => dest_name,
-        :size_gb         => get_option(:boot_disk_size).to_i,
-        :zone_name       => dest_availability_zone.ems_ref,
-        :source_snapshot => source.name,
-      )
-    end
-    # Poll until the operation is complete
-    disk.wait_for { ready? }
-
-    disk
-  end
-
   def prepare_for_clone_task
     clone_options = super
 
-    clone_options[:name] = dest_name
-    clone_options[:disks] = [initial_disk]
+    boot_disk = phase_context[:boot_disk]
+
+    clone_options[:name]         = dest_name
+    clone_options[:disks]        = [boot_disk]
     clone_options[:machine_type] = instance_type.ems_ref
-    clone_options[:zone_name] = dest_availability_zone.ems_ref
+    clone_options[:zone_name]    = dest_availability_zone.ems_ref
 
     clone_options
   end

--- a/app/models/manageiq/providers/google/cloud_manager/provision/disk.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/disk.rb
@@ -1,0 +1,25 @@
+module ManageIQ::Providers::Google::CloudManager::Provision::Disk
+  def create_disks(disks_attrs)
+    disk_results = []
+    source.with_provider_connection do |google|
+      disks_attrs.each do |disk_attrs|
+        disk_results << google.disks.create(disk_attrs)
+      end
+    end
+    disk_results
+  end
+
+  def create_disk(disk_attrs)
+    create_disks([disk_attrs]).first
+  end
+
+  def check_disks_ready(disks_attrs)
+    source.with_provider_connection do |google|
+      disks_attrs.each do |disk_attrs|
+        disk = google.disks.get(disk_attrs[:name], disk_attrs[:zone_name])
+        return false unless disk.ready?
+      end
+    end
+    true
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/state_machine.rb
@@ -11,12 +11,12 @@ module ManageIQ::Providers::Google::CloudManager::Provision::StateMachine
     resource = ManageIQ::Providers::Google::Resource.new(source.location)
 
     phase_context[:boot_disk_attrs] = {
-      :name         => dest_name,
-      :size_gb      => boot_disk_size,
-      :zone_name    => dest_availability_zone.ems_ref,
+      :name      => dest_name,
+      :size_gb   => boot_disk_size,
+      :zone_name => dest_availability_zone.ems_ref,
     }
 
-    source_key = (resource.snapshot?) ? :source_snapshot : :source_image
+    source_key = resource.snapshot? ? :source_snapshot : :source_image
     phase_context[:boot_disk_attrs][source_key] = source.name
 
     phase_context[:boot_disk] = create_disk(

--- a/app/models/manageiq/providers/google/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/state_machine.rb
@@ -1,0 +1,40 @@
+module ManageIQ::Providers::Google::CloudManager::Provision::StateMachine
+  def determine_placement
+    availability_zone = placement
+    options[:dest_availability_zone] = [availability_zone.try(:id), availability_zone.try(:name)]
+    signal :prepare_instance_disks
+  end
+
+  def prepare_instance_disks
+    boot_disk_size = get_option(:boot_disk_size).to_i
+
+    resource = ManageIQ::Providers::Google::Resource.new(source.location)
+
+    phase_context[:boot_disk_attrs] = {
+      :name         => dest_name,
+      :size_gb      => boot_disk_size,
+      :zone_name    => dest_availability_zone.ems_ref,
+    }
+
+    source_key = (resource.snapshot?) ? :source_snapshot : :source_image
+    phase_context[:boot_disk_attrs][source_key] = source.name
+
+    phase_context[:boot_disk] = create_disk(
+      phase_context[:boot_disk_attrs]).get_as_boot_disk(true, true)
+
+    update_and_notify_parent(:message => "Creating disk [#{dest_name}]")
+
+    signal :poll_instance_disks_complete
+  end
+
+  def poll_instance_disks_complete
+    boot_disk = phase_context[:boot_disk_attrs]
+
+    if !check_disks_ready([boot_disk])
+      requeue_phase
+    else
+      update_and_notify_parent(:message => "Disk [#{boot_disk[:name]}] finished creating")
+      signal :prepare_provision
+    end
+  end
+end

--- a/app/models/manageiq/providers/google/resource.rb
+++ b/app/models/manageiq/providers/google/resource.rb
@@ -1,0 +1,51 @@
+module ManageIQ::Providers::Google
+  class Resource
+    def initialize(uri)
+      @type = parse_resource_type(uri)
+    end
+
+    def snapshot?
+      @type == 'snapshots'
+    end
+
+    def image?
+      @type == 'images'
+    end
+
+    def disk?
+      @type == 'disks'
+    end
+
+    def unknown?
+      @type == 'unknown'
+    end
+
+    private
+
+    # Parses a Google resource url and returns the resource from the path.
+    # This method understands both complete urls (starting with
+    # https://www.googleapis.com) as well as partials.
+    def parse_resource_type(uri)
+      return 'unknown' if uri.blank?
+
+      # We can cheat here a bit - most the google APIs (at least in compute.v1)
+      # define resources directly under their type (i.e. snapshots/foo or
+      # images/bar). However, 'images' allow the specification of 'family' which
+      # is an alias to the latest image in a family, breaking the rule.
+      parts = URI.parse(uri).path.split('/')
+
+      # We assume that the resource url follows the pattern:
+      # http://some-google-url.com/some/basepath/resource_type/resource_name
+      _                    = parts[-1] # resource_name, unused here
+      resource_type        = parts[-2]
+      resource_type_prefix = parts[-3]
+
+      return 'unknown' if resource_type.blank?
+
+      # Check for the special case of 'family' as explained above
+      return 'images' if resource_type == 'family' && resource_type_prefix == 'images'
+
+      resource_type
+    end
+  end
+end

--- a/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
@@ -34,7 +34,8 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       assert_specific_flavor
       assert_specific_vm_powered_on
       assert_specific_vm_powered_off
-      assert_specific_template
+      assert_specific_image_template
+      assert_specific_snapshot_template
       assert_specific_cloud_volume
       assert_specific_cloud_volume_snapshot
     end
@@ -48,16 +49,16 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
     expect(CloudNetwork.count).to        eql(1)
     expect(SecurityGroup.count).to       eql(1)
     expect(FirewallRule.count).to        eql(6)
-    expect(VmOrTemplate.count).to        eql(473)
+    expect(VmOrTemplate.count).to        eql(474)
     expect(Vm.count).to                  eql(2)
-    expect(MiqTemplate.count).to         eql(471)
+    expect(MiqTemplate.count).to         eql(472)
     expect(Disk.count).to                eql(2)
     expect(GuestDevice.count).to         eql(0)
     expect(Hardware.count).to            eql(2)
     expect(Network.count).to             eql(4)
-    expect(OperatingSystem.count).to     eql(473)
+    expect(OperatingSystem.count).to     eql(474)
     expect(Relationship.count).to        eql(4)
-    expect(MiqQueue.count).to            eql(473)
+    expect(MiqQueue.count).to            eql(474)
     expect(CloudVolume.count).to         eql(4)
     expect(CloudVolumeSnapshot.count).to eql(1)
   end
@@ -66,11 +67,11 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
     expect(@ems.flavors.size).to            eql(18)
     expect(@ems.key_pairs.size).to          eql(4)
     expect(@ems.availability_zones.size).to eql(13)
-    expect(@ems.vms_and_templates.size).to  eql(473)
+    expect(@ems.vms_and_templates.size).to  eql(474)
     expect(@ems.cloud_networks.size).to     eql(1)
     expect(@ems.security_groups.size).to    eql(1)
     expect(@ems.vms.size).to                eql(2)
-    expect(@ems.miq_templates.size).to      eq(471)
+    expect(@ems.miq_templates.size).to      eq(472)
   end
 
   def assert_specific_zone
@@ -374,7 +375,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
     expect(v.hardware.networks.size).to      eql(2)
   end
 
-  def assert_specific_template
+  def assert_specific_image_template
     name      = "rhel-7-v20151104"
     @template = ManageIQ::Providers::Google::CloudManager::Template.where(:name => name).first
     expected_location = "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20151104"
@@ -406,6 +407,43 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
 
     expect(@template.ext_management_system).to         eq(@ems)
     expect(@template.operating_system.product_name).to eq("linux_redhat")
+    expect(@template.custom_attributes.size).to        eq(0)
+    expect(@template.snapshots.size).to                eq(0)
+  end
+
+  def assert_specific_snapshot_template
+    name      = "wheezy-snapshot-1"
+    @template = ManageIQ::Providers::Google::CloudManager::Template.where(:name => name).first
+    expected_location =
+      "https://www.googleapis.com/compute/v1/projects/civil-tube-113314/global/snapshots/wheezy-snapshot-1"
+
+    expect(@template).to have_attributes(
+      :template              => true,
+      :ems_ref               => "9048940034142591751",
+      :ems_ref_obj           => nil,
+      :uid_ems               => "9048940034142591751",
+      :vendor                => "google",
+      :power_state           => "never",
+      :location              => expected_location,
+      :tools_status          => nil,
+      :boot_time             => nil,
+      :standby_action        => nil,
+      :connection_state      => nil,
+      :cpu_affinity          => nil,
+      :memory_reserve        => nil,
+      :memory_reserve_expand => nil,
+      :memory_limit          => nil,
+      :memory_shares         => nil,
+      :memory_shares_level   => nil,
+      :cpu_reserve           => nil,
+      :cpu_reserve_expand    => nil,
+      :cpu_limit             => nil,
+      :cpu_shares            => nil,
+      :cpu_shares_level      => nil
+    )
+
+    expect(@template.ext_management_system).to         eq(@ems)
+    expect(@template.operating_system.product_name).to eq("unknown")
     expect(@template.custom_attributes.size).to        eq(0)
     expect(@template.snapshots.size).to                eq(0)
   end

--- a/spec/models/manageiq/providers/google/resource_spec.rb
+++ b/spec/models/manageiq/providers/google/resource_spec.rb
@@ -1,0 +1,74 @@
+describe ManageIQ::Providers::Google::Resource do
+  context "created with disk uri" do
+    let(:resource) do
+      uri = 'https://content.googleapis.com/compute/v1/projects/manageiq-dev/zones/us-central1-a/disks/foobar'
+      described_class.new(uri)
+    end
+
+    it 'disk? is true' do
+      expect(resource.disk?).to be(true)
+    end
+  end
+
+  context 'created with image uri' do
+    let(:resource) do
+      uri = 'https://content.googleapis.com/compute/v1/projects/manageiq-dev/global/images/family/centos'
+      described_class.new(uri)
+    end
+
+    it 'image? is true' do
+      expect(resource.image?).to be(true)
+    end
+  end
+
+  context 'created with snapshot uri' do
+    let(:resource) do
+      uri = 'https://content.googleapis.com/compute/v1/projects/manageiq-dev/global/snapshots/dev-snapshot-20160324'
+      described_class.new(uri)
+    end
+
+    it 'snapshot? is true' do
+      expect(resource.snapshot?).to be(true)
+    end
+  end
+
+  context 'created with nil uri' do
+    let(:resource) { described_class.new(nil) }
+
+    it 'unknown? is true' do
+      expect(resource.unknown?).to be(true)
+    end
+  end
+
+  context 'created with empty uri' do
+    let(:resource) { described_class.new("") }
+
+    it 'unknown? is true' do
+      expect(resource.unknown?).to be(true)
+    end
+  end
+
+  context 'created with path of no depth' do
+    let(:resource) { described_class.new("somepath") }
+
+    it 'unknown? is true' do
+      expect(resource.unknown?).to be(true)
+    end
+  end
+
+  context 'created with partial resource path' do
+    let(:resource) { described_class.new("compute/v1/projects/manageiq-dev/zones/us-central1-a/disks/foobar") }
+
+    it 'has correct type' do
+      expect(resource.disk?).to be(true)
+    end
+  end
+
+  context 'created with even more partial resource path' do
+    let(:resource) { described_class.new("projects/manageiq-dev/zones/us-central1-a/disks/foobar") }
+
+    it 'has correct type' do
+      expect(resource.disk?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
To support this change, the cloning process has to be aware of whether the
source is a snapshot or an image. Instances can be created from an image in a
single request; snapshots however cannot. Instead the cloning process detects
whether or not the source is a snapshot via the location url, and if it's a
snapshot a disk is created first before being attached to an instance.