### PR TITLE
Fixup dialog.dialog_fields

### DIFF
--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -6,8 +6,8 @@ class DialogGroup < ApplicationRecord
 
   alias_attribute :order, :position
 
-  def each_dialog_field
-    dialog_fields.each { |df| yield(df) }
+  def each_dialog_field(&block)
+    dialog_fields.each(&block)
   end
 
   def dialog_resources

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -6,22 +6,12 @@ class DialogTab < ApplicationRecord
 
   alias_attribute :order, :position
 
-  def to_h
-    [name.to_sym, values_to_h]
-  end
-
-  def values_to_h
-    result = {}
-    ordered_dialog_resources
-    result
-  end
-
-  def each_dialog_field
-    dialog_groups.each { |dg| dg.each_dialog_field { |df| yield(df) } }
+  def each_dialog_field(&block)
+    dialog_fields.each(&block)
   end
 
   def dialog_fields
-    dialog_groups.collect(&:dialog_fields).flatten!
+    dialog_groups.flat_map(&:dialog_fields)
   end
 
   def dialog_resources

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -106,9 +106,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   end
 
   def init_field_hash
-    result = {}
-    @dialog.each_dialog_field { |df| result[df.name] = df }
-    result
+    @dialog.dialog_fields.each_with_object({}) { |df, result| result[df.name] = df }
   end
 
   def set_value(name, value)

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -1,6 +1,6 @@
 describe DialogGroup do
+  let(:dialog_group) { FactoryGirl.build(:dialog_group, :label => 'group') }
   context "#validate_children" do
-    let(:dialog_group) { FactoryGirl.build(:dialog_group, :label => 'group') }
 
     it "fails without element" do
       expect { dialog_group.save! }
@@ -12,6 +12,13 @@ describe DialogGroup do
       expect_any_instance_of(DialogField).to receive(:valid?)
       expect(dialog_group.errors.full_messages).to be_empty
       dialog_group.validate_children
+    end
+  end
+
+  context "#dialog_fields" do
+    # other tests are in dialog_spec.rb
+    it "returns [] even when no dialog_tab" do
+      expect(dialog_group.dialog_fields).to be_empty
     end
   end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -262,7 +262,9 @@ describe Dialog do
       @dialog_field2 = FactoryGirl.create(:dialog_field, :label => 'field 2', :name => "field_2")
 
       @dialog.dialog_tabs << @dialog_tab
+      @dialog.dialog_tabs << FactoryGirl.create(:dialog_tab, :label => 'tab2')
       @dialog_tab.dialog_groups << @dialog_group
+      @dialog_tab.dialog_groups << FactoryGirl.create(:dialog_group, :label => 'group2')
       @dialog_group.dialog_fields << @dialog_field
       @dialog_group.dialog_fields << @dialog_field2
 

--- a/spec/models/dialog_tab_spec.rb
+++ b/spec/models/dialog_tab_spec.rb
@@ -1,6 +1,6 @@
 describe DialogTab do
+  let(:dialog_tab) { FactoryGirl.build(:dialog_tab, :label => 'tab') }
   context "#validate_children" do
-    let(:dialog_tab) { FactoryGirl.build(:dialog_tab, :label => 'tab') }
 
     it "fails without box" do
       expect { dialog_tab.save! }
@@ -12,6 +12,18 @@ describe DialogTab do
       expect_any_instance_of(DialogGroup).to receive(:valid?)
       expect(dialog_tab.errors.full_messages).to be_empty
       dialog_tab.validate_children
+    end
+  end
+
+  context "#dialog_fields" do
+    # other tests are in dialog_spec.rb
+    it "returns [] even when no dialog_groups" do
+      expect(dialog_tab.dialog_fields).to be_empty
+    end
+
+    it "returns [] when empty dialog_group " do
+      dialog_tab.dialog_groups << FactoryGirl.build(:dialog_group)
+      expect(dialog_tab.dialog_fields).to be_empty
     end
   end
 end


### PR DESCRIPTION
Looked into adding an accessor in fields for ui team.
Noticed that the dialog_fields had too much code.

- Fix `DialogTab#values_to_h` now actually returns value.
- Left `Dialog{,Tab,Group}#each_dialog_field` unused in code. (ok to delete?)

/cc @gmcculloug low priority