### PR TITLE
Fix replication specs

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1239,7 +1239,6 @@
         - chargeback_rates
         - conditions
         - conditions_miq_policies
-        - configurations
         - custom_buttons
         - customization_specs
         - database_backups

--- a/db/migrate/20160405151142_remove_configurations_from_replication_excludes.rb
+++ b/db/migrate/20160405151142_remove_configurations_from_replication_excludes.rb
@@ -1,0 +1,26 @@
+class RemoveConfigurationsFromReplicationExcludes < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    serialize :value
+  end
+
+  EXCLUDES_KEY = "/workers/worker_base/replication_worker/replication/exclude_tables".freeze
+
+  def up
+    say_with_time("Removing configurations from replication excludes") do
+      SettingsChange.where(:key => EXCLUDES_KEY).each do |s|
+        s.value.delete("configurations")
+        s.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time("Adding configurations to replication excludes") do
+      SettingsChange.where(:key => EXCLUDES_KEY).each do |s|
+        s.value << "configurations"
+        s.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20160405151142_remove_configurations_from_replication_excludes_spec.rb
+++ b/spec/migrations/20160405151142_remove_configurations_from_replication_excludes_spec.rb
@@ -1,0 +1,39 @@
+require_migration
+
+describe RemoveConfigurationsFromReplicationExcludes do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+  let(:server_one)           { FactoryGirl.create(:miq_server) }
+  let(:server_two)           { FactoryGirl.create(:miq_server) }
+
+  migration_context :up do
+    it "removes configurations from the replication excludes" do
+      server_one.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(configurations schema_migrations))
+      server_two.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(configurations ar_internal_metadata))
+
+      migrate
+
+      changes = settings_change_stub.where(:key => described_class::EXCLUDES_KEY)
+      changes.each { |c| expect(c.value).not_to include("configurations") }
+    end
+  end
+
+  migration_context :down do
+    it "adds configurations to the replication excludes" do
+      server_one.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(schema_migrations))
+      server_two.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(ar_internal_metadata))
+
+      migrate
+
+      changes = settings_change_stub.where(:key => described_class::EXCLUDES_KEY)
+      changes.each { |c| expect(c.value).to include("configurations") }
+    end
+  end
+end

--- a/spec/replication/replication_helper.rb
+++ b/spec/replication/replication_helper.rb
@@ -1,9 +1,0 @@
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/replication/support/ and its subdirectories.
-Dir[Rails.root.join("spec/replication/support/**/*.rb")].each { |f| require f }
-
-RSpec.configure do |config|
-  # Removing transactions for replication tests, since testing involves
-  #   shelling out to rake tasks, and thus the database must be persisted.
-  config.use_transactional_fixtures = false
-end

--- a/spec/replication/replication_spec.rb
+++ b/spec/replication/replication_spec.rb
@@ -1,6 +1,6 @@
-require_relative "./replication_helper"
-
 describe "pglogical replication" do
+  self.use_transactional_tests = false
+
   let(:slave_db_name)        { Rails.configuration.database_configuration[Rails.env]["database"] }
   let(:master_db_name)       { "#{slave_db_name}_master" }
   let(:replication_set_name) { "test_rep_set" }


### PR DESCRIPTION
Remove the `configurations` table from the excludes and change the way the replication test suite handles transactional tests.

@Fryguy @gtanzillo @bdunne 