### PR TITLE
li_link(): correctly retrieve record id

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -936,7 +936,7 @@ module ApplicationHelper
       link_params = {
         :action  => args[:action].present? ? args[:action] : 'show',
         :display => args[:display],
-        :id      => args[:record_id].to_s
+        :id      => args[:record].present? ? args[:record].id : args[:record_id].to_s
       }
       link_params[:controller] = args[:controller] if args.key?(:controller)
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1627,6 +1627,46 @@ describe ApplicationHelper do
         expect(subject).to have_selector('li.disabled')
       end
     end
+
+    context 'with :record passed in as an argument' do
+      let(:args) do
+        {:if         => true,
+         :controller => 'availability_zone',
+         :record     => FactoryGirl.create(:availability_zone),
+         :action     => 'show_list',
+         :display    => 'something'}
+      end
+
+      subject { li_link(args) }
+
+      it 'renders url correctly' do
+        expect(subject).to have_xpath("//a", :text => %r{\/availability_zone\/show_list\/\d+\?display=something})
+      end
+
+      it 'renders onclick correctly' do
+        expect(subject).to have_xpath("//a[@onclick = 'return miqCheckForChanges()']")
+      end
+    end
+
+    context 'with :record_id passed in as an argument' do
+      let(:args) do
+        {:if         => true,
+         :controller => 'availability_zone',
+         :record_id  => FactoryGirl.create(:availability_zone).id,
+         :action     => 'show_list',
+         :display    => 'something'}
+      end
+
+      subject { li_link(args) }
+
+      it 'renders url correctly' do
+        expect(subject).to have_xpath("//a", :text => %r{\/availability_zone\/show_list\/\d+\?display=something})
+      end
+
+      it 'renders onclick correctly' do
+        expect(subject).to have_xpath("//a[@onclick = 'return miqCheckForChanges()']")
+      end
+    end
   end
 
   describe '#view_to_association' do


### PR DESCRIPTION
`li_link()` accepts `:record` or `:record_id` in its list of url construction arguments.

Current logic of `li_link()`:

```
if (:record was passed in) && (restful route can be constructed)
  link_to()
else
  link_to()
end
```

In some cases, a restful route cannot be constructed for given `:record`, yet we passed `:record` to 
`li_link()`, i.e. we did not correctly retrieve ID for the url construction. This would lead to incorrect URL
being constructed in some parts of our UI (listnavs for example).