### PR TITLE
Add read_only behavior to Condition, MiqPolicy and MiqPolicySet

### DIFF
--- a/app/helpers/application_helper/button/miq_action_modify.rb
+++ b/app/helpers/application_helper/button/miq_action_modify.rb
@@ -1,0 +1,21 @@
+class ApplicationHelper::Button::MiqActionModify < ApplicationHelper::Button::Basic
+  def disabled?
+    @view_context.x_node.split("_").any? do |level|
+      node_type, id = level.split('-')
+      node_type == 'p' && MiqPolicy.find_by(:id => id).try(:read_only)
+    end
+  end
+
+  def calculate_properties
+    super
+    node_type = @view_context.x_node.split("_").last.split('-')[0].to_sym
+
+    ent = {
+      :a  => ui_lookup(:model => "MiqAction"),
+      :ev => ui_lookup(:table => "event")
+    }[node_type]
+
+    params = {:entity => ent, :policy => ui_lookup(:model => "MiqPolicy")}
+    self[:title] = N_("This %{entity} belongs to a read only %{policy} and cannot be modified" % params) if disabled?
+  end
+end

--- a/app/helpers/application_helper/button/read_only.rb
+++ b/app/helpers/application_helper/button/read_only.rb
@@ -1,0 +1,14 @@
+class ApplicationHelper::Button::ReadOnly < ApplicationHelper::Button::Basic
+  def disabled?
+    @record.read_only
+  end
+
+  def calculate_properties
+    super
+    self[:title] = N_(
+      "This %{klass} is read only and cannot be modified" % {
+        :klass => ui_lookup(:model => @record.class.name)
+      }
+    ) if disabled?
+  end
+end

--- a/app/helpers/application_helper/toolbar/condition_center.rb
+++ b/app/helpers/application_helper/toolbar/condition_center.rb
@@ -11,7 +11,8 @@ class ApplicationHelper::Toolbar::ConditionCenter < ApplicationHelper::Toolbar::
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Condition'),
           t,
-          :url_parms => "?type=basic"),
+          :url_parms => "?type=basic",
+          :klass     => ApplicationHelper::Button::ReadOnly),
         button(
           :condition_copy,
           'fa fa-files-o fa-lg',
@@ -30,6 +31,7 @@ class ApplicationHelper::Toolbar::ConditionCenter < ApplicationHelper::Toolbar::
           t = N_('Delete this #{ui_lookup(:model=>@condition.towhat)} Condition'),
           t,
           :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::ReadOnly,
           :confirm   => N_("Are you sure you want to delete this \#{ui_lookup(:model=>@condition.towhat)} Condition?")),
         button(
           :condition_remove,
@@ -37,6 +39,7 @@ class ApplicationHelper::Toolbar::ConditionCenter < ApplicationHelper::Toolbar::
           t = N_('Remove this Condition from Policy [#{@condition_policy.description}]'),
           t,
           :url_parms => "?policy_id=\#{@condition_policy.id}",
+          :klass     => ApplicationHelper::Button::ReadOnly,
           :confirm   => N_("Are you sure you want to remove this Condition from Policy [\#{@condition_policy.description}]?")),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_action_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_action_center.rb
@@ -11,6 +11,7 @@ class ApplicationHelper::Toolbar::MiqActionCenter < ApplicationHelper::Toolbar::
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Action'),
           t,
+          :klass     => ApplicationHelper::Button::MiqActionModify,
           :url_parms => "?type=basic"),
         button(
           :action_delete,

--- a/app/helpers/application_helper/toolbar/miq_event_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_event_center.rb
@@ -11,7 +11,8 @@ class ApplicationHelper::Toolbar::MiqEventCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-edit fa-lg-action',
           t = N_('Edit Actions for this Policy Event'),
           t,
-          :url_parms => "main_div"),
+          :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::MiqActionModify),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_center.rb
@@ -11,7 +11,8 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
           'pficon pficon-edit fa-lg',
           t = N_('Edit Basic Info, Scope, and Notes'),
           t,
-          :url_parms => "?typ=basic"),
+          :url_parms => "?typ=basic",
+          :klass     => ApplicationHelper::Button::ReadOnly),
         button(
           :policy_copy,
           'fa fa-files-o fa-lg',
@@ -25,25 +26,29 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
           t = N_('Delete this #{ui_lookup(:model=>@policy.towhat)} Policy'),
           t,
           :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::ReadOnly,
           :confirm   => N_("Are you sure you want to delete this \#{ui_lookup(:model=>@policy.towhat)} Policy?")),
         button(
           :condition_edit,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Create a new Condition assigned to this Policy'),
           t,
-          :url_parms => "?typ=new"),
+          :url_parms => "?typ=new",
+          :klass     => ApplicationHelper::Button::ReadOnly),
         button(
           :policy_edit_conditions,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Policy\'s Condition assignments'),
           t,
-          :url_parms => "?typ=conditions"),
+          :url_parms => "?typ=conditions",
+          :klass     => ApplicationHelper::Button::ReadOnly),
         button(
           :policy_edit_events,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Policy\'s Event assignments'),
           t,
-          :url_parms => "?typ=events"),
+          :url_parms => "?typ=events",
+          :klass     => ApplicationHelper::Button::ReadOnly),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
@@ -11,13 +11,15 @@ class ApplicationHelper::Toolbar::MiqPolicyProfileCenter < ApplicationHelper::To
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Policy Profile'),
           t,
-          :url_parms => "main_div"),
+          :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::ReadOnly),
         button(
           :profile_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Remove this Policy Profile'),
           t,
           :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::ReadOnly,
           :confirm   => N_("Are you sure you want to remove this Policy Profile?")),
       ]
     ),


### PR DESCRIPTION
Add read_only behavior to Condition, MiqPolicy, Content And MiqPolicySet screens

Based on read_only attribute added in #8012

Profile:
![profile](https://cloud.githubusercontent.com/assets/3010449/14620364/e6bfc2bc-05c4-11e6-8749-6e8f0ea9d6ae.png)

Policy: 
![policy](https://cloud.githubusercontent.com/assets/3010449/14620369/ec4293f4-05c4-11e6-8c73-9d2d9767dcf3.png)

Condition:
![condition](https://cloud.githubusercontent.com/assets/3010449/14620381/f909c756-05c4-11e6-89c7-2047ea9eebbb.png)

Event:
![event](https://cloud.githubusercontent.com/assets/3010449/14620552/ef528080-05c5-11e6-97e4-b30c96af57d5.png)

Action:
![action](https://cloud.githubusercontent.com/assets/3010449/14620554/f33bb3e2-05c5-11e6-8e79-6cfc8986e9a1.png)
