### PR TITLE
Bump httpclient for ruby 2.3 deprecation warnings

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -22,7 +22,7 @@ gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
 gem "fog-openstack",           "~>0.1.2",           :require => false
-gem "httpclient",              "~>2.5.3",           :require => false
+gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.1",           :require => false
 gem "kubeclient",              "=1.1.3",            :require => false
 gem "hawkular-client",         "~>0.2.1",           :require => false


### PR DESCRIPTION
Ruby 2.3.0 deprecated Kernel.timeout:

```
/var/lib/gems/2.3.0/gems/httpclient-2.5.3.3/lib/httpclient/session.rb:762:in `connect': Object#timeout is deprecated, use Timeout.timeout instead.
/var/lib/gems/2.3.0/gems/httpclient-2.5.3.3/lib/httpclient/session.rb:624:in `query': Object#timeout is deprecated, use Timeout.timeout instead. 
/var/lib/gems/2.3.0/gems/httpclient-2.5.3.3/lib/httpclient/session.rb:888:in `parse_header': Object#timeout is deprecated, use Timeout.timeout instead.
/var/lib/gems/2.3.0/gems/httpclient-2.5.3.3/lib/httpclient/session.rb:966:in `read_body_length': Object#timeout is deprecated, use Timeout.timeout instead.
/var/lib/gems/2.3.0/gems/httpclient-2.5.3.3/lib/httpclient/session.rb:624:in `query': Object#timeout is deprecated, use Timeout.timeout instead
```

httpclient fixed this in 2.7.1, https://github.com/nahi/httpclient/pull/287

Users of httpclient: VMwareWebService, VcoWebService, ServiceNowWebService, and winrm
winrm requires httpclient ~> 2.2, >= 2.2.0.2