### PR TITLE
Enhance AnsibleTower Job to process job options

### DIFF
--- a/app/models/mixins/service_configuration_mixin.rb
+++ b/app/models/mixins/service_configuration_mixin.rb
@@ -14,5 +14,7 @@ module ServiceConfigurationMixin
     self.configuration_scripts = [script].compact
   end
 
-  delegate :configuration_manager, :to => :configuration_script, :allow_nil => true
+  def configuration_manager
+    configuration_script.try(:manager)
+  end
 end

--- a/app/models/mixins/service_orchestration_options_mixin.rb
+++ b/app/models/mixins/service_orchestration_options_mixin.rb
@@ -1,0 +1,48 @@
+module ServiceOrchestrationOptionsMixin
+  # options to create the stack: read from DB or build from dialog
+  def stack_options
+    @stack_options ||= get_option(:create_options) || build_stack_create_options
+  end
+
+  # override existing stack options (most likely from dialog)
+  def stack_options=(opts)
+    @stack_options = opts
+    save_option(:create_options, opts)
+  end
+
+  # options to update the stack: read from DB. Cannot directly read from dialog
+  def update_options
+    @update_options ||= get_option(:update_options)
+  end
+
+  # must explicitly call this to set the options for update since they cannot be directly read from dialog
+  def update_options=(opts)
+    @update_options = opts
+    save_option(:update_options, opts)
+  end
+
+  private
+
+  def dup_and_process_password(opts, encrypt = :encrypt)
+    return opts unless opts.kind_of?(Hash)
+
+    opts_dump = opts.deep_dup
+
+    proc = MiqPassword.method(encrypt)
+    opts_dump.each do |_opt_name, opt_val|
+      next unless opt_val.kind_of?(Hash)
+      opt_val.each { |param_key, param_val| opt_val[param_key] = proc.call(param_val) if param_key =~ /password/i }
+    end
+
+    opts_dump
+  end
+
+  def get_option(option_name)
+    dup_and_process_password(options[option_name], :decrypt) if options[option_name]
+  end
+
+  def save_option(option_name, val)
+    options[option_name] = dup_and_process_password(val, :encrypt)
+    save!
+  end
+end

--- a/app/models/service_ansible_tower.rb
+++ b/app/models/service_ansible_tower.rb
@@ -1,11 +1,14 @@
 class ServiceAnsibleTower < Service
   include ServiceConfigurationMixin
+  include ServiceOrchestrationOptionsMixin
 
   alias_method :job_template, :configuration_script
   alias_method :job_template=, :configuration_script=
+  alias_method :job_options, :stack_options
+  alias_method :job_options=, :stack_options=
 
   def launch_job
-    @job = ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job.create_job(job_template, {})
+    @job = ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job.create_job(job_template, job_options)
     add_resource(@job)
     @job
   ensure
@@ -17,10 +20,47 @@ class ServiceAnsibleTower < Service
     @job ||= service_resources.find { |sr| sr.resource.kind_of?(OrchestrationStack) }.try(:resource)
   end
 
+  def build_stack_options_from_dialog(dialog_options)
+    {:extra_vars => extra_vars_from_dialog(dialog_options)}.tap do |launch_options|
+      launch_options[:limit] = dialog_options['dialog_limit'] unless dialog_options['dialog_limit'].blank?
+    end
+  end
+
   private
 
+  # the method name is required by ServiceOrchestrationOptionMixin
+  def build_stack_create_options
+    # job template from dialog_options overrides the one copied from service_template
+    dialog_options = options[:dialog] || {}
+    if dialog_options['dialog_job_template']
+      self.job_template = ConfigurationScript.find(dialog_options['dialog_job_template'])
+    end
+
+    raise _("job template was not set") if job_template.nil?
+
+    build_stack_options_from_dialog(options[:dialog])
+  end
+
   def save_launch_options
-    # TODO
+    options[:create_options] = dup_and_process_password(job_options)
     save!
+  end
+
+  PARAM_PREFIX = 'dialog_param_'.freeze
+  PARAM_PREFIX_LEN = PARAM_PREFIX.size
+  PASSWORD_PREFIX = 'password::dialog_param_'.freeze
+  PASSWORD_PREFIX_LEN = PASSWORD_PREFIX.size
+
+  def extra_vars_from_dialog(dialog_options)
+    params = {}
+
+    dialog_options.each do |attr, val|
+      if attr.start_with?(PARAM_PREFIX)
+        params[attr[PARAM_PREFIX_LEN..-1]] = val
+      elsif attr.start_with?(PASSWORD_PREFIX)
+        params[attr[PASSWORD_PREFIX_LEN..-1]] = MiqPassword.decrypt(val)
+      end
+    end
+    params
   end
 end

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
@@ -3,11 +3,12 @@
 #
 $evm.log("info", "Starting Ansible Tower Post-Provisioning")
 
-task = $evm.root["service_template_provision_task"].destination
+task = $evm.root["service_template_provision_task"]
 raise "service_template_provision_task not found" unless task
 
 service = task.destination
-raise "service is not a type of AnsibleTower" unless service.respond_to?(:job)
+raise "service is not of type AnsibleTower" unless service.respond_to?(:job)
+
 #job = service.job
 
 # You can add logic to process the job object in VMDB

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision.rb
@@ -7,8 +7,21 @@ $evm.log("info", "Starting Ansible Tower Pre-Provisioning")
 task = $evm.root["service_template_provision_task"]
 raise "service_template_provision_task not found" unless task
 
-# service = task.destination
+service = task.destination
+raise "service is not of type AnsibleTower" unless service.respond_to?(:job_template)
 
 # Through service you can examine the job template, configuration manager (i.e., provider)
 # and options to start a job
 # You can also override these selections through service
+# $evm.log("info", "manager = #{service.configuration_manager.name}")
+# $evm.log("info", "template = #{service.job_template.name}")
+
+# Caution: job options may contain passwords.
+# $evm.log("info", "job options = #{service.job_options.inspect}")
+
+# Example how to programmatically modify job options:
+# job_options = service.job_options
+# job_options[:limit] = 'someHost'
+# job_options[:extra_vars]['flavor'] = 'm1.small'
+# # Important: set stack_options
+# service.job_options = job_options

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_ansible_tower.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_ansible_tower.rb
@@ -5,5 +5,7 @@ module MiqAeMethodService
 
     expose :launch_job
     expose :job
+    expose :job_options
+    expose :job_options=
   end
 end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -5,4 +5,7 @@ FactoryGirl.define do
 
   factory :service_orchestration, :class => :ServiceOrchestration, :parent => :service do
   end
+
+  factory :service_ansible_tower, :class => :ServiceAnsibleTower, :parent => :service do
+  end
 end

--- a/spec/models/service_ansible_tower_spec.rb
+++ b/spec/models/service_ansible_tower_spec.rb
@@ -1,0 +1,81 @@
+describe ServiceAnsibleTower do
+  let(:template_by_dialog) { FactoryGirl.create(:configuration_script) }
+  let(:template_by_setter) { FactoryGirl.create(:configuration_script) }
+
+  let(:dialog_options) do
+    {
+      'dialog_job_template'                   => template_by_dialog.id,
+      'dialog_limit'                          => 'myhost',
+      'dialog_param_InstanceType'             => 'cg1.4xlarge',
+      'password::dialog_param_DBRootPassword' => 'v2:{c2XR8/Yl1CS0phoOVMNU9w==}'
+    }
+  end
+
+  let(:parsed_job_options) do
+    {
+      :limit      => 'myhost',
+      :extra_vars => {'InstanceType' => 'cg1.4xlarge', 'DBRootPassword' => 'admin'}
+    }
+  end
+
+  let(:service) do
+    FactoryGirl.create(:service_ansible_tower,
+                       :evm_owner => FactoryGirl.create(:user),
+                       :miq_group => FactoryGirl.create(:miq_group))
+  end
+
+  let(:service_with_dialog_options) do
+    service.options = {:dialog => dialog_options}
+    service
+  end
+
+  let(:service_mix_dialog_setter) do
+    service.job_template = template_by_setter
+    service.options = {:dialog => dialog_options}
+    service
+  end
+
+  describe "#job_options" do
+    it "gets job options set by dialog" do
+      expect(service_with_dialog_options.job_options).to include(parsed_job_options)
+    end
+
+    it "gets jobs options from overridden values" do
+      new_options = {"any_key" => "any_value"}
+      service_with_dialog_options.job_options = new_options
+      expect(service_with_dialog_options.job_options).to eq(new_options)
+    end
+
+    it "encrypts password when saves to DB" do
+      new_options = {:extra_vars => {"my_password" => "secret"}}
+      service_with_dialog_options.job_options = new_options
+      expect(service_with_dialog_options.options[:create_options][:extra_vars]["my_password"]).to eq(MiqPassword.encrypt("secret"))
+    end
+
+    it "prefers the job template set by dialog" do
+      expect(service_mix_dialog_setter.job_template).to eq(template_by_setter)
+      service_mix_dialog_setter.job_options
+      expect(service_mix_dialog_setter.job_template).to eq(template_by_dialog)
+    end
+  end
+
+  describe '#launch_job' do
+    it 'launches a job through ansible tower provider' do
+      allow(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job).to receive(:raw_create_stack) do |template, opts|
+        expect(template).to be_kind_of ConfigurationScript
+        expect(opts).to have_key(:limit)
+        expect(opts).to have_key(:extra_vars)
+      end.and_return(double(:raw_job, :id => 1, :status => "completed"))
+
+      expect(service_mix_dialog_setter.launch_job).to have_attributes(:ems_ref => "1", :status => "completed")
+    end
+
+    it 'always saves options even when the manager fails to create a stack' do
+      ProvisionError = MiqException::MiqOrchestrationProvisionError
+      allow_any_instance_of(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job).to receive(:stack_create).and_raise(ProvisionError, 'test failure')
+
+      expect(service_mix_dialog_setter).to receive(:save_launch_options)
+      expect { service_mix_dialog_setter.launch_job }.to raise_error(ProvisionError)
+    end
+  end
+end


### PR DESCRIPTION
Extract common code to OrchestrationStackOptionsMixin to be shared by OrchestrationStack and AnsibleTower Job

Enable to parse dialog options or set options from the user script and pass it AnsibleTower job launching.