### PR TITLE
fix dashboard provider icons

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -74,14 +74,16 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
           var providers = data.providers;
           if (providers) {
             if (id) {
-              $scope.providerTypeIconClass = dashboardUtilsFactory.iconClassForProvider(data.providers[0].providerType);
+              $scope.providerTypeIconImage = data.providers[0].iconImage
+              $scope.isSingleProvider = true
             } else {
+              $scope.isSingleProvider = false
               $scope.objectStatus.providers.count = 0;
               $scope.objectStatus.providers.notifications = [];
               providers.forEach(function (item) {
                 $scope.objectStatus.providers.count += item.count;
                 $scope.objectStatus.providers.notifications.push({
-                  iconClass: dashboardUtilsFactory.iconClassForProvider(item.providerType),
+                  iconImage: item.iconImage,
                   count: item.count
                 })
               });

--- a/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js
@@ -98,25 +98,6 @@ angular.module('miq.util').factory('dashboardUtilsFactory', function() {
     myDate = Date.parse(date);
     return isNaN(myDate) ? date : myDate
   };
-  var iconClassForProvider = function(provider) {
-    switch (provider) {
-      case "openshift":
-      case "openshift_enterprise":
-        iconClass = "pficon pficon-openshift";
-        break;
-      case "kubernetes":
-        iconClass = "pficon pficon-kubernetes";
-        break;
-      case "atomic":
-        iconClass = "product-vendor-atomic";
-        break;
-      case "atomic_enterprise":
-        iconClass = "product-vendor-atomic-enterprise";
-        break;
-    }
-
-    return iconClass;
-  };
   return {
     parseDate: parseDate,
     createProvidersStatus: createProvidersStatus,
@@ -128,7 +109,6 @@ angular.module('miq.util').factory('dashboardUtilsFactory', function() {
     createServicesStatus: createServicesStatus,
     createImagesStatus: createImagesStatus,
     createRoutesStatus: createRoutesStatus,
-    updateStatus: updateStatus,
-    iconClassForProvider: iconClassForProvider
+    updateStatus: updateStatus
   };
 });

--- a/app/assets/stylesheets/container_providers_dashboard.scss
+++ b/app/assets/stylesheets/container_providers_dashboard.scss
@@ -85,7 +85,8 @@
     padding-bottom: 2px;
     width: 100%;
     text-align: center;
-    display: inline-block
+    display: inline-block;
+    height: 91px;
 }
 
 .single-provider-containers-dashboard .card-pf.card-pf-aggregate-status-mini {

--- a/app/models/mixins/ui_service_mixin.rb
+++ b/app/models/mixins/ui_service_mixin.rb
@@ -1,0 +1,24 @@
+module UiServiceMixin
+  def icons
+    {
+      :ContainerReplicator => {:type => "glyph", :icon => "\uE624", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-replicator
+      :ContainerGroup      => {:type => "glyph", :icon => "\uF1B3", :fontfamily => "FontAwesome"},             # fa-cubes
+      :ContainerNode       => {:type => "glyph", :icon => "\uE621", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-container-node
+      :ContainerService    => {:type => "glyph", :icon => "\uE61E", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-service
+      :ContainerRoute      => {:type => "glyph", :icon => "\uE625", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-route
+      :Container           => {:type => "glyph", :icon => "\uF1B2", :fontfamily => "FontAwesome"},             # fa-cube
+      :Host                => {:type => "glyph", :icon => "\uE600", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-screen
+      :Vm                  => {:type => "glyph", :icon => "\uE90f", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-virtual-machine
+      :Kubernetes          => {:type => "image", :icon => provider_icon(:Kubernetes)},
+      :Openshift           => {:type => "image", :icon => provider_icon(:Openshift)},
+      :OpenshiftEnterprise => {:type => "image", :icon => provider_icon(:OpenshiftEnterprise)},
+      :Atomic              => {:type => "image", :icon => provider_icon(:Atomic)},
+      :AtomicEnterprise    => {:type => "image", :icon => provider_icon(:AtomicEnterprise)}
+    }
+  end
+
+  def provider_icon(provider_type)
+    file_name = "svg/vendor-#{provider_type.to_s.underscore.downcase}.svg"
+    ActionController::Base.helpers.image_path(file_name)
+  end
+end

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -1,4 +1,5 @@
 class ContainerDashboardService
+  include UiServiceMixin
   CPU_USAGE_PRECISION = 2 # 2 decimal points
 
   def initialize(provider_id, controller)
@@ -83,23 +84,22 @@ class ContainerDashboardService
   def providers
     provider_classes_to_ui_types = ManageIQ::Providers::ContainerManager.subclasses.each_with_object({}) { |subclass, h|
       name = subclass.name.split('::')[2]
-      h[subclass.name] = name.underscore.downcase.to_sym }
-
+      h[subclass.name] = name.to_sym
+    }
     providers = @ems.present? ? {@ems.type => 1} : ManageIQ::Providers::ContainerManager.group(:type).count
 
     result = {}
-    providers.each do |type, count|
-      ui_type = provider_classes_to_ui_types[type]
+    providers.each do |provider, count|
+      ui_type = provider_classes_to_ui_types[provider]
       (result[ui_type] ||= build_provider_status(ui_type))[:count] += count
     end
-
     result.values
   end
 
-  def build_provider_status(ui_type)
+  def build_provider_status(provider_type)
     {
-      :providerType => ui_type,
-      :count        => 0
+      :count     => 0,
+      :iconImage => icons[provider_type][:icon]
     }
   end
 

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -1,4 +1,5 @@
 class ContainerTopologyService < TopologyService
+  include UiServiceMixin
 
   def initialize(provider_id)
     @provider_id = provider_id
@@ -21,27 +22,7 @@ class ContainerTopologyService < TopologyService
       topo_items, links = build_recursive_topology(entity, entity_relationships[:ContainerManager], topo_items, links)
     end
 
-    icons = {:ContainerReplicator => {:type => "glyph", :icon => "\uE624", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-replicator
-             :ContainerGroup      => {:type => "glyph", :icon => "\uF1B3", :fontfamily => "FontAwesome"},             # fa-cubes
-             :ContainerNode       => {:type => "glyph", :icon => "\uE621", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-container-node
-             :ContainerService    => {:type => "glyph", :icon => "\uE61E", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-service
-             :ContainerRoute      => {:type => "glyph", :icon => "\uE625", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-route
-             :Container           => {:type => "glyph", :icon => "\uF1B2", :fontfamily => "FontAwesome"},             # fa-cube
-             :Host                => {:type => "glyph", :icon => "\uE600", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-screen
-             :Vm                  => {:type => "glyph", :icon => "\uE90f", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-virtual-machine
-             :Kubernetes          => {:type => "image", :icon => provider_icon(:Kubernetes)},
-             :Openshift           => {:type => "image", :icon => provider_icon(:Openshift)},
-             :OpenshiftEnterprise => {:type => "image", :icon => provider_icon(:OpenshiftEnterprise)},
-             :Atomic              => {:type => "image", :icon => provider_icon(:Atomic)},
-             :AtomicEnterprise    => {:type => "image", :icon => provider_icon(:AtomicEnterprise)}
-    }
-
     populate_topology(topo_items, links, build_kinds, icons)
-  end
-
-  def provider_icon(provider_type)
-    file_name = 'svg/vendor-' + provider_type.to_s.underscore.downcase + '.svg'
-    ActionController::Base.helpers.image_path(file_name)
   end
 
   def entity_display_type(entity)

--- a/app/views/shared/views/_show_containers_dashboard.html.haml
+++ b/app/views/shared/views/_show_containers_dashboard.html.haml
@@ -2,16 +2,15 @@
                                                                             "ng-controller" => "containerDashboardController as dashboard"}
   .row.row-tile-pf
     .col-xs-12.col-sm-12.col-md-2
-      .col-xs-12.provider-card{"pf-card"         => "",
-                               "show-top-border" => "true",
-                               "ng-if"           => "providerTypeIconClass"}
-        %span.provider-icon-large{"ng-class" => "providerTypeIconClass"}
-      %div{:layout                    => "tall",
-           "pf-aggregate-status-card" => "",
-           "show-top-border"          => "true",
-           :status                    => "objectStatus.providers",
-           "ng-if"                    => "!providerTypeIconClass"}
-
+      .provider-card{"pf-card"         => "",
+                     "show-top-border" => "true",
+                     "ng-if"           => "isSingleProvider"}
+        %img.provider-icon-large{"src" =>"{{providerTypeIconImage}}"}
+      %div{:layout                     => "tall",
+           "pf-aggregate-status-card"  => "",
+           "show-top-border"           => "true",
+           :status                     => "objectStatus.providers",
+           "ng-if"                     => "!isSingleProvider"}
     .col-xs-12.col-sm-12.col-md-10
       .row
         .col-xs-6.col-sm-6.col-md-3

--- a/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
@@ -49,11 +49,11 @@
     "providers": [
       {
         "count": 2,
-        "providerType": "openshift"
+        "iconImage": "/assets/svg/vendor-openshift-1d8ff43788707.svg"
       },
       {
         "count": 1,
-        "providerType": "kubernetes"
+        "iconImage": "/assets/svg/vendor-kubernetes-1d8ff43788707.svg"
       }
     ],
     "ems_utilization": {

--- a/spec/javascripts/fixtures/json/container_dashboard_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_response.json
@@ -65,11 +65,11 @@
     "providers": [
       {
         "count": 2,
-        "providerType": "openshift"
+        "iconImage": "/assets/svg/vendor-openshift-1d8ff43788707.svg"
       },
       {
         "count": 1,
-        "providerType": "kubernetes"
+        "iconImage": "/assets/svg/vendor-kubernetes-1d8ff43788707.svg"
       }
     ],
     "ems_utilization": {

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -19,12 +19,10 @@ describe ContainerDashboardService do
       providers_data = ContainerDashboardService.new(nil, nil).providers
 
       # Kubernetes should not appear
-      expect(providers_data).to include(
-        {:providerType => :openshift_enterprise, :count => 1},
-        {:providerType => :openshift, :count => 1},
-        {:providerType => :atomic, :count => 1},
-        {:providerType => :atomic_enterprise, :count => 1}
-      )
+      providers_data.each do |p|
+        expect(p[:iconImage]).not_to be_nil
+        expect(p[:count]).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
Before:
![screencapture-localhost-3000-ems_container-show-2-1461079266104](https://cloud.githubusercontent.com/assets/11256940/14644663/802b38e6-065b-11e6-8fc2-4ecf01d166fe.png)

After:
![screencapture-localhost-3000-ems_container-show-2-1461078994401](https://cloud.githubusercontent.com/assets/11256940/14644470/e1677f94-065a-11e6-847a-5354f5044885.png)


Overview page will still be missing the icons until the next Angular Patternfly release in which we get [this feature](https://github.com/patternfly/angular-patternfly/pull/222)


There was heavy reliance on #7463 for this. Im guessing decorators are the way to go now but that means I have to iterate over all providers and count them by type instead having the DB do it.

Please review @himdel @abonas @martinpovolny 
cc @yaacov @simon3z 