### PR TITLE
UI for adding volumes during Openstack Instance provisioning.

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     # by prepare_volumes
     prepare_volumes = true
     volumes = []
-    keys = %w(volume_name volume_size volume_delete_on_terminate)
+    keys = %w(name size delete_on_terminate)
     while prepare_volumes
       new_volume = {}
       keys.each do |key|

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -40,9 +40,9 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     keys = %w(volume_name volume_size volume_delete_on_terminate)
     while prepare_volumes
       new_volume = {}
-      keys.each do |k|
-        key = :"#{k}_#{volumes.length + 1}"
-        new_volume[key] = values[key] unless values[key].blank?
+      keys.each do |key|
+        indexed_key = :"#{key}_#{volumes.length + 1}"
+        new_volume[key.to_sym] = values[indexed_key] if values.key?(indexed_key)
       end
       if new_volume.blank?
         prepare_volumes = false

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -23,6 +23,36 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     validate_placement(field, values, dlg, fld, value)
   end
 
+  def set_request_values(values)
+    values[:volumes] = prepare_volumes_fields(values)
+    super
+  end
+
+  def prepare_volumes_fields(values)
+    # the provision dialog doesn't handle arrays,
+    # so we have to hack around it to support an arbitrary
+    # number of volumes being added at once.
+    # This looks for volume form fields in the input, and converts
+    # them into an array of hashes that can be understood
+    # by prepare_volumes
+    prepare_volumes = true
+    volumes = []
+    keys = %w(volume_name volume_size volume_delete_on_terminate)
+    while prepare_volumes
+      new_volume = {}
+      keys.each do |k|
+        key = :"#{k}_#{volumes.length + 1}"
+        new_volume[key] = values[key] unless values[key].blank?
+      end
+      if new_volume.blank?
+        prepare_volumes = false
+      else
+        volumes.push new_volume
+      end
+    end
+    volumes
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -813,37 +813,11 @@ class MiqRequestWorkflow
   def set_request_values(values)
     # Ensure that tags selected in the pre-dialog get applied to the request
     values[:vm_tags] = (values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags]).uniq unless @values.nil? || @values[:pre_dialog_vm_tags].blank?
-    values[:volumes] = prepare_volumes_fields(values)
     values[:requester_group] ||= @requester.current_group.description
     email = values[:owner_email]
     if email.present? && values[:owner_group].blank?
       values[:owner_group] = User.find_by_lower_email(email, @requester).try(:miq_group_description)
     end
-  end
-
-  def prepare_volumes_fields(values)
-    # the provision dialog doesn't handle arrays,
-    # so we have to hack around it to support an arbitrary
-    # number of volumes being added at once.
-    # This looks for volume form fields in the input, and converts
-    # them into an array of hashes that can be understood
-    # by prepare_volumes
-    prepare_volumes = true
-    volumes = []
-    keys = %w(volume_name volume_size volume_delete_on_terminate)
-    while prepare_volumes
-      new_volume = {}
-      keys.each do |k|
-        key = :"#{k}_#{volumes.length + 1}"
-        new_volume[key] = values[key] unless values[key].blank?
-      end
-      if new_volume.blank?
-        prepare_volumes = false
-      else
-        volumes.push new_volume
-      end
-    end
-    volumes
   end
 
   def password_helper(values, encrypt = true)

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -21,6 +21,8 @@
         .form-group
           %label.col-md-2.control-label{:valign => "top"}
             = _(workflow.get_field(key, dialog)[:description])
+            - if @edit && workflow.get_field(key, dialog)[:required] && workflow.get_field(key, dialog)[:display] == :edit
+              *
           .col-md-8
             - if workflow.get_field(key, dialog)[:data_type] == :string
               - if @edit && workflow.get_field(key, dialog)[:display] == :edit && !@edit[:stamp_typ]

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -8,24 +8,26 @@
 .form-horizontal#add-volumes-form
   - while (draw_fields)
     #add-volume-fieldset
-      .form-group
-        %label.col-md-2.control-label{:valign => "top"}
-          = _("Volume Name *")
-        .col-md-8
-          %input.form-control{:required => :required, :value => options[:"volume_name_#{counter}"], :type => "text", :id => "volumes__volume_name_#{counter}", :name => "volumes__volume_name_#{counter}", "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
-        .col-md-2
-      .form-group
-        %label.col-md-2.control-label{:valign => "top"}
-          = _("Volume Size *")
-        .col-md-8
-          %input.form-control{:required => :required, :value => options[:"volume_size_#{counter}"], :type => "text", :id => "volumes__volume_size_#{counter}", :name => "volumes__volume_size_#{counter}", "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
-        .col-md-2
-      .form-group
-        %label.col-md-2.control-label{:valign => "top"}
-          = _("Delete on Terminate?")
-        .col-md-8
-          %input{:checked => options[:"volume_delete_on_terminate_#{counter}"], :type => "checkbox", :id => "volumes__volume_delete_on_terminate_#{counter}", :name => "volumes__volume_delete_on_terminate_#{counter}", "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
-        .col-md-2
+      - keys.each do |key|
+        .form-group
+          %label.col-md-2.control-label{:valign => "top"}
+            = _(workflow.get_field(key, dialog)[:description])
+          .col-md-8
+            - if workflow.get_field(key, dialog)[:data_type] == :string
+              %input.form-control{:type              => "text",
+                                  :required          => workflow.get_field(key, dialog)[:required],
+                                  :value             => options[:"#{key}_#{counter}"],
+                                  :id                => "volumes__#{key}_#{counter}",
+                                  :name              => "volumes__#{key}_#{counter}",
+                                  "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+            - elsif workflow.get_field(key, dialog)[:data_type] == :boolean
+              %input{:checked           => options[:"volume_#{key}_#{counter}"],
+                     :type              => "checkbox",
+                     :id                => "volumes__#{key}_#{counter}",
+                     :required          => workflow.get_field(key, dialog)[:required],
+                     :name              => "volumes__#{key}_#{counter}",
+                     "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+          .col-md-2
       %hr
       %div
     - counter += 1

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -5,6 +5,15 @@
 
 %h3
   = label
+
+- if @edit && !options[:readonly]
+  .form-horizontal
+    .form-group
+      .col-md-10
+      .col-md-2
+        %button#add-additional-volume-button
+          Add Volume
+
 .form-horizontal#add-volumes-form
   - while (draw_fields)
     #add-volume-fieldset
@@ -13,35 +22,29 @@
           %label.col-md-2.control-label{:valign => "top"}
             = _(workflow.get_field(key, dialog)[:description])
           .col-md-8
-            - if workflow.get_field(key, dialog)[:display] == :edit
-              - if workflow.get_field(key, dialog)[:data_type] == :string
+            - if workflow.get_field(key, dialog)[:data_type] == :string
+              - if @edit && workflow.get_field(key, dialog)[:display] == :edit && !@edit[:stamp_typ]
                 %input.form-control{:type              => "text",
                                     :required          => workflow.get_field(key, dialog)[:required],
                                     :value             => options[:"#{key}_#{counter}"],
                                     :id                => "volumes__#{key}_#{counter}",
                                     :name              => "volumes__#{key}_#{counter}",
                                     "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
-              - elsif workflow.get_field(key, dialog)[:data_type] == :boolean
-                %input{:checked           => options[:"volume_#{key}_#{counter}"],
-                       :type              => "checkbox",
-                       :id                => "volumes__#{key}_#{counter}",
-                       :required          => workflow.get_field(key, dialog)[:required],
-                       :name              => "volumes__#{key}_#{counter}",
-                       "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
-            - else
-              = options[:"volume_#{key}_#{counter}"]
+              - else
+                = options[:"#{key}_#{counter}"]
+            - elsif workflow.get_field(key, dialog)[:data_type] == :boolean
+              %input{:checked           => options[:"#{key}_#{counter}"],
+                     :type              => "checkbox",
+                     :id                => "volumes__#{key}_#{counter}",
+                     :required          => workflow.get_field(key, dialog)[:required],
+                     :name              => "volumes__#{key}_#{counter}",
+                     :disabled          => !(@edit && workflow.get_field(key, dialog)[:display] == :edit && !@edit[:stamp_typ]),
+                     "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
           .col-md-2
       %hr
       %div
     - counter += 1
     - draw_fields = !options[:"volume_name_#{counter}"].blank? && !options[:"volume_size_#{counter}"].blank?
-
-.form-horizontal
-  .form-group
-    .col-md-10
-    .col-md-2
-      %button#add-additional-volume-button
-        Add Another Volume
 
 :javascript
   (function(){

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -13,20 +13,23 @@
           %label.col-md-2.control-label{:valign => "top"}
             = _(workflow.get_field(key, dialog)[:description])
           .col-md-8
-            - if workflow.get_field(key, dialog)[:data_type] == :string
-              %input.form-control{:type              => "text",
-                                  :required          => workflow.get_field(key, dialog)[:required],
-                                  :value             => options[:"#{key}_#{counter}"],
-                                  :id                => "volumes__#{key}_#{counter}",
-                                  :name              => "volumes__#{key}_#{counter}",
-                                  "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
-            - elsif workflow.get_field(key, dialog)[:data_type] == :boolean
-              %input{:checked           => options[:"volume_#{key}_#{counter}"],
-                     :type              => "checkbox",
-                     :id                => "volumes__#{key}_#{counter}",
-                     :required          => workflow.get_field(key, dialog)[:required],
-                     :name              => "volumes__#{key}_#{counter}",
-                     "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+            - if workflow.get_field(key, dialog)[:display] == :edit
+              - if workflow.get_field(key, dialog)[:data_type] == :string
+                %input.form-control{:type              => "text",
+                                    :required          => workflow.get_field(key, dialog)[:required],
+                                    :value             => options[:"#{key}_#{counter}"],
+                                    :id                => "volumes__#{key}_#{counter}",
+                                    :name              => "volumes__#{key}_#{counter}",
+                                    "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+              - elsif workflow.get_field(key, dialog)[:data_type] == :boolean
+                %input{:checked           => options[:"volume_#{key}_#{counter}"],
+                       :type              => "checkbox",
+                       :id                => "volumes__#{key}_#{counter}",
+                       :required          => workflow.get_field(key, dialog)[:required],
+                       :name              => "volumes__#{key}_#{counter}",
+                       "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+            - else
+              = options[:"volume_#{key}_#{counter}"]
           .col-md-2
       %hr
       %div

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -1,0 +1,79 @@
+- url = url_for(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
+- options = @options ? @options : @edit[:new]
+- if keys.any? { |key| workflow.get_field(key, dialog)[:display] && workflow.get_field(key, dialog)[:display].to_s != "hide" }
+  %h3
+    = label
+- draw_fields = true
+- counter = 1
+.form-horizontal#add-volumes-form
+  - while (draw_fields)
+    #add-volume-fieldset
+      .form-group
+        %label.col-md-2.control-label{:valign => "top"}
+          = _("Volume Name *")
+        .col-md-8
+          %input.form-control{:required => :required, :value => options[:"volume_name_#{counter}"], :type => "text", :id => "volumes__volume_name_#{counter}", :name => "volumes__volume_name_#{counter}", "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+        .col-md-2
+      .form-group
+        %label.col-md-2.control-label{:valign => "top"}
+          = _("Volume Size *")
+        .col-md-8
+          %input.form-control{:required => :required, :value => options[:"volume_size_#{counter}"], :type => "text", :id => "volumes__volume_size_#{counter}", :name => "volumes__volume_size_#{counter}", "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+        .col-md-2
+      .form-group
+        %label.col-md-2.control-label{:valign => "top"}
+          = _("Delete on Terminate?")
+        .col-md-8
+          %input{:checked => options[:"volume_delete_on_terminate_#{counter}"], :type => "checkbox", :id => "volumes__volume_delete_on_terminate_#{counter}", :name => "volumes__volume_delete_on_terminate_#{counter}", "data-miq_observe" => {:interval => ".5", :url => url}.to_json}
+        .col-md-2
+      %hr
+      %div
+    - counter += 1
+    - draw_fields = !options[:"volume_name_#{counter}"].blank? && !options[:"volume_size_#{counter}"].blank?
+
+.form-horizontal
+  .form-group
+    .col-md-10
+    .col-md-2
+      %button#add-additional-volume-button
+        Add Another Volume
+
+
+:javascript
+  (function(){
+      var button = document.getElementById("add-additional-volume-button");
+
+      button.addEventListener("click", function() {
+        var sourceNode = document.getElementById("add-volume-fieldset");
+        var node = duplicateNode(sourceNode, ["id", "name"]);
+
+        sourceNode.parentNode.appendChild(node);
+      }, false);
+
+      var counter = #{counter};
+      function duplicateNode(sourceNode, attributesToBump) {
+        var out = sourceNode.cloneNode(true);
+        var nodes = out.getElementsByTagName("*");
+
+        for (var i = 0, len1 = nodes.length; i < len1; i++) {
+          var node = nodes[i];
+          for (var j = 0, len2 = attributesToBump.length; j < len2; j++) {
+            var attribute = attributesToBump[j];
+            if (node.hasAttribute(attribute)) {
+              node[attribute] = increment_attr(node[attribute]);
+            }
+          }
+          node.value = '';
+          node.checked = false;
+        }
+
+        function increment_attr(str) {
+          str_pieces = str.split("_")
+          str_pieces[str_pieces.length - 1] = counter;
+          return str_pieces.join("_")
+        }
+        counter++;
+        return out;
+      }
+
+  })();

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -1,10 +1,10 @@
 - url = url_for(:action => 'prov_field_changed', :id => "#{@edit[:req_id] || 'new'}") if @edit
 - options = @options ? @options : @edit[:new]
-- if keys.any? { |key| workflow.get_field(key, dialog)[:display] && workflow.get_field(key, dialog)[:display].to_s != "hide" }
-  %h3
-    = label
 - draw_fields = true
 - counter = 1
+
+%h3
+  = label
 .form-horizontal#add-volumes-form
   - while (draw_fields)
     #add-volume-fieldset
@@ -38,34 +38,31 @@
       %button#add-additional-volume-button
         Add Another Volume
 
-
 :javascript
   (function(){
-      var button = document.getElementById("add-additional-volume-button");
+      var button = $("#add-additional-volume-button");
 
-      button.addEventListener("click", function() {
-        var sourceNode = document.getElementById("add-volume-fieldset");
+      button.click(function() {
+        var sourceNode = $("#add-volume-fieldset");
         var node = duplicateNode(sourceNode, ["id", "name"]);
 
-        sourceNode.parentNode.appendChild(node);
-      }, false);
+        sourceNode.parent().append(node);
+      });
 
       var counter = #{counter};
       function duplicateNode(sourceNode, attributesToBump) {
-        var out = sourceNode.cloneNode(true);
-        var nodes = out.getElementsByTagName("*");
+        var out = sourceNode.clone(true);
+        var nodes = out.find('*');
 
-        for (var i = 0, len1 = nodes.length; i < len1; i++) {
-          var node = nodes[i];
-          for (var j = 0, len2 = attributesToBump.length; j < len2; j++) {
-            var attribute = attributesToBump[j];
-            if (node.hasAttribute(attribute)) {
-              node[attribute] = increment_attr(node[attribute]);
+        $.each(nodes, function (ix, node) {
+          $.each(attributesToBump, function (ix, attr) {
+            if (node.hasAttribute(attr)) {
+              $(node).prop(attr, increment_attr($(node).prop(attr)));
             }
-          }
+          });
           node.value = '';
           node.checked = false;
-        }
+        });
 
         function increment_attr(str) {
           str_pieces = str.split("_")
@@ -75,5 +72,4 @@
         counter++;
         return out;
       }
-
   })();

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -72,7 +72,7 @@
             :sysprep_full_name, :sysprep_organization,
             :sysprep_product_id, :sysprep_computer_name,
             :sysprep_per_server_max_connections, :vm_description,
-            :vm_name, :volume_name, :volume_size, :wins_servers].include?(field)
+            :vm_name, :wins_servers].include?(field)
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of the text field

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -72,7 +72,7 @@
             :sysprep_full_name, :sysprep_organization,
             :sysprep_product_id, :sysprep_computer_name,
             :sysprep_per_server_max_connections, :vm_description,
-            :vm_name, :wins_servers].include?(field)
+            :vm_name, :volume_name, :volume_size, :wins_servers].include?(field)
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of the text field
@@ -245,7 +245,7 @@
                :retirement_warn, :cloud_network, :cloud_subnet, :floating_ip_address,
                :resource_group,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
-               :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory, 
+               :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory,
                :vm_maximum_memory, :boot_disk_size].include?(field)
         -# Pull Down fields
         -# Multiple select Pull Down fields

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -75,7 +75,7 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :volumes
-    - keys = [:volume_name, :volume_size, :volume_delete_on_terminate]
+    - keys = [:name, :size, :delete_on_terminate]
     = render(:partial => "/miq_request/prov_dialog_volume_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -75,12 +75,13 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :volumes
+    - keys = [:volume_name, :volume_size, :volume_delete_on_terminate]
     = render(:partial => "/miq_request/prov_dialog_volume_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Volumes"),
         :prefix                     => "/miq_request/",
-        :keys                       => []})
+        :keys                       => keys})
   - when :environment
     - keys = [:placement_auto]
     = render(:partial => "/miq_request/prov_dialog_fieldset",

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -74,6 +74,14 @@
         :label                      => _("Naming"),
         :prefix                     => "/miq_request/",
         :keys                       => keys})
+  - when :volumes
+    - keys = [:volume_name, :volume_size]
+    = render(:partial => "/miq_request/prov_dialog_volume_fieldset",
+      :locals         => {:workflow => wf,
+        :dialog                     => dialog,
+        :label                      => _("Volumes"),
+        :prefix                     => "/miq_request/",
+        :keys                       => keys})
   - when :environment
     - keys = [:placement_auto]
     = render(:partial => "/miq_request/prov_dialog_fieldset",

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -75,13 +75,12 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :volumes
-    - keys = [:volume_name, :volume_size]
     = render(:partial => "/miq_request/prov_dialog_volume_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Volumes"),
         :prefix                     => "/miq_request/",
-        :keys                       => keys})
+        :keys                       => []})
   - when :environment
     - keys = [:placement_auto]
     = render(:partial => "/miq_request/prov_dialog_fieldset",

--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -311,7 +311,7 @@
       :fields:
         :volume_name:
           :description: Volume Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
           :min_length:

--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -311,7 +311,7 @@
       :fields:
         :volume_name:
           :description: Volume Name
-          :required: false
+          :required: true
           :display: :edit
           :data_type: :string
           :min_length:
@@ -324,7 +324,7 @@
           :min_length:
           :max_length: 10
         :volume_delete_on_terminate:
-          :description: Size (gigabytes)
+          :description: Delete on Instance Terminate
           :required: false
           :display: :edit
           :data_type: :boolean

--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -309,21 +309,21 @@
     :volumes:
       :description: Volumes
       :fields:
-        :volume_name:
+        :name:
           :description: Volume Name
           :required: false
           :display: :edit
           :data_type: :string
           :min_length:
           :max_length: 100
-        :volume_size:
+        :size:
           :description: Size (gigabytes)
           :required: false
           :display: :edit
           :data_type: :string
           :min_length:
           :max_length: 10
-        :volume_delete_on_terminate:
+        :delete_on_terminate:
           :description: Delete on Instance Terminate
           :required: false
           :display: :edit

--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -100,7 +100,7 @@
         :owner_email:
           :description: E-Mail
           :required_method: :validate_regex
-          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
           :required: true
           :display: :edit
           :data_type: :string
@@ -306,6 +306,30 @@
           :display: :edit
           :data_type: :integer
       :display: :show
+    :volumes:
+      :description: Volumes
+      :fields:
+        :volume_name:
+          :description: Volume Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :volume_size:
+          :description: Size (gigabytes)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 10
+        :volume_delete_on_terminate:
+          :description: Size (gigabytes)
+          :required: false
+          :display: :edit
+          :data_type: :boolean
+          :default: false
+      :display: :show
     :customize:
       :description: Customize
       :fields:
@@ -378,5 +402,6 @@
   - :service
   - :environment
   - :hardware
+  - :volumes
   - :customize
   - :schedule

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -329,13 +329,13 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
     end
     it "converts numbered volume form fields into an array" do
       volumes = workflow.prepare_volumes_fields(
-        :volume_name_1 => "v1n", :volume_size_1 => "v1s", :volume_delete_on_terminate_1 => true,
-        :volume_name_2 => "v2n", :volume_size_2 => "v2s", :volume_delete_on_terminate_2 => false,
+        :name_1 => "v1n", :size_1 => "v1s", :delete_on_terminate_1 => true,
+        :name_2 => "v2n", :size_2 => "v2s", :delete_on_terminate_2 => false,
         :other_irrelevant_key => 1
       )
       expect(volumes.length).to eq(2)
-      expect(volumes[0]).to eq(:volume_name => "v1n", :volume_size => "v1s", :volume_delete_on_terminate => true)
-      expect(volumes[1]).to eq(:volume_name => "v2n", :volume_size => "v2s", :volume_delete_on_terminate => false)
+      expect(volumes[0]).to eq(:name => "v1n", :size => "v1s", :delete_on_terminate => true)
+      expect(volumes[1]).to eq(:name => "v2n", :size => "v2s", :delete_on_terminate => false)
     end
     it "produces an empty array if there are no volume fields" do
       volumes = workflow.prepare_volumes_fields(:other_irrelevant_key => 1)

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -321,6 +321,28 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
     end
   end
 
+  describe "prepare_volumes_fields" do
+    let(:workflow) do
+      stub_dialog
+      allow_any_instance_of(described_class).to receive(:update_field_visibility)
+      described_class.new({:src_vm_id => template.id}, admin.userid)
+    end
+    it "converts numbered volume form fields into an array" do
+      volumes = workflow.prepare_volumes_fields(
+        :volume_name_1 => "v1n", :volume_size_1 => "v1s", :volume_delete_on_terminate_1 => true,
+        :volume_name_2 => "v2n", :volume_size_2 => "v2s", :volume_delete_on_terminate_2 => false,
+        :other_irrelevant_key => 1
+      )
+      expect(volumes.length).to eq(2)
+      expect(volumes[0]).to eq(:volume_name => "v1n", :volume_size => "v1s", :volume_delete_on_terminate => true)
+      expect(volumes[1]).to eq(:volume_name => "v2n", :volume_size => "v2s", :volume_delete_on_terminate => false)
+    end
+    it "produces an empty array if there are no volume fields" do
+      volumes = workflow.prepare_volumes_fields(:other_irrelevant_key => 1)
+      expect(volumes.length).to eq(0)
+    end
+  end
+
   describe "#make_request" do
     let(:alt_user) { FactoryGirl.create(:user_with_group) }
 


### PR DESCRIPTION
WIP. Depends on https://github.com/ManageIQ/manageiq/pull/7742

I had to hack around the provisioning dialog to support adding arbitrary numbers of disks since that doesn't seem to be a supported provisioning UI pattern already. I could be wrong about this. The form uses javascript to generate the fields and the the workflow model massages the fields into a data structure that #7742 can use.

The supported fields are probably not the right ones (need to clarify with @aufi and @loicavenel), but they are easily changed-- the important bit is the dynamic form. Hence WIP.

![provision_volume_ui](https://cloud.githubusercontent.com/assets/628956/14546529/e6cc6692-0273-11e6-818f-a95c2084347c.png)