### PR TITLE
Temporarily destroy entitlements with miq_groups

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -4,7 +4,7 @@ class MiqGroup < ApplicationRecord
   TENANT_GROUP = "tenant"
 
   belongs_to :tenant
-  has_one    :entitlement
+  has_one    :entitlement, :dependent => :destroy
   has_one    :miq_user_role, :through => :entitlement
   has_and_belongs_to_many :users
   has_many   :vms,         :dependent => :nullify

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -234,4 +234,31 @@ describe MiqUserRole do
       expect(FactoryGirl.build(:miq_user_role)).not_to be_admin_user
     end
   end
+
+  describe "#destroy" do
+    subject { miq_group.entitlement.miq_user_role }
+    let!(:miq_group) { FactoryGirl.create(:miq_group, :role => "EvmRole-administrator") }
+
+    context "when the role has any entitlements" do
+      it "does not allow the role to be deleted" do
+        expect { subject.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
+      end
+    end
+
+    context "with the entitlement removed" do
+      before { miq_group.entitlement.destroy! }
+
+      it "allows the role to be deleted" do
+        expect { subject.destroy! }.not_to raise_error
+      end
+    end
+
+    context "temporary backwards compatibility - groups destroy entitlements, allowing the role to be destroyed" do
+      before { miq_group.destroy! }
+
+      it "allows the role to be deleted" do
+        expect { subject.destroy! }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Entitlements should soon be shared amongst miq_groups so this should not
be the case in the future. But for now, there's no way in the UI to
destroy entitlements (created with groups), so when someone tries to
delete the group (correctly) before deleting a role, they'll get an
error that you cannot delete the role without deleting the associated
entitlements.

Fixes #7896