### PR TITLE
Add PatternFly styling to Area charts

### DIFF
--- a/app/assets/javascripts/miq_c3_config.js
+++ b/app/assets/javascripts/miq_c3_config.js
@@ -178,21 +178,12 @@
       },c3mixins.pfColorPattern,
       $().c3ChartDefaults().getDefaultLineConfig()
     ),
-    Area: _.defaultsDeep({
-        data: {
-          type: 'area'
-        },
-        area: {
-          label: {
-            format: percentLabelFormat
-          },
-          expand: false
-        }
-      },
-      c3mixins.xAxisCategory,
-      c3mixins.pfColorPattern,
-      c3mixins.legendOnRightSide,
-      c3mixins.noTooltip
+    Area: _.defaultsDeep(
+      {
+        axis : {x:{type: 'category'}},
+        data : {type: 'area'},
+      },c3mixins.pfColorPattern,
+      $().c3ChartDefaults().getDefaultAreaConfig()
     ),
     StackedArea: _.defaultsDeep({
         data: {


### PR DESCRIPTION
Parent issue #6627
Add PatternFly styling to Area charts.

![area](https://cloud.githubusercontent.com/assets/9535558/14598540/eb1f35ee-0552-11e6-8585-fb55bc7cdfd2.png)

@martinpovolny please review