### PR TITLE
Incorrect priority order of domains

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1581,7 +1581,7 @@ class MiqAeClassController < ApplicationController
       domains = @edit[:new][:domain_order].reverse!.collect do |domain|
         MiqAeDomain.find_by_name(domain.split(' (Locked)').first).id
       end
-      MiqAeDomain.reset_priority_by_ordered_ids(domains)
+      current_tenant.reset_domain_priority_by_ordered_ids(domains)
       add_flash(_("Priority Order was saved"))
       @sb[:action] = @in_a_form = @edit = session[:edit] = nil  # clean out the saved info
       replace_right_cell([:ae])

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -242,7 +242,7 @@ class Tenant < ApplicationRecord
 
   def reset_domain_priority_by_ordered_ids(ids)
     uneditable_domains = visible_domains - editable_domains
-    uneditable_domains.delete_if { |domain| domain.name == 'ManageIQ' }
+    uneditable_domains.delete_if { |domain| domain.name == MiqAeDatastore::MANAGEIQ_DOMAIN }
     MiqAeDomain.reset_priority_by_ordered_ids(uneditable_domains.collect(&:id) + ids)
   end
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -240,6 +240,12 @@ class Tenant < ApplicationRecord
     ae_domains.where(:system => false).count > 0
   end
 
+  def reset_domain_priority_by_ordered_ids(ids)
+    uneditable_domains = visible_domains - editable_domains
+    uneditable_domains.delete_if { |domain| domain.name == 'ManageIQ' }
+    MiqAeDomain.reset_priority_by_ordered_ids(uneditable_domains.collect(&:id) + ids)
+  end
+
   # The default tenant is the tenant to be used when
   # the url does not map to a known domain or subdomain
   #

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -439,6 +439,24 @@ describe Tenant do
     let(:t1_1) { FactoryGirl.create(:tenant, :name => 'T1_1', :domain => 'a.a.com', :parent => t1) }
     let(:t2_2) { FactoryGirl.create(:tenant, :name => 'T2_1', :domain => 'b.b.com', :parent => t2) }
 
+    context "reset priority" do
+      it "#reset_domain_priority_by_ordered_ids" do
+        FactoryGirl.create(:miq_ae_domain, :name => 'ManageIQ', :priority => 0,
+                           :tenant_id => root_tenant.id, :system => true)
+        FactoryGirl.create(:miq_ae_domain, :name => 'Redhat', :priority => 1,
+                           :tenant_id => root_tenant.id, :system => true)
+        dom3 = FactoryGirl.create(:miq_ae_domain, :name => 'A', :tenant_id => root_tenant.id)
+        dom4 = FactoryGirl.create(:miq_ae_domain, :name => 'B', :tenant_id => root_tenant.id)
+
+        expect(root_tenant.visible_domains.collect(&:name)).to eq(%w(B A Redhat ManageIQ))
+        ids = [dom4.id, dom3.id]
+        root_tenant.reset_domain_priority_by_ordered_ids(ids)
+        expect(root_tenant.visible_domains.collect(&:name)).to eq(%w(A B Redhat ManageIQ))
+        dom4.reload
+        expect(dom4.priority).to eq(2)
+      end
+    end
+
     context "visibility" do
       before do
         dom1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1324094

With the tenant changes we only allow the user to change the priority
of editable domains, when reseting the priority order the locked domains
don't get accounted for and the priority values are off.