### PR TITLE
Handle new Container Image CVE content

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -37,5 +37,13 @@ module ManageIQ::Providers
     def chart_layout_path
       "ManageIQ_Providers_ContainerManager"
     end
+
+    def self.cve_check
+      # TODO: optimize by keeping last hashes of cve streams raising only upon update
+      MiqServer.my_server.zone.ext_management_systems.each do |ems|
+        first_image = ems.container_images.first
+        MiqEvent.raise_evm_event(first_image, 'containerimage_new_cve_content', {}) if first_image
+      end
+    end
   end
 end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -52,6 +52,10 @@ class MiqScheduleWorker::Jobs
     queue_work_on_each_zone(:class_name  => "ExtManagementSystem", :method_name => "authentication_check_schedule")
   end
 
+  def ems_container_check_cves
+    queue_work(:class_name  => "ManageIQ::Providers::ContainerManager", :method_name => "cve_check", :task_id => "cve_check", :server_guid => MiqServer.my_guid)
+  end
+
   def storage_authentication_check_schedule
     queue_work_on_each_zone(:class_name  => "StorageManager",      :method_name => "authentication_check_schedule")
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -188,6 +188,12 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue [:job_check_for_evm_snapshots, job_not_found_delay]
     end
 
+    # Schedule - Daily check for new CVE content for container images
+    every = worker_setting_or_default(:container_cve_check_interval, 1.day)
+    @schedules[:all] << system_schedule_every(every, :first_in => every) do
+      enqueue :ems_container_check_cves
+    end
+
     # Queue a JobProxyDispatcher dispatch task at high priority unless there's already one on the queue
     # This dispatch method goes through all pending jobs to see if there's a free proxy available to work on one of them
     # It is very expensive to constantly do this, hence the need to ensure only one is on the queue at one time

--- a/db/fixtures/miq_actions.csv
+++ b/db/fixtures/miq_actions.csv
@@ -10,6 +10,7 @@ evm_event,Show EVM Event on Timeline
 script,Execute an external script
 prevent,Prevent current event from proceeding
 container_image_analyze,Initiate SmartState Analysis for Container Image
+container_image_scan_all,Sequentially scan all container provider images
 vm_start,Start Virtual Machine
 vm_stop,Stop Virtual Machine
 vm_suspend,Suspend Virtual Machine

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -168,3 +168,4 @@ containerimage_created,Container Image Discovered,Default,container_operations
 containerimage_compliance_check,Container Image Compliance Check,Default,compliance
 containerimage_compliance_passed,Container Image Compliance Passed,Default,compliance
 containerimage_compliance_failed,Container Image Compliance Failed,Default,compliance
+containerimage_new_cve_content,Container Image New CVE Content,Default,compliance


### PR DESCRIPTION
This pr introduces an event and an action. Once a policy based on them is seeded we should have full OOTB support for the OpenSCAP integration. The action sequentially scans images to avoid overloading the provider
