### PR TITLE
Relationship should hide resources that no longer exists

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -33,7 +33,7 @@ class Relationship < ApplicationRecord
 
   def self.resources(relationships)
     MiqPreloader.preload(relationships, :resource)
-    relationships.collect(&:resource)
+    relationships.collect(&:resource).compact
   end
 
   def self.resource_pair(relationship)


### PR DESCRIPTION
There are no foreign keys. Thus, sooner or later things will slip. Then,
this function may return [nil, nil, ...] when listing members of a set
or childs. The code that calls this is surprised to get list of nils.

Addressing ui failures like:
```
FATAL -- : Error caught: [NoMethodError] undefined method `item_type' for nil:NilClass
app/controllers/ops_controller/settings/analysis_profiles.rb:30:in `block in ap_show'
app/controllers/ops_controller/settings/analysis_profiles.rb:29:in `each'
app/controllers/ops_controller/settings/analysis_profiles.rb:29:in `ap_show'
app/controllers/ops_controller/settings/common.rb:1096:in `settings_get_info'
app/controllers/ops_controller.rb:454:in `get_node_info'
app/controllers/ops_controller.rb:159:in `tree_select'
```