### PR TITLE
Typo. Refer to correct model class.

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -15,7 +15,7 @@ class MiqExpression
     ManageIQ::Providers::ConfigurationManager
     Container
     ContainerGroup
-    ContainerImages
+    ContainerImage
     ContainerNode
     ContainerProject
     ContainerService


### PR DESCRIPTION
This fixes (and translates) display_name in report editor and also in
tools/doc/reportable_fields_to_csv.rb

@miq-bot add_label bug, providers/containers