### PR TITLE
Show tenant name next to service template name in catalog tree

### DIFF
--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -108,7 +108,7 @@ class TreeNodeBuilder
     when ScanItemSet          then generic_node(object.name, "scan_item_set.png")
     when Service              then generic_node(object.name, object.picture ? "../../../pictures/#{object.picture.basename}" : "service.png")
     when ServiceResource      then generic_node(object.resource_name, object.resource_type == "VmOrTemplate" ? "vm.png" : "service_template.png")
-    when ServiceTemplate      then generic_node(object.name, object.picture ? "../../../pictures/#{object.picture.basename}" : "service_template.png")
+    when ServiceTemplate      then service_template_node
     when ServiceTemplateCatalog then generic_node(object.name, "service_template_catalog.png")
     when Storage              then generic_node(object.name, "storage.png")
     when User                 then generic_node(object.name, "user.png")
@@ -295,6 +295,11 @@ class TreeNodeBuilder
     generic_node(object.name, "miq_region.png", object[0])
     @node[:expand] = true
     @node
+  end
+
+  def service_template_node
+    generic_node(object.name, object.picture ? "../../../pictures/#{object.picture.basename}" : "service_template.png")
+    @node[:title] += " (%s)" % object.tenant.name unless object.tenant.ancestors.empty?
   end
 
   def zone_node

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -273,7 +273,9 @@ describe TreeNodeBuilder do
     end
 
     it 'ServiceTemplate node' do
-      template = FactoryGirl.build(:service_template, :name => 'test template')
+      template = FactoryGirl.build(:service_template,
+        :name   => 'test template',
+        :tenant => FactoryGirl.create(:tenant))
       node = TreeNodeBuilder.build(template, nil, {})
       expect(node).not_to be_nil
     end


### PR DESCRIPTION
Before:
![ct-before](https://cloud.githubusercontent.com/assets/6648365/14467831/65164a60-00dd-11e6-8edc-078b4d617668.jpg)


After:
![ct-after](https://cloud.githubusercontent.com/assets/6648365/14467839/6b0a49c6-00dd-11e6-98b6-8f0641c61abd.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1305026