### PR TITLE
Fix broken non-automate selects

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1228,16 +1228,21 @@ function miqInitSelectPicker() {
   $('.bootstrap-select > button[title]').not('.selectpicker').tooltip({container: 'none'});
 }
 
-function miqSelectPickerEvent(element, url, options){
-  $('#' + element).on('change', function(){
-    var selected = $('#' + element).val();
-    options =  typeof options !== 'undefined' ? options : {};
-    options.no_encoding = true;
+function miqSelectPickerEvent(element, url, options) {
+  options = options || {};
+  options.no_encoding = true;
+  var firstarg = ! _.contains(url, '?');
 
-    var firstarg = ! _.contains(url, '?');
-    $.when(miqJqueryRequest(url + (firstarg ? '?' : '&') + element + '=' + escape(selected), options)).done(function() {
-      options.callback.call();
+  $('#' + element).on('change', function() {
+    var selected = $(this).val();
+    var finalUrl = url + (firstarg ? '?' : '&') + element + '=' + escape(selected);
+
+    miqJqueryRequest(finalUrl, options).done(function() {
+      if (options.callback) {
+        options.callback();
+      }
     });
+
     return true;
   });
 }

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -141,6 +141,7 @@ describe('miq_application.js', function() {
       var html = '<div class="col-md-4 ui-sortable" id="col1"><div id="t_0|10000000000764" title="Drag this Tab to a new location"></div><div id="t_3|" title="Drag this Tab to a new location" class=""></div><div id="t_1|10000000000765" title="Drag this Tab to a new location"></div><div id="t_2|10000000000766" title="Drag this Tab to a new location"></div></div>'
       setFixtures(html);
     });
+
     it('updates element Id with new order', function () {
       ManageIQ.widget.dashboardUrl = 'dialog_res_reorder';
       miqUpdateElementsId($('.col-md-4'));
@@ -148,6 +149,27 @@ describe('miq_application.js', function() {
         return e.id;
       }).toArray().join(" ");
       expect(str).toEqual("t_0|10000000000764 t_1| t_2|10000000000765 t_3|10000000000766")
+    });
+  });
+
+  describe('miqSelectPickerEvent', function () {
+    beforeEach(function () {
+      var html = '<input id="miq-select-picker-1" value="bar">';
+      setFixtures(html);
+    });
+
+    it("doesn't die on null callback", function() {
+      spyOn(window, 'miqJqueryRequest').and.returnValue({
+        done: function(fn) { fn(); },
+      });
+
+      miqSelectPickerEvent('miq-select-picker-1', '/foo/');
+
+      $('#miq-select-picker-1').val('quux').trigger('change');
+
+      expect(miqJqueryRequest).toHaveBeenCalledWith('/foo/?miq-select-picker-1=quux', {
+        no_encoding: true,
+      });
     });
   });
 


### PR DESCRIPTION
Since #7661, `miqSelectPickerEvent` fails when not passed `callback` in options - yet that callback is only passed in for automate selects - which means it broke every other select in the UI :).

Adding a spec to catch this the next time, `miqSelectPickerEvent` now only attempts to call `callback` when passed one.

@eclarizio Can you take a look please? Also, in the last commit, I refactored the `attemptAutoRefreshTrigger` logic to get rid of the duplications and just define it once...

@miq-bot add_label bug, ui

Closes #7814, closes #7848, closes #7866 