### PR TITLE
Appliance Console summary screen fix.

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -36,6 +36,11 @@ I18n.backend.load_translations
 $terminal.wrap_at = 80
 $terminal.page_at = 25
 
+def summary_entry(field, value)
+  dfield = "#{field}:"
+  "#{dfield.ljust(24)} #{value}"
+end
+
 require 'appliance_console/errors'
 
 [:INT, :TERM, :ABRT, :TSTP].each { |s| trap(s) { raise MiqSignalError } }
@@ -116,21 +121,22 @@ module ApplianceConsole
       configured = ApplianceConsole::DatabaseConfiguration.configured?
 
       summary_attributes = [
-        "Hostname:", host,
-        "IP Address:", ip,
-        "Netmask:", mask,
-        "Gateway:", gw,
-        "Primary DNS:", dns1,
-        "Secondary DNS:", dns2,
-        "Search Order:", order,
-        "MAC Address:", mac,
-        "Timezone:", timezone,
-        "Local Database:", ApplianceConsole::Utilities.pg_status,
-        "#{I18n.t("product.name")} Database:", configured ? "postgres @ #{dbhost || "localhost"}" : "not configured",
-        "Database/Region:", configured ? "#{database} / #{region || 0}" : "not configured",
-        "External Auth:", ExternalHttpdAuthentication.config_status,
-        "#{I18n.t("product.name")} Version:", version,
-        "#{I18n.t("product.name")} Console:", configured ? "https://#{ip}" : "not configured"
+        summary_entry("Hostname", host),
+        summary_entry("IP Address", ip),
+        summary_entry("Netmask", mask),
+        summary_entry("Gateway", gw),
+        summary_entry("Primary DNS", dns1),
+        summary_entry("Secondary DNS", dns2),
+        summary_entry("Search Order", order),
+        summary_entry("MAC Address", mac),
+        summary_entry("Timezone", timezone),
+        summary_entry("Local Database", ApplianceConsole::Utilities.pg_status),
+        summary_entry("#{I18n.t("product.name")} Database",
+                      configured ? "postgres @ #{dbhost || "localhost"}" : "not configured"),
+        summary_entry("Database/Region", configured ? "#{database} / #{region || 0}" : "not configured"),
+        summary_entry("External Auth", ExternalHttpdAuthentication.config_status),
+        summary_entry("#{I18n.t("product.name")} Version", version),
+        summary_entry("#{I18n.t("product.name")} Console", configured ? "https://#{ip}" : "not configured")
       ]
 
       clear_screen
@@ -140,7 +146,7 @@ Welcome to the #{I18n.t("product.name")} Virtual Appliance.
 
 To modify the configuration, use a web browser to access the management page.
 
-#{$terminal.list(summary_attributes, :columns_across, 2)}
+#{$terminal.list(summary_attributes)}
         EOL
 
       press_any_key


### PR DESCRIPTION
Assures that not all lines get wrapped around if just one row needs to.

**Before**:
```text
Welcome to the ManageIQ Virtual Appliance.

To modify the configuration, use a web browser to access the management page.

Hostname:                                             
somehost.some.domain.com                      
IP Address:                                            1.2.3.4                

Netmask:                                               255.255.255.0            

Gateway:                                               1.2.3.5              

Primary DNS:                                           1.2.3.6               

Secondary DNS:                                         1.2.3.7              

Search Order:                                         
some.long.optional.domain.name.com some.domain.com
MAC Address:                                           00:50:56:b3:bf:ff        

Timezone:                                              America/New_York         

Local Database:                                        running                  

ManageIQ Database:                                     postgres @ localhost

-- press enter/return to continue or q to stop -- 

Database/Region:                                       vmdb_production / 0      

External Auth:                                         not configured           

ManageIQ Version:                                      master                   

ManageIQ Console:                                      https://1.2.3.4        



Press any key to continue.

```

**After**:
```text
Welcome to the ManageIQ Virtual Appliance.

To modify the configuration, use a web browser to access the management page.

Hostname:                somehost.some.domain.com
IP Address:              1.2.3.4
Netmask:                 255.255.255.0
Gateway:                 1.2.3.5
Primary DNS:             1.2.3.6
Secondary DNS:           1.2.3.7
Search Order:            some.long.optional.domain.name.com som
e.domain.com
MAC Address:             00:50:56:b3:bf:ff
Timezone:                America/New_York
Local Database:          running
ManageIQ Database:       postgres @ localhost
Database/Region:         vmdb_production / 0
External Auth:           not configured
ManageIQ Version:        master
ManageIQ Console:        https://1.2.3.4


Press any key to continue.
```
