### PR TITLE
Enable DEBUG messages in simulate_queue_worker

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -19,6 +19,7 @@ module Vmdb
     # Development helper method for Rails console for simulating queue workers.
     def simulate_queue_worker(break_on_complete = false)
       raise NotImplementedError, "not implemented in production mode" if Rails.env.production?
+      Rails.logger.level = :DEBUG
       loop do
         q = MiqQueue.where(MiqQueue.arel_table[:queue_name].not_eq("miq_server")).order(:id).first
         if q


### PR DESCRIPTION
In case `:level_rails:` is set on `info`, I can't see any output from `simulate_queue_worker`. This PR fixes the problem.

@skateman 