### PR TITLE
Remove :_type_disabled for models in migrations, where type column doesn't exist #2

### DIFF
--- a/db/migrate/20160308093916_migrate_security_protocol_atribute_to_endpoints.rb
+++ b/db/migrate/20160308093916_migrate_security_protocol_atribute_to_endpoints.rb
@@ -1,7 +1,5 @@
 class MigrateSecurityProtocolAtributeToEndpoints < ActiveRecord::Migration[5.0]
-  class Endpoint < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
+  class Endpoint < ActiveRecord::Base; end
 
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI

--- a/db/migrate/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets.rb
+++ b/db/migrate/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets.rb
@@ -9,7 +9,6 @@ class MoveNetworkPortCloudSubnetIdToNetworkPortsCloudSubnets < ActiveRecord::Mig
 
   class CloudSubnetNetworkPort < ActiveRecord::Base
     self.table_name = "cloud_subnets_network_ports"
-    self.inheritance_column = :_type_disabled
   end
 
   def up

--- a/db/migrate/20160328204930_remove_miq_server_product_update_join_table.rb
+++ b/db/migrate/20160328204930_remove_miq_server_product_update_join_table.rb
@@ -1,6 +1,5 @@
 class RemoveMiqServerProductUpdateJoinTable < ActiveRecord::Migration[5.0]
   class SettingsChange < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     serialize :value
   end
 

--- a/db/migrate/20160405151142_remove_configurations_from_replication_excludes.rb
+++ b/db/migrate/20160405151142_remove_configurations_from_replication_excludes.rb
@@ -1,6 +1,5 @@
 class RemoveConfigurationsFromReplicationExcludes < ActiveRecord::Migration[5.0]
   class SettingsChange < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
     serialize :value
   end
 

--- a/db/migrate/20160406195810_add_id_primary_key_to_join_tables.rb
+++ b/db/migrate/20160406195810_add_id_primary_key_to_join_tables.rb
@@ -37,9 +37,7 @@ class AddIdPrimaryKeyToJoinTables < ActiveRecord::Migration[5.0]
     "storages_vms_and_templates"                         => "storage_id, vm_or_template_id"
   }.freeze
 
-  class MiqRegion < ApplicationRecord
-    self.inheritance_column = :_type_disabled
-  end
+  class MiqRegion < ActiveRecord::Base; end
 
   def up
     say_with_time("Removing composite primary keys from join tables") do

--- a/db/migrate/20160413202128_sti_configuration_script.rb
+++ b/db/migrate/20160413202128_sti_configuration_script.rb
@@ -1,5 +1,5 @@
 class StiConfigurationScript < ActiveRecord::Migration[5.0]
-  class ConfigurationScript < ApplicationRecord
+  class ConfigurationScript < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
   end
 


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/6739

we have some new migrations, so I ran my script again from https://github.com/ManageIQ/manageiq/pull/7354 (updated) 

cc @Fryguy @jrafanie 