### PR TITLE
JS specs - fail on parse errors

### DIFF
--- a/spec/javascripts/helpers/fail-on-error.js
+++ b/spec/javascripts/helpers/fail-on-error.js
@@ -1,0 +1,20 @@
+// if you get a failing test in this file, most likely, *another* spec
+// file has a syntax error, causing all the tests inside to be skipped
+
+window.was_syntax_error = null;
+
+window.onerror = function(err) {
+  window.was_syntax_error = err;
+  console.error(err);
+};
+
+window.addEventListener('error', function(err) {
+  window.was_syntax_error = err;
+  console.error(err);
+}, true);
+
+describe("Parse errors", function() {
+  it("shouldn't happen", function() {
+    expect(window.was_syntax_error).toEqual(null);
+  });
+});


### PR DESCRIPTION
When a js spec file has a syntax error, only a small error in the browser console is shown (nothing when running under rake test:javascript), and all the tests in that particular file are skipped.

This adds another js test, that should fail whenever a file had a syntax error, so that we can at least notice these failures.

~~Current test failure unrelated(-ish) - https://github.com/ManageIQ/manageiq/issues/7859.~~
~~(Though we may want to hold off merging until that one is fixed, so that people don't get failing tests for surprising reasons.)~~