### PR TITLE
Don't install bower globally

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,6 @@ Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system "gem install bundler --conservative"
   system "bundle check || bundle install"
-  system "which bower || npm install -g bower"
   system "bower install --allow-root -F --config.analytics=false"
 
   puts "\n== Copying sample files =="


### PR DESCRIPTION
Currently the "bin/setup" script tries to install bower using the "-g" option.
If Node.js and NPM are installed globally, for example using the RPM packaging
system, the directory where this will try to install will be owned by the
"root" user, thus forcing the complete installation to use the "root" user as
well. This patch changes the script so that it doesn't use the "-g" option,
which works for non-privileged users.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>