### PR TITLE
Fix rbac tree editor to present feature permissions accurately

### DIFF
--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -31,7 +31,7 @@ class OpsController
 
       section.items.each do |item|
         if item.kind_of?(Menu::Section) # recurse for sections
-          feature = build_section(item, true) # FIXME: parent_checked
+          feature = build_section(item, parent_checked)
           kids.push(feature)
         else # kind_of?(Menu::Item) # add item features
           next if item.feature.nil?


### PR DESCRIPTION
Addressing role editor which showed almost all the features as checked
even though the features were not accessible for the role.

@miq-bot add_label bug, ui

/cc @martinpovolny You may want to take a look.