### PR TITLE
C3 charts donut and pie PatternFly styling

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1571,6 +1571,9 @@ function chartData(type, data, data2) {
   if (_.isObject(data.axis) && _.isObject(data.axis.y) && _.isObject(data.axis.y.tick) && _.isObject(data.axis.y.tick.format)) {
     var o = data.axis.y.tick.format;
     data.axis.y.tick.format = ManageIQ.charts.formatters[o.function].c3(o.options);
+    if(type == 'Donut' || type == 'Pie'){
+      data.tooltip = {format: {value: ManageIQ.charts.formatters[o.function].c3(o.options)}};
+    }
   }
   var config = _.cloneDeep(ManageIQ.charts.c3config[type]);
   return _.defaultsDeep({}, config, data, data2);

--- a/app/assets/javascripts/miq_c3_config.js
+++ b/app/assets/javascripts/miq_c3_config.js
@@ -139,36 +139,22 @@
       $().c3ChartDefaults().getDefaultGroupedBarConfig()
     ),
 
-    Pie: _.defaultsDeep({
-      data: {
-        type: 'pie'
-      },
-      pie: {
-        label: {
-          format: percentLabelFormat
-        },
-        expand: false
-      }
-    },
-      c3mixins.pfColorPattern,
-      c3mixins.legendOnRightSide,
-      c3mixins.noTooltip
+    Pie: _.defaultsDeep(
+      {
+        data: {type: 'pie'},
+        tooltip: {show: true},
+        legend: { show: true, position: 'right'}
+      },c3mixins.pfColorPattern,
+      $().c3ChartDefaults().getDefaultDonutConfig()
     ),
 
-    Donut: _.defaultsDeep({
-      data: {
-        type: 'donut'
-      },
-      donut: {
-        label: {
-          format: percentLabelFormat
-        },
-        expand: false
-      }
-    },
-      c3mixins.pfColorPattern,
-      c3mixins.legendOnRightSide,
-      c3mixins.noTooltip
+  Donut: _.defaultsDeep(
+      {
+        data: {type: 'donut'},
+        tooltip: {show: true},
+        legend: { show: true, position: 'right'}
+      },c3mixins.pfColorPattern,
+      $().c3ChartDefaults().getDefaultDonutConfig()
     ),
 
     Line: _.defaultsDeep(

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -424,7 +424,7 @@ module ReportFormatter
         tooltip = key
         tooltip = _('no value') if key.blank?
         a.push(:value   => data[aggreg][raw_column_name],
-               :tooltip => key)
+               :tooltip => tooltip)
         categories.push([tooltip, data[aggreg][raw_column_name]])
       end
 


### PR DESCRIPTION
Parent issue #6627
C3 charts donut and pie PatternFly styling, problem with no value ""
![donut](https://cloud.githubusercontent.com/assets/9535558/14639472/43202718-063d-11e6-9b02-e3e47e2172d6.png)
![pie](https://cloud.githubusercontent.com/assets/9535558/14639473/442605b0-063d-11e6-8412-bf8022bdfe02.png)

