### PR TITLE
Separate aaam from scope version counterpart

### DIFF
--- a/app/models/cim_base_storage_extent.rb
+++ b/app/models/cim_base_storage_extent.rb
@@ -1,27 +1,12 @@
-class CimBaseStorageExtent < ActsAsArModel
+class CimBaseStorageExtent < ActsAsArScope
   set_columns_hash(CimStorageExtent.columns_hash.keys.each_with_object({}) { |c, h| h[c.to_sym] = CimStorageExtent.columns_hash[c].type })
-
-  def self._virtual_columns_hash
-    CimStorageExtent._virtual_columns_hash
-  end
-
-  def self._virtual_reflections
-    CimStorageExtent._virtual_reflections
-  end
 
   def self.aar_scope
     CimStorageExtent.where(:id => base_storage_extent_ids)
   end
 
+  # TODO: this is really inefficient. please fix
   def self.base_storage_extent_ids
     CimComputerSystem.all.collect(&:base_storage_extents).flatten.compact.uniq.collect(&:id)
-  end
-
-  def self.reflections
-    CimStorageExtent.reflections
-  end
-
-  def self.table_name
-    CimStorageExtent.table_name
   end
 end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -492,7 +492,7 @@ module Rbac
   end
 
   def self.method_with_scope(ar_scope, options)
-    if ar_scope < ActsAsArModel || (ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?)
+    if ar_scope.respond_to?(:instances_are_derived?) ? ar_scope.instances_are_derived? : (ar_scope < ActsAsArModel)
       ar_scope.all(options)
     else
       ar_scope.apply_legacy_finder_options(options)

--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -142,51 +142,29 @@ class ActsAsArModel
   # Find routines
   #
 
-  def self.where(*args)
-    return aar_scope.where(*args) if self.respond_to?(:aar_scope)
-    raise NotImplementedError
-  end
-
-  def self.find(*args)
-    return aar_scope.find(*args) if self.respond_to?(:aar_scope)
-    raise NotImplementedError
-  end
-
   def self.all(*args)
-    if !self.respond_to?(:aar_scope)
-      find(:all, *args)
-    elsif args.empty? || args.size == 1 && args.first.respond_to?(:empty?) && args.first.empty?
-      # avoid warnings
-      aar_scope
-    else
-      aar_scope.all(*args)
-    end
+    find(:all, *args)
   end
 
   def self.first(*args)
-    return aar_scope.first(*args) if self.respond_to?(:aar_scope)
     find(:first, *args)
   end
 
   def self.last(*args)
-    return aar_scope.last(*args) if self.respond_to?(:aar_scope)
     find(:last, *args)
   end
 
   def self.count(*args)
-    return aar_scope.count(*args) if self.respond_to?(:aar_scope)
     all(*args).size
   end
 
   def self.find_by_id(*id)
-    return aar_scope.find_by_id(*id) if self.respond_to?(:aar_scope)
     options = id.extract_options!
     options.merge!(:conditions => {:id => id.first})
     first(options)
   end
 
   def self.find_all_by_id(*ids)
-    return aar_scope.find_all_by_id(*args) if self.respond_to?(:aar_scope)
     options = ids.extract_options!
     options.merge!(:conditions => {:id => ids.flatten})
     all(options)

--- a/lib/acts_as_ar_scope.rb
+++ b/lib/acts_as_ar_scope.rb
@@ -1,0 +1,28 @@
+# this is an extension to act as ar_model
+# this allows a developer to formulate results as a scope
+# all other behavior is handled from there
+class ActsAsArScope < ActsAsArModel
+  # user required to add aar_scope
+  class << self
+    delegate :includes, :references, :limit, :order, :offset, :select, :where, :to => :aar_scope
+    delegate :find, :first, :last, :find_by_id, :find_by, :count, :to => :aar_scope
+
+    delegate :klass, :to => :aar_scope, :prefix => true
+    delegate :table_name, :reflections, :to => :aar_scope_klass
+    delegate :_virtual_columns_hash, :virtual_reflections, :to => :aar_scope_klass
+  end
+
+  def self.all(*args)
+    if args.empty? || args.size == 1 && args.first.respond_to?(:empty?) && args.first.empty?
+      # avoid warnings
+      aar_scope
+    else
+      aar_scope.all(*args)
+    end
+  end
+
+  # TODO: goal is for this to be false
+  def self.instances_are_derived?
+    true
+  end
+end

--- a/spec/lib/acts_as_ar_model_spec.rb
+++ b/spec/lib/acts_as_ar_model_spec.rb
@@ -1,6 +1,4 @@
 describe ActsAsArModel do
-  before { base_class }
-
   # id is a default column included regardless if it's in the set_columns_hash
   let(:col_names_syms) { [:str, :id, :int, :flt, :dt] }
   let(:col_names_strs) { %w(str id int flt dt) }
@@ -55,40 +53,5 @@ describe ActsAsArModel do
     it(".base_model") { expect(sub_class.base_model).to eq(sub_class) }
 
     it { expect(sub_class.attribute_names).to be_empty }
-  end
-
-  context "AR backed model" do
-    # model contains ids of important vms - acts like ar model
-    let(:important_vm_model) do
-      Class.new(ActsAsArModel) do
-        def self.vm_ids
-          @vm_ids ||= []
-        end
-
-        def self.vm_ids=(new_ids)
-          @vm_ids = new_ids
-        end
-
-        def self.aar_scope
-          Vm.where(:id => vm_ids)
-        end
-      end
-    end
-
-    it ".all" do
-      good = FactoryGirl.create_list(:vm, 3)
-      bad = FactoryGirl.create_list(:vm, 1)
-
-      important_vm_model.vm_ids += good.map(&:id)
-
-      expect(important_vm_model.all.order(:id)).to eq(good)
-      expect(important_vm_model.all.order('id desc').first).to eq(good.last)
-      expect(important_vm_model.first).to eq(good.first)
-      expect(important_vm_model.last).to eq(good.last)
-      expect(important_vm_model.all.count).to eq(3)
-      expect(important_vm_model.all.order('id desc').first).to eq(good.last)
-      expect(important_vm_model.where(:id => good.last.id).count).to eq(1)
-      expect(important_vm_model.where(:id => bad.last.id).count).to eq(0)
-    end
   end
 end

--- a/spec/lib/acts_as_ar_scope_spec.rb
+++ b/spec/lib/acts_as_ar_scope_spec.rb
@@ -1,0 +1,42 @@
+describe ActsAsArScope do
+  context "AR backed model" do
+    # model contains ids of important vms - acts like ar model
+    let(:important_vm_model) do
+      Class.new(ActsAsArScope) do
+        def self.vm_ids
+          @vm_ids ||= []
+        end
+
+        def self.vm_ids=(new_ids)
+          @vm_ids = new_ids
+        end
+
+        def self.aar_scope
+          Vm.where(:id => vm_ids)
+        end
+      end
+    end
+
+    it "delegates to :aar_scope" do
+      good = FactoryGirl.create_list(:vm, 3)
+      bad = FactoryGirl.create_list(:vm, 1)
+
+      important_vm_model.vm_ids += good.map(&:id)
+
+      expect(important_vm_model.all.order(:id)).to eq(good)
+      expect(important_vm_model.all.order('id desc').first).to eq(good.last)
+      expect(important_vm_model.all.count).to eq(3)
+      expect(important_vm_model.first).to eq(good.first)
+      expect(important_vm_model.last).to eq(good.last)
+      expect(important_vm_model.order(:id => 'desc').first).to eq(good.last)
+      expect(important_vm_model.limit(1).order('id desc')).to eq([good.last])
+      expect(important_vm_model.offset(good.size - 1).order(:id)).to eq([good.last])
+      expect(important_vm_model.where(:id => good.last.id).count).to eq(1)
+      expect(important_vm_model.where(:id => bad.last.id).count).to eq(0)
+      expect(important_vm_model.includes(:ext_management_system).where(:id => good.last.id).count).to eq(1)
+      expect(important_vm_model.order('id desc').first).to eq(good.last)
+      expect(important_vm_model.find(good.first.id)).to eq(good.first)
+      expect(important_vm_model.find_by(:id => good.first.id)).to eq(good.first)
+    end
+  end
+end


### PR DESCRIPTION
There is a way to build a virtual model that works like a regular scope.
This lets us move the `acts_as_active_record_model` implementations towards standard rails models.

This simplifies rbac scope delegation work, and gets us closer to using good old fashioned scopes in rbac.

/cc @Fryguy I simplified this. Closer to getting pure AR here.
