### PR TITLE
OpenStack cloud doesn't require AMQP hostname

### DIFF
--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -9,7 +9,6 @@
                         "name"        => "#{prefix}_hostname",
                         "ng-model"    => "#{ng_model}.#{prefix}_hostname",
                         "maxlength"   => "#{MAX_NAME_LEN}",
-                        "required"    => "",
                         "checkchange" => ""}
     %span.help-block{"ng-show" => "angularForm.#{prefix}_hostname.$error.required"}
       = _("Required")


### PR DESCRIPTION
OpenStack cloud doesn't require AMQP hostname

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1327133