### PR TITLE
Add read_only attribute to MiqPolicy and Condition

### DIFF
--- a/db/migrate/20160417105237_add_read_only_to_policies.rb
+++ b/db/migrate/20160417105237_add_read_only_to_policies.rb
@@ -1,0 +1,6 @@
+class AddReadOnlyToPolicies < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_policies, :read_only, :boolean
+    add_column :conditions,   :read_only, :boolean
+  end
+end


### PR DESCRIPTION
First discussed [here](https://github.com/ManageIQ/manageiq/pull/7966#issuecomment-210555570)

Behavior added in #8018

Note: MiqPolicySet as a miq_set already has a read_only attribute