### PR TITLE
Fix some style problems with UI plugins.

### DIFF
--- a/app/views/stylesheets/_template50.html.haml
+++ b/app/views/stylesheets/_template50.html.haml
@@ -1,9 +1,5 @@
-:css
 - if big_iframe
   :css
     @media (min-width: 1080px) {
       .navbar-pf ul > li.active { margin-bottom: 0 !important; }
       .navbar-nav ul > li > ul { display:none }
-      body { padding-top: #{padding_top}px !important }
-    }
-


### PR DESCRIPTION
 * variable not defined (remove)
 * padding should not be there because the menu should be on the left

ping @simaishi : this is one of fixes needed to make UI plugins work with the new menu

@epwinchell, @skateman : the menu should stay visible when the UI plugin is active. So this is markup issue. @skateman : can you handle this bug?

before the fix:
![ui-plug-before](https://cloud.githubusercontent.com/assets/51095/14667666/9e5303f0-06e0-11e6-96a8-a48d936b0931.png)


after the fix:
![ui-plugin-bug](https://cloud.githubusercontent.com/assets/51095/14667616/6cb4b62c-06e0-11e6-85d5-20674ad96642.png)
