### PR TITLE
Run tags in a single query

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -113,7 +113,7 @@ class Tag < ApplicationRecord
   end
 
   # @param tag_names [Array<String>] list of non namespaced tags
-  def self.for_names(tag_names, ns = nil)
+  def self.for_names(tag_names, ns)
     fq_tag_names = tag_names.collect { |tag_name| File.join(ns, tag_name) }
     where(:name => fq_tag_names)
   end

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -47,12 +47,13 @@ module ActsAsTaggable
 
     def with_any_tags(tag_ids)
       taggings = reflect_on_association(:taggings).klass.arel_table
-      if tag_ids.length > 1
-        where(Tagging.where(arel_taggings_include(taggings, tag_ids)).exists)
-      else
-        taggings = taggings.alias("taggings#{tag_ids.first%1000}")
+      if tag_ids.length == 1
+        # alias to a unique table name
+        taggings = taggings.alias("taggings#{tag_ids.first%1_000_000_000}")
         joins(arel_table.join(taggings, Arel::Nodes::InnerJoin)
                         .on(arel_taggings_include(taggings, tag_ids)).join_sources)
+      else
+        where(Tagging.where(arel_taggings_include(taggings, tag_ids)).exists)
       end
     end
 

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -215,6 +215,30 @@ describe Classification do
       expect(all_tagged_with(Host, [[full_tag_name(ent12)], [full_tag_name(ent21)]])).not_to eq([host2])
     end
 
+    it "find with multiple tags" do
+      cat1 = Classification.find_by_name "test_single_value_category"
+      ent11 = cat1.entries[0]
+      ent12 = cat1.entries[1]
+
+      cat2 = Classification.find_by_name "test_multi_value_category"
+      ent21 = cat2.entries[0]
+      ent22 = cat2.entries[1]
+
+      ent11.assign_entry_to(host2)
+      ent21.assign_entry_to(host2)
+
+      # success
+      expect(any_tagged_with(Host, [[full_tag_name(ent12), full_tag_name(ent11)], [full_tag_name(ent21)]])
+            ).to eq([host2])
+      expect(all_tagged_with(Host, [[full_tag_name(ent11)], [full_tag_name(ent11)]])).to eq([host2])
+
+      # failure
+      expect(all_tagged_with(Host, [[full_tag_name(ent12), full_tag_name(ent11)], [full_tag_name(ent21)]])
+            ).not_to eq([host2])
+      expect(all_tagged_with(Host, [[full_tag_name(ent11)], [full_tag_name(ent22)]])).not_to eq([host2])
+      expect(all_tagged_with(Host, [[full_tag_name(ent12)], [full_tag_name(ent21)]])).not_to eq([host2])
+    end
+
     it "should test find by entry" do
       cat = Classification.find_by_name "test_multi_value_category"
       ent1 = cat.entries[0]


### PR DESCRIPTION
When fetching records with a tag filter, a `distinct`, `join` or a `group by` was used to determine the `id` values that are valid.

This required bringing back all ids that are tagged by any of the tags and then performing set logic locally.

The change:

- converted the individual tag exists queries to use exists (basically a join without the need for a group by or distinct)
- merge all these the individual tag queries into a single query
