### PR TITLE
Removed the select with perf_cols when querying metrics for capacity planning

### DIFF
--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -589,7 +589,7 @@ module VimPerformanceAnalysis
 
     ext_options ||= {}
     Metric::Helper.find_for_interval_name("daily", ext_options[:time_profile] || ext_options[:tz], ext_options[:class])
-                  .order("timestamp").select(perf_cols)
+                  .order("timestamp") #.select(perf_cols) - Currently passing perf_cols to select is broken because it includes virtual cols. This is actively being worked on.
                   .where(:resource => obj, :timestamp => Metric::Helper.time_range_from_hash(range))
   end
 

--- a/spec/models/vim_performance_analysis_spec.rb
+++ b/spec/models/vim_performance_analysis_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe VimPerformanceAnalysis do
   #   end
   # end
 
+  describe ".get_daily_perf" do
+    it "should not raise an error" do
+      range       = {:days => 7, :end_date => "2016-04-19T23:00:00Z".to_time}
+      ext_options = {:tz => "UTC", :time_profile => time_profile}
+      perf_cols   = [:max_cpu_usagemhz_rate_average, :derived_cpu_available, :total_vcpus, :max_derived_memory_used, :derived_memory_available, :used_space, :total_space]
+      expect { described_class.get_daily_perf(host1, range, ext_options, perf_cols).all.inspect }.not_to raise_error
+    end
+  end
+
   private
 
   def add_rollup(vm, timestamp, tag = tag_text)


### PR DESCRIPTION
- This is necessary because some of the columns that were passed in are not actual columns but are actually methods that calculate values on the fly.
- Examples would be - :max_cpu_usagemhz_rate_average, :total_vcpus, :max_derived_memory_used, :used_space, :total_space

Fixes issue #8067

/cc @kbrock 