### PR TITLE
Fix @gtl_url for ems_cluster_controller

### DIFF
--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -24,7 +24,7 @@ class EmsClusterController < ApplicationController
     @ems_cluster = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@ems_cluster)
 
-    @gtl_url = "/ems_cluster"
+    @gtl_url = "/show"
 
     case @display
     when "download_pdf", "main", "summary_only"


### PR DESCRIPTION
The `@gtl_url`  variable needs to be set to action name, not controller name.

This problem would lead to url for GTL icons being rendered incorrectly
(doubled controller name, no action name).