### PR TITLE
Fix styling of two-state view buttons.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -174,7 +174,7 @@ class ApplicationHelper::ToolbarBuilder
     )
     apply_common_props(props, bgi)
 
-    props[:selected] = "true" if build_toolbar_select_button(bgi[:buttonTwoState])
+    props[:selected] = true if build_toolbar_select_button(bgi[:buttonTwoState])
 
     _add_separator(index)
     props

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -45,7 +45,7 @@ module ToolbarHelper
   def view_mode_buttons(buttons)
     content_tag(:ul, :class => 'list-inline') do
       buttons.collect do |button|
-        toolbar_button_normal(button, true)
+        toolbar_button_view(button)
       end.join('').html_safe
     end
   end
@@ -157,10 +157,22 @@ module ToolbarHelper
 
   # Render normal push child button
   #
-  def toolbar_button_normal(props, view_button = false)
+  def toolbar_button_normal(props)
     hidden = props[:hidden]
-    cls = if view_button
-            props[:enabled] ? '' : 'active '
+    cls = props[:enabled] ? '' : 'disabled '
+    content_tag(:li, :class => cls + (hidden ? 'hidden' : '')) do
+      content_tag(:a, prepare_tag_keys(props).update(:href => '#')) do
+        (toolbar_image(props) + _(props[:text].to_s).html_safe)
+      end
+    end
+  end
+
+  # Render normal/twostate view button
+  #
+  def toolbar_button_view(props)
+    hidden = props[:hidden]
+    cls = if props[:type] == 'buttonTwoState'
+            props[:selected] ? 'active' : ''
           else
             props[:enabled] ? '' : 'disabled '
           end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1305423
https://bugzilla.redhat.com/show_bug.cgi?id=1305668

There are 2 ways view buttons states are rendered:
a) enabled/disabled
b) two state selected/not selected

This should be unified in a separate PR.

![view-button-after](https://cloud.githubusercontent.com/assets/51095/14677369/b40d07c8-0711-11e6-84c5-92faf53cf87c.png)
