### PR TITLE
Remove unneeded Tag#add, remove, tag_remove

### DIFF
--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -22,8 +22,7 @@ class MiqPolicySet < ApplicationRecord
 
   def destroy_policy_tags
     # handle policy assignment removal for deleted policy profile
-    tag = "/miq_policy/assignment/#{self.class.to_s.underscore}/#{id}"
-    Tag.remove(tag, :ns => "*")
+    Tag.find_by(:name => "/miq_policy/assignment/#{self.class.to_s.underscore}/#{id}").try!(:destroy)
   end
 
   def add_to(ids, db)

--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -3,8 +3,7 @@ module MiqPolicyMixin
 
   def add_policy(policy)
     ns = "/miq_policy"
-    cat = "assignment"
-    cat += "/" + policy.class.to_s.underscore
+    cat = "assignment/#{policy.class.to_s.underscore}"
     tag = policy.id.to_s
 
     tag_add(tag, :ns => ns, :cat => cat)
@@ -13,8 +12,7 @@ module MiqPolicyMixin
 
   def remove_policy(policy)
     ns = "/miq_policy"
-    cat = "assignment"
-    cat += "/" + policy.class.to_s.underscore
+    cat = "assignment/#{policy.class.to_s.underscore}"
     tag = policy.id.to_s
 
     tags = tag_list(:ns => ns, :cat => cat).split

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,14 +10,6 @@ class Tag < ApplicationRecord
     File.join(Tag.get_namespace(options), name)
   end
 
-  def self.remove(list, options = {})
-    ns = Tag.get_namespace(options)
-    Tag.parse(list).each do |name|
-      tag = Tag.find_by_name(File.join(ns, name))
-      tag.destroy unless tag.nil?
-    end
-  end
-
   def self.tags(options = {})
     query = Tag.includes(:taggings)
     query = query.where(Tagging.arel_table[:taggable_type].eq options[:taggable_type])

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,13 +10,6 @@ class Tag < ApplicationRecord
     File.join(Tag.get_namespace(options), name)
   end
 
-  def self.add(list, options = {})
-    ns = Tag.get_namespace(options)
-    Tag.parse(list).each do |name|
-      Tag.find_or_create_by(:name => find_by_name(File.join(ns, name)))
-    end
-  end
-
   def self.remove(list, options = {})
     ns = Tag.get_namespace(options)
     Tag.parse(list).each do |name|

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -127,17 +127,6 @@ module ActsAsTaggable
     end
   end
 
-  def tag_remove(list, options = {})
-    # remove taggings from object
-    ns = Tag.get_namespace(options)
-    Tag.parse(list).each do |name|
-      taggings
-        .includes(:tag)
-        .where(Tag.arel_table[:name].eq File.join(ns, name))
-        .destroy_all
-    end
-  end
-
   def tagged_with(options = {})
     tagging = Tagging.arel_table
     query = Tag.includes(:taggings).references(:taggings)


### PR DESCRIPTION
These are no longer referenced.

I stumbled across these while reducing `find_tagged_with`

/cc @jrafanie ideas if these are called via dynamic means?