### PR TITLE
Rename configuration_manager_id columns to manager_id

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -522,7 +522,7 @@ class ProviderForemanController < ApplicationController
       case @record.type
       when "ManageIQ::Providers::Foreman::ConfigurationManager"
         options = {:model => "ConfigurationProfile", :match_via_descendants => ConfiguredSystem}
-        options[:where_clause] = ["configuration_manager_id IN (?)", provider.id]
+        options[:where_clause] = ["manager_id IN (?)", provider.id]
         @no_checkboxes = true
         process_show_list(options)
         add_unassigned_configuration_profile_record(provider.id)
@@ -559,7 +559,7 @@ class ProviderForemanController < ApplicationController
       options = {:model => "ConfiguredSystem", :match_via_descendants => ConfiguredSystem}
       options[:where_clause] = ["configuration_profile_id IN (?)", @configuration_profile_record.id]
       options[:where_clause] =
-        ["configuration_manager_id IN (?) AND \
+        ["manager_id IN (?) AND \
           configuration_profile_id IS NULL", id] if empty_configuration_profile_record?(@configuration_profile_record)
       process_show_list(options)
       record_model = ui_lookup(:model => model ? model : TreeBuilder.get_model_for_prefix(@nodetype))
@@ -916,7 +916,7 @@ class ProviderForemanController < ApplicationController
 
   def list_row_id(row)
     if row['name'] == _("Unassigned Profiles Group") && row['id'].nil?
-      "-#{row['configuration_manager_id']}-unassigned"
+      "-#{row['manager_id']}-unassigned"
     else
       to_cid(row['id'])
     end
@@ -947,13 +947,13 @@ class ProviderForemanController < ApplicationController
 
   def add_unassigned_configuration_profile_record(provider_id)
     unprovisioned_configured_systems =
-      ConfiguredSystem.where(:configuration_manager_id => provider_id, :configuration_profile_id => nil).count
+      ConfiguredSystem.where(:manager_id => provider_id, :configuration_profile_id => nil).count
 
     return if unprovisioned_configured_systems == 0
 
     unassigned_configuration_profile_desc = unassigned_configuration_profile_name = _("Unassigned Profiles Group")
     unassigned_configuration_profile = ConfigurationProfile.new
-    unassigned_configuration_profile.configuration_manager_id = provider_id
+    unassigned_configuration_profile.manager_id = provider_id
     unassigned_configuration_profile.name = unassigned_configuration_profile_name
     unassigned_configuration_profile.description = unassigned_configuration_profile_desc
 
@@ -964,7 +964,7 @@ class ProviderForemanController < ApplicationController
        'my_zone'                        => unassigned_configuration_profile.my_zone,
        'region_description'             => unassigned_configuration_profile.region_description,
        'name'                           => unassigned_configuration_profile_name,
-       'configuration_manager_id'       => provider_id
+       'manager_id'                     => provider_id
       }
 
     add_unassigned_configuration_profile_record_to_view(unassigned_profile_row, unassigned_configuration_profile)

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -3,7 +3,7 @@ class ConfigurationProfile < ApplicationRecord
   include ReportableMixin
 
   acts_as_miq_taggable
-  belongs_to :configuration_manager, :class_name => 'ManageIQ::Providers::ConfigurationManager'
+  belongs_to :manager, :class_name => 'ExtManagementSystem'
   belongs_to :parent, :class_name => 'ConfigurationProfile'
   belongs_to :customization_script_ptable
   belongs_to :customization_script_medium
@@ -67,7 +67,7 @@ class ConfigurationProfile < ApplicationRecord
     @tag_hash ||= configuration_tags.index_by(&:class)
   end
 
-  alias_method :manager, :configuration_manager
+  alias_method :configuration_manager, :manager
 
   def total_configured_systems
     Rbac.filtered(configured_systems, :match_via_descendants => ConfiguredSystem).count

--- a/app/models/configuration_script.rb
+++ b/app/models/configuration_script.rb
@@ -1,6 +1,6 @@
 class ConfigurationScript < ApplicationRecord
   belongs_to :inventory_root_group, :class_name => "EmsFolder"
-  belongs_to :manager,              :class_name => "ExtManagementSystem", :foreign_key => :configuration_manager_id
+  belongs_to :manager,              :class_name => "ExtManagementSystem"
 
   include ProviderObjectMixin
 end

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -4,18 +4,18 @@ class ConfiguredSystem < ApplicationRecord
 
   acts_as_miq_taggable
   belongs_to :configuration_location
-  belongs_to :configuration_manager, :class_name => 'ManageIQ::Providers::ConfigurationManager'
   belongs_to :configuration_organization
   belongs_to :configuration_profile
   belongs_to :customization_script_medium
   belongs_to :customization_script_ptable
   belongs_to :inventory_root_group, :class_name => "EmsFolder"
+  belongs_to :manager,              :class_name => "ExtManagementSystem"
   belongs_to :operating_system_flavor
   has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
   has_and_belongs_to_many :configuration_tags
 
   alias_attribute :name,    :hostname
-  alias_method    :manager, :configuration_manager
+  alias_method    :configuration_manager, :manager
 
   delegate :name, :to => :configuration_profile,         :prefix => true, :allow_nil => true
   delegate :name, :to => :configuration_architecture,    :prefix => true, :allow_nil => true

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/configured_system.rb
@@ -1,10 +1,6 @@
 class ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem < ::ConfiguredSystem
   include ProviderObjectMixin
 
-  belongs_to :manager,
-             :class_name  => 'ConfigurationManager',
-             :foreign_key => 'configuration_manager_id'
-
   def provider_object(connection = nil)
     (connection || connection_source.connect).api.hosts.find(manager_ref)
   end

--- a/app/models/manageiq/providers/configuration_manager.rb
+++ b/app/models/manageiq/providers/configuration_manager.rb
@@ -2,9 +2,9 @@ class ManageIQ::Providers::ConfigurationManager < ::ExtManagementSystem
   require_nested :InventoryGroup
   require_nested :InventoryRootGroup
 
-  has_many :configured_systems,     :dependent => :destroy
-  has_many :configuration_profiles, :dependent => :destroy
-  has_many :configuration_scripts,  :dependent => :destroy
+  has_many :configured_systems,     :dependent => :destroy, :foreign_key => "manager_id"
+  has_many :configuration_profiles, :dependent => :destroy, :foreign_key => "manager_id"
+  has_many :configuration_scripts,  :dependent => :destroy, :foreign_key => "manager_id"
   has_many :inventory_groups,       :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
 
   virtual_column  :total_configuration_profiles, :type => :integer

--- a/app/models/manageiq/providers/foreman/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/configured_system.rb
@@ -21,12 +21,12 @@ class ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem < ::C
   end
 
   def ext_management_system
-    configuration_manager
+    manager
   end
 
   private
 
   def connection_source(options = {})
-    options[:connection_source] || configuration_manager
+    options[:connection_source] || manager
   end
 end

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -36,7 +36,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
   def x_get_tree_cmf_kids(object, count_only)
     assigned_configuration_profile_objs =
       count_only_or_objects(count_only,
-                            rbac_filtered_objects(ConfigurationProfile.where(:configuration_manager_id => object[:id]),
+                            rbac_filtered_objects(ConfigurationProfile.where(:manager_id => object[:id]),
                                                   :match_via_descendants => ConfiguredSystem),
                             "name")
     unassigned_configuration_profile_objs =
@@ -47,14 +47,14 @@ class TreeBuilderConfigurationManager < TreeBuilder
 
   def fetch_unassigned_configuration_profile_objects(count_only, configuration_manager_id)
     unprovisioned_configured_systems = ConfiguredSystem.where(:configuration_profile_id => nil,
-                                                              :configuration_manager_id => configuration_manager_id)
+                                                              :manager_id               => configuration_manager_id)
     unprovisioned_configured_systems_filtered = rbac_filtered_objects(unprovisioned_configured_systems,
                                                                       :match_via_descendants => ConfiguredSystem)
     if unprovisioned_configured_systems_filtered.count > 0
       unassigned_id = "#{configuration_manager_id}-unassigned"
       unassigned_configuration_profile =
-        [ConfigurationProfile.new(:name                     => "Unassigned Profiles Group|#{unassigned_id}",
-                                  :configuration_manager_id => configuration_manager_id)]
+        [ConfigurationProfile.new(:name       => "Unassigned Profiles Group|#{unassigned_id}",
+                                  :manager_id => configuration_manager_id)]
       unassigned_configuration_profile_objs = count_only_or_objects(count_only,
                                                                     unassigned_configuration_profile,
                                                                     nil)

--- a/db/migrate/20160414192525_rename_configuration_manager_to_manager.rb
+++ b/db/migrate/20160414192525_rename_configuration_manager_to_manager.rb
@@ -1,0 +1,7 @@
+class RenameConfigurationManagerToManager < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :configuration_profiles, :configuration_manager_id, :manager_id
+    rename_column :configuration_scripts,  :configuration_manager_id, :manager_id
+    rename_column :configured_systems,     :configuration_manager_id, :manager_id
+  end
+end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -6,32 +6,32 @@ describe ProviderForemanController do
 
     @provider = ManageIQ::Providers::Foreman::Provider.create(:name => "testForeman", :url => "10.8.96.102", :zone => @zone)
     @config_mgr = ManageIQ::Providers::Foreman::ConfigurationManager.find_by_provider_id(@provider.id)
-    @config_profile = ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile.create(:name                     => "testprofile",
-                                                                                                      :description              => "testprofile",
-                                                                                                      :configuration_manager_id => @config_mgr.id)
-    @config_profile2 = ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile.create(:name                     => "testprofile2",
-                                                                                                       :description              => "testprofile2",
-                                                                                                       :configuration_manager_id => @config_mgr.id)
+    @config_profile = ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile.create(:name        => "testprofile",
+                                                                                                      :description => "testprofile",
+                                                                                                      :manager_id  => @config_mgr.id)
+    @config_profile2 = ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile.create(:name        => "testprofile2",
+                                                                                                       :description => "testprofile2",
+                                                                                                       :manager_id  => @config_mgr.id)
     @configured_system = ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem.create(:hostname                 => "test_configured_system",
                                                                                                      :configuration_profile_id => @config_profile.id,
-                                                                                                     :configuration_manager_id => @config_mgr.id)
+                                                                                                     :manager_id               => @config_mgr.id)
     @configured_system2a = ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem.create(:hostname                 => "test2a_configured_system",
                                                                                                        :configuration_profile_id => @config_profile2.id,
-                                                                                                       :configuration_manager_id => @config_mgr.id)
+                                                                                                       :manager_id               => @config_mgr.id)
     @configured_system2b = ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem.create(:hostname                 => "test2b_configured_system",
                                                                                                        :configuration_profile_id => @config_profile2.id,
-                                                                                                       :configuration_manager_id => @config_mgr.id)
+                                                                                                       :manager_id               => @config_mgr.id)
     @configured_system_unprovisioned =
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem.create(:hostname                 => "configured_system_unprovisioned",
                                                                                   :configuration_profile_id => nil,
-                                                                                  :configuration_manager_id => @config_mgr.id)
+                                                                                  :manager_id               => @config_mgr.id)
 
     @provider2 = ManageIQ::Providers::Foreman::Provider.create(:name => "test2Foreman", :url => "10.8.96.103", :zone => @zone)
     @config_mgr2 = ManageIQ::Providers::Foreman::ConfigurationManager.find_by_provider_id(@provider2.id)
     @configured_system_unprovisioned2 =
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem.create(:hostname                 => "configured_system_unprovisioned2",
                                                                                   :configuration_profile_id => nil,
-                                                                                  :configuration_manager_id => @config_mgr2.id)
+                                                                                  :manager_id               => @config_mgr2.id)
     controller.instance_variable_set(:@sb, :active_tree => :configuration_manager_providers_tree)
 
     [@configured_system, @configured_system2a, @configured_system2b, @configured_system_unprovisioned2].each do |cs|

--- a/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
@@ -1,12 +1,9 @@
 describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow do
   include WorkflowSpecHelper
 
-  let(:admin) { FactoryGirl.create(:user_with_group) }
-  let(:system) do
-    FactoryGirl.create(:configured_system_foreman,
-                       :hostname              => 'host',
-                       :configuration_manager => FactoryGirl.create(:configuration_manager_foreman))
-  end
+  let(:admin)   { FactoryGirl.create(:user_with_group) }
+  let(:manager) { FactoryGirl.create(:configuration_manager_foreman) }
+  let(:system)  { FactoryGirl.create(:configured_system_foreman, :manager => manager) }
 
   it "#allowed_configuration_profiles" do
     cp       = FactoryGirl.build(:configuration_profile, :name => "test profile")
@@ -48,7 +45,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
       expect(request).to be_valid
       expect(request).to be_a_kind_of(MiqProvisionConfiguredSystemRequest)
       expect(request.request_type).to eq("provision_via_foreman")
-      expect(request.description).to eq("Foreman install on [host]")
+      expect(request.description).to eq("Foreman install on [#{system.name}]")
       expect(request.requester).to eq(admin)
       expect(request.userid).to eq(admin.userid)
       expect(request.requester_name).to eq(admin.name)


### PR DESCRIPTION
Renaming columns to be consistent with the rest of the Configuration Management tables.