### PR TITLE
ar_taggable - ruby to query

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -112,6 +112,12 @@ class Tag < ApplicationRecord
     list
   end
 
+  # @param tag_names [Array<String>] list of non namespaced tags
+  def self.for_names(tag_names, ns = nil)
+    fq_tag_names = tag_names.collect { |tag_name| File.join(ns, tag_name) }
+    where(:name => fq_tag_names)
+  end
+
   def self.find_by_classification_name(name, region_id = Classification.my_region_number,
                                        ns = Classification::DEFAULT_NAMESPACE, parent_id = 0)
     in_region(region_id).find_by_name(Classification.name2tag(name, parent_id, ns))

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -33,11 +33,10 @@ module ActsAsTaggable
     # @option options :all [String] list of tags that are all required (ignored if any is provided)
     # @option options :separator delimiter for the tags provied by all and any
     def find_tagged_with(options = {})
-      options = {:separator => ' '}.merge(options)
-      options[:ns] = Tag.get_namespace(options)
+      ns = Tag.get_namespace(options)
 
-      tag_names = ActsAsTaggable.split_tag_names(options[:any] || options[:all], options[:separator])
-      fq_tag_names = tag_names.collect { |tag_name| File.join(options[:ns], tag_name) }
+      tag_names = ActsAsTaggable.split_tag_names(options[:any] || options[:all], options[:separator] || ' ')
+      fq_tag_names = tag_names.collect { |tag_name| File.join(ns, tag_name) }
       raise "No tags were passed to :any or :all options" if fq_tag_names.empty?
 
       tag_ids = Tag.where(:name => fq_tag_names).pluck(:id)

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -36,9 +36,7 @@ module ActsAsTaggable
       tag_names = ActsAsTaggable.split_tag_names(options[:any] || options[:all], options[:separator] || ' ')
       raise "No tags were passed to :any or :all options" if tag_names.empty?
 
-      ns = Tag.get_namespace(options)
-      fq_tag_names = tag_names.collect { |tag_name| File.join(ns, tag_name) }
-      tag_ids = Tag.where(:name => fq_tag_names).pluck(:id)
+      tag_ids = Tag.for_names(tag_names, Tag.get_namespace(options)).pluck(:id)
       # Bailout if not all tags passed in exist. (may want to do this with :any as well)
       return none if options[:all] && tag_ids.length != tag_names.length
 

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -26,6 +26,12 @@ module ActsAsTaggable
   end
 
   module ClassMethods
+    # @option options :cat [String|nil] optional category for the tags
+    # @option options :ns  [String|nil] optional namespace for the tags
+
+    # @option options :any [String] list of tags that at least one is required
+    # @option options :all [String] list of tags that are all required (ignored if any is provided)
+    # @option options :separator delimiter for the tags provied by all and any
     def find_tagged_with(options = {})
       options = {:separator => ' '}.merge(options)
       options[:ns] = Tag.get_namespace(options)

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -33,16 +33,14 @@ module ActsAsTaggable
     # @option options :all [String] list of tags that are all required (ignored if any is provided)
     # @option options :separator delimiter for the tags provied by all and any
     def find_tagged_with(options = {})
-      ns = Tag.get_namespace(options)
-
       tag_names = ActsAsTaggable.split_tag_names(options[:any] || options[:all], options[:separator] || ' ')
+      raise "No tags were passed to :any or :all options" if tag_names.empty?
+
+      ns = Tag.get_namespace(options)
       fq_tag_names = tag_names.collect { |tag_name| File.join(ns, tag_name) }
-      raise "No tags were passed to :any or :all options" if fq_tag_names.empty?
-
       tag_ids = Tag.where(:name => fq_tag_names).pluck(:id)
-
-      # Bailout if not enough tags were found
-      return none if options[:all] && tag_ids.length != fq_tag_names.length
+      # Bailout if not all tags passed in exist. (may want to do this with :any as well)
+      return none if options[:all] && tag_ids.length != tag_names.length
 
       taggings = Tagging.arel_table
       self_arel = arel_table


### PR DESCRIPTION
In Rbac, we use `ar_taggable#find_tags_by_grouping` to fetch ids that go back into a query.
The larger goal is to turn that into a scope.

The tagging portion for `find_tagged_with` can be a scope, but `find_tags_by_grouping` fetches all the ids in a loop and combines.

This PR is prep for merging `find_tagged_with` and `find_tags_by_grouping`.

/cc @Fryguy 