### PR TITLE
SSA: Save parent file handle for Qcow type of disk

### DIFF
--- a/gems/pending/disk/modules/QcowDisk.rb
+++ b/gems/pending/disk/modules/QcowDisk.rb
@@ -116,7 +116,7 @@ module QcowDisk
     @downstreamDisk = dInfo.downstreamDisk
     self.diskType = "#{diskType}-#{@downstreamDisk.diskType}" if @downstreamDisk
 
-    # save the handle for Qcow disks in case of opening their parent disks
+    # Ensure all the disks in the chain are opened before we return (required to address RHEV SSA UID issues).
     backing_file_handle
   end
 

--- a/gems/pending/disk/modules/QcowDisk.rb
+++ b/gems/pending/disk/modules/QcowDisk.rb
@@ -115,6 +115,9 @@ module QcowDisk
     @dOffset = dInfo.offset
     @downstreamDisk = dInfo.downstreamDisk
     self.diskType = "#{diskType}-#{@downstreamDisk.diskType}" if @downstreamDisk
+
+    # save the handle for Qcow disks in case of opening their parent disks
+    backing_file_handle
   end
 
   def getBase


### PR DESCRIPTION
Keep using euid 36 to save the backing_file_handle in Qcow disk, in case of parent disks are opened.

https://bugzilla.redhat.com/show_bug.cgi?id=1321282