### PR TITLE
[WIP] MiqExpression::Field#associations returns classes

### DIFF
--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -9,7 +9,12 @@ class MiqExpression::Field
 
   def self.parse(field)
     match = FIELD_REGEX.match(field) or raise ParseError, field
-    new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:column])
+    model = match[:model_name].constantize
+    klass = model
+    associations = match[:associations].to_s.split(".").collect do |association|
+      klass = klass.reflection_with_virtual(association).klass
+    end
+    new(model, associations, match[:column])
   end
 
   attr_reader :model, :associations, :column
@@ -33,7 +38,7 @@ class MiqExpression::Field
     if associations.none?
       model
     else
-      associations.last.classify.constantize
+      associations.last
     end
   end
 

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -44,12 +44,17 @@ RSpec.describe MiqExpression::Field do
 
     it "can parse the associations when there is one present" do
       field = "Vm.host-name"
-      expect(described_class.parse(field).associations).to eq(["host"])
+      expect(described_class.parse(field).associations).to eq([Host])
     end
 
     it "can parse the associations when there are many present" do
       field = "Vm.host.hardware-id"
-      expect(described_class.parse(field).associations).to eq(%w(host hardware))
+      expect(described_class.parse(field).associations).to eq([Host, Hardware])
+    end
+
+    it "can parse the associations when one overrides the class name" do
+      field = "Vm.users-name"
+      expect(described_class.parse(field).associations).to eq([Account])
     end
 
     it "will raise a parse error when given a field with unsupported syntax" do
@@ -82,7 +87,7 @@ RSpec.describe MiqExpression::Field do
     end
 
     it "returns true for a :datetime type column on an association" do
-      field = described_class.new(Vm, ["guest_applications"], "install_time")
+      field = described_class.new(Vm, [GuestApplication], "install_time")
       expect(field).to be_datetime
     end
   end
@@ -94,7 +99,7 @@ RSpec.describe MiqExpression::Field do
     end
 
     it "returns the model of the target association if there are associations" do
-      field = described_class.new(Vm, ["guest_applications"], "name")
+      field = described_class.new(Vm, [GuestApplication], "name")
       expect(field.target).to eq(GuestApplication)
     end
   end


### PR DESCRIPTION
By iterating over the association names and using
`Model.reflection_with_virtual` we can:

* verify the integrity of the field's associations
* avoid calling `classify` and `constantize` on these strings
* avoid failures where the name of the association does not map easily
  onto the name of the class, e.g. users/Account

@miq-bot add-label core, bug
/cc @gtanzillo @yrudman @kbrock 