### PR TITLE
fix_auth needs to run in rails environment after Vmdb::Settings refactoring

### DIFF
--- a/tools/fix_auth.rb
+++ b/tools/fix_auth.rb
@@ -11,6 +11,8 @@ if __FILE__ == $PROGRAM_NAME
   $LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(.. gems pending))))
 end
 
+require File.expand_path('../../config/environment', __FILE__)
+
 require 'active_support/all'
 require 'active_support/concern'
 require 'fix_auth/auth_model'


### PR DESCRIPTION
We cannot just require Vmdb::Settings as we would need to hardcode lot
of `require` statements all over the vmdb_helper. Such requires, however
would be implicit in rails envronment.

Addressing:
```
tools/fix_auth/models.rb:88:in `contenders': uninitialized constant FixAuth::FixSettingsChange::Vmdb (NameError)
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/auth_model.rb:84:in `run'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/fix_auth.rb:65:in `block (2 levels) in fix_database_passwords'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/fix_auth.rb:64:in `each'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/fix_auth.rb:64:in `block in fix_database_passwords'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/fix_auth.rb:61:in `each'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/fix_auth.rb:61:in `fix_database_passwords'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/fix_auth.rb:92:in `run'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/cli.rb:37:in `run'
	from /home/slukasik-f23/data/redhat/git/hub/ManageIQ/manageiq/tools/fix_auth/cli.rb:41:in `run'
	from tools/fix_auth.rb:24:in `<main>'
```

Relates to https://bugzilla.redhat.com/show_bug.cgi?id=1323258

@miq add_label core, bug