### PR TITLE
Remove extraneous 3rd argument to d_read

### DIFF
--- a/gems/pending/disk/modules/MSCommon.rb
+++ b/gems/pending/disk/modules/MSCommon.rb
@@ -140,7 +140,7 @@ module MSCommon
           if parent.nil?
             buf << MemoryBuffer.create(thisLen)
           else
-            buf << parent.d_read(pos + buf.length, thisLen, mark_dirty)
+            buf << parent.d_read(pos + buf.length, thisLen)
           end
         else
           @file.seek(getAbsSectorLoc(blockNum, secNum) + byteOffset, IO::SEEK_SET)


### PR DESCRIPTION
One of two calls to d_read for the parent disk was obviously left over from an
earlier incarnation of this code.  It is using an undefined and unnecessary
3rd argument which resulted in an unknown method exception.
The extra argument has been removed and the code tested.

@roliveri @Fryguy @chessbyte please review and merge.  Thanks.