### PR TITLE
ArTagging.find_tags_by_grouping use scope

### DIFF
--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -74,9 +74,8 @@ module ActsAsTaggable
 
       return find_tagged_with(options.merge(:all => fixed_conditions)) if inner_lists.empty?
 
-      offset = options.delete(:offset)
+      offset = options.delete(:offset) || 0
       limit = options.delete(:limit)
-      count = options.delete(:count)
       results = nil
       list.each do |inner_list|
         ret = find_tagged_with(options.merge(:any => inner_list))
@@ -88,11 +87,7 @@ module ActsAsTaggable
         results = results.select { |obj| ret.include?(obj) }
         break if results.empty?
       end
-      if limit
-        offset ||= 0
-        results = results[offset..offset + limit - 1]
-      end
-      count ? results.length : results
+      limit ? results[offset...(offset + limit)] : results
     end
 
     def tags(options = {})

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -74,8 +74,6 @@ module ActsAsTaggable
 
       return find_tagged_with(options.merge(:all => fixed_conditions)) if inner_lists.empty?
 
-      offset = options.delete(:offset) || 0
-      limit = options.delete(:limit)
       results = nil
       list.each do |inner_list|
         ret = find_tagged_with(options.merge(:any => inner_list))
@@ -87,7 +85,7 @@ module ActsAsTaggable
         results = results.select { |obj| ret.include?(obj) }
         break if results.empty?
       end
-      limit ? results[offset...(offset + limit)] : results
+      results
     end
 
     def tags(options = {})

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -65,27 +65,7 @@ module ActsAsTaggable
     # find_tagged_with(:all) is used for multiple inner lists
     def find_tags_by_grouping(list, options = {})
       options[:ns] = Tag.get_namespace(options)
-
-      # any inner arrays with only 1 element doesn't need an 'IN' clause.
-      # These can all be handled together in a single 'AND' query
-      #
-      # the inner_lists need to be added as separate queries.
-      inner_lists, fixed_conditions = list.partition { |item| item.kind_of?(Array) && item.length > 1 }
-
-      return find_tagged_with(options.merge(:all => fixed_conditions)) if inner_lists.empty?
-
-      results = nil
-      list.each do |inner_list|
-        ret = find_tagged_with(options.merge(:any => inner_list))
-        if results.nil?
-          results = ret
-          next
-        end
-
-        results = results.select { |obj| ret.include?(obj) }
-        break if results.empty?
-      end
-      results
+      list.inject(self) { |results, tags| results.find_tagged_with(options.merge(:any => tags)) }
     end
 
     def tags(options = {})


### PR DESCRIPTION
The is the final step for tag filters.

**before:**
Perform a `distinct` and `count(*)`, possibly `group by` for every set of tags.
These queries were expensive and required a separate query per tag category.

**after:**
We're performing a lighter sub query per tag. And these subqueries are brought together so only one query is performed. The one query is part of the main query, so no additional hits to the database and can go directly into rbac.

**NOTE:**
This is never called with `:limit`, `:offset`. The code that calls with `:condition` (and is ignored) has the callers changed. Since this uses scopes, the caller just uses `where(conditions)`.

May be easier to grok if #8009 is merged first
