### PR TITLE
[WIP] Pass encrypted password with subscription

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -18,6 +18,7 @@ class MiqRegionRemote < ApplicationRecord
 
   def self.validate_connection_settings(host, port, username, password, database = nil, adapter = nil)
     database, adapter = prepare_default_fields(database, adapter)
+    password = MiqPassword.try_decrypt(password)
 
     log_details = "Host: [#{host}]}, Database: [#{database}], Adapter: [#{adapter}], User: [#{username}]"
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -105,9 +105,11 @@ class PglogicalSubscription < ActsAsArModel
 
   def self.dsn_attributes(dsn)
     attrs = connection.class.parse_dsn(dsn)
-    attrs.select! { |k, _v| [:dbname, :host, :user, :port].include?(k) }
+    attrs.select! { |k, _v| [:dbname, :host, :user, :password, :port].include?(k) }
     port = attrs.delete(:port)
     attrs[:port] = port.to_i unless port.blank?
+    pass = attrs.delete(:password)
+    attrs[:password] = MiqPassword.encrypt(pass) unless pass.blank?
     attrs
   end
   private_class_method :dsn_attributes

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -30,6 +30,7 @@ describe PglogicalSubscription do
         "dbname"               => "vmdb's_test",
         "host"                 => "example.com",
         "user"                 => "root",
+        "password"             => "v2:{S6ucMa3S0q7q2l2Lcqb6AQ==}",
         "provider_region"      => 0,
         "provider_region_name" => "The region"
       },


### PR DESCRIPTION
This greatly simplifies UI form validation and allows for the user to validate an existing subscription without re-entering the password for a previously saved subscription.

@h-kataria can you give some more detail around this

@gtanzillo @Fryguy