### PR TITLE
Add a Infinity placeholder on tier range

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -655,7 +655,9 @@ class ChargebackController < ApplicationController
       rate_tiers = []
       @edit[:new][:tiers][detail_index].each do |tier|
         rate_tier = tier[:id] ? ChargebackTier.find(tier[:id]) : ChargebackTier.new
+        if tier[:start].blank? then tier[:start] = "Infinity" end
         rate_tier.start  = tier[:start]
+        if tier[:finish].blank? then tier[:finish] = "Infinity" end
         rate_tier.finish = tier[:finish]
         rate_tier.chargeback_rate_detail_id = rate_detail.id
         rate_tier.fixed_rate  = tier[:fixed_rate]

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -75,11 +75,15 @@
             %td{:rowspan => num_tiers}
               = select_tag("per_unit_#{detail_index}", options_for_select(measure[:measures], detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
           %td
-            = text_field_tag("start_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:start],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
+            - tier_val = (@edit[:new][:tiers][detail_index][0][:start].to_s.eql? "Infinity")   ? "" : @edit[:new][:tiers][detail_index][0][:start]
+            = text_field_tag("start_#{detail_index}_0", tier_val,
+              :maxlength => MAX_NAME_LEN,
+              :placeholder => _("Infinity"),
+              "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
           %td
-            = text_field_tag("finish_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:finish],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            - tier_val = (@edit[:new][:tiers][detail_index][0][:finish].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][detail_index][0][:finish]
+            = text_field_tag("finish_#{detail_index}_0", tier_val,
+              :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           %td{:align => 'right'}
             = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
               :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
@@ -101,11 +105,13 @@
           - tier = @edit[:new][:tiers][detail_index][tier_index]
           %tr{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
             %td
-              = text_field_tag("start_#{detail_index}_#{tier_index}", tier[:start],
-                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+              - tier_val = (tier[:start].to_s.eql? "Infinity") ? "" : tier[:start]
+              = text_field_tag("start_#{detail_index}_#{tier_index}", tier_val,
+                :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td
-              = text_field_tag("finish_#{detail_index}_#{tier_index}", tier[:finish],
-                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+              - tier_val = (tier[:finish].to_s.eql? "Infinity")  ? "" : tier[:finish]
+              = text_field_tag("finish_#{detail_index}_#{tier_index}", tier_val,
+                :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td{:align => "right"}
               = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier[:fixed_rate],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -23,11 +23,13 @@
     %td{:rowspan => n.to_s}
       = select_tag("per_unit_#{i}", options_for_select(measure[:measures], r[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
   %td
-    = text_field_tag("start_#{i}_0", @edit[:new][:tiers][i.to_i][0][:start],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
+    - tier_val = (@edit[:new][:tiers][i.to_i][0][:start].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][i.to_i][0][:start]
+    = text_field_tag("start_#{i}_0", tier_val,
+      :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
   %td
-    = text_field_tag("finish_#{i}_0", @edit[:new][:tiers][i.to_i][0][:finish],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    - tier_val = (@edit[:new][:tiers][i.to_i][0][:finish].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][i.to_i][0][:finish]
+    = text_field_tag("finish_#{i}_0", tier_val,
+      :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td{:align => 'right'}
     = text_field_tag("fixed_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:fixed_rate],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -5,11 +5,13 @@
 
 %tr.rdetail.new_tier{:id => "rate_detail_row_#{i}_#{n - 1}"}
   %td
-    = text_field_tag("start_#{i}_#{n - 1}",  @edit[:new][:tiers][i.to_i][n - 1][:start],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    - tier_val = (@edit[:new][:tiers][i.to_i][n - 1][:start].to_s.eql? "Infinity")  ? "" : @edit[:new][:tiers][i.to_i][n - 1][:start]
+    = text_field_tag("start_#{i}_#{n - 1}", tier_val,
+      :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td
-    = text_field_tag("finish_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:finish],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    - tier_val = (@edit[:new][:tiers][i.to_i][n - 1][:finish].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][i.to_i][n - 1][:finish]
+    = text_field_tag("finish_#{i}_#{n - 1}", tier_val,
+      :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td{:align => 'right'}
     = text_field_tag("fixed_rate_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:fixed_rate],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)


### PR DESCRIPTION
When defining tiers, currently the user needs to type Infinity in the upper layer. It should be done in a way that is better understood by the customer. 
After talk with @lpichler and @himdel, my proposal is is to use placeholder, when input is empty placeholder is appeared and it means infinity value. 

![Chargeback with Infinity place holder](http://res.cloudinary.com/ddtbdqfq7/image/upload/v1460621766/Tier_xvjmr0.png)

