### PR TITLE
Fix image name parsing for Azure

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -554,7 +554,8 @@ module ManageIQ::Providers
       end
 
       def build_image_name(image)
-        "#{image.uri.split(%r{Microsoft.Compute\/}i)[1].split('.').first}"
+        # Strip the .vhd and Azure GUID extension, but retain path and base name.
+        File.join(File.dirname(image.name), File.basename(File.basename(image.name, '.*'), '.*'))
       end
 
       def build_image_description(image)


### PR DESCRIPTION
This fixes an issue where the custom private image name parsing in Azure will fail if the container path does not contain "Microsoft.Compute".

It also includes the toplevel directory in the output. For example, it previously would show:

    Images/miq-test-container/test-win2k12-img-osDisk

But will now show:

    Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk

    