### PR TITLE
Create a new subscription column in the ext_management_systems table.

### DIFF
--- a/db/migrate/20160404152107_add_subscription_to_ext_management_system.rb
+++ b/db/migrate/20160404152107_add_subscription_to_ext_management_system.rb
@@ -1,0 +1,9 @@
+class AddSubscriptionToExtManagementSystem < ActiveRecord::Migration[5.0]
+  def up
+    add_column :ext_management_systems, :subscription, :string
+  end
+
+  def down
+    remove_column :ext_management_systems, :subscription
+  end
+end


### PR DESCRIPTION
This migration is part of a larger solution for the BZ # below. Model changes can be found [here](https://github.com/ManageIQ/manageiq/pull/7905) and [here](https://github.com/ManageIQ/manageiq/pull/7361).
The reason we need a subscription column is to connect to a specific Azure subscription associated with a tenant.

https://bugzilla.redhat.com/show_bug.cgi?id=1318356