### PR TITLE
Container entities should have fine-grained rbac

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -16,10 +16,13 @@ class MiqExpression
     Container
     ContainerGroup
     ContainerImage
+    ContainerImageRegistry
     ContainerNode
     ContainerProject
     ContainerService
     ContainerReplicator
+    ContainerRoute
+    ContainerService
     ManageIQ::Providers::CloudManager
     EmsCluster
     EmsClusterPerformance

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -11,7 +11,13 @@ module Rbac
     ConfiguredSystem
     Container
     ContainerGroup
+    ContainerImage
+    ContainerImageRegistry
     ContainerNode
+    ContainerProject
+    ContainerReplicator
+    ContainerRoute
+    ContainerService
     EmsCluster
     EmsFolder
     ExtManagementSystem


### PR DESCRIPTION
We already have fine grained access control for Containers, Groups,
and Nodes.

Until this change all the Images, Registries, Projects, Replicators
and Services are presented to anyone, regardless of policy tags.

Also relates to https://bugzilla.redhat.com/show_bug.cgi?id=1296980

@miq-bot add_label providers/containers

/cc @simon3z 