### PR TITLE
Dialog#dialog_fields - skip nils

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -32,7 +32,7 @@ class Dialog < ApplicationRecord
   end
 
   def dialog_fields
-    dialog_tabs.collect(&:dialog_fields).flatten!
+    dialog_tabs.collect(&:dialog_fields).compact.flatten!
   end
 
   def field_name_exist?(name)


### PR DESCRIPTION
This causes dialog_fields to not return nils when a dialog tab has no fields.

Previously, if `dialog_tabs[*].dialog_fields` returned nil, #content would fail with
`NoMethodError: undefined method 'values' for nil:NilClass`.

Closes #8144 

@abellotti mind reviewing please? (Because [283aeb21](https://github.com/ManageIQ/manageiq/commit/283aeb214e16e55fd1fa2db937d942c9144c762a#diff-ab119f9583edfc24f96ecba56bc8b0e5R99).)