### PR TITLE
Docker Appliance Cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
                    psmisc                  \
                    lvm2                    \
                    openldap-clients        \
+                   gdbm-devel              \
                    &&                      \
     yum clean all
 
@@ -83,9 +84,8 @@ RUN ${APPLIANCE_ROOT}/setup && \
 echo "export PATH=\$PATH:/opt/rubies/ruby-2.2.4/bin" >> /etc/default/evm && \
 mkdir ${APP_ROOT}/log/apache && \
 mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
-echo "# This file intentionally left blank. CFME maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \
-echo "export APP_ROOT=${APP_ROOT}" >> /etc/default/evm && \
-cp /etc/motd.manageiq /etc/motd
+echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \
+echo "export APP_ROOT=${APP_ROOT}" >> /etc/default/evm
 
 ## Change workdir to application root, build/install gems
 WORKDIR ${APP_ROOT}
@@ -111,7 +111,7 @@ RUN ln -s /var/www/miq/vmdb/docker-assets/docker_initdb /usr/bin
 RUN systemctl enable memcached appliance-initialize evmserverd evminit evm-watchdog miqvmstat miqtop
 
 ## Expose required container ports
-EXPOSE 80 443 3000 4000 5900-5999
+EXPOSE 80 443
 
 # Atomic Labels
 # The UNINSTALL label by DEFAULT will attempt to delete a container (rm) and image (rmi) if the container NAME is the same as the actual IMAGE
@@ -123,7 +123,7 @@ LABEL name="manageiq" \
           release="latest" \
           architecture="x86_64" \
           url="http://manageiq.org/" \
-          summary="ManageIQ development image" \
+          summary="ManageIQ appliance image" \
           description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
           INSTALL='docker run -ti --privileged \
                     --name ${NAME}_volume \
@@ -135,9 +135,6 @@ LABEL name="manageiq" \
                     --volumes-from ${NAME}_volume \
                     -p 80:80 \
                     -p 443:443 \
-                    -p 3000:3000 \
-                    -p 4000:4000 \
-                    -p 5900-5999:5900-5999 \
                     $IMAGE' \
           STOP='docker stop ${NAME}_run && \
           echo "Container ${NAME}_run has been stopped"' \

--- a/docker-assets/README.md
+++ b/docker-assets/README.md
@@ -1,4 +1,4 @@
-# ManageIQ Devel Docker Build
+# ManageIQ Docker Appliance
 
 This image provides ManageIQ using the official Centos7 dockerhub build as a base along with PostgreSQL.
 
@@ -11,7 +11,7 @@ It needs to be initiated from the root directory of the manageiq git repository
 docker build -t manageiq .
 ```
 
-It has been tested and validated under docker-1.10 (Fedora23) and 1.8.2 (Centos7)
+The image has been tested and validated under docker-1.10 (Fedora23) and 1.8.2 (Centos7)
 
 
 ## Run
@@ -20,9 +20,9 @@ It has been tested and validated under docker-1.10 (Fedora23) and 1.8.2 (Centos7
 
 The first time you run the container, it will initialize the database, **please allow 2-4 mins** for MIQ to respond.
 ```
-docker run --privileged -di -p 3000:3000 -p 4000:4000 -p 5900-5999:5900-5999 manageiq
+docker run --privileged -di -p 80:80 -p 443:443 manageiq
 ```
-please note you can ommit some ports from the run command if you don't need to use them
+Please note you can ommit some ports from the run command if you don't need to use them
 
 
 ### On Atomic host
@@ -39,7 +39,7 @@ atomic uninstall -n <name> manageiq
 
 ### On standard distribution
 ```
-docker run --privileged -di -p 3000:3000 -p 4000:4000 -p 5900-5999:5900-5999 docker.io/manageiq/manageiq
+docker run --privileged -di -p 80:80 -p 443:443 docker.io/manageiq/manageiq
 ```
 
 ### On Atomic host
@@ -51,12 +51,12 @@ atomic run docker.io/manageiq/manageiq
 Note due to resource limitations you can not run more than a single container of manageiq on the same Atomic host
 
 ## Access
-The web interface is exposed at port 3000. Default login credentials.
+The web interface is exposed at port 443. Default login credentials.
 
 Point your web browser to :
 
 ```
-http://<your-ip-address>:3000
+https://<your-ip-address>
 ```
 
 For console access, please use docker exec from docker host :


### PR DESCRIPTION
- Updated image documentation to reflect changes to appliance mode
- Removed unnecessary motd handling
- Adjusted CFME naming in favor of ManageIQ on ssl.conf
- Removed 3000 and 4000 from exposed ports
- Added gdbm-devel to main yum call (ruby build dep)
- Updated Atomic labels to reflect changes