### PR TITLE
Fix amazon refersher to use legacy refresh

### DIFF
--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/network_manager/refresher.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/network_manager/refresher.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers
   class Amazon::NetworkManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
-    def parse_inventory(ems, _targets)
+    def parse_legacy_inventory(ems)
       ManageIQ::Providers::Amazon::NetworkManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end
 


### PR DESCRIPTION
The Amazon Network Manager slipped in before `parse_legacy_inventory` was added to the `EmsRefresherMixin` denoting legacy refresh processes that are not yet ready to do targeted refresh.

/cc @Fryguy 