### PR TITLE
Fix middleware topology not being displayed 

### DIFF
--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -1,7 +1,7 @@
 class MiddlewareTopologyService < TopologyService
   def initialize(provider_id)
     @provider_id = provider_id
-    @providers = retrieve_providers(@provider_id, ManageIQ::Providers::MiddlewareManager)
+    @providers = retrieve_providers(ManageIQ::Providers::MiddlewareManager, @provider_id)
   end
 
   def build_topology


### PR DESCRIPTION
after generic topology parameters change in #6668

@miq-bot add_label topology, providers/hawkular