### PR TITLE
[Depends on ManageIQ/ovirt#48] Probe and save oVirt API path

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -36,7 +36,7 @@ gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=1.1.0",            :require => false
 gem "openscap",                "~>0.4.3",           :require => false
-gem "ovirt",                   "~>0.8.0",           :require => false
+gem "ovirt",                   "~>0.9.0",           :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -12,6 +12,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
   let(:ems_cluster)   { FactoryGirl.create(:ems_cluster, :ext_management_system => ems) }
   let(:template)      { FactoryGirl.create(:template_redhat, :ext_management_system => ems) }
   let(:rhevm_vm)      { FactoryGirl.create(:vm_redhat) }
+  let(:ovirt_service) { double("Ovirt::Service", :api_path => "/api") }
 
   before do
     @task = FactoryGirl.create(:miq_provision_redhat,
@@ -25,6 +26,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
       :dest_cluster             => ems_cluster,
       :get_provider_destination => rhevm_vm
     )
+
+    allow(Ovirt::Service).to receive_messages(:new => ovirt_service)
 
     allow(rhevm_vm).to receive_messages(:nics => [rhevm_nic1, rhevm_nic2])
     allow(Ovirt::Cluster).to receive_messages(:find_by_href => rhevm_cluster)

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_0.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_0.yml
@@ -2,6 +2,17 @@
 http_interactions:
 - request:
     method: get
+    uri: https://192.168.252.231:8443/api
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      WWW-Authenticate:
+      - Basic realm="RESTAPI"
+  recorded_at: Tue, 26 Apr 2016 10:00:00 GMT
+- request:
+    method: get
     uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api
     body:
       encoding: US-ASCII

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
@@ -2,6 +2,17 @@
 http_interactions:
 - request:
     method: get
+    uri: https://192.168.252.230/api
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      WWW-Authenticate:
+      - Basic realm="RESTAPI"
+  recorded_at: Tue, 26 Apr 2016 11:15:00 GMT
+- request:
+    method: get
     uri: https://evm%40manageiq.com:password@192.168.252.230/api
     body:
       encoding: US-ASCII


### PR DESCRIPTION
This patch changes the oVirt provider so that it will determine the path
of the oVirt API probing the candidates. Once determined it will be
saved to the "path" column of the "endpoints" table, and the next time
it is required it will be retrieved from the table without probing.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>