### PR TITLE
Define active record relations for vm and cloud volume

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -11,12 +11,10 @@ class CloudVolume < ApplicationRecord
   belongs_to :base_snapshot, :class_name => 'CloudVolumeSnapshot', :foreign_key => :cloud_volume_snapshot_id
   has_many   :cloud_volume_snapshots
   has_many   :attachments, :class_name => 'Disk', :as => :backing
+  has_many   :hardwares, :through => :attachments
+  has_many   :vms, :through => :hardwares, :foreign_key => :vm_or_template_id
 
   acts_as_miq_taggable
-
-  def vms
-    attachments.map { |disk| disk.hardware.vm }
-  end
 
   def self.available
     joins("LEFT OUTER JOIN disks ON disks.backing_id = cloud_volumes.id")

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -17,9 +17,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   has_one  :floating_ip, :foreign_key => :vm_id
   has_many :floating_ips
   has_many :security_groups, :through => :network_ports
-
-  has_many :disks, :through => :hardware
-  has_many :cloud_volumes, :through => :disks, :source => :backing, source_type: "CloudVolume"
+  has_many :cloud_volumes, :through => :disks, :source => :backing, :source_type => "CloudVolume"
 
   has_and_belongs_to_many :key_pairs, :join_table              => :key_pairs_vms,
                                       :foreign_key             => :vm_id,

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -18,6 +18,9 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   has_many :floating_ips
   has_many :security_groups, :through => :network_ports
 
+  has_many :disks, :through => :hardware
+  has_many :cloud_volumes, :through => :disks, :source => :backing, source_type: "CloudVolume"
+
   has_and_belongs_to_many :key_pairs, :join_table              => :key_pairs_vms,
                                       :foreign_key             => :vm_id,
                                       :association_foreign_key => :authentication_id,

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -57,6 +57,7 @@ class VmOrTemplate < ApplicationRecord
 
   has_one                   :operating_system, :dependent => :destroy
   has_one                   :hardware, :dependent => :destroy
+  has_many                  :disks, :through => :hardware
   belongs_to                :host
   belongs_to                :ems_cluster
 


### PR DESCRIPTION
Define relation vm has_many cloud_volumes and vice versa, replacing old methods that were using several SQL queries to get this relation