### PR TITLE
Fix Sat6 subscription organization handling

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -572,9 +572,8 @@ module OpsController::Settings::Common
 
     case @sb[:active_tab]                                               # No @edit[:current].config for Filters since there is no config file
     when 'settings_rhn_edit'
-      for key in [:proxy_address, :use_proxy, :proxy_userid, :proxy_password, :proxy_verify,
-                  :register_to, :server_url, :repo_name, :customer_org,
-                  :customer_userid, :customer_password, :customer_verify]
+      [:proxy_address, :use_proxy, :proxy_userid, :proxy_password, :proxy_verify, :register_to, :server_url, :repo_name,
+       :customer_org, :customer_org_display, :customer_userid, :customer_password, :customer_verify].each do |key|
         new[key] = params[key] if params[key]
       end
       if params[:register_to] || params[:action] == "repo_default_name"

--- a/app/views/ops/_settings_rhn_edit_tab.html.haml
+++ b/app/views/ops/_settings_rhn_edit_tab.html.haml
@@ -92,10 +92,10 @@
           = _("Organization")
         .col-md-8
           - if @edit[:organizations].length == 1
-            = @edit[:new][:customer_org]
+            = @edit[:new][:customer_org_display]
           - else
             = select_tag('customer_org',
-                          options_for_select((@edit[:new][:customer_org] ? [] : [["<Choose>", nil]]) + Array(@edit[:organizations].sort_by { |k, _v| k.downcase }),
+                          options_for_select((@edit[:new][:customer_org_display] ? [] : [["<Choose>", nil]]) + Array(@edit[:organizations].sort_by { |k, _v| k.downcase }),
                                              @edit[:new][:customer_org]),
                           'data-miq_sparkle_on'  => true,
                           'data-miq_sparkle_off' => true,


### PR DESCRIPTION
This was preventing correctly saving the organization name,
which prevented any one from subscribing to updates from Sat6.

Created a new form key which stores the organization display name.

https://bugzilla.redhat.com/show_bug.cgi?id=1301607

@Fryguy @h-kataria please review