### PR TITLE
Check for nil metric fields in containers dashboard

### DIFF
--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -160,10 +160,10 @@ class ContainerDashboardService
 
     daily_provider_metrics.each do |metric|
       date = metric.timestamp.strftime("%Y-%m-%d")
-      used_cpu[date] += metric.v_derived_cpu_total_cores_used
-      used_mem[date] += metric.derived_memory_used
-      total_cpu[date] += metric.derived_vm_numvcpus
-      total_mem[date] += metric.derived_memory_available
+      used_cpu[date] += metric.v_derived_cpu_total_cores_used if metric.v_derived_cpu_total_cores_used.present?
+      used_mem[date] += metric.derived_memory_used if metric.derived_memory_used.present?
+      total_cpu[date] += metric.derived_vm_numvcpus if metric.derived_vm_numvcpus.present?
+      total_mem[date] += metric.derived_memory_available if metric.derived_memory_available.present?
     end
 
     if used_cpu.any?
@@ -194,7 +194,7 @@ class ContainerDashboardService
     MetricRollup.with_interval_and_time_range("hourly", (1.day.ago.beginning_of_hour.utc)..(Time.now.utc))
                 .where(:resource => (@ems || ManageIQ::Providers::ContainerManager.all)).each do |m|
       hour = m.timestamp.beginning_of_hour.utc
-      hourly_network_trend[hour] += m.net_usage_rate_average
+      hourly_network_trend[hour] += m.net_usage_rate_average if m.net_usage_rate_average.present?
     end
 
     if hourly_network_trend.any?
@@ -209,7 +209,7 @@ class ContainerDashboardService
     daily_network_metrics = Hash.new(0)
     daily_provider_metrics.each do |m|
       day = m.timestamp.strftime("%Y-%m-%d")
-      daily_network_metrics[day] += m.net_usage_rate_average
+      daily_network_metrics[day] += m.net_usage_rate_average if m.net_usage_rate_average.present?
     end
 
     if daily_network_metrics.any?

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -28,7 +28,7 @@ describe ContainerDashboardService do
     end
   end
 
-  context "node_utilization" do
+  context "ems_utilization" do
     it "shows aggregated metrics from last 30 days only" do
       ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
       ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
@@ -63,10 +63,17 @@ describe ContainerDashboardService do
         :cpu_usage_rate_average   => 100,
         :time_profile             => time_profile)
 
+      nil_fielded_metric = FactoryGirl.create(
+        :metric_rollup_cm_daily,
+        :timestamp    => old_date,
+        :time_profile => time_profile)
+
       ems_openshift.metric_rollups << current_metric_openshift
       ems_openshift.metric_rollups << old_metric
+      ems_openshift.metric_rollups << nil_fielded_metric
       ems_kubernetes.metric_rollups << current_metric_kubernetes
       ems_kubernetes.metric_rollups << old_metric.dup
+      ems_kubernetes.metric_rollups << nil_fielded_metric.dup
 
       node_utilization_all_providers = described_class.new(nil, controller).ems_utilization
       node_utilization_single_provider = described_class.new(ems_openshift.id, controller).ems_utilization
@@ -112,6 +119,131 @@ describe ContainerDashboardService do
   end
 
   context "heatmaps" do
+    it "shows aggregated metrics from last 30 days only" do
+      ems_openshift = FactoryGirl.create(:ems_openshift, :name => 'openshift', :zone => @zone)
+      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :name => 'kubernetes', :zone => @zone)
+
+      @node1 = FactoryGirl.create(:container_node, :name => 'node1')
+      @node2 = FactoryGirl.create(:container_node, :name => 'node2')
+      @node3 = FactoryGirl.create(:container_node, :name => 'node3')
+      @node4 = FactoryGirl.create(:container_node, :name => 'node4')
+      ems_openshift.container_nodes << @node1 << @node2
+      ems_kubernetes.container_nodes << @node3 << @node4
+
+      [ems_kubernetes, ems_openshift].each do |p|
+        p.container_nodes.each do |node|
+          node.metric_rollups << FactoryGirl.create(
+            :metric_rollup_cm_hr,
+            :timestamp                  => 1.hour.ago.utc,
+            :cpu_usage_rate_average     => 90,
+            :mem_usage_absolute_average => 90,
+            :derived_vm_numvcpus        => 4,
+            :net_usage_rate_average     => 90,
+            :derived_memory_available   => 8192,
+            :derived_memory_used        => 4096)
+        end
+      end
+
+      heatmaps_all_providers = described_class.new(nil, controller).heatmaps
+      heatmaps_single_provider = described_class.new(ems_openshift, controller).heatmaps
+
+      expect(heatmaps_all_providers).to eq(
+        :nodeCpuUsage    => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node3.id,
+            :node     => "node3",
+            :provider => "kubernetes",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node4.id,
+            :node     => "node4",
+            :provider => "kubernetes",
+            :total    => 4,
+            :percent  => 0.9
+          }],
+        :nodeMemoryUsage => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node3.id,
+            :node     => "node3",
+            :provider => "kubernetes",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node4.id,
+            :node     => "node4",
+            :provider => "kubernetes",
+            :total    => 8192,
+            :percent  => 0.9
+          }]
+      )
+
+      expect(heatmaps_single_provider).to eq(
+        :nodeCpuUsage    => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 4,
+            :percent  => 0.9
+          }
+        ],
+        :nodeMemoryUsage => [
+          {
+            :id       => @node1.id,
+            :node     => "node1",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          },
+          {
+            :id       => @node2.id,
+            :node     => "node2",
+            :provider => "openshift",
+            :total    => 8192,
+            :percent  => 0.9
+          }
+        ]
+      )
+    end
+
     it "returns hash with nil values when no metrics available" do
       ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
       heatmaps_all_providers = described_class.new(nil, controller).heatmaps
@@ -191,10 +323,17 @@ describe ContainerDashboardService do
         :net_usage_rate_average => 1500,
         :time_profile           => time_profile)
 
+      nil_fields_metric = FactoryGirl.create(
+        :metric_rollup_cm_hr,
+        :timestamp    => old_date,
+        :time_profile => time_profile)
+
       ems_openshift.metric_rollups << current_metric_openshift
       ems_openshift.metric_rollups << old_metric
+      ems_openshift.metric_rollups << nil_fields_metric
       ems_kubernetes.metric_rollups << current_metric_kubernetes
       ems_kubernetes.metric_rollups << old_metric.dup
+      ems_kubernetes.metric_rollups << nil_fields_metric.dup
 
       hourly_network_trends = described_class.new(nil, controller).hourly_network_metrics
       hourly_network_trends_single_provider = described_class.new(ems_openshift.id, controller).hourly_network_metrics


### PR DESCRIPTION
Sometimes the metric fields used in the dashboard are ```nil``` and we should check for that.
I went over the dashboard code and added checks wherever I think a problem might occur due to a `nil` field.


@moolitayer @simon3z Please review 

@miq-bot add_label providers/containers, bug