### PR TITLE
Add Field#reflections

### DIFF
--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -33,6 +33,16 @@ class MiqExpression::Field
     column_type == :string
   end
 
+  def reflections
+    klass = model
+    associations.collect do |association|
+      klass.reflect_on_association(association).tap do |reflection|
+        return unless reflection
+        klass = reflection.klass
+      end
+    end
+  end
+
   def target
     if associations.none?
       model

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -37,7 +37,7 @@ class MiqExpression::Field
     klass = model
     associations.collect do |association|
       klass.reflect_on_association(association).tap do |reflection|
-        return unless reflection
+        raise ArgumentError, "One or more associations are invalid: #{associations.join(", ")}" unless reflection
         klass = reflection.klass
       end
     end

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -47,7 +47,7 @@ class MiqExpression::Field
     if associations.none?
       model
     else
-      associations.last.classify.constantize
+      reflections.last.klass
     end
   end
 

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -80,14 +80,14 @@ RSpec.describe MiqExpression::Field do
       expect(field.reflections).to match([an_object_having_attributes(:klass => Account)])
     end
 
-    it "returns nil if the field has virtual associations" do
+    it "raises an error if the field has virtual associations" do
       field = described_class.new(Vm, ["processes"], "name")
-      expect(field.reflections).to be_nil
+      expect { field.reflections }.to raise_error(/One or more associations are invalid: processes/)
     end
 
-    it "returns nil if the field has invalid associations" do
+    it "raises an error if the field has invalid associations" do
       field = described_class.new(Vm, %w(foo bar), "name")
-      expect(field.reflections).to be_nil
+      expect { field.reflections }.to raise_error(/One or more associations are invalid: foo, bar/)
     end
   end
 

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -58,6 +58,39 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe "#reflections" do
+    it "returns an empty array if there are no associations" do
+      field = described_class.new(Vm, [], "name")
+      expect(field.reflections).to be_empty
+    end
+
+    it "returns the reflections of fields with one association" do
+      field = described_class.new(Vm, ["host"], "name")
+      expect(field.reflections).to match([an_object_having_attributes(:klass => Host)])
+    end
+
+    it "returns the reflections of fields with multiple associations" do
+      field = described_class.new(Vm, %w(host hardware), "guest_os")
+      expect(field.reflections).to match([an_object_having_attributes(:klass => Host),
+                                          an_object_having_attributes(:klass => Hardware)])
+    end
+
+    it "can handle associations which override the class name" do
+      field = described_class.new(Vm, ["users"], "name")
+      expect(field.reflections).to match([an_object_having_attributes(:klass => Account)])
+    end
+
+    it "returns nil if the field has virtual associations" do
+      field = described_class.new(Vm, ["processes"], "name")
+      expect(field.reflections).to be_nil
+    end
+
+    it "returns nil if the field has invalid associations" do
+      field = described_class.new(Vm, %w(foo bar), "name")
+      expect(field.reflections).to be_nil
+    end
+  end
+
   describe "#date?" do
     it "returns true for fields of column type :date" do
       field = described_class.new(Vm, [], "retires_on")


### PR DESCRIPTION
Adds a reflections method so that

* `#target` stops doing `.classify.constantize`, which can break with associations that don't use the default class name
* CONTAINS expressions can later use this to get the scope of the reflections, if any, which it requires when doing `#to_sql`

/cc @kbrock @gtanzillo @yrudman 
@miq-bot add-label core, bug