### PR TITLE
Infra provider discovery fails

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -152,7 +152,7 @@ class ExtManagementSystem < ApplicationRecord
 
   def self.create_discovered_ems(ost)
     ip = ost.ipaddr
-    unless with_ipaddress(ip).exist?
+    unless with_ipaddress(ip).exists?
       hostname = Socket.getaddrinfo(ip, nil)[0][2]
 
       ems_klass, ems_name = if ost.hypervisor.include?(:scvmm)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -6,6 +6,16 @@ describe ExtManagementSystem do
     expect(described_class.model_name_from_emstype('foo')).to be_nil
   end
 
+  it ".create_discovered_ems" do
+    ost = OpenStruct.new(:ipaddr => "0.0.0.0", :hypervisor => [:virtualcenter])
+
+    allow(MiqServer).to receive(:my_server).and_return(
+      double("MiqServer", :zone => double("Zone", :name => "foo", :id => 1)))
+    expect(AuditEvent).to receive(:success)
+
+    described_class.create_discovered_ems(ost)
+  end
+
   let(:all_types_and_descriptions) do
     {
       "ansible_tower_configuration" => "Ansible Tower Configuration",


### PR DESCRIPTION
When creating a new provider from an ip range using ExtManagementSystem#create_discovered_ems it fails with a NoMethodError exception trying to call exist? instead of exists?

```
[----] I, [2016-04-19T02:30:38.114470 #2997:cf7998]  INFO -- : MIQ(Host.discoverHost) Discovered: #<OpenStruct ipaddr="12.3.4.123", usePing=nil, timeout=10, discover_types=[:virtualcenter], os=[:mswin], hypervisor=[:virtualcenter]>
[----] E, [2016-04-19T02:30:38.206449 #2997:cf7998] ERROR -- : [NoMethodError]: undefined method `exist?' for #<ActiveRecord::Relation []>  Method:[rescue in discoverHost]
[----] E, [2016-04-19T02:30:38.206862 #2997:cf7998] ERROR -- : /opt/rh/cfme-gemset/bundler/gems/rails-efaa6e4f79d4/activerecord/lib/active_record/relation/delegation.rb:124:in `method_missing'
/opt/rh/cfme-gemset/bundler/gems/rails-efaa6e4f79d4/activerecord/lib/active_record/relation/delegation.rb:94:in `method_missing'
/var/www/miq/vmdb/app/models/ext_management_system.rb:155:in `create_discovered_ems'
/var/www/miq/vmdb/app/models/host.rb:989:in `discoverHost'
```