### PR TITLE
Re-enable text interpolation after i18n changes

### DIFF
--- a/app/controllers/mixins/authorization_messages_mixin.rb
+++ b/app/controllers/mixins/authorization_messages_mixin.rb
@@ -3,7 +3,7 @@ module AuthorizationMessagesMixin
 
   def notify_about_unauthorized_items(item, table)
     if unauthorized_count > 0
-      @bottom_msg = _('* You are not authorized to view other %{items} on this %{:table}') %
+      @bottom_msg = _('* You are not authorized to view other %{items} on this %{table}') %
         {:items => pluralize(unauthorized_count, item.singularize), :table => table}
     end
   end


### PR DESCRIPTION
Addressing UI text:
 * You are not authorized to view other %{items} on this %{:table}

@miq-bot add_label ui, bug