### PR TITLE
Fixed issue when adding new chargeback rate

### DIFF
--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -4,6 +4,8 @@ class ChargebackTier < ApplicationRecord
   validates :start,  :numericality => {:greater_than_or_equal_to => 0, :less_than => Float::INFINITY}
   validates :finish, :numericality => {:greater_than_or_equal_to => 0}
 
+  FORM_ATTRIBUTES = %i(fixed_rate variable_rate start finish).freeze
+
   def self.to_float(s)
     if s.to_s.include?("Infinity")
       Float::INFINITY


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/7832 point #1

Basically same idea as https://github.com/ManageIQ/manageiq/pull/5828/commits/08fe0a24113648051d839cf931420479413f6bd2 

So we are getting default values from yaml when we are adding new chargeback rate. This yaml file used also for default chargeback rate when we are seeding. 

There are a several values so it seemed to me ok to leave it in this yaml file than leave it in some constants - but If you have other idea - let me know, please!

 In this PR - I reduced origin code and updated related code.

please review @gtanzillo @amaurygonzalez @tledesma 

thank you!
