### PR TITLE
Fix creation of plural form in ui_lookup()

### DIFF
--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -35,8 +35,7 @@ class OrchestrationStackController < ApplicationController
       @showtype = @display
       notify_about_unauthorized_items(title, ui_lookup(:tables => 'orchestration_stack'))
     when "security_groups"
-      table = "security_groups"
-      title = ui_lookup(:tables => table)
+      title = ui_lookup(:tables => "security_group")
       kls   = SecurityGroup
       drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @orchestration_stack.name, :title => title},
                       :url  => "/orchestration_stack/show/#{@orchestration_stack.id}?display=#{@display}")


### PR DESCRIPTION
Using :tables as argument is sufficient for `ui_lookup()` to return a plural form. The table name itself
should not be pluralized (it should be passed in as singular).