### PR TITLE
Orchestration Template: use in_use? rather than stacks.length test

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -739,7 +739,7 @@ class CatalogController < ApplicationController
     checked[0] = params[:id] if checked.blank? && params[:id]
     elements = OrchestrationTemplate.where(:id => checked)
     elements.each do |ot|
-      if ot.stacks.length > 0
+      if ot.in_use?
         add_flash(_("Orchestration template \"%{name}\" is read-only and cannot be deleted.") %
           {:name => ot.name}, :error)
       else
@@ -1007,7 +1007,7 @@ class CatalogController < ApplicationController
       ot = OrchestrationTemplate.find_by_id(@edit[:rec_id])
       ot.name = @edit[:new][:name]
       ot.description = @edit[:new][:description]
-      if ot.stacks.length == 0
+      unless ot.in_use?
         ot.content = params[:template_content]
         ot.draft = @edit[:new][:draft]
       end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1153,7 +1153,7 @@ class ApplicationHelper::ToolbarBuilder
     when "OrchestrationTemplateCfn", "OrchestrationTemplateHot", "OrchestrationTemplateAzure"
       case id
       when "orchestration_template_remove"
-        return "Read-only Orchestration Template cannot be deleted" if @record.stacks.length > 0
+        return "Read-only Orchestration Template cannot be deleted" if @record.in_use?
       end
     when "Service"
       case id

--- a/app/views/catalog/_ot_edit.html.haml
+++ b/app/views/catalog/_ot_edit.html.haml
@@ -27,7 +27,7 @@
                           :class => "form-control",
                           "data-miq_observe" => {:interval => '.5',
                                                  :url      => url}.to_json)
-      - if @record.stacks.length == 0
+      - unless @record.in_use?
         .form-group
           %label.col-md-2.control-label
             = _('Draft')
@@ -37,7 +37,7 @@
 
   %hr
     = text_area_tag("template_content", @edit[:current][:content], :style => "display:none;")
-    - if params[:action] != "explorer" && @record.stacks.length == 0
+    - if params[:action] != "explorer" && !@record.in_use?
       = render :partial => "/layouts/my_code_mirror",
         :locals => {:text_area_id => "template_content",
                     :mode         => "yaml",

--- a/app/views/catalog/_ot_tree_show.html.haml
+++ b/app/views/catalog/_ot_tree_show.html.haml
@@ -20,7 +20,7 @@
       %label.col-md-2.control-label
         = _('Read Only')
       .col-md-8
-        = @record.stacks.length > 0 ? _("True") : _("False")
+        = @record.in_use? ? _("True") : _("False")
     .form-group
       %label.col-md-2.control-label
         = _('Created On')

--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -21,7 +21,7 @@
             - when :draft, :orderable?
               = @record.orchestration_template.send(sym) ? _("True") : _("False")
             - when :read_only
-              = @record.orchestration_template.stacks.empty? ? _("False") : _("True")
+              = @record.orchestration_template.in_use? ? _("True") : _("False")
             - else
               = @record.orchestration_template.send(sym)
 


### PR DESCRIPTION
We already have a model method `in_use?` which semantically does the same thing
as `stacks.length > 0` test, so we should use that instead.