### PR TITLE
Fix validation messages in chargeback rate

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -934,7 +934,7 @@ class ChargebackController < ApplicationController
   end
 
   def display_detail_errors(detail, errors)
-    errors.each { |field, msg| add_flash("'#{detail.description}' #{field.to_s.capitalize} #{msg}", :error) }
+    errors.each { |field, msg| add_flash("'#{detail.description}' #{field.to_s.humanize.downcase} #{msg}", :error) }
   end
 
   def add_row(i, pos, code_currency)

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -1,6 +1,6 @@
 class ChargebackTier < ApplicationRecord
   belongs_to :chargeback_rate_detail
-  validates :fixed_rate, :variable_rate, :start, :finish, :numericality => true
+  validates :fixed_rate, :variable_rate, :numericality => true
   validates :start,  :numericality => {:greater_than_or_equal_to => 0, :less_than => Float::INFINITY}
   validates :finish, :numericality => {:greater_than_or_equal_to => 0}
 

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -42,7 +42,7 @@
         %th{:rowspan => "2"}= _('Currency')
       %tr
         %th= _("Start")
-        %th= _("End")
+        %th= _("Finish")
         %th= _("Fixed")
         %th= _("Variable")
     %tbody

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -22,7 +22,7 @@
         %th{:rowspan => "2"}= _('Units')
       %tr
         %th= _("Start")
-        %th= _("End")
+        %th= _("Finish")
         %th= _("Fixed")
         %th= _("Variable")
     %tbody


### PR DESCRIPTION
this fix provides:
1. avoiding doubled validation messages for start and finish attribute
2. rename models in validation messages to be more readable
3. change remaining 'end's in table to be uniform

before
![screen shot 2016-04-18 at 13 56 43](https://cloud.githubusercontent.com/assets/14937244/14603374/8f697dd4-056d-11e6-8ca9-dd63b4e5d823.png)

after
![screen shot 2016-04-18 at 13 55 50](https://cloud.githubusercontent.com/assets/14937244/14603383/a04ca59a-056d-11e6-9f10-5d14230a7c20.png)

I am not sure about point 3 but I am doing it to be uniform. (Is it OK ?)

cc @gtanzillo @amaurygonzalez @tledesma 


