### PR TITLE
Adding vm has many cloud_networks relation to cloud vm

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -10,6 +10,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
 
   has_many :network_ports, :as => :device
   has_many :cloud_subnets, :through => :network_ports
+  has_many :cloud_networks, :through => :cloud_subnets
   has_many :network_routers, :through => :cloud_subnets
   # Keeping floating_ip for backwards compatibility. Keeping association through vm_id foreign key, because of Amazon
   # ec2, it allows to associate floating ips without network ports


### PR DESCRIPTION
We will need this relation, until we change cloud_network to
network_group. This fixes 500 in azure and google provider
vm detail pages.