### PR TITLE
Don't use constant from UiConstants for generating tenant quota report

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -147,7 +147,7 @@ module OpsHelper::TextualSummary
                   when "general_number_precision_0"
                     value.to_i
                   when "gigabytes_human"
-                    value.to_f / GIGABYTE
+                    value.to_f / 1.0.gigabyte
                   else
                     value.to_f
                 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1299963 (last comment)

When you use for worker(I was using `report_sync` for development) for generating tenant quota report (it is enough to use simulate_queue_worker) 
it throws error below because it is not able to load constant GIGABYTE from UiConstants module.

I think that this case is not possible to include in specs, so I am leaving it without spec. 

cc @gtanzillo 

```
[----] E, [2016-04-18T15:11:59.334311 #86052:3ff2adc5e204] ERROR -- : [NameError]: uninitialized constant OpsHelper::TextualSummary::GIGABYTE  Method:[rescue in _async_generate_table]
[----] E, [2016-04-18T15:11:59.334374 #86052:3ff2adc5e204] ERROR -- : /Users/liborpichler/manageiq/app/helpers/ops_helper/textual_summary.rb:150:in `convert_to_format'
/Users/liborpichler/manageiq/app/models/tenant_quota.rb:69:in `format_quota_value'
/Users/liborpichler/manageiq/app/models/miq_report/generator/html.rb:74:in `block (2 levels) in build_html_rows'
/Users/liborpichler/manageiq/app/models/miq_report/generator/html.rb:66:in `each'
/Users/liborpichler/manageiq/app/models/miq_report/generator/html.rb:66:in `each_with_index'
/Users/liborpichler/manageiq/app/models/miq_report/generator/html.rb:66:in `block in build_html_rows'
/Users/liborpichler/manageiq/app/models/miq_report/generator/html.rb:44:in `each'
/Users/liborpichler/manageiq/app/models/miq_report/generator/html.rb:44:in `each_with_index'
/Users/liborpichler/manageiq/app/models/miq_report/generator/html.rb:44:in `build_html_rows'
/Users/liborpichler/manageiq/app/models/miq_report/generator.rb:329:in `build_create_results'
/Users/liborpichler/manageiq/app/models/miq_report/generator/async.rb:105:in `_async_generate_table'
/Users/liborpichler/manageiq/app/models/miq_queue.rb:347:in `block in deliver'
/usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/timeout.rb:88:in `block in timeout'
/usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/timeout.rb:32:in `block in catch'
/usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/timeout.rb:32:in `catch'
/usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/timeout.rb:32:in `catch'
/usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/timeout.rb:103:in `timeout'
/Users/liborpichler/manageiq/app/models/miq_queue.rb:343:in `deliver'
/Users/liborpichler/manageiq/lib/vmdb/console_methods.rb:25:in `block in simulate_queue_worker'
/Users/liborpichler/manageiq/lib/vmdb/console_methods.rb:22:in `loop'
/Users/liborpichler/manageiq/lib/vmdb/console_methods.rb:22:in `simulate_queue_worker'
```
