### PR TITLE
Implement before_ae_starts in ServiceTemplateProvisionTask

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -40,6 +40,7 @@ class MiqRequestTask < ApplicationRecord
 
     # If this request has a miq_request_task parent use that, otherwise the parent is the miq_request
     parent = miq_request_task || miq_request
+    parent.reload
     parent.update_request_status
   end
 

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -169,6 +169,14 @@ class ServiceTemplateProvisionTask < MiqRequestTask
     end
   end
 
+  def before_ae_starts(_options)
+    reload
+    unless state.to_s.downcase == "active"
+      _log.info("Executing #{request_class::TASK_DESCRIPTION} request: [#{description}]")
+      update_and_notify_parent(:state => "active", :status => "Ok", :message => "In Process")
+    end
+  end
+
   def after_ae_delivery(ae_result)
     _log.info("ae_result=#{ae_result.inspect}")
     reload

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -49,6 +49,16 @@ describe ServiceTemplateProvisionTask do
                          :resource_type   => 'ServiceTemplate').id
     end
 
+    describe "#before_ae_starts" do
+      it "updates the task state to active when task starts" do
+        @task_0.before_ae_starts({})
+        expect(@task_0).to have_attributes(
+          :state   => 'active',
+          :status  => 'Ok',
+          :message => 'In Process')
+      end
+    end
+
     it "deliver_to_automate" do
       automate_args = {
         :object_type      => 'ServiceTemplateProvisionTask',


### PR DESCRIPTION
1. Implement `before_ae_starts` that will be called by the AE engine. See #7841 for more information. With this implementation generic service based provisioning can change the state to `Active` like VM provisioning when the task begins.

2. Reload parent in `update_and_notify_parent`. The fix forces to reload the relationships between request and tasks so that the request's state can be corrected updated.
