### PR TITLE
Discover domain name embedded in Git Repository

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -54,11 +54,8 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def self.import_git_repo(options)
-    options['ref'] ||= DEFAULT_BRANCH
-    options['ref_type'] ||= BRANCH
-
-    git_repo = GitRepository.find(options['git_repo_id'])
-    raise "Git repository with id #{options['git_repo_id']} not found" unless git_repo
+    git_repo = GitRepository.find(options['git_repository_id'])
+    raise "Git repository with id #{options['git_repository_id']} not found" unless git_repo
 
     MiqAeDomain.find_by(:name => options['domain']).try(:destroy) if options['domain']
     import_options(git_repo, options)
@@ -127,7 +124,11 @@ class MiqAeDomain < MiqAeNamespace
   def self.import_options(git_repo, options)
     options['git_dir'] = git_repo.directory_name
     options['preview'] ||= false
-    case options['ref_type'].downcase
+    options['ref'] ||= DEFAULT_BRANCH
+    options['ref_type'] ||= BRANCH
+    options['ref_type'] = options['ref_type'].downcase
+
+    case options['ref_type']
     when BRANCH
       options['branch'] = options['ref']
     when TAG

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -28,8 +28,9 @@ class MiqAeYamlImport
     _log.info("Importing domain:    <#{domain_name}>")
     reset_stats
     @single_domain = true
-    domain_name == ALL_DOMAINS ? import_all_domains : import_domain(domain_folder(domain_name), domain_name)
+    result = domain_name == ALL_DOMAINS ? import_all_domains : import_domain(domain_folder(domain_name), domain_name)
     log_stats
+    result
   end
 
   def log_stats
@@ -49,12 +50,13 @@ class MiqAeYamlImport
 
   def import_all_domains
     @single_domain = false
-    sorted_domain_files.each do |file|
+    domains = sorted_domain_files.collect do |file|
       directory = File.dirname(file)
       @domain_name = directory.split("/").last
       import_domain(directory, @domain_name)
     end
     MiqAeDatastore.reset_default_namespace if @restore && !@preview
+    domains
   end
 
   def sorted_domain_files
@@ -80,6 +82,7 @@ class MiqAeYamlImport
       import_all_namespaces(domain_folder, domain_obj, domain_name)
     end
     update_attributes(domain_obj) if @single_domain && domain_obj
+    domain_obj
   end
 
   def domain_properties(domain_folder, name)

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -85,7 +85,7 @@ class MiqAeYamlImport
     else
       import_all_namespaces(domain_folder, domain_obj, domain_name)
     end
-    update_attributes(domain_obj) if @single_domain && domain_obj
+    update_attributes(domain_obj) if domain_obj
     domain_obj
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -75,6 +75,10 @@ class MiqAeYamlImport
     domain_name = domain_yaml.fetch_path('object', 'attributes', 'name')
     domain_obj = MiqAeDomain.find_by_fqname(domain_name, false)
     track_stats('domain', domain_obj)
+    if domain_obj && !@preview && @options['overwrite']
+      domain_obj.destroy
+      domain_obj = nil
+    end
     domain_obj ||= add_domain(domain_yaml, @tenant) unless @preview
     if @options['namespace']
       import_namespace(File.join(domain_folder, @options['namespace']), domain_obj, domain_name)

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import_gitfs.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import_gitfs.rb
@@ -38,7 +38,7 @@ class MiqAeYamlImportGitfs < MiqAeYamlImport
   end
 
   def domain_files(domain)
-    glob_str = File.join(domain, DOMAIN_YAML_FILENAME)
+    glob_str = (domain == '*') ? File.join('**', DOMAIN_YAML_FILENAME) : File.join('**', domain, DOMAIN_YAML_FILENAME)
     @files.select { |entry| File.fnmatch(glob_str, entry, @fn_flags) }
   end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -178,7 +178,9 @@ describe MiqAeDomain do
       expect(MiqAeImport).to receive(:new).with(any_args).and_return(git_import)
       expect_any_instance_of(GitRepository).to receive(:branch_info).with(branch_name).and_return(info)
       allow(git_import).to receive(:import) { MiqAeDomain.create(:name => domain_name) }
-      dom1 = MiqAeDomain.import_git_repo(domain_name, repo.id, @user.current_tenant.id, branch_name)
+      options = {'domain' => domain_name, 'git_repo_id' => repo.id,
+                 'tenant_id' => @user.current_tenant.id, 'ref' => branch_name}
+      dom1 = MiqAeDomain.import_git_repo(options)
       expect(dom1.attributes).to have_attributes(commit_hash)
     end
 
@@ -187,7 +189,9 @@ describe MiqAeDomain do
       expect(MiqAeImport).to receive(:new).with(any_args).and_return(git_import)
       expect_any_instance_of(GitRepository).to receive(:branch_info).with(branch_name).and_return(info)
       allow(git_import).to receive(:import) { [MiqAeDomain.create(:name => domain_name)] }
-      dom1 = MiqAeDomain.import_git_repo(nil, repo.id, @user.current_tenant.id, branch_name)
+      options = {'git_repo_id' => repo.id,
+                 'tenant_id' => @user.current_tenant.id, 'ref' => branch_name}
+      dom1 = MiqAeDomain.import_git_repo(options)
 
       expect(dom1.attributes).to have_attributes(commit_hash)
     end
@@ -197,7 +201,9 @@ describe MiqAeDomain do
       expect(MiqAeImport).to receive(:new).with(any_args).and_return(git_import)
       allow(git_import).to receive(:import) { nil }
       expect do
-        MiqAeDomain.import_git_repo(domain_name, repo.id, @user.current_tenant.id, branch_name)
+        options = {'git_repo_id' => repo.id,
+                   'tenant_id' => @user.current_tenant.id, 'ref' => branch_name}
+        MiqAeDomain.import_git_repo(options)
       end.to raise_error(MiqAeException::DomainNotFound)
     end
 


### PR DESCRIPTION
When a user imports a domain from a Git repostiory, they
might not know the domain name. This PR discovers the domain
name embedded in the repository and uses that to build the
domain in Postgres.

Use the current logged in user's tenant_id when importing the domain.

Since the requests get routed thru the queue we can't use any of the objects directly and have to use the ids of the object.