### PR TITLE
Refactor Field to leverage arel table

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -642,28 +642,23 @@ class MiqExpression
     when "equal", "="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      table = Arel::Table.new(field.table_name)
-      clause = table[field.column].eq(Arel::Nodes::Quoted.new(exp[operator]["value"])).to_sql
+      clause = field.arel_table[field.column].eq(exp[operator]["value"]).to_sql
     when ">"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      table = Arel::Table.new(field.table_name)
-      clause = table[field.column].gt(Arel::Nodes::Quoted.new(exp[operator]["value"])).to_sql
+      clause = field.arel_table[field.column].gt(exp[operator]["value"]).to_sql
     when ">="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      table = Arel::Table.new(field.table_name)
-      clause = table[field.column].gteq(Arel::Nodes::Quoted.new(exp[operator]["value"])).to_sql
+      clause = field.arel_table[field.column].gteq(exp[operator]["value"]).to_sql
     when "<"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      table = Arel::Table.new(field.table_name)
-      clause = table[field.column].lt(Arel::Nodes::Quoted.new(exp[operator]["value"])).to_sql
+      clause = field.arel_table[field.column].lt(exp[operator]["value"]).to_sql
     when "<="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      table = Arel::Table.new(field.table_name)
-      clause = table[field.column].lteq(Arel::Nodes::Quoted.new(exp[operator]["value"])).to_sql
+      clause = field.arel_table[field.column].lteq(exp[operator]["value"]).to_sql
     when "!=", "before", "after"
       col_type = self.class.get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if col_type == :date || col_type == :datetime

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -642,23 +642,23 @@ class MiqExpression
     when "equal", "="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_table[field.column].eq(exp[operator]["value"]).to_sql
+      clause = field.arel_attribute.eq(exp[operator]["value"]).to_sql
     when ">"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_table[field.column].gt(exp[operator]["value"]).to_sql
+      clause = field.arel_attribute.gt(exp[operator]["value"]).to_sql
     when ">="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_table[field.column].gteq(exp[operator]["value"]).to_sql
+      clause = field.arel_attribute.gteq(exp[operator]["value"]).to_sql
     when "<"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_table[field.column].lt(exp[operator]["value"]).to_sql
+      clause = field.arel_attribute.lt(exp[operator]["value"]).to_sql
     when "<="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_table[field.column].lteq(exp[operator]["value"]).to_sql
+      clause = field.arel_attribute.lteq(exp[operator]["value"]).to_sql
     when "!=", "before", "after"
       col_type = self.class.get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if col_type == :date || col_type == :datetime

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -642,23 +642,23 @@ class MiqExpression
     when "equal", "="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_attribute.eq(exp[operator]["value"]).to_sql
+      clause = field.eq(exp[operator]["value"]).to_sql
     when ">"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_attribute.gt(exp[operator]["value"]).to_sql
+      clause = field.gt(exp[operator]["value"]).to_sql
     when ">="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_attribute.gteq(exp[operator]["value"]).to_sql
+      clause = field.gteq(exp[operator]["value"]).to_sql
     when "<"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_attribute.lt(exp[operator]["value"]).to_sql
+      clause = field.lt(exp[operator]["value"]).to_sql
     when "<="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.arel_attribute.lteq(exp[operator]["value"]).to_sql
+      clause = field.lteq(exp[operator]["value"]).to_sql
     when "!=", "before", "after"
       col_type = self.class.get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if col_type == :date || col_type == :datetime

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -29,8 +29,6 @@ class MiqExpression::Field
     column_type == :datetime
   end
 
-  private
-
   def target
     if associations.none?
       model
@@ -38,6 +36,8 @@ class MiqExpression::Field
       associations.last.classify.constantize
     end
   end
+
+  private
 
   def column_type
     target.type_for_attribute(column).type

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -29,6 +29,10 @@ class MiqExpression::Field
     column_type == :datetime
   end
 
+  def arel_attribute
+    arel_table[column]
+  end
+
   def target
     if associations.none?
       model

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -13,7 +13,7 @@ class MiqExpression::Field
   end
 
   attr_reader :model, :associations, :column
-  delegate :arel_table, :to => :target
+  delegate :eq, :not_eq, :lteq, :gteq, :lt, :gt, :to => :arel_attribute
 
   def initialize(model, associations, column)
     @model = model
@@ -29,10 +29,6 @@ class MiqExpression::Field
     column_type == :datetime
   end
 
-  def arel_attribute
-    arel_table[column]
-  end
-
   def target
     if associations.none?
       model
@@ -42,6 +38,12 @@ class MiqExpression::Field
   end
 
   private
+
+  delegate :arel_table, :to => :target
+
+  def arel_attribute
+    arel_table[column]
+  end
 
   def column_type
     target.type_for_attribute(column).type

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -13,7 +13,7 @@ class MiqExpression::Field
   end
 
   attr_reader :model, :associations, :column
-  delegate :table_name, :to => :target
+  delegate :arel_table, :to => :target
 
   def initialize(model, associations, column)
     @model = model

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -39,10 +39,8 @@ class MiqExpression::Field
 
   private
 
-  delegate :arel_table, :to => :target
-
   def arel_attribute
-    arel_table[column]
+    target.arel_attribute(column)
   end
 
   def column_type

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -87,15 +87,15 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
-  describe "#table_name" do
-    it "returns the table name of the model when there are no associations" do
+  describe "#target" do
+    it "returns the model when there are no associations" do
       field = described_class.new(Vm, [], "name")
-      expect(field.table_name).to eq("vms")
+      expect(field.target).to eq(Vm)
     end
 
-    it "returns the table name of the target association if there are associations" do
+    it "returns the model of the target association if there are associations" do
       field = described_class.new(Vm, ["guest_applications"], "name")
-      expect(field.table_name).to eq("guest_applications")
+      expect(field.target).to eq(GuestApplication)
     end
   end
 end

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -19,22 +19,22 @@ describe MiqExpression do
 
     it "generates the SQL for a < expression" do
       sql, * = described_class.new("<" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
-      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" < '2'")
+      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" < 2")
     end
 
     it "generates the SQL for a <= expression" do
       sql, * = described_class.new("<=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
-      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" <= '2'")
+      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" <= 2")
     end
 
     it "generates the SQL for a > expression" do
       sql, * = described_class.new(">" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
-      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" > '2'")
+      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" > 2")
     end
 
     it "generates the SQL for a >= expression" do
       sql, * = described_class.new(">=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
-      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" >= '2'")
+      expect(sql).to eq("\"hardwares\".\"cpu_sockets\" >= 2")
     end
 
     it "generates the SQL for a LIKE expression" do


### PR DESCRIPTION
This change internalizes the process of creating an arel table using a field's data into `Field` itself. It goes a little further in adding some sugar to `Field` by delegating the Arel methods to provide a neater interface:

```ruby
field.eq(some_value).to_sql
```

I believe that because of this change values do not need to be quoted anymore (at least it won't complain if they aren't).

Minor, but this change also makes `Field#target` public because it contains some important logic I could no longer test indirectly through `Field#table_name` (which was removed). Not ideal IMO but will do for now.

Note: https://github.com/ManageIQ/manageiq/pull/7871, https://github.com/ManageIQ/manageiq/pull/7870, https://github.com/ManageIQ/manageiq/pull/7842, https://github.com/ManageIQ/manageiq/pull/7837 will all have to be updated if this gets merged first. If it gets merged last, I'll have to update this PR to accommodate those changes.

/cc @kbrock @gtanzillo @yrudman 
@miq-bot add-label refactoring, core