### PR TITLE
Add logic for ORDERED_CLASSES at EvmDatabase

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -14,9 +14,12 @@ class EvmDatabase
     MiqGroup
     User
     MiqReport
+    VmdbDatabase
+  )
+
+  ORDERED_CLASSES = %w(
     RssFeed
     MiqWidget
-    VmdbDatabase
   )
 
   RAILS_ENGINE_MODEL_CLASS_NAMES = %w(MiqAeDatastore)
@@ -28,7 +31,7 @@ class EvmDatabase
   end
 
   def self.seedable_model_class_names
-    find_seedable_model_class_names + RAILS_ENGINE_MODEL_CLASS_NAMES
+    ORDERED_CLASSES + (find_seedable_model_class_names - ORDERED_CLASSES) + RAILS_ENGINE_MODEL_CLASS_NAMES
   end
 
   def self.seed_primordial

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -20,4 +20,13 @@ describe EvmDatabase do
       described_class.seed_primordial
     end
   end
+
+  describe ".find_seedable_model_class_names" do
+    it "returns ordered classes first" do
+      stub_const("EvmDatabase::ORDERED_CLASSES", %w(a z))
+      stub_const("EvmDatabase::RAILS_ENGINE_MODEL_CLASS_NAMES", [])
+      expect(described_class).to receive(:find_seedable_model_class_names).and_return(%w(a c z))
+      expect(described_class.seedable_model_class_names).to eq(%w(a z c))
+    end
+  end
 end


### PR DESCRIPTION
Use new logic for RssFeed and MiqWidget.

First discussed [here](https://github.com/ManageIQ/manageiq/pull/7966#discussion_r59780937)
Note: ORDERED_CLASSES are not tested for having a seed method, just like PRIMORDIAL_CLASSES and RAILS_ENGINE_MODEL_CLASS_NAMES.