### PR TITLE
CRUD operations on MiddlewareServer should be handled by Hawkular provider

### DIFF
--- a/app/helpers/application_helper/toolbar/middleware_server_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_server_center.rb
@@ -13,15 +13,7 @@ class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::To
           N_('Show Capacity & Utilization data for this Server'),
           N_('Utilization'),
           :url       => "/show",
-          :url_parms => "?display=performance"),
-        button(
-          :middleware_server_timeline,
-          'product product-timeline fa-lg',
-          N_('Show Timelines for this Server'),
-          N_('Timelines'),
-          :enabled   => "false",
-          :url       => "/show",
-          :url_parms => "?display=timeline"),
+          :url_parms => "?display=performance")
       ]
     ),
   ])

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3314,23 +3314,6 @@
         :description: Show Capacity & Utilization data of Middleware Servers
         :feature_type: view
         :identifier: middleware_server_perf
-    - :name: Modify
-      :description: Modify Middleware Servers
-      :feature_type: admin
-      :identifier: middleware_server_admin
-      :children:
-      - :name: Remove
-        :description: Remove Middleware Servers from the VMDB
-        :feature_type: admin
-        :identifier: middleware_server_delete
-      - :name: Edit
-        :description: Edit a Middleware Server
-        :feature_type: admin
-        :identifier: middleware_server_edit
-      - :name: Add
-        :description: Add a Middleware Server
-        :feature_type: admin
-        :identifier: middleware_server_new
     - :name: Operate
       :description: Perform Operations on Middleware Servers
       :feature_type: control

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1025 }
+  let(:expected_feature_count) { 1021 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
Add/Remove buttons are unused and not implemented.
Fixes #8103 
Attaching a screenshot with the unused buttons fixed
![image](https://cloud.githubusercontent.com/assets/1662329/15015538/ce584452-120c-11e6-9208-a1e44ee0bb56.png)
