### PR TITLE
Fix for used disk size not showing up on VMs

### DIFF
--- a/gems/pending/metadata/VmConfig/VmConfig.rb
+++ b/gems/pending/metadata/VmConfig/VmConfig.rb
@@ -612,9 +612,8 @@ class VmConfig
         vimDs = miqvm.vim.getVimDataStore(ds)
       end
 
-      configType = "vmx"
-      require configType + "Config"
-      extend Kernel.const_get(configType.capitalize + "Config")
+      require "metadata/VmConfig/vmxConfig"
+      extend Kernel.const_get("VmxConfig")
       snapshot_file = File.join(dir, File.basename(name, ".*") + ".vmsd")
       Timeout.timeout(60) do
         process_file(convert_vmsd(vimDs.get_file_content(snapshot_file)))


### PR DESCRIPTION
Fix a broken require which was throwing an exception when running
SSA on a VM.  This caused no XML to be returned for the disks
section of VmConfig, so the "Used Size" and "Partitions Aligned"
were always empty for a VM.

https://bugzilla.redhat.com/show_bug.cgi?id=1322902