### PR TITLE
Refactor: Use existing mixin to show authorization warning

### DIFF
--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -1,4 +1,5 @@
 class CloudObjectStoreContainerController < ApplicationController
+  include AuthorizationMessagesMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -54,14 +55,7 @@ class CloudObjectStoreContainerController < ApplicationController
       )
       @view, @pages = get_view(kls, :parent => @record, :association => :cloud_object_store_objects)
       @showtype = "cloud_object_store_objects"
-      if @view.extras[:total_count] && @view.extras[:auth_count] &&
-         @view.extras[:total_count] > @view.extras[:auth_count]
-        unauthorized_count = @view.extras[:total_count] - @view.extras[:auth_count]
-        @bottom_msg = _("* You are not authorized to view %{children} on this %{model}") % {
-          :children => pluralize(unauthorized_count, "#{title}"),
-          :model    => ui_lookup(:table => "cloud_object_store")
-        }
-      end
+      notify_about_unauthorized_items(title, ui_lookup(:table => "cloud_object_store"))
     end
 
     if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]


### PR DESCRIPTION
The CloudObjectStoreContainer has been introduced after the
AuthorizationMessagesMixin

@miq-bot add_label refactoring, ui