### PR TITLE
Move MiqGroup filters to Entitlements

### DIFF
--- a/app/controllers/api_controller/groups.rb
+++ b/app/controllers/api_controller/groups.rb
@@ -1,5 +1,5 @@
 class ApiController
-  INVALID_GROUP_ATTRS = %w(id href group_type)
+  INVALID_GROUP_ATTRS = %w(id href group_type).freeze
 
   module Groups
     def create_resource_groups(_type, _id, data)

--- a/app/controllers/api_controller/groups.rb
+++ b/app/controllers/api_controller/groups.rb
@@ -6,6 +6,7 @@ class ApiController
       validate_group_data(data)
       parse_set_role(data)
       parse_set_tenant(data)
+      parse_set_filters(data)
       group = collection_class(:groups).create(data)
       if group.invalid?
         raise BadRequestError, "Failed to add a new group - #{group.errors.full_messages.join(', ')}"
@@ -18,6 +19,7 @@ class ApiController
       parse_set_role(data)
       parse_set_tenant(data)
       group = resource_search(id, type, collection_class(:groups))
+      parse_set_filters(data, :entitlement_id => group.entitlement.try(:id))
       raise BadRequestError, "Cannot edit a read-only group" if group.read_only
       edit_resource(type, id, data)
     end
@@ -34,15 +36,21 @@ class ApiController
       data.merge!("tenant" => tenant) if tenant
     end
 
+    # HACK: Format attrs to use accepts_nested_attributes_for (Entitlements)
+    # Required for backwards compatibility of creating filters via group
+    def parse_set_filters(data, entitlement_id: nil)
+      filters = data.delete("filters")
+      data.merge!("entitlement_attributes" => {"id" => entitlement_id, "filters" => filters}) if filters
+    end
+
     def group_data_includes_invalid_attrs(data)
       data.keys.select { |k| INVALID_GROUP_ATTRS.include?(k) }.compact.join(", ") if data
     end
 
     def validate_group_data(data)
-      klass = collection_class(:groups)
       bad_attrs = group_data_includes_invalid_attrs(data)
       raise BadRequestError, "Invalid attribute(s) #{bad_attrs} specified for a group" if bad_attrs.present?
-      raise BadRequestError, "Invalid filters specified" unless klass.valid_filters?(data["filters"])
+      raise BadRequestError, "Invalid filters specified" unless Entitlement.valid_filters?(data["filters"])
     end
   end
 end

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1162,8 +1162,9 @@ module OpsController::OpsRbac
       @set_filter_values.push(value)
     end
     rbac_group_make_subarrays # Need to have category arrays of item arrays for and/or logic
-    group.set_managed_filters(@set_filter_values)
-    group.set_belongsto_filters(@edit[:new][:belongsto].values) # Set belongs to to hash values
+    group.entitlement ||= Entitlement.new
+    group.entitlement.set_managed_filters(@set_filter_values)
+    group.entitlement.set_belongsto_filters(@edit[:new][:belongsto].values) # Set belongs to to hash values
   end
 
   # Need to make arrays by category containing arrays of items so the filtering logic can apply

--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -1,4 +1,6 @@
 class Entitlement < ApplicationRecord
   belongs_to :miq_group
   belongs_to :miq_user_role
+
+  serialize :filters
 end

--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -3,4 +3,64 @@ class Entitlement < ApplicationRecord
   belongs_to :miq_user_role
 
   serialize :filters
+
+  def self.valid_filters?(filters_hash)
+    return true  unless filters_hash                  # nil ok
+    return false unless filters_hash.kind_of?(Hash)   # must be Hash
+    return true  if filters_hash.blank?               # {} ok
+    filters_hash["managed"].present? || filters_hash["belongsto"].present?
+  end
+
+  def self.remove_tag_from_all_managed_filters(tag)
+    find_each do |entitlement|
+      entitlement.remove_tag_from_managed_filter(tag)
+      entitlement.save if entitlement.filters_changed?
+    end
+  end
+
+  def has_filters?
+    get_managed_filters.present? || get_belongsto_filters.present?
+  end
+
+  def get_filters(type = nil)
+    if type
+      (filters.respond_to?(:key?) && filters[type.to_s]) || []
+    else
+      filters || {"managed" => [], "belongsto" => []}
+    end
+  end
+
+  def get_managed_filters
+    get_filters("managed")
+  end
+
+  def get_belongsto_filters
+    get_filters("belongsto")
+  end
+
+  def set_filters(type, filter)
+    self.filters ||= {}
+    filters[type.to_s] = filter
+  end
+
+  def set_managed_filters(filter)
+    set_filters("managed", filter)
+  end
+
+  def set_belongsto_filters(filter)
+    set_filters("belongsto", filter)
+  end
+
+  def remove_tag_from_managed_filter(filter_to_remove)
+    if get_managed_filters.present?
+      *category, _tag = filter_to_remove.split("/")
+      category = category.join("/")
+      self.filters["managed"].each do |filter|
+        next unless filter.first.starts_with?(category)
+        next unless filter.include?(filter_to_remove)
+        filter.delete(filter_to_remove)
+      end
+      self.filters["managed"].reject!(&:empty?)
+    end
+  end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -24,6 +24,9 @@ class MiqGroup < ApplicationRecord
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
   before_destroy :ensure_can_be_destroyed
 
+  # For REST API compatibility only; Don't use otherwise!
+  accepts_nested_attributes_for :entitlement
+
   serialize :settings
 
   default_value_for :group_type, USER_GROUP

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -24,7 +24,6 @@ class MiqGroup < ApplicationRecord
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
   before_destroy :ensure_can_be_destroyed
 
-  serialize :filters
   serialize :settings
 
   default_value_for :group_type, USER_GROUP

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -4,7 +4,7 @@ class MiqGroup < ApplicationRecord
   TENANT_GROUP = "tenant"
 
   belongs_to :tenant
-  has_one    :entitlement, :dependent => :destroy
+  has_one    :entitlement, :dependent => :destroy, :autosave => true
   has_one    :miq_user_role, :through => :entitlement
   has_and_belongs_to_many :users
   has_many   :vms,         :dependent => :nullify

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -310,6 +310,7 @@ module Rbac
     user_filters = user.try(:get_filters) || miq_group.try(:get_filters) || {}
     user_filters = user_filters.dup
     user_filters["managed"] ||= []
+    user_filters["belongsto"] ||= []
 
     [user, miq_group, user_filters]
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -160,7 +160,7 @@ class Tag < ApplicationRecord
   private
 
   def remove_from_managed_filters
-    MiqGroup.remove_tag_from_all_managed_filters(name)
+    Entitlement.remove_tag_from_all_managed_filters(name)
   end
 
   def name_path

--- a/db/migrate/20160414123914_add_filters_to_entitlements.rb
+++ b/db/migrate/20160414123914_add_filters_to_entitlements.rb
@@ -1,0 +1,5 @@
+class AddFiltersToEntitlements < ActiveRecord::Migration[5.0]
+  def change
+    add_column :entitlements, :filters, :text
+  end
+end

--- a/db/migrate/20160414124134_move_filters_to_entitlements.rb
+++ b/db/migrate/20160414124134_move_filters_to_entitlements.rb
@@ -1,0 +1,33 @@
+class MoveFiltersToEntitlements < ActiveRecord::Migration[5.0]
+  class MiqGroup < ActiveRecord::Base
+    has_one :entitlement, :class_name => 'MoveFiltersToEntitlements::Entitlement'
+    serialize :filters
+  end
+
+  class Entitlement < ActiveRecord::Base
+    belongs_to :miq_group, :class_name => 'MoveFiltersToEntitlements::MiqGroup'
+    serialize :filters
+  end
+
+  def up
+    say_with_time 'Moving MiqGroup filters to Entitlements' do
+      MiqGroup.find_each do |group|
+        if group.filters && group.entitlement
+          group.entitlement.filters = group.filters
+          group.entitlement.save!
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Moving Entitlement filters back to MiqGroups' do
+      Entitlement.find_each do |entitlement|
+        if entitlement.filters && entitlement.miq_group
+          entitlement.miq_group.filters = entitlement.filters
+          entitlement.miq_group.save!
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20160414132130_remove_filters_from_miq_groups.rb
+++ b/db/migrate/20160414132130_remove_filters_from_miq_groups.rb
@@ -1,0 +1,5 @@
+class RemoveFiltersFromMiqGroups < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :miq_groups, :filters, :text
+  end
+end

--- a/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -110,9 +110,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
   context "with applied tags" do
     before do
       FactoryGirl.create(:classification_cost_center_with_tags)
-      admin.current_group.set_managed_filters([['/managed/cc/001']])
-      admin.current_group.set_belongsto_filters([])
-      admin.current_group.save
+      admin.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [['/managed/cc/001']],
+                                                                         'belongsto' => []})
 
       2.times { FactoryGirl.create(:availability_zone_amazon, :ems_id => ems.id) }
       2.times do

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -40,8 +40,9 @@ describe VmInfraController do
         ems = FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder])
 
         user = FactoryGirl.create(:user_admin)
-        user.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [["/managed/service_level/gold"]],
-                                                                          'belongsto' => []})
+        user.current_group.entitlement = Entitlement.create!
+        user.current_group.entitlement.set_managed_filters([["/managed/service_level/gold"]])
+        user.current_group.save
         login_as user
         expect(controller.send(:rbac_filtered_objects, [ems_folder], :match_via_descendants => "VmOrTemplate")).to(
           eq([ems_folder]))

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -40,7 +40,8 @@ describe VmInfraController do
         ems = FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder])
 
         user = FactoryGirl.create(:user_admin)
-        user.current_group.set_managed_filters([["/managed/service_level/gold"]])
+        user.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [["/managed/service_level/gold"]],
+                                                                          'belongsto' => []})
         login_as user
         expect(controller.send(:rbac_filtered_objects, [ems_folder], :match_via_descendants => "VmOrTemplate")).to(
           eq([ems_folder]))

--- a/spec/migrations/20160414124134_move_filters_to_entitlements_spec.rb
+++ b/spec/migrations/20160414124134_move_filters_to_entitlements_spec.rb
@@ -1,0 +1,38 @@
+require_migration
+
+describe MoveFiltersToEntitlements do
+  let(:miq_group_stub)   { migration_stub(:MiqGroup) }
+  let(:entitlement_stub) { migration_stub(:Entitlement) }
+  let(:filters) do
+    {"managed"   => [["/hue/hue/hue", "/stuff"], ["here"]],
+     "belongsto" => ["/stuffs/here"]}
+  end
+
+  migration_context :up do
+    let!(:miq_group) do
+      miq_group_stub.create!(:entitlement => entitlement,
+                             :filters     => filters)
+    end
+    let!(:entitlement) { entitlement_stub.create!(:filters => nil) }
+
+    it "moves filters to the associated entitlement" do
+      expect(entitlement.filters).to be_nil
+      migrate
+      expect(entitlement.reload.filters).to eq(filters)
+    end
+  end
+
+  migration_context :down do
+    let!(:miq_group) do
+      miq_group_stub.create!(:entitlement => entitlement,
+                             :filters     => nil)
+    end
+    let!(:entitlement) { entitlement_stub.create!(:filters => filters) }
+
+    it "moves filters to the associated entitlement" do
+      expect(miq_group.filters).to be_nil
+      migrate
+      expect(miq_group.reload.filters).to eq(filters)
+    end
+  end
+end

--- a/spec/models/entitlement_spec.rb
+++ b/spec/models/entitlement_spec.rb
@@ -1,4 +1,26 @@
 require 'rails_helper'
 
-RSpec.describe Entitlement, :type => :model do
+describe Entitlement do
+  describe "::remove_tag_from_all_managed_filters" do
+    let!(:entitlement1) { FactoryGirl.create(:entitlement) }
+    let!(:entitlement2) { FactoryGirl.create(:entitlement) }
+    let(:filters) do
+      [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"], ["/managed/my_name/test"]]
+    end
+
+    before do
+      entitlement1.set_managed_filters([["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"],
+                                        ["/managed/my_name/test"]])
+      entitlement2.set_managed_filters([["/managed/prov_max_memory/1024"]])
+      [entitlement1, entitlement2].each(&:save)
+    end
+
+    it "removes managed filter from all groups" do
+      described_class.remove_tag_from_all_managed_filters("/managed/prov_max_memory/1024")
+
+      expect(entitlement1.reload.get_managed_filters).to match_array([["/managed/prov_max_memory/test"],
+                                                                      ["/managed/my_name/test"]])
+      expect(entitlement2.reload.get_managed_filters).to be_empty
+    end
+  end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -60,9 +60,8 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
   context "with applied tags" do
     before do
       FactoryGirl.create(:classification_cost_center_with_tags)
-      admin.current_group.set_managed_filters([['/managed/cc/001']])
-      admin.current_group.set_belongsto_filters([])
-      admin.current_group.save
+      admin.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [['/managed/cc/001']],
+                                                                         'belongsto' => []})
       ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A0", :supports_32_bit => false,
                                         :supports_64_bit => true)
       ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A1", :supports_32_bit => false,

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -60,8 +60,9 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
   context "with applied tags" do
     before do
       FactoryGirl.create(:classification_cost_center_with_tags)
-      admin.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [['/managed/cc/001']],
-                                                                         'belongsto' => []})
+      admin.current_group.entitlement = Entitlement.create!
+      admin.current_group.entitlement.set_managed_filters([['/managed/cc/001']])
+      admin.current_group.save!
       ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A0", :supports_32_bit => false,
                                         :supports_64_bit => true)
       ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A1", :supports_32_bit => false,

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -74,8 +74,9 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
 
     before do
       FactoryGirl.create(:classification_cost_center_with_tags)
-      admin.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [['/managed/cc/001']],
-                                                                         'belongsto' => []})
+      admin.current_group.entitlement = Entitlement.create!
+      admin.current_group.entitlement.set_managed_filters([['/managed/cc/001']])
+      admin.current_group.save!
 
       2.times { FactoryGirl.create(:availability_zone_amazon, :ems_id => provider.id) }
       2.times { FactoryGirl.create(:security_group_openstack, :ext_management_system => provider.network_manager) }

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -74,9 +74,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
 
     before do
       FactoryGirl.create(:classification_cost_center_with_tags)
-      admin.current_group.set_managed_filters([['/managed/cc/001']])
-      admin.current_group.set_belongsto_filters([])
-      admin.current_group.save
+      admin.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [['/managed/cc/001']],
+                                                                         'belongsto' => []})
 
       2.times { FactoryGirl.create(:availability_zone_amazon, :ems_id => provider.id) }
       2.times { FactoryGirl.create(:security_group_openstack, :ext_management_system => provider.network_manager) }

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -3,8 +3,8 @@ describe MiqGroup do
     subject { FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator") }
 
     before do
-      subject.entitlement.filters = { 'managed'   => [['some managed filter']],
-                                      'belongsto' => [['some belongsto filter']] }
+      subject.entitlement.set_managed_filters([['some managed filter']])
+      subject.entitlement.set_belongsto_filters([['some belongsto filter']])
       subject.entitlement.save!
     end
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -1,100 +1,98 @@
 describe MiqGroup do
-  context "set as Super Administrator" do
-    before(:each) do
-      @miq_group = FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator")
-    end
+  context "as a Super Administrator" do
+    subject { FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator") }
 
-    context "#get_filters" do
+    describe "#get_filters" do
       it "normal" do
         expected = {:test => "test filter"}
-        @miq_group.filters = expected
-        expect(@miq_group.get_filters).to eq(expected)
+        subject.filters = expected
+        expect(subject.get_filters).to eq(expected)
       end
 
       it "when nil" do
-        @miq_group.filters = nil
-        expect(@miq_group.get_filters).to eq("managed" => [], "belongsto" => [])
+        subject.filters = nil
+        expect(subject.get_filters).to eq("managed" => [], "belongsto" => [])
       end
 
       it "when {}" do
-        @miq_group.filters = {}
-        expect(@miq_group.get_filters).to eq({})
+        subject.filters = {}
+        expect(subject.get_filters).to eq({})
       end
     end
 
-    context "#has_filters?" do
+    describe "#has_filters?" do
       it "normal" do
-        @miq_group.filters = {"managed" => %w(a)}
-        expect(@miq_group).to be_has_filter
+        subject.filters = {"managed" => %w(a)}
+        expect(subject).to be_has_filter
       end
 
       it "when other" do
-        @miq_group.filters = {"other" => %(x)}
-        expect(@miq_group).not_to be_has_filter
+        subject.filters = {"other" => %(x)}
+        expect(subject).not_to be_has_filter
       end
 
       it "when nil" do
-        @miq_group.filters = nil
-        expect(@miq_group).not_to be_has_filter
+        subject.filters = nil
+        expect(subject).not_to be_has_filter
       end
 
       it "when {}" do
-        @miq_group.filters = {}
-        expect(@miq_group).not_to be_has_filter
+        subject.filters = {}
+        expect(subject).not_to be_has_filter
       end
     end
 
     %w(managed belongsto).each do |type|
-      context "#get_#{type}_filters" do
+      describe "#get_#{type}_filters" do
         let(:method) { "get_#{type}_filters" }
 
         it "normal" do
           expected = {type => "test filter"}
-          @miq_group.filters = expected
-          expect(@miq_group.public_send(method)).to eq(expected[type])
+          subject.filters = expected
+          expect(subject.public_send(method)).to eq(expected[type])
         end
 
         it "when nil" do
-          @miq_group.filters = nil
-          expect(@miq_group.public_send(method)).to eq([])
+          subject.filters = nil
+          expect(subject.public_send(method)).to eq([])
         end
 
         it "when []" do
-          @miq_group.filters = []
-          expect(@miq_group.public_send(method)).to eq([])
+          subject.filters = []
+          expect(subject.public_send(method)).to eq([])
         end
 
         it "missing the #{type} key" do
           expected = {"something" => "test filter"}
-          @miq_group.filters = expected
-          expect(@miq_group.public_send(method)).to eq([])
+          subject.filters = expected
+          expect(subject.public_send(method)).to eq([])
         end
       end
 
       it "#set_#{type}_filters" do
         filters = {type => "test"}
-        @miq_group.public_send("set_#{type}_filters", filters[type])
-        expect(@miq_group.public_send("get_#{type}_filters")).to eq(filters[type])
-        expect(@miq_group.get_filters).to eq(filters)
+        subject.public_send("set_#{type}_filters", filters[type])
+        expect(subject.public_send("get_#{type}_filters")).to eq(filters[type])
+        expect(subject.get_filters).to eq(filters)
       end
     end
 
     it "should return user role name" do
-      expect(@miq_group.miq_user_role_name).to eq("EvmRole-super_administrator")
+      expect(subject.miq_user_role_name).to eq("EvmRole-super_administrator")
     end
 
     it "should set group type to 'system' " do
-      expect(@miq_group.group_type).to eq("system")
+      expect(subject.group_type).to eq("system")
     end
 
     it "should return user count" do
       # TODO: - add more users to check for proper user count...
-      expect(@miq_group.user_count).to eq(0)
+      expect(subject.user_count).to eq(0)
     end
 
     it "should strip group description of leading and trailing spaces" do
-      @miq_group.description = "      leading and trailing white spaces     "
-      expect(@miq_group.description).to eq("leading and trailing white spaces")
+      subject.description = "      leading and trailing white spaces     "
+      expect(subject.description).to eq("leading and trailing white spaces")
     end
   end
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -4,26 +4,6 @@ describe MiqGroup do
       @miq_group = FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator")
     end
 
-    describe ".remove_tag_from_all_managed_filters" do
-      let(:other_miq_group) { FactoryGirl.create(:miq_group) }
-      let(:filters) { [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"], ["/managed/my_name/test"]] }
-
-      before do
-        @miq_group.set_managed_filters(filters)
-        other_miq_group.set_managed_filters(filters)
-        [@miq_group, other_miq_group].each(&:save)
-      end
-
-      it "removes managed filter from all groups" do
-        MiqGroup.all.each { |group| expect(group.get_managed_filters).to match_array(filters) }
-
-        MiqGroup.remove_tag_from_all_managed_filters("/managed/my_name/test")
-
-        expected_filters = [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"]]
-        MiqGroup.all.each { |group| expect(group.get_managed_filters).to match_array(expected_filters) }
-      end
-    end
-
     context "#get_filters" do
       it "normal" do
         expected = {:test => "test filter"}

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -220,7 +220,8 @@ describe MiqReport do
       user  = FactoryGirl.create(:user_with_group)
       group = user.current_group
       allow(User).to receive_messages(:server_timezone => "UTC")
-      group.update_attributes(:filters => {"managed" => [["/managed/environment/prod"]], "belongsto" => []})
+      group.entitlement = Entitlement.new(:filters => {"managed" => [["/managed/environment/prod"]], "belongsto" => []})
+      group.save!
 
       report = MiqReport.new(:db => "Vm")
       results, attrs = report.paged_view_search(
@@ -243,7 +244,8 @@ describe MiqReport do
       vm1 = FactoryGirl.create(:vm_vmware, :name => "VA", :storage => FactoryGirl.create(:storage, :name => "SA"))
       vm2 = FactoryGirl.create(:vm_vmware, :name => "VB", :storage => FactoryGirl.create(:storage, :name => "SB"))
       tag = "/managed/environment/prod"
-      group.update_attributes(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.entitlement = Entitlement.new(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.save!
       vm1.tag_with(tag, :ns => "*")
       vm2.tag_with(tag, :ns => "*")
 
@@ -310,7 +312,8 @@ describe MiqReport do
       vm2 =  FactoryGirl.create(:vm_vmware, :name => "VB",  :host => FactoryGirl.create(:host, :name => "HB"))
       vm3 =  FactoryGirl.create(:vm_vmware, :name => "VAA", :host => FactoryGirl.create(:host, :name => "HAA"))
       tag =  "/managed/environment/prod"
-      group.update_attributes(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.entitlement = Entitlement.new(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.save!
 
       # vm1's host.name starts with HA but isn't tagged
       vm2.tag_with(tag, :ns => "*")

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -220,7 +220,8 @@ describe MiqReport do
       user  = FactoryGirl.create(:user_with_group)
       group = user.current_group
       allow(User).to receive_messages(:server_timezone => "UTC")
-      group.entitlement = Entitlement.new(:filters => {"managed" => [["/managed/environment/prod"]], "belongsto" => []})
+      group.entitlement = Entitlement.new
+      group.entitlement.set_managed_filters([["/managed/environment/prod"]])
       group.save!
 
       report = MiqReport.new(:db => "Vm")
@@ -244,7 +245,8 @@ describe MiqReport do
       vm1 = FactoryGirl.create(:vm_vmware, :name => "VA", :storage => FactoryGirl.create(:storage, :name => "SA"))
       vm2 = FactoryGirl.create(:vm_vmware, :name => "VB", :storage => FactoryGirl.create(:storage, :name => "SB"))
       tag = "/managed/environment/prod"
-      group.entitlement = Entitlement.new(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.entitlement = Entitlement.new
+      group.entitlement.set_managed_filters([[tag]])
       group.save!
       vm1.tag_with(tag, :ns => "*")
       vm2.tag_with(tag, :ns => "*")
@@ -312,7 +314,8 @@ describe MiqReport do
       vm2 =  FactoryGirl.create(:vm_vmware, :name => "VB",  :host => FactoryGirl.create(:host, :name => "HB"))
       vm3 =  FactoryGirl.create(:vm_vmware, :name => "VAA", :host => FactoryGirl.create(:host, :name => "HAA"))
       tag =  "/managed/environment/prod"
-      group.entitlement = Entitlement.new(:filters => {"managed" => [[tag]], "belongsto" => []})
+      group.entitlement = Entitlement.new
+      group.entitlement.set_managed_filters([[tag]])
       group.save!
 
       # vm1's host.name starts with HA but isn't tagged

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -313,7 +313,10 @@ describe Rbac do
 
         context "with only managed filters" do
           before(:each) do
-            group.entitlement = Entitlement.create!(:filters => {"managed" => [["/managed/environment/prod"], ["/managed/service_level/silver"]], "belongsto" => []})
+            group.entitlement = Entitlement.new
+            group.entitlement.set_managed_filters([["/managed/environment/prod"], ["/managed/service_level/silver"]])
+            group.entitlement.set_belongsto_filters([])
+            group.save!
 
             @tags = ["/managed/environment/prod"]
             @host2.tag_with(@tags.join(' '), :ns => '*')
@@ -355,7 +358,10 @@ describe Rbac do
 
         context "with only belongsto filters" do
           before(:each) do
-            group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => ["/belongsto/ExtManagementSystem|ems1"]})
+            group.entitlement = Entitlement.new
+            group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|ems1"])
+            group.entitlement.set_managed_filters([])
+            group.save!
 
             ems1 = FactoryGirl.create(:ems_vmware, :name => 'ems1')
             @host1.update_attributes(:ext_management_system => ems1)
@@ -446,7 +452,10 @@ describe Rbac do
           end
 
           it "finds one EMS with belongsto filters" do
-            group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+            group.entitlement = Entitlement.new
+            group.entitlement.set_belongsto_filters([@vm_folder_path])
+            group.entitlement.set_managed_filters([])
+            group.save!
             results = Rbac.search(:class => "ExtManagementSystem", :results_format => :objects, :user => user)
             objects = results.first
             expect(objects).to eq([@ems])
@@ -468,7 +477,10 @@ describe Rbac do
           expect(objects.length).to eq(2)
           expect(objects).to match_array([@vm, @template])
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@vm_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(0)
@@ -478,7 +490,10 @@ describe Rbac do
             v.save
           end
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@vm_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(2)
@@ -491,7 +506,10 @@ describe Rbac do
           expect(objects.length).to eq(1)
           expect(objects).to match_array([@vm])
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@vm_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
 
           results = Rbac.search(:class => "Vm", :results_format => :objects, :user => user)
           objects = results.first
@@ -502,7 +520,10 @@ describe Rbac do
             v.save
           end
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@vm_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results = Rbac.search(:class => "Vm", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(1)
@@ -515,7 +536,10 @@ describe Rbac do
           expect(objects.length).to eq(1)
           expect(objects).to match_array([@template])
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@vm_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
 
           results = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :user => user)
           objects = results.first
@@ -526,7 +550,10 @@ describe Rbac do
             v.save
           end
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@vm_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(1)
@@ -567,7 +594,10 @@ describe Rbac do
         it "returns all host's VMs and templates when host filter is set up" do
           @host_1.parent = @hfolder # add host to folder's hierarchy
           mtc_folder_path_with_host = "#{@mtc_folder_path}/EmsFolder|host/Host|#{@host_1.name}"
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [mtc_folder_path_with_host]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([mtc_folder_path_with_host])
+          group.entitlement.set_managed_filters([])
+          group.save!
 
           ["ManageIQ::Providers::Vmware::InfraManager::Vm", "Vm"].each do |klass|
             results2 = Rbac.search(:class => klass, :user => user, :results_format => :objects).first
@@ -598,7 +628,10 @@ describe Rbac do
         end
 
         it "get all the vm or templates with belongsto filter" do
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@cluster_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results, attrs = Rbac.search(:class => "VmOrTemplate", :user => user, :results_format => :objects)
           expect(results.length).to eq(0)
           expect(attrs[:total_count]).to eq(4)
@@ -608,7 +641,10 @@ describe Rbac do
             v.with_relationship_type("ems_metadata") { v.parent = @rp }
             v.save
           end
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@cluster_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
 
           results2, attrs = Rbac.search(:class => "VmOrTemplate", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@cluster_folder_path]})
@@ -618,21 +654,30 @@ describe Rbac do
         end
 
         it "get all the hosts with belongsto filter" do
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@cluster_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results, attrs = Rbac.search(:class => "Host", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@cluster_folder_path]})
           expect(attrs[:total_count]).to eq(4)
           expect(attrs[:auth_count]).to eq(1)
           expect(results.length).to eq(1)
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@mtc_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@mtc_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results2, attrs = Rbac.search(:class => "Host", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@mtc_folder_path]})
           expect(attrs[:total_count]).to eq(4)
           expect(attrs[:auth_count]).to eq(1)
           expect(results2.length).to eq(1)
 
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@ems_folder_path]})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@ems_folder_path])
+          group.entitlement.set_managed_filters([])
+          group.save!
           results3, attrs = Rbac.search(:class => "Host", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@ems_folder_path]})
           expect(attrs[:total_count]).to eq(4)
@@ -841,7 +886,9 @@ describe Rbac do
 
       context "with only managed filters (FB9153, FB11442)" do
         before(:each) do
-          group.entitlement = Entitlement.create!(:filters => {"managed" => [["/managed/environment/prod"], ["/managed/service_level/silver"]], "belongsto" => []})
+          group.entitlement = Entitlement.new
+          group.entitlement.set_managed_filters([["/managed/environment/prod"], ["/managed/service_level/silver"]])
+          group.save!
         end
 
         context ".search" do

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -313,7 +313,7 @@ describe Rbac do
 
         context "with only managed filters" do
           before(:each) do
-            group.update_attributes(:filters => {"managed" => [["/managed/environment/prod"], ["/managed/service_level/silver"]], "belongsto" => []})
+            group.entitlement = Entitlement.create!(:filters => {"managed" => [["/managed/environment/prod"], ["/managed/service_level/silver"]], "belongsto" => []})
 
             @tags = ["/managed/environment/prod"]
             @host2.tag_with(@tags.join(' '), :ns => '*')
@@ -323,7 +323,7 @@ describe Rbac do
           it ".search finds the right HostPerformance rows" do
             @host1.tag_with(@tags.join(' '), :ns => '*')
             results, attrs = Rbac.search(:class => "HostPerformance", :user => user, :results_format => :objects)
-            expect(attrs[:user_filters]).to eq(group.filters)
+            expect(attrs[:user_filters]).to eq(group.get_filters)
             expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
             expect(attrs[:auth_count]).to eq(@timestamps.length)
             expect(results.length).to eq(@timestamps.length)
@@ -335,7 +335,7 @@ describe Rbac do
             @vm.tag_with(@tags.join(' '), :ns => '*')
 
             results, attrs = Rbac.search(:targets => HostPerformance, :class => "HostPerformance", :user => user, :results_format => :objects, :match_via_descendants => Vm)
-            expect(attrs[:user_filters]).to eq(group.filters)
+            expect(attrs[:user_filters]).to eq(group.get_filters)
             expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
             expect(attrs[:auth_count]).to eq(@timestamps.length)
             expect(results.length).to eq(@timestamps.length)
@@ -345,7 +345,7 @@ describe Rbac do
           it ".search filters out the wrong HostPerformance rows" do
             @host1.tag_with(@tags.join(' '), :ns => '*')
             results, attrs = Rbac.search(:targets => HostPerformance.all, :class => "HostPerformance", :user => user, :results_format => :objects)
-            expect(attrs[:user_filters]).to eq(group.filters)
+            expect(attrs[:user_filters]).to eq(group.get_filters)
             expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
             expect(attrs[:auth_count]).to eq(@timestamps.length)
             expect(results.length).to eq(@timestamps.length)
@@ -355,7 +355,7 @@ describe Rbac do
 
         context "with only belongsto filters" do
           before(:each) do
-            group.update_attributes(:filters => {"managed" => [], "belongsto" => ["/belongsto/ExtManagementSystem|ems1"]})
+            group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => ["/belongsto/ExtManagementSystem|ems1"]})
 
             ems1 = FactoryGirl.create(:ems_vmware, :name => 'ems1')
             @host1.update_attributes(:ext_management_system => ems1)
@@ -372,7 +372,7 @@ describe Rbac do
 
           it ".search finds the right HostPerformance rows" do
             results, attrs = Rbac.search(:class => "HostPerformance", :user => user, :results_format => :objects)
-            expect(attrs[:user_filters]).to eq(group.filters)
+            expect(attrs[:user_filters]).to eq(group.get_filters)
             expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
             expect(attrs[:auth_count]).to eq(@timestamps.length)
             expect(results.length).to eq(@timestamps.length)
@@ -381,7 +381,7 @@ describe Rbac do
 
           it ".search filters out the wrong HostPerformance rows" do
             results, attrs = Rbac.search(:targets => HostPerformance.all, :class => "HostPerformance", :user => user, :results_format => :objects)
-            expect(attrs[:user_filters]).to eq(group.filters)
+            expect(attrs[:user_filters]).to eq(group.get_filters)
             expect(attrs[:total_count]).to eq(@timestamps.length * hosts.length)
             expect(attrs[:auth_count]).to eq(@timestamps.length)
             expect(results.length).to eq(@timestamps.length)
@@ -446,7 +446,7 @@ describe Rbac do
           end
 
           it "finds one EMS with belongsto filters" do
-            group.update_attributes(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+            group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
             results = Rbac.search(:class => "ExtManagementSystem", :results_format => :objects, :user => user)
             objects = results.first
             expect(objects).to eq([@ems])
@@ -468,7 +468,7 @@ describe Rbac do
           expect(objects.length).to eq(2)
           expect(objects).to match_array([@vm, @template])
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
           results = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(0)
@@ -478,7 +478,7 @@ describe Rbac do
             v.save
           end
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
           results = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(2)
@@ -491,7 +491,7 @@ describe Rbac do
           expect(objects.length).to eq(1)
           expect(objects).to match_array([@vm])
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
 
           results = Rbac.search(:class => "Vm", :results_format => :objects, :user => user)
           objects = results.first
@@ -502,7 +502,7 @@ describe Rbac do
             v.save
           end
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
           results = Rbac.search(:class => "Vm", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(1)
@@ -515,7 +515,7 @@ describe Rbac do
           expect(objects.length).to eq(1)
           expect(objects).to match_array([@template])
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
 
           results = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :user => user)
           objects = results.first
@@ -526,7 +526,7 @@ describe Rbac do
             v.save
           end
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@vm_folder_path]})
           results = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :user => user)
           objects = results.first
           expect(objects.length).to eq(1)
@@ -567,7 +567,7 @@ describe Rbac do
         it "returns all host's VMs and templates when host filter is set up" do
           @host_1.parent = @hfolder # add host to folder's hierarchy
           mtc_folder_path_with_host = "#{@mtc_folder_path}/EmsFolder|host/Host|#{@host_1.name}"
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [mtc_folder_path_with_host]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [mtc_folder_path_with_host]})
 
           ["ManageIQ::Providers::Vmware::InfraManager::Vm", "Vm"].each do |klass|
             results2 = Rbac.search(:class => klass, :user => user, :results_format => :objects).first
@@ -598,7 +598,7 @@ describe Rbac do
         end
 
         it "get all the vm or templates with belongsto filter" do
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
           results, attrs = Rbac.search(:class => "VmOrTemplate", :user => user, :results_format => :objects)
           expect(results.length).to eq(0)
           expect(attrs[:total_count]).to eq(4)
@@ -608,7 +608,7 @@ describe Rbac do
             v.with_relationship_type("ems_metadata") { v.parent = @rp }
             v.save
           end
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
 
           results2, attrs = Rbac.search(:class => "VmOrTemplate", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@cluster_folder_path]})
@@ -618,21 +618,21 @@ describe Rbac do
         end
 
         it "get all the hosts with belongsto filter" do
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@cluster_folder_path]})
           results, attrs = Rbac.search(:class => "Host", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@cluster_folder_path]})
           expect(attrs[:total_count]).to eq(4)
           expect(attrs[:auth_count]).to eq(1)
           expect(results.length).to eq(1)
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@mtc_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@mtc_folder_path]})
           results2, attrs = Rbac.search(:class => "Host", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@mtc_folder_path]})
           expect(attrs[:total_count]).to eq(4)
           expect(attrs[:auth_count]).to eq(1)
           expect(results2.length).to eq(1)
 
-          group.update_attributes(:filters => {"managed" => [], "belongsto" => [@ems_folder_path]})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [], "belongsto" => [@ems_folder_path]})
           results3, attrs = Rbac.search(:class => "Host", :user => user, :results_format => :objects)
           expect(attrs[:user_filters]).to eq({"managed" => [], "belongsto" => [@ems_folder_path]})
           expect(attrs[:total_count]).to eq(4)
@@ -841,7 +841,7 @@ describe Rbac do
 
       context "with only managed filters (FB9153, FB11442)" do
         before(:each) do
-          group.update_attributes(:filters => {"managed" => [["/managed/environment/prod"], ["/managed/service_level/silver"]], "belongsto" => []})
+          group.entitlement = Entitlement.create!(:filters => {"managed" => [["/managed/environment/prod"], ["/managed/service_level/silver"]], "belongsto" => []})
         end
 
         context ".search" do
@@ -890,7 +890,7 @@ describe Rbac do
 
             expect(results.length).to eq(2)
             expect(attrs[:auth_count]).to eq(2)
-            expect(attrs[:user_filters]["managed"]).to eq(group.filters['managed'])
+            expect(attrs[:user_filters]["managed"]).to eq(group.get_managed_filters)
             expect(attrs[:total_count]).to eq(2)
           end
         end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -115,14 +115,14 @@ describe Tag do
   end
 
   describe "#destroy" do
-    let(:miq_group)       { FactoryGirl.create(:miq_group) }
-    let(:other_miq_group) { FactoryGirl.create(:miq_group) }
+    let(:miq_group)       { FactoryGirl.create(:miq_group, :entitlement => Entitlement.create!) }
+    let(:other_miq_group) { FactoryGirl.create(:miq_group, :entitlement => Entitlement.create!) }
     let(:filters)         { [["/managed/prov_max_memory/test"], ["/managed/my_name/test"]] }
     let(:tag)             { FactoryGirl.create(:tag, :name => "/managed/my_name/test") }
 
     before :each do
-      miq_group.set_managed_filters(filters)
-      other_miq_group.set_managed_filters(filters)
+      miq_group.entitlement.set_managed_filters(filters)
+      other_miq_group.entitlement.set_managed_filters(filters)
       [miq_group, other_miq_group].each(&:save)
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,9 +50,11 @@ describe User do
     let(:bfilters) { {"belongsto" => "b"} }
     let(:miq_group) { FactoryGirl.create(:miq_group, :entitlement => entitlement) }
     let(:entitlement) do
-      FactoryGirl.create(:entitlement,
-                         :filters => {'managed' => mfilters,
-                                      'belongsto' => bfilters})
+      entitlement = FactoryGirl.create(:entitlement)
+      entitlement.set_managed_filters(mfilters)
+      entitlement.set_belongsto_filters(bfilters)
+      entitlement.save!
+      entitlement
     end
 
     it "should check for and get Managed and Belongs-to filters from the group" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,13 +48,11 @@ describe User do
     let(:user) { FactoryGirl.create(:user, :miq_groups => [miq_group]) }
     let(:mfilters) { {"managed"   => "m"} }
     let(:bfilters) { {"belongsto" => "b"} }
-    let(:miq_group) { FactoryGirl.create(:miq_group) }
-
-    before do
-      miq_group.set_managed_filters(mfilters)
-      miq_group.set_belongsto_filters(bfilters)
-      miq_group.save
-      user.reload
+    let(:miq_group) { FactoryGirl.create(:miq_group, :entitlement => entitlement) }
+    let(:entitlement) do
+      FactoryGirl.create(:entitlement,
+                         :filters => {'managed' => mfilters,
+                                      'belongsto' => bfilters})
     end
 
     it "should check for and get Managed and Belongs-to filters from the group" do

--- a/spec/presenters/tree_builder_containers_spec.rb
+++ b/spec/presenters/tree_builder_containers_spec.rb
@@ -26,7 +26,8 @@ describe TreeBuilderContainers do
     end
 
     it "returns tagged containers, logged user with tag filter" do
-      user.current_group.set_managed_filters([tag.name])
+      user.current_group.entitlement = Entitlement.create!
+      user.current_group.entitlement.set_managed_filters([tag.name])
       @tree = TreeBuilderContainers.new("containers_tree", "containers", {}, true)
       results = get_tree_results(@tree)
       expect(results).to match_array(["Tagged Container"])

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -122,11 +122,12 @@ describe ApiController do
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      res = response_hash["results"].first
-      group_id = res["id"]
-      expect(MiqGroup.exists?(group_id)).to be_truthy
-
-      expect_result_to_match_hash(res, sample_group)
+      group_id = response_hash["results"][0]["id"]
+      expected_group = MiqGroup.find_by(:id => group_id)
+      expect(expected_group).to be_present
+      expect(expected_group.description).to eq(sample_group["description"])
+      expect(expected_group.entitlement).to be_present
+      expect(expected_group.entitlement.filters).to eq(sample_group["filters"])
     end
 
     it "supports multiple group creation" do


### PR DESCRIPTION
Moves `miq_group.filters` to `entitlements` as-is.