### PR TITLE
Skip a test which causes sporadic failure

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -91,7 +91,7 @@ describe "MiqAeMethodDispatch" do
                                    'ae_instances' => ae_instances))
   end
 
-  it "long running method" do
+  it "long running method", :skip => "Fails sporadically because 2 seconds is not long enough" do
     File.delete(@pidfile) if File.exist?(@pidfile)
     setup_model(rip_van_winkle_script)
     # Set the timeout to 2 seconds so we can terminate


### PR DESCRIPTION
The test expects Automate to launch the method in 2 seconds. In some
scenations it takes longer than 2 seconds and we get sporadic failures.
Removing it temporarily till we can write a better test around this

https://github.com/ManageIQ/manageiq/pull/7679#issuecomment-206683273