### PR TITLE
Clear the my_server cache so we can detect role changes faster.

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -13,6 +13,9 @@ module MiqServer::WorkerManagement::Monitor
   include_concern 'Validation'
 
   def monitor_workers
+    # Clear the my_server cache so we can detect role and possibly other changes faster
+    self.class.my_server_clear_cache
+
     resync_needed, sync_message = sync_needed?
 
     # Sync the workers after sync'ing the child worker settings


### PR DESCRIPTION
With a cached MiqServer, sync_needed? fails to detect changes to active roles
within a reasonable amount of time.

The default cache_with_timeout value is 5 minutes.

With this change, we'll refetch the my_server with each iteration of the monitor
loop.

https://bugzilla.redhat.com/show_bug.cgi?id=1325738

Note, @gtanzillo and I tried to write a test to recreate this but the setup was too complicated and we weren't able to do it. 😭 