### PR TITLE
Fix adding new tiers in chargeback rates

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -571,7 +571,14 @@ class ChargebackController < ApplicationController
     @edit[:new][:code_currency] = rate_details[0].detail_currency.code
 
     rate_details.each_with_index do |detail, detail_index|
-      temp                    = detail.slice(:per_time, :per_unit, :detail_measure, :group, :source)
+      temp = detail.slice(:per_time, :per_unit, :detail_measure, :group, :source)
+
+      if temp[:detail_measure].present?
+        detail_measure = temp.delete(:detail_measure)
+        temp[:detail_measure] = {}
+        temp[:detail_measure][:measures] = detail_measure.measures
+      end
+
       temp[:id]               = params[:typ] == "copy" ? nil : detail.id
       temp[:per_time]         ||= "hourly"
       temp[:group]            = detail.group

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -73,12 +73,12 @@
           - else
             /if the rate detail have a metric associated, display an options field with per_unit selected
             %td{:rowspan => num_tiers}
-              = select_tag("per_unit_#{detail_index}", options_for_select(measure.measures, detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
+              = select_tag("per_unit_#{detail_index}", options_for_select(measure[:measures], detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
           %td
             = text_field_tag("start_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:start],
               :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
           %td
-            = text_field_tag("end_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:finish],
+            = text_field_tag("finish_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:finish],
               :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           %td{:align => 'right'}
             = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
@@ -104,7 +104,7 @@
               = text_field_tag("start_#{detail_index}_#{tier_index}", tier[:start],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td
-              = text_field_tag("end_#{detail_index}_#{tier_index}", tier[:finish],
+              = text_field_tag("finish_#{detail_index}_#{tier_index}", tier[:finish],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td{:align => "right"}
               = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier[:fixed_rate],

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -26,7 +26,7 @@
     = text_field_tag("start_#{i}_0", @edit[:new][:tiers][i.to_i][0][:start],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
   %td
-    = text_field_tag("end_#{i}_0", @edit[:new][:tiers][i.to_i][0][:finish],
+    = text_field_tag("finish_#{i}_0", @edit[:new][:tiers][i.to_i][0][:finish],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td{:align => 'right'}
     = text_field_tag("fixed_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:fixed_rate],

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -8,7 +8,7 @@
     = text_field_tag("start_#{i}_#{n - 1}",  @edit[:new][:tiers][i.to_i][n - 1][:start],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td
-    = text_field_tag("end_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:finish],
+    = text_field_tag("finish_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:finish],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td{:align => 'right'}
     = text_field_tag("fixed_rate_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:fixed_rate],


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/7832
point #5 (https://github.com/ManageIQ/manageiq/issues/7832#issuecomment-209322734)

Changes:
- Adding and storing new tiers when editing exiting chargeback rate fixed 
- Detection for contiguous tier updated (now we are first validating and then storing if valid)
- Avoiding storing AR object of ChargebackRateDetailMeasure (and related issue fixed) into session


please review 
@gtanzillo @tledesma @amaurygonzalez @h-kataria 

thanks!
