### PR TITLE
Fix save_as_orderable for an existing template

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -126,7 +126,7 @@ class OrchestrationTemplate < ApplicationRecord
     return save! if draft?
 
     old_template = self.class.find_with_content(content)
-    return save! if old_template.nil? || old_template.orderable
+    return save! if old_template.nil? || old_template.orderable || old_template.id == id
 
     new_record? ? replace_with_old_template(old_template) : transfer_stacks(old_template)
   end

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -258,6 +258,15 @@ describe OrchestrationTemplate do
           expect(described_class.find_by(:id => existing_discovered_template.id)).to be_nil
         end
       end
+
+      context "when there is no conflict" do
+        it "converts a discovered template to orderable" do
+          allow(existing_discovered_template).to receive_messages(:validate_format => nil)
+          expect(existing_discovered_template.orderable).to be_falsey
+          expect(existing_discovered_template.save_as_orderable!).to be_truthy
+          expect(existing_discovered_template.orderable).to be_truthy
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The problem was discovered in #7822.

The code before the fix works properly if an existing template modifies the content but its content conflicts with another existing template. However if the existing template does not change content but only wants to modify the orderable flag, it actually gets deleted.

The fix checks to see whether the duplicated template is the working template itself. If yes we only need to save it as orderable.