### PR TITLE
Optionally connect to a specific subscription in Azure.

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -31,7 +31,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       service_account: '',
       emstype_vm: false,
       ems_common: true,
-      azure_tenant_id: ''
+      azure_tenant_id: '',
+      subscription: ''
     };
     $scope.formId = emsCommonFormId;
     $scope.afterGet = false;
@@ -91,6 +92,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.service_account                 = data.service_account;
 
         $scope.emsCommonModel.azure_tenant_id                 = data.azure_tenant_id;
+        $scope.emsCommonModel.subscription                    = data.subscription;
 
         if($scope.emsCommonModel.default_userid != '') {
           $scope.emsCommonModel.default_password = $scope.emsCommonModel.default_verify = miqService.storedPasswordPlaceholder;

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -245,7 +245,7 @@ module Mixins
 
       if ems.kind_of?(ManageIQ::Providers::Azure::CloudManager)
         ems.azure_tenant_id = params[:azure_tenant_id]
-        ems.subscription    = params[:subscription]
+        ems.subscription    = params[:subscription] unless params[:subscription].blank?
       end
 
       build_connection(ems, default_endpoint, amqp_endpoint)

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -159,6 +159,7 @@ module Mixins
 
       if @ems.kind_of?(ManageIQ::Providers::Azure::CloudManager)
         azure_tenant_id = @ems.azure_tenant_id
+        subscription    = @ems.subscription
         client_id       = @ems.authentication_userid ? @ems.authentication_userid : ""
         client_key      = @ems.authentication_password ? @ems.authentication_password : ""
       end
@@ -186,6 +187,7 @@ module Mixins
                        :amqp_userid                     => amqp_userid,
                        :service_account                 => service_account ? service_account : "",
                        :azure_tenant_id                 => azure_tenant_id ? azure_tenant_id : "",
+                       :subscription                    => subscription ? subscription : "",
                        :client_id                       => client_id ? client_id : "",
                        :client_key                      => client_key ? client_key : "",
                        :project                         => project ? project : "",
@@ -241,7 +243,10 @@ module Mixins
         ems.host_default_vnc_port_end = params[:host_default_vnc_port_end].blank? ? nil : params[:host_default_vnc_port_end].to_i
       end
 
-      ems.azure_tenant_id = params[:azure_tenant_id] if ems.kind_of?(ManageIQ::Providers::Azure::CloudManager)
+      if ems.kind_of?(ManageIQ::Providers::Azure::CloudManager)
+        ems.azure_tenant_id = params[:azure_tenant_id]
+        ems.subscription    = params[:subscription]
+      end
 
       build_connection(ems, default_endpoint, amqp_endpoint)
     end
@@ -293,6 +298,7 @@ module Mixins
                          :provider_region   => ems.provider_region,
                          :hostname          => ems.hostname,
                          :azure_tenant_id   => azure_tenant_id,
+                         :subscription      => ems.subscription,
                          :port              => ems.port,
                          :api_version       => ems.api_version,
                          :security_protocol => ems.security_protocol,

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -98,6 +98,16 @@
         %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.required"}
           = _("Required")
 
+    .form-group{"ng-class" => "{'has-error': angularForm.subscription.$invalid}", "ng-if" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'azure'"}
+      %label.col-md-2.control-label{"for" => "textInput-markup"}
+        = _('Subscription ID')
+      .col-md-8
+        %input.form-control{"type"        => "text",
+                            "id"          => "textInput-markup",
+                            "name"        => "subscription",
+                            "ng-model"    => "emsCommonModel.subscription",
+                            "checkchange" => ""}
+
     .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
         = _("API Version")

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -278,6 +278,7 @@ FactoryGirl.define do
   factory :ems_azure_with_authentication,
           :parent => :ems_azure do
     azure_tenant_id "ABCDEFGHIJABCDEFGHIJ0123456789AB"
+    subscription "0123456789ABCDEFGHIJABCDEFGHIJKL"
     after :create do |x|
       x.authentications << FactoryGirl.create(:authentication)
     end

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -214,6 +214,7 @@ describe('emsCommonFormController', function() {
       id: 12345,
       name: 'Azure',
       azure_tenant_id: '10.22.33.44',
+      subscription: '12345659-1234-41a4-a7ad-3ce6d1091234',
       emstype: 'azure',
       zone: 'default',
       emstype_vm: false,
@@ -246,6 +247,10 @@ describe('emsCommonFormController', function() {
 
     it('sets the azure_tenant_id', function () {
       expect($scope.emsCommonModel.azure_tenant_id).toEqual('10.22.33.44');
+    })
+
+    it('sets the subscription', function () {
+      expect($scope.emsCommonModel.subscription).toEqual('12345659-1234-41a4-a7ad-3ce6d1091234');
     });
 
     it('sets the zone to default', function() {


### PR DESCRIPTION
**Current logic**:
Currently we do not prompt the user to enter a subscription ID when adding an Azure provider. Instead, we connect to the first active subscription. 

**The problem**:
We ignore inventory associated all subscriptions except one, and there could be many subscriptions associated with a tenant.

**The fix**:
In this PR we accept a subscription ID from the user and create an Azure provider object specifically for that subscription. 
The subscription ID is optional. Refer to #7361 to review how we handle the scenario where no subscription id is provided.

https://bugzilla.redhat.com/show_bug.cgi?id=1318356

