### PR TITLE
Add service model for AnsibleTower ConfigurationScript

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script.rb
@@ -1,5 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceConfigurationScript < MiqAeServiceModelBase
-    expose :run
+    expose :inventory_root_group, :association => true
+    expose :manager,              :association => true
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configuration_script.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configuration_script.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript < MiqAeServiceConfigurationScript
+    expose :run
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager-inventory_group.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager-inventory_group.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_ConfigurationManager_InventoryGroup < MiqAeServiceEmsFolder
+    expose :manager, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager-inventory_root_group.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager-inventory_root_group.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_ConfigurationManager_InventoryRootGroup < MiqAeServiceManageIQ_Providers_ConfigurationManager_InventoryGroup
+    expose :configuration_scripts, :association => true
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_configuration_script_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_configuration_script_spec.rb
@@ -6,5 +6,13 @@ module MiqAeServiceConfigurationScriptSpec
     it "get the service model class" do
       expect { described_class }.not_to raise_error
     end
+
+    it "#inventory_root_group" do
+      expect(described_class.instance_methods).to include(:inventory_root_group)
+    end
+
+    it "#manager" do
+      expect(described_class.instance_methods).to include(:manager)
+    end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configuration_script_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configuration_script_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module MiqAeServiceManageIQProvidersAnsibleTowerConfigurationManagerConfigurationScriptSpec
+  include MiqAeEngine
+  describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript do
+    it "get the service model class" do
+      expect { described_class }.not_to raise_error
+    end
+
+    it "#run" do
+      expect(described_class.instance_methods).to include(:run)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_group_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_group_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+module MiqAeServiceManageIQProvidersConfigurationManagerInventoryGroupSpec
+  include MiqAeEngine
+  describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_ConfigurationManager_InventoryGroup do
+    it "get the service model class" do
+      expect { described_class }.not_to raise_error
+    end
+
+    it "#manager" do
+      expect(described_class.instance_methods).to include(:manager)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_root_group_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_root_group_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+module MiqAeServiceManageIQProvidersConfigurationManagerInventoryRootGroupSpec
+  include MiqAeEngine
+  describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_ConfigurationManager_InventoryRootGroup do
+    it "get the service model class" do
+      expect { described_class }.not_to raise_error
+    end
+
+    it "#configuration_scripts" do
+      expect(described_class.instance_methods).to include(:configuration_scripts)
+    end
+  end
+end


### PR DESCRIPTION
Add the missing service model for AnsibleTower ConfiguraitonScript introduced with #7943.

Add missing service model for InventoryGroup and InventoryRootGroup
@gmcculloug @bdunne please review