### PR TITLE
Fix undefined route when switching to grid/tile view

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -2,6 +2,10 @@ module EmsCommon
   extend ActiveSupport::Concern
   include AuthorizationMessagesMixin
 
+  def gtl_url
+    restful? ? '/' : '/show'
+  end
+
   def show
     @display = params[:display] || "main" unless control_selected?
 
@@ -10,7 +14,7 @@ module EmsCommon
     @ems = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@ems)
 
-    @gtl_url = "/show"
+    @gtl_url = gtl_url
     @showtype = "config"
     drop_breadcrumb({:name => ui_lookup(:tables => @table_name), :url => "/#{@table_name}/show_list?page=#{@current_page}&refresh=y"}, true)
 


### PR DESCRIPTION
Fix undefined route when switching to grid/tile view, ems_cloud
is using restful routes, so there is no /show

Exception when clicking on tile view e.g. on ems_cloud page, clicking on relation cloud_tenants

No route matches [GET] "/ems_cloud/show/23"

Rails.root: /home/Ladas/Projects/cfme/manageiq

Application Trace | Framework Trace | Full Trace
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/railties/lib/rails/rack/logger.rb:36:in `call_app'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/railties/lib/rails/rack/logger.rb:26:in `call'
request_store (1.3.1) lib/request_store/middleware.rb:9:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/actionpack/lib/action_dispatch/middleware/request_id.rb:24:in `call'
rack (2.0.0.alpha) lib/rack/method_override.rb:22:in `call'
rack (2.0.0.alpha) lib/rack/runtime.rb:22:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/actionpack/lib/action_dispatch/middleware/executor.rb:12:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/actionpack/lib/action_dispatch/middleware/static.rb:136:in `call'
rack (2.0.0.alpha) lib/rack/sendfile.rb:111:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-597fa0b42f90/railties/lib/rails/engine.rb:522:in `call'
puma (3.3.0) lib/puma/configuration.rb:224:in `call'
puma (3.3.0) lib/puma/server.rb:561:in `handle_request'
puma (3.3.0) lib/puma/server.rb:406:in `process_client'
puma (3.3.0) lib/puma/server.rb:271:in `block in run'
puma (3.3.0) lib/puma/thread_pool.rb:111:in `call'
puma (3.3.0) lib/puma/thread_pool.rb:111:in `block in spawn_thread'