### PR TITLE
Chargeback rate fixes when saving form

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -652,11 +652,7 @@ class ChargebackController < ApplicationController
     @rate_tiers = []
     @edit[:new][:details].each_with_index do |detail, detail_index|
       rate_detail = detail[:id] ? ChargebackRateDetail.find(detail[:id]) : ChargebackRateDetail.new
-      rate_detail.per_time    = detail[:per_time]
-      rate_detail.per_unit    = detail[:per_unit]
-      rate_detail.source      = detail[:source]
-      rate_detail.group       = detail[:group]
-      rate_detail.description = detail[:description]
+      rate_detail.attributes = detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
       rate_detail_edit = @edit[:new][:details][detail_index]
       # C: Record the currency selected in the edit view, in my chargeback_rate_details table
       rate_detail.chargeback_rate_detail_currency_id = rate_detail_edit[:currency]
@@ -667,12 +663,9 @@ class ChargebackController < ApplicationController
       @edit[:new][:tiers][detail_index].each do |tier|
         rate_tier = tier[:id] ? ChargebackTier.find(tier[:id]) : ChargebackTier.new
         tier[:start] = Float::INFINITY if tier[:start].blank?
-        rate_tier.start  = tier[:start]
         tier[:finish] = Float::INFINITY if tier[:finish].blank?
-        rate_tier.finish = tier[:finish]
+        rate_tier.attributes = tier.slice(*ChargebackTier::FORM_ATTRIBUTES)
         rate_tier.chargeback_rate_detail_id = rate_detail.id
-        rate_tier.fixed_rate  = tier[:fixed_rate]
-        rate_tier.variable_rate = tier[:variable_rate]
         rate_tiers.push(rate_tier)
       end
       @rate_tiers[detail_index] = rate_tiers

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -227,7 +227,7 @@ class ChargebackController < ApplicationController
 
   def cb_rate_show
     @display = "main"
-    @record.chargeback_rate_details.to_a.sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
+    @record.chargeback_rate_details
     if @record.nil?
       redirect_to :action => "cb_rates_list", :flash_msg => _("Error: Record no longer exists in the database"), :flash_error => true
       return
@@ -596,7 +596,7 @@ class ChargebackController < ApplicationController
 
       tiers[detail_index] ||= []
 
-      detail.chargeback_tiers.to_a.sort_by { |ct| [ct[:start]] }.each do |tier|
+      detail.chargeback_tiers.each do |tier|
         new_tier = tier.slice(*ChargebackTier::FORM_ATTRIBUTES)
         new_tier[:id] = params[:typ] == "copy" ? nil : tier.id
         new_tier[:chargeback_rate_detail_id] = params[:typ] == "copy" ? nil : detail.id
@@ -609,8 +609,6 @@ class ChargebackController < ApplicationController
       @edit[:new][:num_tiers][detail_index] = tiers[detail_index].size
       @edit[:new][:details].push(temp)
     end
-
-    @edit[:new][:details].sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
 
     @edit[:new][:per_time_types] = per_time_types_from
 

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -3,6 +3,9 @@ class ChargebackRateDetail < ApplicationRecord
   belongs_to :detail_measure, :class_name => "ChargebackRateDetailMeasure", :foreign_key => :chargeback_rate_detail_measure_id
   belongs_to :detail_currency, :class_name => "ChargebackRateDetailCurrency", :foreign_key => :chargeback_rate_detail_currency_id
   has_many :chargeback_tiers, :dependent => :destroy, :autosave => true
+
+  default_scope { order(:group => :asc, :description => :asc) }
+
   validates :group, :source, :presence => true
   validate :contiguous_tiers?
 
@@ -213,7 +216,7 @@ class ChargebackRateDetail < ApplicationRecord
         detail_new.detail_currency = ChargebackRateDetailCurrency.find_by(:name => detail[:type_currency])
         detail_new.metric = detail[:metric]
 
-        detail[:tiers].each do |tier|
+        detail[:tiers].sort_by { |tier| tier[:start] }.each do |tier|
           detail_new.chargeback_tiers << ChargebackTier.new(tier.slice(*ChargebackTier::FORM_ATTRIBUTES))
         end
 
@@ -221,6 +224,6 @@ class ChargebackRateDetail < ApplicationRecord
       end
     end
 
-    rate_details
+    rate_details.sort_by { |rd| [rd[:group], rd[:description]] }
   end
 end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -6,7 +6,7 @@ class ChargebackRateDetail < ApplicationRecord
   validates :group, :source, :presence => true
   validate :contiguous_tiers?
 
-  FORM_ATTRIBUTES = %i(description per_time per_unit metric group source).freeze
+  FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric).freeze
 
   # Set the rates according to the tiers
   def find_rate(value)
@@ -211,6 +211,8 @@ class ChargebackRateDetail < ApplicationRecord
         detail_new = ChargebackRateDetail.new(detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES))
         detail_new.detail_measure = ChargebackRateDetailMeasure.find_by(:name => detail[:measure])
         detail_new.detail_currency = ChargebackRateDetailCurrency.find_by(:name => detail[:type_currency])
+        detail_new.metric = detail[:metric]
+
         detail[:tiers].each do |tier|
           detail_new.chargeback_tiers << ChargebackTier.new(tier.slice(*ChargebackTier::FORM_ATTRIBUTES))
         end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -2,7 +2,7 @@ class ChargebackRateDetail < ApplicationRecord
   belongs_to :chargeback_rate
   belongs_to :detail_measure, :class_name => "ChargebackRateDetailMeasure", :foreign_key => :chargeback_rate_detail_measure_id
   belongs_to :detail_currency, :class_name => "ChargebackRateDetailCurrency", :foreign_key => :chargeback_rate_detail_currency_id
-  has_many :chargeback_tiers, :dependent => :destroy
+  has_many :chargeback_tiers, :dependent => :destroy, :autosave => true
   validates :group, :source, :presence => true
   validate :contiguous_tiers?
 
@@ -145,13 +145,6 @@ class ChargebackRateDetail < ApplicationRecord
   def save_tiers(tiers)
     temp = self.class.new(:chargeback_tiers => tiers)
     if temp.contiguous_tiers?
-      tiers.each do |tier|
-        unless tier.valid?
-          errors.add(:tier, tier.errors.full_messages.first)
-          return
-        end
-        tier.save
-      end
       self.chargeback_tiers.replace(tiers)
     else
       temp.errors.each {|a, e| errors.add(a, e)}

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -4,6 +4,8 @@ class ChargebackTier < ApplicationRecord
   validates :start,  :numericality => {:greater_than_or_equal_to => 0, :less_than => Float::INFINITY}
   validates :finish, :numericality => {:greater_than_or_equal_to => 0}
 
+  default_scope { order(:start => :asc) }
+
   FORM_ATTRIBUTES = %i(fixed_rate variable_rate start finish).freeze
 
   def self.to_float(s)

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
 - currency = ChargebackRateDetailCurrency.currencies_for_select
 #flash_msg_div
 #form_div
@@ -28,101 +28,8 @@
           options_for_select(currency, @edit[:new][:currency]),
           "data-miq_observe" => {:url => url}.to_json)
 
-  %h3= _('Rate Details')
-  %table.table.table-bordered
-    %thead
-      %tr
-        %th{:rowspan => "2"}= _('Group')
-        %th{:rowspan => "2"}= _('Description')
-        %th{:rowspan => "2"}= _('Per Time')
-        %th{:rowspan => "2"}= _('Per Unit')
-        %th{:colspan => "2"}= _('Range')
-        %th{:colspan => "2"}= _('Rate')
-        %th{:rowspan => "2"}= _('Actions')
-        %th{:rowspan => "2"}= _('Currency')
-      %tr
-        %th= _("Start")
-        %th= _("Finish")
-        %th= _("Fixed")
-        %th= _("Variable")
-    %tbody
-      %strong
-        = _('* Caution: The value Range end will not be included in the tier.')
-      - @edit[:new][:details].each_with_index do |detail, detail_index|
-        - @cur_group = detail[:group] if @cur_group.nil?
-        - if @cur_group != detail[:group]
-          - @cur_group = detail[:group]
-          %tr
-            %td.active{:colspan => "10"} &nbsp;
-        - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
-
-        %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}
-          %td{:rowspan => num_tiers}
-            = h(rate_detail_group(detail[:group]))
-          %td{:rowspan => num_tiers}
-            = detail[:description]
-          %td{:rowspan => num_tiers}
-            = select_tag("per_time_#{detail_index}",
-              options_for_select(@edit[:new][:per_time_types].invert, @edit[:new][:details][detail_index][:per_time]),
-              "data-miq_observe" => {:url => url}.to_json)
-          - measure = @edit[:new][:details][detail_index][:detail_measure]
-          - if measure.nil?
-            /if the rate detail don't have a metric associated, display the per_unit_display
-            %td{:rowspan => num_tiers}
-              = detail[:per_unit_display]
-          - else
-            /if the rate detail have a metric associated, display an options field with per_unit selected
-            %td{:rowspan => num_tiers}
-              = select_tag("per_unit_#{detail_index}", options_for_select(measure[:measures], detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
-          %td
-            - tier_val = (@edit[:new][:tiers][detail_index][0][:start].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][detail_index][0][:start]
-            = text_field_tag("start_#{detail_index}_0", tier_val,
-              :maxlength => MAX_NAME_LEN,
-              :placeholder => _("Infinity"),
-              "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
-          %td
-            - tier_val = (@edit[:new][:tiers][detail_index][0][:finish].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][detail_index][0][:finish]
-            = text_field_tag("finish_#{detail_index}_0", tier_val,
-              :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %td{:align => 'right'}
-            = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %td{:align => 'right'}
-            = text_field_tag("variable_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:variable_rate],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %td.action
-            = button_tag(_("Add"),
-                         :class   => "btn btn-default",
-                         :alt     => t = _("Add a new tier"),
-                         :title   => t,
-                         :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
-                                                               :detail_index => detail_index,
-                                                               :button       => "add")}');")
-          /Show the code of the currency selected by the user
-          %td{:id => "column_currency_#{detail_index}", :rowspan => num_tiers}
-            = @edit[:new][:code_currency]
-        - (1..num_tiers.to_i - 1).each do |tier_index|
-          - tier = @edit[:new][:tiers][detail_index][tier_index]
-          %tr{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
-            %td
-              - tier_val = (tier[:start].to_s.eql? "Infinity") ? "" : tier[:start]
-              = text_field_tag("start_#{detail_index}_#{tier_index}", tier_val,
-                :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %td
-              - tier_val = (tier[:finish].to_s.eql? "Infinity") ? "" : tier[:finish]
-              = text_field_tag("finish_#{detail_index}_#{tier_index}", tier_val,
-                :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %td{:align => "right"}
-              = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier[:fixed_rate],
-                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %td{:align => "right"}
-              = text_field_tag("variable_rate_#{detail_index}_#{tier_index}", tier[:variable_rate],
-                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %td.action
-              = button_tag(_("Delete"),
-                   :class   => "btn btn-default",
-                   :alt     => t = _("Remove the tier"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
-                                                         :index  => "#{detail_index}-#{tier_index}",
-                                                         :button => "remove")}');")
+  %h3
+    = _('Rate Details')
+  %strong
+    = _('* Caution: The value Range end will not be included in the tier.')
+  = render "cb_rate_edit_table"

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -1,0 +1,90 @@
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
+%table.table.table-bordered{:id => "chargeback_rate_edit_form"}
+  %thead
+    %tr
+      %th{:rowspan => "2"}= _('Group')
+      %th{:rowspan => "2"}= _('Description')
+      %th{:rowspan => "2"}= _('Per Time')
+      %th{:rowspan => "2"}= _('Per Unit')
+      %th{:colspan => "2"}= _('Range')
+      %th{:colspan => "2"}= _('Rate')
+      %th{:rowspan => "2"}= _('Actions')
+      %th{:rowspan => "2"}= _('Currency')
+    %tr
+      %th= _("Start")
+      %th= _("Finish")
+      %th= _("Fixed")
+      %th= _("Variable")
+  %tbody
+    - @edit[:new][:details].each_with_index do |detail, detail_index|
+      - @cur_group = detail[:group] if @cur_group.nil?
+      - if @cur_group != detail[:group]
+        - @cur_group = detail[:group]
+        %tr
+          %td.active{:colspan => "10"} &nbsp;
+      - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
+
+      %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}
+        %td{:rowspan => num_tiers}
+          = h(rate_detail_group(detail[:group]))
+        %td{:rowspan => num_tiers}
+          = detail[:description]
+        %td{:rowspan => num_tiers}
+          = select_tag("per_time_#{detail_index}",
+            options_for_select(@edit[:new][:per_time_types].invert, @edit[:new][:details][detail_index][:per_time]),
+            "data-miq_observe" => {:url => url}.to_json)
+        - measure = @edit[:new][:details][detail_index][:detail_measure]
+        - if measure.nil?
+          /if the rate detail don't have a metric associated, display the per_unit_display
+          %td{:rowspan => num_tiers}
+            = detail[:per_unit_display]
+        - else
+          /if the rate detail have a metric associated, display an options field with per_unit selected
+          %td{:rowspan => num_tiers}
+            = select_tag("per_unit_#{detail_index}", options_for_select(measure[:measures], detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
+        %td
+          - tier_val = (@edit[:new][:tiers][detail_index][0][:start].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][detail_index][0][:start]
+          = text_field_tag("start_#{detail_index}_0", tier_val,
+            :maxlength => MAX_NAME_LEN,
+            :placeholder => _("Infinity"),
+            "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
+        %td
+          - tier_val = (@edit[:new][:tiers][detail_index][0][:finish].to_s.eql? "Infinity") ? "" : @edit[:new][:tiers][detail_index][0][:finish]
+          = text_field_tag("finish_#{detail_index}_0", tier_val,
+            :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+        %td{:align => 'right'}
+          = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
+            :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+        %td{:align => 'right'}
+          = text_field_tag("variable_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:variable_rate],
+            :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+        %td.action
+          = button_tag(_("Add"), :class => "btn btn-default", :alt => t = _("Add a new tier"), :title => t,
+                                 :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_add",
+                                                                       :detail_index => detail_index,
+                                                                       :button => "add")}');")
+        /Show the code of the currency selected by the user
+        %td{:id => "column_currency_#{detail_index}", :rowspan => num_tiers}
+          = @edit[:new][:code_currency]
+      - (1..num_tiers.to_i - 1).each do |tier_index|
+        - tier = @edit[:new][:tiers][detail_index][tier_index]
+        %tr{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
+          %td
+            - tier_val = (tier[:start].to_s.eql? "Infinity") ? "" : tier[:start]
+            = text_field_tag("start_#{detail_index}_#{tier_index}", tier_val,
+              :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td
+            - tier_val = (tier[:finish].to_s.eql? "Infinity") ? "" : tier[:finish]
+            = text_field_tag("finish_#{detail_index}_#{tier_index}", tier_val,
+              :maxlength => MAX_NAME_LEN, :placeholder => _("Infinity"), "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td{:align => "right"}
+            = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier[:fixed_rate],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td{:align => "right"}
+            = text_field_tag("variable_rate_#{detail_index}_#{tier_index}", tier[:variable_rate],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td.action
+            = button_tag(_("Delete"), :class => "btn btn-default", :alt => t = _("Remove the tier"), :title => t,
+                                      :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
+                                                                            :index => "#{detail_index}-#{tier_index}",
+                                                                            :button => "remove")}');")

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -148,4 +148,138 @@ describe ChargebackController do
       expect(assigns(:edit)[:cb_assign][:cis]).to eq({})
     end
   end
+
+  context "chargeback rate form actions" do
+    # indexing inputs regard to database
+    # html inputs have names(and ids) in form "start_0_0", "finish_0_2"
+    # it means "start_[num_of_rate_detail]_[num_of_tier]"
+
+    # for example we have in database:
+    # chargeback_rate => [
+    #                     chargeback_rate_details_0 => [
+    #                                                 chargeback_tiers_0  => index of tier : 0_0
+    #                                                 chargeback_tiers_1  => index of tier : 0_1
+    #                                                 chargeback_tiers_2  => index of tier : 0_2
+    #                                                ]
+    #                     chargeback_rate_details_1 => [
+    #                                                 chargeback_tiers_0  => index of tier : 1_0
+    #                                                 chargeback_tiers_1  => index of tier : 1_1
+    #                                                 chargeback_tiers_2  => index of tier : 1_2
+    #                                                ]
+    # ]
+    #
+
+    render_views
+
+    let(:chargeback_rate) { FactoryGirl.create(:chargeback_rate_with_details) }
+
+    # this index represent first rate detail( "Allocated Memory in MB") chargeback_rate
+    let(:index_to_rate_type) { "0" }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      allow_any_instance_of(described_class).to receive(:center_toolbar_filename).and_return("chargeback_center_tb")
+      seed_session_trees('chargeback', :cb_rates_tree, "xx-Compute_cr-#{controller.to_cid(chargeback_rate.id)}")
+    end
+
+    def expect_input(body, selector, value)
+      expect(body).to have_selector("input[value='#{value}']##{selector}")
+    end
+
+    def expect_rendered_tiers(body, tiers, order_of_rate_detail = 0)
+      tiers.each_with_index do |tier, index|
+        expect_input(body, "start_#{order_of_rate_detail}_#{index}", tier[:start])
+        finish_tier_value = tier[:finish] == Float::INFINITY ? "" : tier[:finish]
+        expect_input(body, "finish_#{order_of_rate_detail}_#{index}", finish_tier_value)
+      end
+    end
+
+    def change_form_value(field, value)
+      post :cb_rate_form_field_changed, :params => {:id => chargeback_rate.id, field => value}
+    end
+
+    it "renders edit form with correct values" do
+      post :x_button, :params => {:pressed => "chargeback_rates_edit", :id => chargeback_rate.id}
+      response_body = response.body.delete('\\')
+      expect(response).to render_template(:partial => 'chargeback/_cb_rate_edit')
+      expect(response).to render_template(:partial => 'chargeback/_cb_rate_edit_table')
+
+      expect_input(response_body, "description", "foo")
+
+      expect_rendered_tiers(response_body, [{:start => "0.0", :finish => "20.0"},
+                                            {:start => "20.0", :finish => "40.0"},
+                                            {:start => "40.0", :finish => Float::INFINITY}])
+
+      expect_rendered_tiers(response_body, [{:start => "0.0", :finish => Float::INFINITY}], 1)
+    end
+
+    it "removes requested tier line from edit from" do
+      post :x_button, :params => {:pressed => "chargeback_rates_edit", :id => chargeback_rate.id}
+      post :cb_tier_remove, :params => {:button => "remove", :index => "0-1"}
+
+      response_body = response.body.delete('\\').gsub('u003e', ">").gsub('u003c', "<")
+
+      expect(response).to render_template(:partial => 'chargeback/_cb_rate_edit_table')
+
+      expect_rendered_tiers(response_body, [{:start => "0.0", :finish => "20.0"},
+                                            {:start => "40.0", :finish => Float::INFINITY}])
+
+      expect_rendered_tiers(response_body, [{:start => "0.0", :finish => Float::INFINITY}], 1)
+    end
+
+    it "removes requested tier line and add 2 new tiers line from edit from" do
+      count_of_tiers = chargeback_rate.chargeback_rate_details[index_to_rate_type.to_i].chargeback_tiers.count
+      post :x_button, :params => {:pressed => "chargeback_rates_edit", :id => chargeback_rate.id}
+      post :cb_tier_remove, :params => {:button => "remove", :index => "#{index_to_rate_type}-1"}
+      post :cb_tier_add, :params => {:button => "add", :detail_index => index_to_rate_type}
+      post :cb_tier_add, :params => {:button => "add", :detail_index => index_to_rate_type}
+
+      response_body = response.body.delete('\\').gsub('u003e', ">").gsub('u003c', "<")
+
+      count_of_last_tier = count_of_tiers - 1 + 2 # one tier removed, two tiers added
+      selector = "#{index_to_rate_type}_#{count_of_last_tier - 1}"
+      expect_input(response_body, "start_#{selector}", "")
+      expect_input(response_body, "finish_#{selector}", "")
+    end
+
+    it "saves edited chargeback rate" do
+      post :x_button, :params => {:pressed => "chargeback_rates_edit", :id => chargeback_rate.id}
+
+      # remove second tier for rate detail; (values  {:start => "20.0", :finish => "40.0"})
+      post :cb_tier_remove, :params => {:button => "remove", :index => "#{index_to_rate_type}-1"}
+
+      # add new tier, new position is index_to_rate_type-1
+      post :cb_tier_add, :params => {:button => "add", :detail_index => index_to_rate_type}
+
+      # add new tier at, new position is index_to_rate_type-2
+      post :cb_tier_add, :params => {:button => "add", :detail_index => index_to_rate_type}
+
+      # after these actions we have for rate detail values:
+      # 0-0 :start => 0.0, :finish => 20.0
+      # 0-1 :start => 40.0, :finish => Infinity
+      # 0-2 :start => Infinity, :finish => Infinity
+      # 0-3 :start => Infinity, :finish => Infinity
+
+      # add values to newly added tiers to be valid
+      change_form_value(:start_0_1, "20.0")
+      change_form_value(:finish_0_1, "50.0")
+      change_form_value(:start_0_2, "50.0")
+      change_form_value(:finish_0_2, "70.0")
+      change_form_value(:start_0_3, "70.0")
+
+      # so after updating form values we have tiers with valid values
+      # 0-0 :start => 0.0, :finish => 30.0
+      # 0-1 :start => 30.0, :finish => 50.0
+      # 0-2 :start => 50.0, :finish => 70.0
+      # 0-3 :start => 70.0, :finish => Infinity
+
+      post :cb_rate_edit, :params => {:button => "save", :id => chargeback_rate.id}
+
+      rate_detail = ChargebackRate.find(chargeback_rate.id).chargeback_rate_details[index_to_rate_type.to_i]
+      expect(rate_detail.chargeback_tiers[0]).to have_attributes(:start => 0.0, :finish => 20.0)
+      expect(rate_detail.chargeback_tiers[1]).to have_attributes(:start => 20.0, :finish => 50.0)
+      expect(rate_detail.chargeback_tiers[2]).to have_attributes(:start => 50.0, :finish => 70.0)
+      expect(rate_detail.chargeback_tiers[3]).to have_attributes(:start => 70.0, :finish => Float::INFINITY)
+    end
+  end
 end

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -2,5 +2,13 @@ FactoryGirl.define do
   factory :chargeback_rate do
     guid        { MiqUUID.new_guid }
     description 'foo'
+    rate_type 'Compute'
+  end
+
+  factory :chargeback_rate_with_details, :parent => :chargeback_rate do
+    after(:create) do |chargeback_rate|
+      chargeback_rate.chargeback_rate_details << FactoryGirl.create(:chargeback_rate_detail_memory_used_with_tiers)
+      chargeback_rate.chargeback_rate_details << FactoryGirl.create(:chargeback_rate_detail_memory_allocated_with_tiers)
+    end
   end
 end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -2,6 +2,28 @@ FactoryGirl.define do
   factory :chargeback_rate_detail do
     group   "unknown"
     source  "unknown"
+
+    trait :euro do
+      detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency_EUR) }
+    end
+
+    trait :bytes do
+      detail_measure { FactoryGirl.create(:chargeback_rate_detail_measure_bytes) }
+    end
+
+    trait :tiers do
+      chargeback_tiers { [FactoryGirl.create(:chargeback_tier)] }
+    end
+
+    trait :tiers_with_three_intervals do
+      chargeback_tiers do
+        [
+          FactoryGirl.create(:chargeback_tier_first_of_three),
+          FactoryGirl.create(:chargeback_tier_second_of_three),
+          FactoryGirl.create(:chargeback_tier_third_of_three)
+        ]
+      end
+    end
   end
 
   factory :chargeback_rate_detail_cpu_used, :parent => :chargeback_rate_detail do
@@ -84,4 +106,10 @@ FactoryGirl.define do
     source      "compute_1"
     per_time    "daily"
   end
+
+  factory :chargeback_rate_detail_memory_allocated_with_tiers, :parent => :chargeback_rate_detail_memory_allocated,
+                                                               :traits => [:euro, :bytes, :tiers_with_three_intervals]
+
+  factory :chargeback_rate_detail_memory_used_with_tiers, :parent => :chargeback_rate_detail_memory_used,
+                                                          :traits => [:euro, :bytes, :tiers]
 end

--- a/spec/factories/chargeback_tier.rb
+++ b/spec/factories/chargeback_tier.rb
@@ -4,5 +4,30 @@ FactoryGirl.define do
     finish Float::INFINITY
     fixed_rate 0.0
     variable_rate 0.0
+
+    trait :first_of_three do
+      start 0.0
+      finish 20.0
+      fixed_rate 0.1
+      variable_rate 0.2
+    end
+
+    trait :second_of_three do
+      start 20.0
+      finish 40.0
+      fixed_rate 0.3
+      variable_rate 0.4
+    end
+
+    trait :third_of_three do
+      start 40.0
+      finish Float::INFINITY
+      fixed_rate 0.5
+      variable_rate 0.6
+    end
   end
+
+  factory :chargeback_tier_first_of_three, :traits => [:first_of_three], :parent => :chargeback_tier
+  factory :chargeback_tier_second_of_three, :traits => [:second_of_three], :parent => :chargeback_tier
+  factory :chargeback_tier_third_of_three, :traits => [:third_of_three], :parent => :chargeback_tier
 end


### PR DESCRIPTION
1. When saving existing chargeback rate form it throws errors. It was because chargeback tiers has been passed in wrong order for saving

2. Validation message was doubled when 'Fixed' and 'Variable' were entered incorrectly.
Remove code which causing doubling message and using autosave for saving ChargebackTiers.

before
![screen shot 2016-04-19 at 13 30 46](https://cloud.githubusercontent.com/assets/14937244/14637669/1cb30c26-0633-11e6-9ed8-0d35a6b0cd09.png)

after
![screen shot 2016-04-19 at 13 30 23](https://cloud.githubusercontent.com/assets/14937244/14637676/2a0a38cc-0633-11e6-856d-59fb47fc17ed.png)

  3 .  metric column was not stored when adding new chargeback rate for ChargebackRateDetail model
  4 .  fix for removing related line of chargeback tier. 
       scenario: add 4 tiers for 'Allocated CPU Count'(example), save, edit again and then remove for example third tier but forth tier was deleted. there is gif with issue (I am sorry for quality)
![remove_line](https://cloud.githubusercontent.com/assets/14937244/14647307/731be964-065d-11e6-8ba0-4a85e8245886.gif)







cc @gtanzillo 
fyi @tledesma @amaurygonzalez 