### PR TITLE
Include all codemirror js and css sources statically

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -56,6 +56,12 @@
 //= require dynatree/jquery.dynatree
 //= require miq_dynatree
 //= require codemirror
+//= require codemirror/modes/css
+//= require codemirror/modes/htmlmixed
+//= require codemirror/modes/javascript
+//= require codemirror/modes/ruby
+//= require codemirror/modes/shell
+//= require codemirror/modes/xml
 //= require codemirror/modes/yaml
 //= require spin.js/spin
 //= require spin.js/jquery.spin

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,6 +15,7 @@
  *= require schedule_editor
  *= require miq_dynatree
  *= require codemirror
+ *= require codemirror/themes/eclipse
  *= require jqplot
  *= require kubernetes-topology-graph/dist/topology-graph
  *= require jquery-ui-miq-theme/jquery-ui-1.9.2.custom

--- a/app/views/layouts/_my_code_mirror.html.haml
+++ b/app/views/layouts/_my_code_mirror.html.haml
@@ -1,26 +1,12 @@
 - text_area_id ||= "miqNone"
 - url ||= "form_field_changed"
 - mode ||= "yaml"
-- theme ||= "eclipse"
 - line_numbers ||= false
 - height ||= "auto"
 - width ||= "auto"
 - read_only ||= false
-- multi_mode ||= false
 - no_focus ||= false
 
-- if multi_mode
-  - modes.each do |mode|
-    = javascript_include_tag "codemirror/modes/#{mode}"
-- elsif mode == "htmlmixed"
-  = javascript_include_tag "codemirror/modes/javascript"
-  = javascript_include_tag "codemirror/modes/css"
-  = javascript_include_tag "codemirror/modes/#{mode}"
-  = javascript_include_tag "codemirror/modes/xml"
-- else
-  = javascript_include_tag "codemirror/modes/#{mode}"
-- unless theme == "default"
-  = stylesheet_link_tag "codemirror/themes/#{theme}"
 :javascript
   if (miqDomElementExists('#{text_area_id}')) {
     var textarea = $('##{text_area_id}')[0];
@@ -28,7 +14,7 @@
       mode:          '#{mode}',
       lineNumbers:   #{line_numbers},
       matchBrackets: true,
-      theme:         '#{theme}',
+      theme:         'eclipse',
       readOnly:      #{read_only ? "'nocursor'".html_safe : false}
     });
     ManageIQ.editor.on('change', function (cm, change) {

--- a/app/views/pxe/explorer.html.haml
+++ b/app/views/pxe/explorer.html.haml
@@ -14,5 +14,4 @@
 = render(:partial => "/layouts/my_code_mirror",
   :locals => {:text_area_id => "miq_none",
     :mode => "xml",
-    :modes => %w(shell xml),
-    :multi_mode => true})
+    :modes => %w(shell xml)})


### PR DESCRIPTION
After 5ff566f7c5ab2d869bb2f06283c76e9a5765a0d1, all javascript and css includes included via
jQuery would throw an error in javascript console.

Including these sources statically during application start will solve this problem.

@martinpovolny @himdel @h-kataria 