### PR TITLE
Set correct STI type after the quota has been renamed

### DIFF
--- a/db/migrate/20160413191759_correct_sti_type_on_cloud_resource_quota.rb
+++ b/db/migrate/20160413191759_correct_sti_type_on_cloud_resource_quota.rb
@@ -1,0 +1,18 @@
+class CorrectStiTypeOnCloudResourceQuota < ActiveRecord::Migration[5.0]
+  class CloudResourceQuota < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  NEW_TYPE = 'ManageIQ::Providers::Openstack::CloudManager::CloudResourceQuota'.freeze
+  OLD_TYPE = 'CloudResourceQuotaOpenstack'.freeze
+  EVEN_OLDER_TYPE = 'OpenstackResourceQuota'.freeze
+
+  def up
+    CloudResourceQuota.where(:type => OLD_TYPE).update_all(:type => NEW_TYPE)
+    CloudResourceQuota.where(:type => EVEN_OLDER_TYPE).update_all(:type => NEW_TYPE)
+  end
+
+  def down
+    CloudResourceQuota.where(:type => NEW_TYPE).update_all(:type => OLD_TYPE)
+  end
+end

--- a/spec/migrations/20160413191759_correct_sti_type_on_cloud_resource_quota_spec.rb
+++ b/spec/migrations/20160413191759_correct_sti_type_on_cloud_resource_quota_spec.rb
@@ -1,0 +1,43 @@
+require_migration
+
+describe CorrectStiTypeOnCloudResourceQuota do
+  let(:cloud_resource_quota_stub) { migration_stub(:CloudResourceQuota) }
+  let(:crq_entries) do
+    [
+      {:old => {:type => 'somethingelse'},
+       :new => {:type => 'somethingelse'}},
+      {:old => {:type => described_class::OLD_TYPE},
+       :new => {:type => described_class::NEW_TYPE}},
+      {:old => {:type => described_class::EVEN_OLDER_TYPE},
+       :new => {:type => described_class::NEW_TYPE}},
+    ]
+  end
+
+  migration_context :up do
+    it 'migrates a series of representative rows' do
+      crq_entries.each do |x|
+        x[:up] = cloud_resource_quota_stub.create!(x[:old])
+      end
+
+      migrate
+
+      crq_entries.each do |x|
+        expect(x[:up].reload.type).to eq(x[:new][:type])
+      end
+    end
+  end
+
+  migration_context :down do
+    it 'migrates a series of representative rows' do
+      crq_entries.each do |x|
+        x[:up] = cloud_resource_quota_stub.create!(x[:new])
+      end
+
+      migrate
+
+      crq_entries.take(2).each do |x|
+        expect(x[:up].reload.type).to eq(x[:old][:type])
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1289936

Original rename was #666.  :smiling_imp: The other one was due to provider namespacing.
I prefer to re-run rename on both old names, as we have workaround for
rhbz#1289936 public and users might have applied it manually at any time.

@miq-bot add_label bug, providers/openstack

/cc @Ladas 