### PR TITLE
[WIP] GCE targeted refresh

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresher.rb
@@ -2,7 +2,11 @@ module ManageIQ::Providers::Google
   class CloudManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
-    def parse_legacy_inventory(ems)
+    def collect_inventory_for_targets(ems, targets)
+      [[ems, nil]]
+    end
+
+    def parse_targeted_inventory(ems, target, inventory)
       ManageIQ::Providers::Google::CloudManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end
 

--- a/app/models/manageiq/providers/google/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresher.rb
@@ -7,8 +7,10 @@ module ManageIQ::Providers::Google
         data = Hash.new { |h, k| h[k] = {} }
 
         case target
-        when ExtManagementSystem, VmOrTemplate
+        when ExtManagementSystem
           get_gce_data(ems, target, data)
+        when VmOrTemplate
+          get_vm_data(ems, target, data)
         end
 
         [target, data]
@@ -36,6 +38,38 @@ module ManageIQ::Providers::Google
       end
     end
 
+    def get_vm_data(ems, target, data)
+      GCE_INVENTORY_TYPES.each { |k|  data[k] = [] }
+
+      ems.with_provider_connection do |google|
+        server = google.servers.get(target.name)
+        unless server.nil?
+          zone_name   = parse_uid_from_url(server.zone)
+          zone        = google.zones.get(zone_name) unless zone_name.nil?
+
+          flavor_name = parse_uid_from_url(server.machine_type)
+          flavor      = google.flavors.get(flavor_name) unless flavor_name.nil?
+
+          networks = server.network_interfaces.to_a.collect do |nic|
+            network_name = parse_uid_from_url(nic["network"])
+            google.networks.get(network_name) unless network_name.nil?
+          end
+
+          disks = server.disks.to_a.collect do |disk|
+            disk_name = parse_uid_from_url(disk["source"])
+            google.disks.get(disk_name) unless disk_name.nil?
+          end
+
+          data[:project]  = google.projects.get(google.project)
+          data[:zones]    << zone unless zone.nil?
+          data[:flavors]  << flavor unless flavor.nil?
+          data[:networks] = networks
+          data[:disks]    = disks
+          data[:servers]  = [server]
+        end
+      end
+    end
+
     def parse_targeted_inventory(_ems, _target, inventory)
       ManageIQ::Providers::Google::CloudManager::RefreshParser.ems_inv_to_hashes(inventory, refresher_options)
     end
@@ -47,6 +81,10 @@ module ManageIQ::Providers::Google
 
     def post_process_refresh_classes
       [::Vm]
+    end
+
+    def parse_uid_from_url(url)
+      URI(url).path.split('/')[-1] unless url.nil?
     end
   end
 end


### PR DESCRIPTION
Using the new generic targeted refresh logic in the EmsRefresherMixin, split up collection and parsing of GCE inventory.  This also sets up the possibility to refresh individual instances in the future.