### PR TITLE
Rescue StandardError rather than RuntimeError in PglogicalSubscription.save_all!

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -47,7 +47,7 @@ class PglogicalSubscription < ActsAsArModel
     subscription_list.each do |s|
       begin
         s.save!
-      rescue RuntimeError => e
+      rescue StandardError => e
         errors << "Failed to save subscription to #{s.host}: #{e.message}"
       end
     end

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -258,7 +258,7 @@ describe PglogicalSubscription do
       allow(pglogical).to receive(:node_create).and_return(double(:check => nil))
 
       # subscription is created
-      expect(pglogical).to receive(:subscription_create).ordered.and_raise("Error one")
+      expect(pglogical).to receive(:subscription_create).ordered.and_raise(PG::Error.new("Error one"))
       expect(pglogical).to receive(:subscription_create) do |name, dsn, replication_sets, sync_structure|
         expect(name).to eq("region_3_subscription")
         expect(dsn).to include("host='test-3.example.com'")


### PR DESCRIPTION
`PG::Error` does not inherit from `RuntimeError` so query errors were not being
rescued properly.

@gtanzillo @h-kataria 