### PR TITLE
Add autosave dependency for chargebackrate_details relation in ChargebackRate model

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -17,7 +17,7 @@ class ChargebackRate < ApplicationRecord
 
   include AssignmentMixin
 
-  has_many :chargeback_rate_details, :dependent => :destroy
+  has_many :chargeback_rate_details, :dependent => :destroy, :autosave => true
 
   validates_presence_of     :description, :guid
   validates_uniqueness_of   :guid


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/7832  point #6

fixes storing currency, unit and per_time when form is saved


cc @gtanzillo @amaurygonzalez  @tledesma 