### PR TITLE
trim down find_filtered_children

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2315,13 +2315,13 @@ class ApplicationController < ActionController::Base
     mfilters = user ? user.get_managed_filters : []
     bfilters = user ? user.get_belongsto_filters : []
 
-    if db.respond_to?(:find_filtered) && !mfilters.empty?
+    if db.respond_to?(:find_tags_by_grouping) && !mfilters.empty?
       result = db.where(options[:conditions]).find_tags_by_grouping(mfilters, :ns => "*")
     else
       result = db.apply_legacy_finder_options(options)
     end
 
-    result = MiqFilter.apply_belongsto_filters(result, bfilters) if db.respond_to?(:find_filtered) && result
+    result = MiqFilter.apply_belongsto_filters(result, bfilters) if db.respond_to?(:apply_belongsto_filters) && result
 
     result
   end

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -162,11 +162,11 @@ class MiqCapacityController < ApplicationController
     if filter_value && filter_value != "<Choose>"
       case params[:filter_typ]
       when "host"
-        vms = Host.find(filter_value).find_filtered_children("vms")
+        vms = Host.find(filter_value).vms
       when "ems"
-        vms = ExtManagementSystem.find(filter_value).find_filtered_children("vms")
+        vms = ExtManagementSystem.find(filter_value).vms
       when "cluster"
-        vms = EmsCluster.find(filter_value).find_filtered_children("all_vms")
+        vms = EmsCluster.find(filter_value).all_vms
       when "filter"
         vms = MiqSearch.find(filter_value).results(:userid => current_userid)
       else

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -162,11 +162,11 @@ class MiqCapacityController < ApplicationController
     if filter_value && filter_value != "<Choose>"
       case params[:filter_typ]
       when "host"
-        vms, = Host.find(filter_value).find_filtered_children("vms")
+        vms = Host.find(filter_value).find_filtered_children("vms")
       when "ems"
-        vms, = ExtManagementSystem.find(filter_value).find_filtered_children("vms")
+        vms = ExtManagementSystem.find(filter_value).find_filtered_children("vms")
       when "cluster"
-        vms, = EmsCluster.find(filter_value).find_filtered_children("all_vms")
+        vms = EmsCluster.find(filter_value).find_filtered_children("all_vms")
       when "filter"
         vms = MiqSearch.find(filter_value).results(:userid => current_userid)
       else

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -9,15 +9,14 @@ module MiqPolicyController::Rsop
         case @sb[:rsop][:filter]
         when "vm"
           vms = [Vm.find(@sb[:rsop][:filter_value])]
-          count = 1
         when "ems"
-          vms, count = ExtManagementSystem.find(@sb[:rsop][:filter_value]).find_filtered_children("vms")
+          vms = ExtManagementSystem.find(@sb[:rsop][:filter_value]).find_filtered_children("vms")
         when "cluster"
-          vms, count = EmsCluster.find(@sb[:rsop][:filter_value]).find_filtered_children("all_vms")
+          vms = EmsCluster.find(@sb[:rsop][:filter_value]).find_filtered_children("all_vms")
         when "host"
-          vms, count = Host.find(@sb[:rsop][:filter_value]).find_filtered_children("vms")
+          vms = Host.find(@sb[:rsop][:filter_value]).find_filtered_children("vms")
         end
-        if count > 0
+        if vms.length > 0
           @sb[:rsop][:out_of_scope] = true
           @sb[:rsop][:passed] = true
           @sb[:rsop][:failed] = true

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -10,11 +10,11 @@ module MiqPolicyController::Rsop
         when "vm"
           vms = [Vm.find(@sb[:rsop][:filter_value])]
         when "ems"
-          vms = ExtManagementSystem.find(@sb[:rsop][:filter_value]).find_filtered_children("vms")
+          vms = ExtManagementSystem.find(@sb[:rsop][:filter_value]).vms
         when "cluster"
-          vms = EmsCluster.find(@sb[:rsop][:filter_value]).find_filtered_children("all_vms")
+          vms = EmsCluster.find(@sb[:rsop][:filter_value]).all_vms
         when "host"
-          vms = Host.find(@sb[:rsop][:filter_value]).find_filtered_children("vms")
+          vms = Host.find(@sb[:rsop][:filter_value]).vms
         end
         if vms.length > 0
           @sb[:rsop][:out_of_scope] = true

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -20,11 +20,7 @@ module MiqFilter
 
   def self.find_children_of_via_reflection(obj, reflection)
     result = obj.send(reflection.name)
-    if reflection.macro == :has_one || reflection.macro == :belongs_to
-      result ? [result] : []
-    else
-      result
-    end
+    result ? Array.wrap(result) : []
   end
 
   def self.find_children_of_via_method(obj, assoc)

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -99,11 +99,6 @@ module MiqFilter
     end
   end
 
-  def self.count_children_of(obj, assoc, options = {})
-    result = find_children_of(obj, assoc, options).first
-    result ? result.length : 0
-  end
-
   def self.belongsto2object(tag)
     belongsto2object_list(tag).last
   end

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -18,7 +18,7 @@ module MiqFilter
     mode
   end
 
-  def self.find_children_of_via_reflection(obj, reflection, options = {})
+  def self.find_children_of_via_reflection(obj, reflection)
     db = reflection.class_name.constantize
     if db.respond_to?(:find_filtered)
       if reflection.macro == :belongs_to
@@ -30,19 +30,12 @@ module MiqFilter
         conditions = "#{reflection.foreign_key} = #{obj.id}"
       end
       conditions += " AND (#{reflection.options[:conditions]})" if reflection.options[:conditions]
-      options.delete(:include)
-      options.delete(:includes)
-      result, total_count = db.find_filtered(options.merge(:conditions => conditions))
+      result, total_count = db.find_filtered(:conditions => conditions)
     else
-      options.delete(:tag_filters)
       if reflection.macro == :has_one
         result = [obj.send(reflection.name)]
       else
         result = obj.send(reflection.name)
-                 .where(options[:conditions])
-                 .order(options[:order])
-                 .offset(options[:offset])
-                 .limit(options[:limit])
       end
       total_count = result.length
     end

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -30,7 +30,8 @@ module MiqFilter
         conditions = "#{reflection.foreign_key} = #{obj.id}"
       end
       conditions += " AND (#{reflection.options[:conditions]})" if reflection.options[:conditions]
-      db.find_filtered(:conditions => conditions)
+      result = where(conditions)
+      [result, result.length]
     else
       result = obj.send(reflection.name)
       if reflection.macro == :has_one

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -34,8 +34,8 @@ module MiqFilter
       [result, result.length]
     else
       result = obj.send(reflection.name)
-      if reflection.macro == :has_one
-        [[result], 1]
+      if reflection.macro == :has_one || reflection.macro == :belongs_to
+        result ? [[result], 1] : [[], 0]
       else
         [result, result.length]
       end

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -42,41 +42,10 @@ module MiqFilter
     end
   end
 
-  def self.find_children_of_via_method(obj, assoc, options = {})
-    db = obj.class
+  def self.find_children_of_via_method(obj, assoc)
     unfiltered = obj.send(assoc)
-    if db.respond_to?(:find_filtered)
-      if options[:tag_filters]
-        mfilters = options[:tag_filters]["managed"]
-        bfilters = options[:tag_filters]["belongsto"]
-      end
-      mfilters ||= []
-      bfilters ||= []
-      result = unfiltered.collect do |r|
-        next unless r.is_tagged_with_grouping?(mfilters, :ns => "*")
-        next unless apply_belongsto_filters([r], bfilters) == [r]
-        r
-      end.compact
-    else
       result = unfiltered
-    end
-
     total_count = unfiltered.length
-
-    # Need to honor order
-    if options[:order]
-      col, direction = options[:order].split
-      direction ||= "ASC"
-      result.sort! { |x, y| x.send(col) <=> y.send(col) }
-      result.reverse! if direction == "DESC"
-    end
-
-    # Need to honor limit and offset
-    if options[:limit]
-      options[:offset] ||= 0
-      result = result[options[:offset]..options[:offset] + options[:limit] - 1]
-    end
-
     return result, total_count
   end
 

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -3,41 +3,6 @@ module MiqFilter
     MiqReportable.records2table(records, only_columns)
   end
 
-  def self.determine_mode_for_find_children_of(reflection, obj, assoc)
-    mode = nil
-    if reflection.nil? || reflection.macro == :has_and_belongs_to_many
-      if obj.respond_to?(assoc)
-        mode = :by_method
-      else
-        raise "no relationship found for \"#{assoc}\"" if reflection.nil?
-      end
-    else
-      mode = :by_reflection
-    end
-
-    mode
-  end
-
-  def self.find_children_of_via_reflection(obj, reflection)
-    result = obj.send(reflection.name)
-    result ? Array.wrap(result) : []
-  end
-
-  def self.find_children_of_via_method(obj, assoc)
-    obj.send(assoc)
-  end
-
-  def self.find_children_of(obj, assoc)
-    reflection = obj.class.reflect_on_association(assoc.to_sym)
-    mode       = determine_mode_for_find_children_of(reflection, obj, assoc)
-
-    case mode
-    when :by_reflection  then find_children_of_via_reflection(obj, reflection)
-    when :by_method      then find_children_of_via_method(obj, assoc)
-    else                      raise _("Unknown mode: <%{mode}>") % {:mode => mode.inspect}
-    end
-  end
-
   def self.belongsto2object(tag)
     belongsto2object_list(tag).last
   end

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -88,13 +88,13 @@ module MiqFilter
     return result, total_count
   end
 
-  def self.find_children_of(obj, assoc, options = {})
+  def self.find_children_of(obj, assoc)
     reflection = obj.class.reflect_on_association(assoc.to_sym)
     mode       = determine_mode_for_find_children_of(reflection, obj, assoc)
 
     case mode
-    when :by_reflection  then find_children_of_via_reflection(obj, reflection, options)
-    when :by_method      then find_children_of_via_method(obj, assoc, options)
+    when :by_reflection  then find_children_of_via_reflection(obj, reflection)
+    when :by_method      then find_children_of_via_method(obj, assoc)
     else                      raise _("Unknown mode: <%{mode}>") % {:mode => mode.inspect}
     end
   end

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -43,10 +43,8 @@ module MiqFilter
   end
 
   def self.find_children_of_via_method(obj, assoc)
-    unfiltered = obj.send(assoc)
-      result = unfiltered
-    total_count = unfiltered.length
-    return result, total_count
+    result = obj.send(assoc)
+    [result, result.length]
   end
 
   def self.find_children_of(obj, assoc)

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -19,26 +19,11 @@ module MiqFilter
   end
 
   def self.find_children_of_via_reflection(obj, reflection)
-    db = reflection.class_name.constantize
-    if db.respond_to?(:find_filtered)
-      if reflection.macro == :belongs_to
-        objid = obj.send(reflection.foreign_key)
-        return [[], 0] if objid.nil?
-
-        conditions = "id = #{objid}"
-      else
-        conditions = "#{reflection.foreign_key} = #{obj.id}"
-      end
-      conditions += " AND (#{reflection.options[:conditions]})" if reflection.options[:conditions]
-      result = where(conditions)
-      [result, result.length]
+    result = obj.send(reflection.name)
+    if reflection.macro == :has_one || reflection.macro == :belongs_to
+      result ? [[result], 1] : [[], 0]
     else
-      result = obj.send(reflection.name)
-      if reflection.macro == :has_one || reflection.macro == :belongs_to
-        result ? [[result], 1] : [[], 0]
-      else
-        [result, result.length]
-      end
+      [result, result.length]
     end
   end
 

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -21,15 +21,14 @@ module MiqFilter
   def self.find_children_of_via_reflection(obj, reflection)
     result = obj.send(reflection.name)
     if reflection.macro == :has_one || reflection.macro == :belongs_to
-      result ? [[result], 1] : [[], 0]
+      result ? [result] : []
     else
-      [result, result.length]
+      result
     end
   end
 
   def self.find_children_of_via_method(obj, assoc)
-    result = obj.send(assoc)
-    [result, result.length]
+    obj.send(assoc)
   end
 
   def self.find_children_of(obj, assoc)

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -30,17 +30,15 @@ module MiqFilter
         conditions = "#{reflection.foreign_key} = #{obj.id}"
       end
       conditions += " AND (#{reflection.options[:conditions]})" if reflection.options[:conditions]
-      result, total_count = db.find_filtered(:conditions => conditions)
+      db.find_filtered(:conditions => conditions)
     else
+      result = obj.send(reflection.name)
       if reflection.macro == :has_one
-        result = [obj.send(reflection.name)]
+        [[result], 1]
       else
-        result = obj.send(reflection.name)
+        [result, result.length]
       end
-      total_count = result.length
     end
-
-    return result, total_count
   end
 
   def self.find_children_of_via_method(obj, assoc, options = {})

--- a/app/models/mixins/filterable_mixin.rb
+++ b/app/models/mixins/filterable_mixin.rb
@@ -1,12 +1,6 @@
 module FilterableMixin
   extend ActiveSupport::Concern
 
-  def find_filtered_children(assoc)
-    raise "no relationship found for \"#{assoc}\"" unless self.respond_to?(assoc)
-    result = self.send(assoc)
-    result ? Array.wrap(result) : []
-  end
-
   def authorized_for_user?(userid)
     user     = User.find_by_userid(userid)
     mfilters = user ? user.get_managed_filters : []

--- a/app/models/mixins/filterable_mixin.rb
+++ b/app/models/mixins/filterable_mixin.rb
@@ -1,8 +1,10 @@
 module FilterableMixin
   extend ActiveSupport::Concern
 
-  def find_filtered_children(table)
-    MiqFilter.find_children_of(self, table)
+  def find_filtered_children(assoc)
+    raise "no relationship found for \"#{assoc}\"" unless self.respond_to?(assoc)
+    result = self.send(assoc)
+    result ? Array.wrap(result) : []
   end
 
   def authorized_for_user?(userid)

--- a/app/models/mixins/filterable_mixin.rb
+++ b/app/models/mixins/filterable_mixin.rb
@@ -35,8 +35,8 @@ module FilterableMixin
     end
   end
 
-  def find_filtered_children(table, options = {})
-    MiqFilter.find_children_of(self, table, options)
+  def find_filtered_children(table)
+    MiqFilter.find_children_of(self, table)
   end
 
   def authorized_for_user?(userid)

--- a/app/models/mixins/filterable_mixin.rb
+++ b/app/models/mixins/filterable_mixin.rb
@@ -33,18 +33,9 @@ module FilterableMixin
 
       return result, total_count
     end
-
-    def count_filtered(options = {})
-      result = find_filtered(options).first
-      result ? result.length : 0
-    end
   end
 
   def find_filtered_children(table, options = {})
-    MiqFilter.find_children_of(self, table, options)
-  end
-
-  def count_filtered_children(table, options = {})
     MiqFilter.find_children_of(self, table, options)
   end
 

--- a/app/models/mixins/filterable_mixin.rb
+++ b/app/models/mixins/filterable_mixin.rb
@@ -1,40 +1,6 @@
 module FilterableMixin
   extend ActiveSupport::Concern
 
-  module ClassMethods
-    def find_filtered(options = {})
-      filters = options.delete(:tag_filters)
-      mfilters = filters && filters["managed"] ? filters["managed"] : []
-      bfilters = filters && filters["belongsto"] ? filters["belongsto"] : []
-      options[:include] = get_include_for_find(options[:include]) unless options.delete(:eager_loading) == false
-      if mfilters.blank?
-        # do normal find if no filters
-        result = where(options[:conditions])
-                 .order(options[:order])
-                 .joins(options[:join] || options[:joins])
-                 .includes(options[:include])
-                 .select(options[:select])
-        total_count = result.length
-      else
-        # get count of results unfiltered
-        total_count = options[:conditions] ? count(options[:conditions]) : count
-
-        # do tag find
-        # self.find_tagged_with(options.merge(:all => filters, :ns => "*"))
-        result = find_tags_by_grouping(mfilters, options.merge(:ns => "*"))
-      end
-
-      result = MiqFilter.apply_belongsto_filters(result, bfilters)
-
-      if options[:limit]
-        options[:offset] ||= 0
-        result = result[options[:offset]..options[:offset] + options[:limit] - 1]
-      end
-
-      return result, total_count
-    end
-  end
-
   def find_filtered_children(table)
     MiqFilter.find_children_of(self, table)
   end
@@ -46,13 +12,13 @@ module FilterableMixin
     db       = self.class
     result   = true
 
-    if db.respond_to?(:find_filtered) && !mfilters.empty?
+    if db.respond_to?(:find_tags_by_grouping) && !mfilters.empty?
       recs = db.where(:id => id).find_tags_by_grouping(mfilters, :ns => "*").first
       # result = false if recs.nil?
       return false if recs.nil?
     end
 
-    if db.respond_to?(:find_filtered)
+    if db.respond_to?(:apply_belongsto_filters)
       result = false unless MiqFilter.apply_belongsto_filters([self], bfilters) == [self]
     end
 


### PR DESCRIPTION
The previous pr (#8000) uncovered a number of keys that were being passed into `find_tags_by_grouping` but ignored, namely `conditions`.

This pr fixes looked at the callers of `find_tags_by_group` all the way back to `find_filtered_children`. Turns out the whole chain is not necessary.

1. remove dead code paths. (easily detected since the options hash wasn't even sent.)
2. fix one instance where `:conditions` was passed but ignored.

/cc @matthewd heh.
/cc @chrisarcand FYI

**UPDATED:** changed the title and description to try and be more clear.