### PR TITLE
Add event catcher support for Google provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,11 +80,11 @@ gem "ansible_tower_client",           "~>0.2.0",   :require => false
 gem "aws-sdk",                        "~>2.2.19",  :require => false
 gem "dalli",                          "~>2.7.4",   :require => false
 gem "elif",                           "=0.1.0",    :require => false
-gem "google-api-client",              "< 0.9", ">= 0.6.2", :require => false
-gem "fog-google",                     "~>0.2.0",   :require => false
+gem "google-api-client",              "~>0.8.6",   :require => false
+gem "fog-google",                     "~>0.3.0",   :require => false
 gem "hamlit",                         "~>2.0.0",   :require => false
 gem "inifile",                        "~>3.0",     :require => false
-gem "logging",                        "~>1.6.1",   :require => false  # Ziya depends on this
+gem "logging",                        "~>1.8",     :require => false  # Ziya depends on this
 gem "net_app_manageability",          ">=0.1.0",   :require => false
 gem "net-ping",                       "~>1.7.4",   :require => false
 gem "net-ssh",                        "~>2.9.2",   :require => false

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :AvailabilityZone
+  require_nested :EventCatcher
   require_nested :EventParser
   require_nested :Flavor
   require_nested :Provision
@@ -87,6 +88,8 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
     # specify Compute as the default
     when 'compute', nil
       ::Fog::Compute.new(config)
+    when 'pubsub'
+      ::Fog::Google::Pubsub.new(config.except(:provider))
     else
       raise ArgumentError, "Unknown service: #{options[:service]}"
     end
@@ -95,7 +98,7 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   def connect(options = {})
     require 'fog/google'
 
-    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(options[:auth_type])
+    raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(options[:auth_type])
 
     auth_token = authentication_token(options[:auth_type])
     self.class.raw_connect(project, auth_token, options)

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Google::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+end

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
@@ -1,0 +1,51 @@
+class ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner <
+  ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  include ManageIQ::Providers::Google::EventCatcherMixin
+
+  # Request the event monitor to stop running.
+  def stop_event_monitor
+    @event_monitor_handle.try(:stop)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  # Start monitoring for events. This method blocks forever until
+  # #stop_event_monitor is called.
+  def monitor_events
+    _log.info "#{log_prefix} Monitoring for events"
+    event_monitor_handle.each_batch do |events|
+      event_monitor_running
+      _log.debug "#{log_prefix} Received events #{events.collect { |e| parse_event_type(e) }}"
+      @queue.enq events
+      sleep_poll_normal
+    end
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def process_event(event)
+    if filtered?(event)
+      _log.info(
+        "#{log_prefix} Skipping filtered Google event #{parse_event_type(event)} for #{parse_resource_id(event)}"
+      )
+    else
+      _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{parse_resource_id(event)}"
+      EmsEvent.add_queue('add_google', @cfg[:ems_id], event)
+    end
+  end
+
+  private
+
+  def event_monitor_handle
+    @event_monitor_handle ||= ManageIQ::Providers::Google::CloudManager::EventCatcher::Stream.new(@ems)
+  end
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  def filtered?(event)
+    event_type = parse_event_type(event)
+    filtered_events.include?(event_type)
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb
@@ -1,0 +1,53 @@
+# Helper class responsible for polling a Google Pubsub topic and retreiving
+# event type messages. Parsing of the message is deferred to the caller of
+# #poll.
+class ManageIQ::Providers::Google::CloudManager::EventCatcher::Stream
+  def initialize(ems)
+    @ems = ems
+    @collecting_events = true
+  end
+
+  # Stop capturing events. Once stopped, event collection cannot be resumed.
+  def stop
+    @collecting_events = false
+  end
+
+  # Poll for events (blocks forever until #stop is called)
+  def each_batch
+    while @collecting_events
+      yield events.map { |e| JSON.parse(e.message['data']) }
+    end
+  end
+
+  private
+
+  # Poll for messages. This makes a service call to the Google Pubsub service
+  # and returns any messages generated from the activity log. Note that these
+  # messages are acknowledged before returning, so the caller has no
+  # responsibility to explicitly acknowledge them.
+  #
+  # @return [Array<Fog::Google::Pubsub::ReceivedMessage>] possibly empty list of messages
+  def events
+    # For now, return immediately with up to 10 messages
+    @ems.with_provider_connection(:service => 'pubsub') do |google|
+      subscription = get_or_create_subscription(google)
+      subscription.pull(:return_immediately => true, :max_messages => 10).tap do |msgs|
+        subscription.acknowledge(msgs)
+      end
+    end
+  end
+
+  def get_or_create_subscription(google)
+    google.subscriptions.get(subscription_name) ||
+      google.subscriptions.create(:name  => subscription_name,
+                                  :topic => topic_name)
+  end
+
+  def subscription_name
+    "projects/#{@ems.project}/subscriptions/manageiq-eventcatcher-#{@ems.guid}"
+  end
+
+  def topic_name
+    "projects/#{@ems.project}/topics/manageiq-activity-log"
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_parser.rb
@@ -1,14 +1,19 @@
 module ManageIQ::Providers::Google::CloudManager::EventParser
+  extend ManageIQ::Providers::Google::EventCatcherMixin
+
   def self.event_to_hash(event, ems_id)
     log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
 
-    _log.debug { "#{log_header}event: [#{event["eventType"]}]" }
+    event_type = parse_event_type(event)
+    timestamp = event.fetch_path('metadata', 'timestamp')
+
+    _log.debug { "#{log_header}event: [#{event_type}]" }
 
     event_hash = {
-      :event_type => event["eventType"],
+      :event_type => event_type,
       :source     => "GOOGLE",
-      :message    => event["configurationItemDiff"],
-      :timestamp  => event["notificationCreationTime"],
+      :message    => event_type,
+      :timestamp  => timestamp,
       :full_data  => event,
       :ems_id     => ems_id
     }

--- a/app/models/manageiq/providers/google/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/google/event_catcher_mixin.rb
@@ -1,0 +1,20 @@
+module ManageIQ::Providers::Google::EventCatcherMixin
+  def parse_event_type(event)
+    event_type = event.fetch_path('structPayload', 'event_type')
+    event_subtype = event.fetch_path('structPayload', 'event_subtype')
+
+    event_type = "unknown" if event_type.blank?
+    event_subtype = "unknown" if event_subtype.blank?
+
+    event_type = event_type.downcase.camelize
+
+    "#{event_type}_#{event_subtype}"
+  end
+
+  def parse_resource_id(event)
+    resource_id = event.fetch_path('structPayload', 'resource', 'id')
+    resource_id = "unknown" if resource_id.blank?
+
+    resource_id
+  end
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -38,6 +38,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
+    ManageIQ::Providers::Google::CloudManager::EventCatcher
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
     ManageIQ::Providers::Atomic::ContainerManager::EventCatcher
@@ -120,6 +121,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
+    ManageIQ::Providers::Google::CloudManager::EventCatcher
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
     ManageIQ::Providers::Atomic::ContainerManager::EventCatcher

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -175,7 +175,7 @@
       - USER_FAILED_ADD_HOST
       - USER_FAILED_ADD_VM_TEMPLATE
       - virtualMachines_write_EndRequest
-      - compute_instance_insert
+      - GceOperationDone_compute.instances.insert
       - VmConnectedEvent
       - VmCreatedEvent
       - VmDeployedEvent
@@ -299,7 +299,7 @@
       - USER_REMOVE_VM_TEMPLATE
       - USER_REMOVE_VM_TEMPLATE_FINISHED
       - virtualMachines_delete_EndRequest
-      - compute_instance_delete
+      - GceOperationDone_compute.instances.delete
       - VmDisconnectedEvent
       - VmRemovedEvent
       - image.delete
@@ -634,8 +634,8 @@
       - virtualMachines_deallocate_EndRequest
       - virtualMachines_start_EndRequest
       - virtualMachines_restart_EndRequest
-      - compute_instance_start
-      - compute_instance_stop
+      - GceOperationDone_compute.instances.start
+      - GceOperationDone_compute.instances.stop
       - VM_DOWN
       - VM_DOWN_ERROR
       - VM_PAUSED_ENOSPC
@@ -1152,6 +1152,8 @@
         :poll: 15.seconds
       :event_catcher_hawkular:
         :poll: 10.seconds
+      :event_catcher_google:
+        :poll: 15.seconds
       :event_catcher_kubernetes:
         :poll: 1.seconds
       :event_catcher_openshift:

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: GceOperationDone_compute.instances.delete
+    inherits:
+    description:
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_insert.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_insert.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: GceOperationDone_compute.instances.insert
+    inherits:
+    description:
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_start.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_start.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: GceOperationDone_compute.instances.start
+    inherits:
+    description:
+  fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_start&param="
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_stop.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/GOOGLE.class/gce_operation_done_compute_instances_stop.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: GceOperationDone_compute.instances.stop
+    inherits:
+    description:
+  fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_poweroff&param="
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
This handles the following four events:
* VM Creation
* VM Deletion
* VM Start
* VM Stop

Closes #7902

For directions on setting up events with the Google Cloud provider in ManageIQ, see this gist: https://gist.github.com/selmanj/fd25da94b0f8d6f65415409e98659bf2