### PR TITLE
Network manager topology fix n plus 1 problem on network port security groups

### DIFF
--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -10,7 +10,8 @@ class NetworkPort < ApplicationRecord
   belongs_to :cloud_tenant
   belongs_to :device, :polymorphic => true
 
-  has_and_belongs_to_many :security_groups
+  has_many :network_port_security_groups
+  has_many :security_groups, :through => :network_port_security_groups
 
   has_one :floating_ip
   # TODO(lsmola) can this really happen? If not remove it

--- a/app/models/network_port_security_group.rb
+++ b/app/models/network_port_security_group.rb
@@ -1,0 +1,6 @@
+class NetworkPortSecurityGroup < ApplicationRecord
+  self.table_name = "network_ports_security_groups"
+
+  belongs_to :network_port
+  belongs_to :security_group
+end


### PR DESCRIPTION
Fix network_topology n+1 problem
    
Fix network_topology n+1 problem on network_port -> security_groups

Seems like HABTM is broken, the NetowrkPort.includes(:security_groups).to_a generates N+1 queries. When changed to has_many :through, this is fixed