### PR TITLE
Fix action_url for gtl view showing provisioned vms

### DIFF
--- a/app/views/miq_request/_provisions.html.haml
+++ b/app/views/miq_request/_provisions.html.haml
@@ -1,2 +1,2 @@
 #main_div
-  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  = render :partial => "layouts/gtl", :locals => {:action_url => "show"}


### PR DESCRIPTION
This is to fix the following error thrown by link_to():

```
No route matches {:action=>"show/10000000000272", :controller=>"miq_request", :id=>"10000000000272", :sort_choice=>"Status"}
```

seen when navigating to `Services -> Requests -> [fulfilled provisioning request]` -> Provisioned VMs

https://bugzilla.redhat.com/show_bug.cgi?id=1317074