### PR TITLE
Container provider timeline crash

### DIFF
--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -1,0 +1,96 @@
+module ReportFormatter
+  class TimelineMessage
+    include CompressedIds
+
+    def vm_name
+      "<a href=\"/vm/show/#{to_cid(@event.vm_or_template_id)}\">#{@text}</a>" if @event.vm_or_template_id
+    end
+
+    def src_vm_name
+      "<a href=\"/vm/show/#{to_cid(@event.src_vm_or_template.id)}\">#{@text}</a>" if @event.src_vm_or_template
+    end
+
+    def dest_vm_name
+      "<a href=\"/vm/show/#{to_cid(@event.dest_vm_or_template_id)}\">#{@text}</a>" if @event.dest_vm_or_template_id
+    end
+
+    def host_name
+      "<a href=\"/host/show/#{to_cid(@event.host_id)}\">#{@text}</a>" if @event.host_id
+    end
+
+    def dest_host_name
+      "<a href=\"/host/show/#{to_cid(@event.dest_host_id)}\">#{@text}</a>" if @event.dest_host_id
+    end
+
+    def ems_cluster_name
+      "<a href=\"/ems_cluster/show/#{to_cid(@event.ems_cluster_id)}\">#{@text}</a>" if @event.ems_cluster_id
+    end
+
+    def availability_zone_name
+      if @event.availability_zone_id
+        "<a href=\"/availability_zone/show/#{to_cid(@event.availability_zone_id)}\">#{@text}</a>"
+      end
+    end
+
+    def container_node_name
+      "<a href=\"/container_node/show/#{to_cid(@event.container_node_id)}\">#{@text}</a>" if @event.container_node_id
+    end
+
+    def container_group_name
+      "<a href=\"/container_group/show/#{to_cid(@event.container_group_id)}\">#{@text}</a>" if @event.container_group_id
+    end
+
+    def container_name
+      "<a href=\"/container/tree_select/?id=cnt-#{to_cid(@event.container_id)}\">#{@text}</a>" if @event.container_id
+    end
+
+    def container_replicator_name
+      if @event.container_replicator_id
+        "<a href=\"/container_replicator/show/#{to_cid(@event.container_replicator_id)}\">#{@text}</a>"
+      end
+    end
+
+    def ext_management_system_name
+      if @event.ext_management_system && @event.ext_management_system.id
+        provider_id = @event.ext_management_system.id
+        if @ems_cloud
+          # restful route is used for cloud provider unlike infrastructure provider
+          "<a href=\"/ems_cloud/#{provider_id}\">#{@text}</a>"
+        elsif @ems_container
+          "<a href=\"/ems_container/#{to_cid(provider_id)}\">#{@text}</a>"
+        else
+          "<a href=\"/ems_infra/#{to_cid(provider_id)}\">#{@text}</a>"
+        end
+      end
+    end
+
+    def resource_name
+      if mri.db == 'BottleneckEvent'
+        db = if @ems_cloud && @event.resource_type == 'ExtManagementSystem'
+               'ems_cloud'
+             elsif @event.resource_type == 'ExtManagementSystem'
+               'ems_infra'
+             else
+               @event.resource_type.underscore
+             end
+        "<a href=\"/#{db}/#{to_cid(@event.resource_id)}\">#{@event.resource_name}</a>"
+      end
+    end
+
+    def set_parameters(column, row, event, flags)
+      @event, @ems_cloud, @ems_container = event, flags[:ems_cloud], flags[:ems_container]
+      @text = if row[column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(column)
+                format_timezone(Time.parse(row[column].to_s).utc, flags[:time_zone], "gtl")
+              else
+                row[column].to_s
+              end
+    end
+
+    def message_html(column, row, event, flags)
+      set_parameters(column, row, event, flags)
+
+      field = column.tr('.', '_').to_sym
+      respond_to?(field) ? send(field).to_s : @text
+    end
+  end
+end

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -29,3 +29,59 @@ describe ReportFormatter::ReportTimeline do
     end
   end
 end
+
+describe ReportFormatter::TimelineMessage do
+  describe '#message_html on container event' do
+    row = {}
+    let(:ems) { FactoryGirl.create(:ems_redhat, :id => 42) }
+    let(:event) do
+      FactoryGirl.create(:ems_event,
+                         :event_type            => 'CONTAINER_CREATED',
+                         :ems_id                => 6,
+                         :container_group_name  => 'hawkular-cassandra-1-wb1z6',
+                         :container_namespace   => 'openshift-infra',
+                         :container_name        => 'hawkular-cassandra-1',
+                         :ext_management_system => ems)
+    end
+
+    flags = {:ems_cloud     => false,
+             :ems_container => true,
+             :time_zone     => nil}
+    tests = {'event_type'                 => 'test timeline',
+             'ext_management_system.name' => '<a href="/ems_container/42">test timeline</a>',
+             'container_node_name'        => ''}
+
+    tests.each do |column, href|
+      it "Evaluate column #{column} content" do
+        row[column] = 'test timeline'
+        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags)
+        expect(val).to eq(href)
+      end
+    end
+  end
+
+  describe '#message_html on vm event' do
+    row = {}
+    let(:vm) { FactoryGirl.create(:vm_redhat, :id => 42) }
+    let(:event) do
+      FactoryGirl.create(:ems_event,
+                         :event_type     => 'VM_CREATED',
+                         :vm_or_template => vm)
+    end
+
+    flags = {:ems_cloud     => false,
+             :ems_container => false,
+             :time_zone     => nil}
+    tests = {'event_type'                 => 'test timeline',
+             'ext_management_system.name' => '',
+             'src_vm_name'                => '<a href="/vm/show/42">test timeline</a>'}
+
+    tests.each do |column, href|
+      it "Evaluate column #{column} content" do
+        row[column] = 'test timeline'
+        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags)
+        expect(val).to eq(href)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix container provider timeline crash.

Add checks, and remove unnecessary checks, for fields before using them.

**Before**:
Issue: https://github.com/ManageIQ/manageiq/issues/6508
![screenshot-2016-04-25-11-28-22](https://cloud.githubusercontent.com/assets/2181522/14778010/39449832-0ad9-11e6-97e5-469660812ab7.png)

**After**:
![screenshot-2016-04-25-11-30-15](https://cloud.githubusercontent.com/assets/2181522/14778003/2f346098-0ad9-11e6-914a-eaf199d2ad1e.png)

