### PR TITLE
Schema change: add label->tag mapping table.

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -1,0 +1,16 @@
+class ContainerLabelTagMapping < ApplicationRecord
+  # A mapping matches labels on `resource_type` (NULL means any), `name` (required),
+  # and `value` (NULL means any).
+  #
+  # Different labels might map to one tag, and one label might map to multiple tags.
+  #
+  # There are 2 kinds of rows:
+  # - When `label_value` is specified, we map only this value to a specific `tag`.
+  # - When `label_value` is NULL, we map this name with any value to per-value tags.
+  #   In this case, `tag` specifies the category under which to create
+  #   the value-specific tag (and classification) on demand.
+  #   We then also add a specific `label_value`->specific `tag` mapping here.
+  belongs_to :tag
+
+  validates :label_name, :presence => true
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,8 @@ class Tag < ApplicationRecord
   virtual_has_one :category,       :class_name => "Classification"
   virtual_has_one :categorization, :class_name => "Hash"
 
+  has_many :container_label_tag_mappings
+
   before_destroy :remove_from_managed_filters
 
   def self.to_tag(name, options = {})

--- a/db/migrate/20160414185708_create_container_label_tag_mappings.rb
+++ b/db/migrate/20160414185708_create_container_label_tag_mappings.rb
@@ -1,0 +1,12 @@
+class CreateContainerLabelTagMappings < ActiveRecord::Migration[5.0]
+  def change
+    create_table :container_label_tag_mappings do |t|
+      t.string :labeled_resource_type
+      t.string :label_name
+      t.text :label_value
+      t.belongs_to :tag, :type => :bigint
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
Extracted schema+model from ongoing work on #7605.
cc @Fryguy @kbrock @zeari @moolitayer @simon3z 
We'd like to get this, or similar, merged before the freeze.

Summary:

- The goal is assigining Tags for some but not all labels.
  [Reminder: labels are stored as CustomAttribute with polymorphic resource, string name & value; unlike Tagging, there is no central object like Tag that all labels with same name & value point to.]

- I'm matching on resource_type (null means any), name (required), value (null means any).
  - Any-value mapping rows don't map to a single tag, but one tag per value (created on demand).
    In such mappings `tag_id` means the category under which to create tags.

[I UPDATED this description to reflect current status.]