### PR TITLE
Fixed escaping in launch_html5_console by including the required module

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1,5 +1,6 @@
 module VmCommon
   extend ActiveSupport::Concern
+  include ActionView::Helpers::JavaScriptHelper
 
   # handle buttons pressed on the button bar
   def button


### PR DESCRIPTION
Fixes #7956