### PR TITLE
Never return [nil] when asked for policy.event_definitions

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -89,7 +89,7 @@ class MiqPolicy < ApplicationRecord
   end
 
   def miq_event_definitions
-    miq_policy_contents.collect(&:miq_event_definition).uniq
+    miq_policy_contents.collect(&:miq_event_definition).compact.uniq
   end
   alias_method :events, :miq_event_definitions
 

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -100,6 +100,16 @@ describe MiqPolicy do
       end
     end
 
+    describe '#miq_event_definitions' do
+      before do
+        policy.miq_policy_contents.push(FactoryGirl.create(:miq_policy_content))
+      end
+
+      it 'lists event definition' do
+        expect(policy.miq_event_definitions).to eq([event])
+      end
+    end
+
     describe "#sync_events, #add_event, #delete_event" do
       let(:new_events) { [FactoryGirl.create(:miq_event_definition), FactoryGirl.create(:miq_event_definition)] }
 


### PR DESCRIPTION
Addressing error on /miq_policy/explorer
```
FATAL -- : Error caught: [NoMethodError] undefined method `description' for nil:NilClass
gems/pending/util/extensions/miq-object.rb:9:in `deep_send'
app/presenters/tree_builder.rb:449:in `block (2 levels) in count_only_or_objects'
app/presenters/tree_builder.rb:449:in `collect'
app/presenters/tree_builder.rb:449:in `block in count_only_or_objects'
app/presenters/tree_builder.rb:449:in `each'
app/presenters/tree_builder.rb:449:in `sort_by'
app/presenters/tree_builder.rb:449:in `count_only_or_objects'
app/presenters/tree_builder_policy_profile.rb:36:in `x_get_tree_po_kids'
app/presenters/tree_builder.rb:388:in `x_get_tree_objects'
app/presenters/tree_builder.rb:417:in `x_build_node'
app/presenters/tree_builder.rb:418:in `block in x_build_node'
app/presenters/tree_builder.rb:417:in `map'
app/presenters/tree_builder.rb:417:in `x_build_node'
app/presenters/tree_builder.rb:435:in `x_build_node_dynatree'
app/presenters/tree_builder.rb:313:in `block in x_build_dynatree'
app/presenters/tree_builder.rb:308:in `map'
app/presenters/tree_builder.rb:308:in `x_build_dynatree'
app/presenters/tree_builder.rb:245:in `build_tree'
app/presenters/tree_builder.rb:173:in `initialize'
app/controllers/application_controller/feature.rb:28:in `new'
app/controllers/application_controller/feature.rb:28:in `build_tree'
app/controllers/miq_policy_controller.rb:262:in `block in explorer'
app/controllers/miq_policy_controller.rb:262:in `collect'
app/controllers/miq_policy_controller.rb:262:in `explorer'
```