### PR TITLE
Sporadic faliure

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_state_machine_new_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_state_machine_new_spec.rb
@@ -76,9 +76,7 @@ describe "MiqAeStateMachine" do
       it "should not raise error" do
         Timecop.freeze do
           obj = test_class
-          Timecop.travel(5) do
-            expect { obj.enforce_max_time('max_time' => '6.seconds') }.to_not raise_error
-          end
+          expect { obj.enforce_max_time('max_time' => '6.seconds') }.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
Removed the timetravel since we are just checking if its
within the max time limit

The failure was 
Failure/Error: expect { obj.enforce_max_time('max_time' => '6.seconds') }.to_not raise_error
     
       expected no Exception, got #<RuntimeError: time in state <6.000100612640381 seconds> exceeded maximum of <6.seconds>> with backtrace: