### PR TITLE
Set Azure ems subscription to default subscription if not already set.

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -12,9 +12,17 @@ module ManageIQ::Providers
       end
 
       def initialize(ems, options = nil)
-        @ems               = ems
-        @config            = ems.connect
-        @subscription_id   = @config.subscription_id
+        @ems    = ems
+        @config = ems.connect
+
+        # Save the default subscription ID to the database if one wasn't provided.
+        unless ems.subscription
+          ems.subscription = @config.subscription_id
+          ems.save
+        end
+
+        @subscription_id = ems.subscription
+
         # TODO(lsmola) NetworkManager, remove network endpoints once this is entirely moved under NetworkManager
         @nis               = ::Azure::Armrest::Network::NetworkInterfaceService.new(@config)
         @ips               = ::Azure::Armrest::Network::IpAddressService.new(@config)


### PR DESCRIPTION
At the moment we do not require a subscription ID for an Azure cloud provider, but just recently we added the ability to specify a subscription ID, and added a backing column in the database.

However, the refresher doesn't currently use it by default. It needs to use the specified subscription ID if provided, or it needs to set and save the default subscription ID if one is not provided. This does both.