### PR TITLE
Don't allow deletion of default chargeback rates

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -182,6 +182,13 @@ class ChargebackController < ApplicationController
       session[:changed] = params[:typ] == "copy" ? true : false
 
       @rate = params[:typ] == "new" ? ChargebackRate.new : ChargebackRate.find(params[:id])
+      @record = @rate
+
+      if params[:typ] == "edit" && @rate.default?
+        add_flash(_("Default Chargeback Rate \"%{name}\" cannot be edited.") % {:name => @rate.description}, :error)
+        render_flash
+        return
+      end
 
       cb_rate_set_form_vars
 

--- a/app/helpers/application_helper/button/chargeback_rate_edit.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_edit.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::ChargebackRateEdit < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @record.default?
+      self[:enabled] = false
+      self[:title] = _("Default Chargeback Rate cannot be edited.")
+    end
+  end
+end

--- a/app/helpers/application_helper/button/chargeback_rate_remove.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_remove.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::ChargebackRateRemove < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @record.default?
+      self[:enabled] = false
+      self[:title] = _("Default Chargeback Rate cannot be removed.")
+    end
+  end
+end

--- a/app/helpers/application_helper/toolbar/chargeback_center.rb
+++ b/app/helpers/application_helper/toolbar/chargeback_center.rb
@@ -50,7 +50,8 @@ class ApplicationHelper::Toolbar::ChargebackCenter < ApplicationHelper::Toolbar:
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Chargeback Rate'),
           t,
-          :url_parms => "main_div"),
+          :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::ChargebackRateEdit),
         button(
           :chargeback_rates_copy,
           'fa fa-files-o fa-lg',
@@ -63,7 +64,8 @@ class ApplicationHelper::Toolbar::ChargebackCenter < ApplicationHelper::Toolbar:
           N_('Remove this Chargeback Rate from the VMDB'),
           N_('Remove from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Chargeback Rate will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Chargeback Rate?")),
+          :confirm   => N_("Warning: This Chargeback Rate will be permanently removed from the Virtual Management Database. Are you sure you want to remove this Chargeback Rate?"),
+          :klass     => ApplicationHelper::Button::ChargebackRateRemove),
       ]
     ),
   ])

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -14,6 +14,7 @@ class ChargebackRate < ApplicationRecord
   # and is brought in by the call to acts_as_miq_taggable in the AssignmentMixin #
   ################################################################################
   before_destroy :ensure_unassigned
+  before_destroy :ensure_nondefault
 
   include AssignmentMixin
 
@@ -169,6 +170,13 @@ class ChargebackRate < ApplicationRecord
   def ensure_unassigned
     if assigned?
       errors.add(:rate, "rate is assigned and cannot be deleted")
+      throw :abort
+    end
+  end
+
+  def ensure_nondefault
+    if default?
+      errors.add(:rate, "default rate cannot be deleted")
       throw :abort
     end
   end

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -47,5 +47,20 @@ describe ChargebackRate do
       expect(cbr.errors.count).to be(1)
       expect(cbr.errors.first).to include("rate is assigned and cannot be deleted")
     end
+
+    it "when default" do
+      cbr = FactoryGirl.create(:chargeback_rate, :description => "Default", :default => true)
+      cbr.destroy
+      expect(cbr).to_not be_destroyed
+      expect(cbr.errors.count).to be(1)
+      expect(cbr.errors.first).to include("default rate cannot be deleted")
+    end
+
+    it "when non-default" do
+      cbr = FactoryGirl.create(:chargeback_rate, :description => "Non-default", :default => false)
+      cbr.destroy
+      expect(cbr).to be_destroyed
+      expect(cbr.errors.count).to be(0)
+    end
   end
 end


### PR DESCRIPTION
Default chargeback rates are seeded during database initialization and their deletion results into
several problems propagated into UI (in several places we assume existence of these default rates).

https://bugzilla.redhat.com/show_bug.cgi?id=1284014

@lpichler 