### PR TITLE
Bump image-inspector-client gem and image-inspector container versions

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -134,7 +134,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def collect_compliance_data(image)
-    return unless image_inspector_client.respond_to? :fetch_oscap_arf
     _log.info "collecting compliance data for #{options[:docker_image_id]}"
     openscap_result = image.openscap_result || OpenscapResult.new(:container_image => image)
     openscap_result.attach_raw_result(image_inspector_client.fetch_oscap_arf)
@@ -296,7 +295,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
             :image           => inspector_image,
             :command         => [
               "/usr/bin/image-inspector",
+              "--chroot",
               "--image=#{options[:image_full_name]}",
+              "--scan-type=openscap",
               "--serve=0.0.0.0:#{options[:pod_port]}"
             ],
             :ports           => [{:containerPort => options[:pod_port]}],
@@ -320,6 +321,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def inspector_image
-    'docker.io/openshift/image-inspector:v1.0.z'
+    'docker.io/openshift/image-inspector:v2.0.z'
   end
 end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -23,7 +23,7 @@ gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
 gem "fog-openstack",           "~>0.1.2",           :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
-gem "image-inspector-client",  "~>1.0.1",           :require => false
+gem "image-inspector-client",  "~>1.0.2",           :require => false
 gem "kubeclient",              "=1.1.3",            :require => false
 gem "hawkular-client",         "~>0.2.1",           :require => false
 gem "linux_admin",             "~>0.16.0",          :require => false


### PR DESCRIPTION
Bump versions and adapt client code for OpenSCAP support.

~~Marking as WIP until an image-inspector container is released.~~