### PR TITLE
Mount WebsocketServer as a normal rails route in development mode

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2566,4 +2566,8 @@ Vmdb::Application.routes.draw do
   resources :ems_cloud, :as => :ems_clouds
   resources :ems_infra, :as => :ems_infras
   match "/auth/:provider/callback" => "sessions#create", :via => :get
+
+  if Rails.env.development?
+    mount WebsocketServer.new => '/ws'
+  end
 end


### PR DESCRIPTION
For easier testing & debugging remote VM consoles