### PR TITLE
Simplify Tag.get_namespace and ActsAsTaggable.split_tag_names

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -86,11 +86,14 @@ class Tag < ApplicationRecord
     end
   end
 
+  # @option options :ns [String, nil]
+  # @option options :cat [String, nil] optional category to add to the end (with a slash)
+  # @return [String] downcases namespace or category
   def self.get_namespace(options)
-    options = {:ns => '/user'}.merge(options)
-    ns = options[:ns]
-    ns = "" if [:none, "none", "*", nil].include?(options[:ns])
-    options[:cat].nil? ? ns.downcase : [ns, options[:cat]].join("/").downcase
+    ns = options.fetch(:ns, '/user')
+    ns = "" if [:none, "none", "*", nil].include?(ns)
+    ns += "/" + options[:cat] if options[:cat]
+    ns.downcase
   end
 
   def self.filter_ns(tags, ns)

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -11,14 +11,18 @@ end
 module ActsAsTaggable
   extend ActiveSupport::Concern
 
+  # @param tags [String,Array]
+  # @param separator [String] Separator used if tags is a string
+  # @return array of unique tag names
   def self.split_tag_names(tags, separator)
-    tag_names = []
-    if tags.kind_of?(Array)
-      tag_names.push(tags)
-    elsif tags.kind_of?(String)
-      tag_names.push((separator.kind_of?(Proc) ? separator.call(tags) : tags.split(separator)))
-    end
-    tag_names.flatten.map(&:strip).uniq.compact
+    case tags
+    when Array
+      tags.flatten.compact
+    when String
+      tags.split(separator)
+    else
+      []
+    end.map(&:strip).uniq
   end
 
   module ClassMethods


### PR DESCRIPTION
Simplify and document 2 tag methods

This is part of rbac consolidate descendant lookup work (1 of the 3 rbac performance initiatives)

/cc @gtanzillo 