### PR TITLE
Show Cloud Volumes relationship on Cloud VM details view (Depends on #8143)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1784,7 +1784,8 @@ class ApplicationController < ActionController::Base
                    "show_list"
                  end
 
-    ajax_url = ! %w(OntapStorageSystem OntapLogicalDisk OntapStorageVolume OntapFileShare SecurityGroup).include?(view.db)
+    ajax_url = ! %w(OntapStorageSystem OntapLogicalDisk OntapStorageVolume
+                    OntapFileShare SecurityGroup CloudVolume).include?(view.db)
     ajax_url = false if request.parameters[:controller] == "service" && view.db == "Vm"
     ajax_url = false unless @explorer
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -606,6 +606,10 @@ module VmCommon
     show_association('cloud_subnets', _('Networks'), 'cloud_subnet', :cloud_subnets, CloudNetwork)
   end
 
+  def cloud_volumes
+    show_association('cloud_volumes', _('Cloud Volumes'), 'cloud_volume', :cloud_volumes, CloudVolume)
+  end
+
   def network_routers
     show_association('network_routers', _('Routers'), 'network_router', :network_routers, NetworkRouter)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,7 +222,9 @@ module ApplicationHelper
                 NetworkRouter
                 NetworkPort
                 CloudNetwork
-                CloudSubnet).include?(view.db)
+                CloudSubnet
+                CloudVolume
+                ).include?(view.db)
             return url_for(:controller => controller, :action => "show") + "/"
           elsif ["Vm"].include?(view.db) && parent && request.parameters[:controller] != "vm"
             # this is to handle link to a vm in vm explorer from service explorer

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -12,7 +12,7 @@ module VmCloudHelper::TextualSummary
   def textual_group_vm_cloud_relationships
     %i(ems ems_infra cluster host availability_zone cloud_tenant flavor vm_template drift scan_history service
        cloud_network cloud_subnet orchestration_stack cloud_networks cloud_subnets network_routers security_groups
-       floating_ips network_ports)
+       floating_ips network_ports cloud_volumes)
   end
 
   def textual_group_template_cloud_relationships
@@ -616,6 +616,18 @@ module VmCloudHelper::TextualSummary
     if cloud_tenant && role_allows(:feature => "cloud_tenant_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
+    end
+    h
+  end
+
+  def textual_cloud_volumes
+    label = ui_lookup(:tables => "cloud_volumes")
+    num = @record.number_of(:cloud_volumes)
+    h = {:label => label, :image => "cloud_volume", :value => num}
+    if num > 0 && role_allows(:feature => "cloud_volume_show_list")
+      h[:title]    = _("Show all Cloud Volumes attached to this VM.")
+      h[:explorer] = true
+      h[:link]     = url_for(:action => 'cloud_volumes', :id => @record, :display => "cloud_volumes")
     end
     h
   end

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -9,7 +9,7 @@
   - if @explorer
     -# used for most gtl lists
     #list_grid
-      - ajax_url = ! %w(OntapStorageSystem OntapLogicalDisk OntapStorageVolume OntapFileShare SecurityGroup FloatingIp NetworkRouter CloudSubnet CloudNetwork NetworkPort).include?(view.db)
+      - ajax_url = ! %w(OntapStorageSystem OntapLogicalDisk OntapStorageVolume OntapFileShare SecurityGroup FloatingIp NetworkRouter CloudSubnet CloudNetwork NetworkPort CloudVolume).include?(view.db)
       - ajax_url = false if request.parameters[:controller] == "service" && view.db == "Vm"
       -# don't need a row url to be AJAX when displaying a list of other CI's inside explorer
       = render(:partial => 'layouts/list_grid',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2333,6 +2333,7 @@ Vmdb::Application.routes.draw do
         network_ports
         cloud_subnets
         cloud_networks
+        cloud_volumes
         show
         squash_toggle
         tagging_edit


### PR DESCRIPTION
Adds UI link for the Cloud VM -> Cloud Volume relationship.
![cloud_volumes_relationship](https://cloud.githubusercontent.com/assets/628956/14693019/7702bcf2-0729-11e6-945a-4fbc3c76e966.png)

Depends on https://github.com/ManageIQ/manageiq/pull/8143

@Loicavenel 