### PR TITLE
Fix issue where some workers would delay their start for ~5 minutes

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -243,7 +243,6 @@ class MiqServer < ApplicationRecord
     end
 
     server.update_attributes(server_hash)
-    my_server_clear_cache
 
     _log.info("Server IP Address: #{server.ipaddress}")    unless server.ipaddress.blank?
     _log.info("Server Hostname: #{server.hostname}")       unless server.hostname.blank?


### PR DESCRIPTION
The server object in question is also the same as the object held by the
MiqServer.my_server cache.  When the cache is cleared this clears
the local object from the cache.  Thus, later calls to
MiqWorker.has_required_role? will end up getting a fresh object.
However, that fresh object does not yet have the roles properly set up
yet, and the workers fail to start.

Previously this code worked because the old VMDB::Config would more
frequently clear the MiqServer.my_server cache.  Thus, at some point
after setting the roles, but before has_required_role? was called, the
cache would be cleared.  As this no longer happens, the server's monitor
loop would have to wait for the MiqServer.my_server cache to clear,
which is at most 5 minutes.

We don't need to clear the cache at startup as the object we are working
on is accurate, and will be persisted at the appropriate time.  Thus, we
can just avoid creating a new cache object entirely, and calls to
MiqServer.my_server will have accurate data.

Fixes #7781 

@blomquisg @chessbyte @jrafanie Please review
cc @roliveri @agrare @jerryk55 