### PR TITLE
i18n: fix dictionary lookup for non-english locales

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -28,7 +28,7 @@ class Dictionary
   end
 
   def self.i18n_lookup(type, text)
-    result = I18n.t("dictionary.#{type}.#{text}")
+    result = I18n.t("dictionary.#{type}.#{text}", :locale => "en")
     result.start_with?("translation missing:") ? nil : result
   end
   private_class_method :i18n_lookup


### PR DESCRIPTION
The intended workflow for dictionary lookup:
1. use I18n.t() and *english* dictionary (config/locales/en.yml) to find *english* string for the key
2. apply gettext to the english string found in previous step. This should return the translated text.

To make this actually work in non-english locales, we need to explicitly tell I18n.t to use english locale (i.e. to use en.yml), otherwise respective locale yaml (ja.yml, nl.yml, etc.) would be used (i.e. the nice english string would in step one not be found).