### PR TITLE
Fix misleading tooltip in orchestration template toolbar

### DIFF
--- a/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
+++ b/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
@@ -2,12 +2,14 @@ class ApplicationHelper::Button::OrchestrationTemplateEditRemove < ApplicationHe
   def calculate_properties
     super
     if @view_context.x_active_tree == :ot_tree && @record
-      self[:enabled] = !@record.in_use?
-      self[:title] = if self[:id] =~ /_edit$/
-                       _('Orchestration Templates that are in use cannot be edited')
-                     else
-                       _('Orchestration Templates that are in use cannot be removed')
-                     end
+      if @record.in_use?
+        self[:enabled] = false
+        self[:title] = if self[:id] =~ /_edit$/
+                         _('Orchestration Templates that are in use cannot be edited')
+                       else
+                         _('Orchestration Templates that are in use cannot be removed')
+                       end
+      end
     end
   end
 end


### PR DESCRIPTION
Tooltip telling the orchestration template cannot be removed / edited needs to be put in place
only if the template is in use (not in all cases).

https://bugzilla.redhat.com/show_bug.cgi?id=1295941