### PR TITLE
Fix for a few residual errors/typo in ems_infra controller

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -153,7 +153,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       ($scope.emsCommonModel.emstype == "openstack" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "scvmm" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "openstack_infra" && $scope.emsCommonModel.default_hostname ||
-       $scope.emsCommonModel.emstype == "rhevm" && $scope.emsCommonModel.default_hostname && $scope.emsCommonModel.default_api_port ||
+       $scope.emsCommonModel.emstype == "rhevm" && $scope.emsCommonModel.default_hostname ||
        $scope.emsCommonModel.emstype == "vmwarews" && $scope.emsCommonModel.default_hostname)) &&
       ($scope.emsCommonModel.default_userid != '' && $scope.angularForm.default_userid.$valid &&
        $scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid &&

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -230,7 +230,7 @@ module Mixins
                        :metrics_api_port            => metrics_port,
                        :default_security_protocol   => default_security_protocol,
                        :amqp_security_protocol      => amqp_security_protocol,
-                       :api_version                 => @ems.api_version,
+                       :api_version                 => @ems.api_version ? @ems.api_version : "v2",
                        :provider_region             => @ems.provider_region,
                        :default_userid              => @ems.authentication_userid ? @ems.authentication_userid : "",
                        :amqp_userid                 => amqp_userid,

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -358,7 +358,7 @@ module Mixins
       end
       if ems.kind_of?(ManageIQ::Providers::Redhat::InfraManager) &&
          ems.supports_authentication?(:metrics) && params[:metrics_userid]
-        metrics_password = params[:metrics_password] ? params[:metrics_password] : @ems.authentication_password(:metrics)
+        metrics_password = params[:metrics_password] ? params[:metrics_password] : ems.authentication_password(:metrics)
         creds[:metrics] = {:userid => params[:metrics_userid], :password => metrics_password}
       end
       if ems.supports_authentication?(:auth_key) && params[:service_account]


### PR DESCRIPTION
Found a few residual errors post #7808 merge listed below -

1. `rhevm` port can be empty, therefore Validate button could be activated even when port is not populated
2. Set the default value for Openstack API Version to `Keystone v2`
3. Fix typo `s/@ems/ems` in `metrics` password