### PR TITLE
Add Endpoint#api_version & #path to better support connection logic

### DIFF
--- a/db/migrate/20160413175651_add_api_version_adn_path_to_endpoint.rb
+++ b/db/migrate/20160413175651_add_api_version_adn_path_to_endpoint.rb
@@ -1,0 +1,6 @@
+class AddApiVersionAdnPathToEndpoint < ActiveRecord::Migration[5.0]
+  def change
+    add_column :endpoints, :api_version, :string
+    add_column :endpoints, :path,        :string
+  end
+end


### PR DESCRIPTION
This will allow us to migrate away from the `url` column for AnsibleTower