### PR TITLE
set shutting-down state when terminating an instance in aws

### DIFF
--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
@@ -5,6 +5,6 @@ module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
     with_provider_object(&:terminate)
-    self.update_attributes!(:raw_power_state => "pending") # show state as suspended
+    update_attributes!(:raw_power_state => "shutting-down")
   end
 end


### PR DESCRIPTION
When terminating an instance, we are setting the state to pending, which
means suspended in our terminology. But for aws once terminated
instances cannot be woken up again.

running -> shutting-down -> terminated
This is described also in Amazon AWS documentation:
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html

addressed https://bugzilla.redhat.com/show_bug.cgi?id=1324578