### PR TITLE
NetworkManager make certain relations distinct

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/azure/network_manager/security_group.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::Azure::NetworkManager::SecurityGroup < ::SecurityGroup
-  has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
+  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 end

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -9,14 +9,14 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   belongs_to :cloud_tenant
 
   has_many :network_ports, :as => :device
-  has_many :cloud_subnets, :through => :network_ports
-  has_many :cloud_networks, :through => :cloud_subnets
-  has_many :network_routers, :through => :cloud_subnets
+  has_many :cloud_subnets, -> { distinct }, :through => :network_ports
+  has_many :cloud_networks, -> { distinct }, :through => :cloud_subnets
+  has_many :network_routers, -> { distinct }, :through => :cloud_subnets
   # Keeping floating_ip for backwards compatibility. Keeping association through vm_id foreign key, because of Amazon
   # ec2, it allows to associate floating ips without network ports
   has_one  :floating_ip, :foreign_key => :vm_id
   has_many :floating_ips
-  has_many :security_groups, :through => :network_ports
+  has_many :security_groups, -> { distinct }, :through => :network_ports
   has_many :cloud_volumes, :through => :disks, :source => :backing, :source_type => "CloudVolume"
 
   has_and_belongs_to_many :key_pairs, :join_table              => :key_pairs_vms,

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
@@ -3,6 +3,6 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private < Ma
 
   has_many :cloud_subnets, :class_name  => "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet",
                            :foreign_key => :cloud_network_id
-  has_many :network_routers, :through => :cloud_subnets
-  has_many :public_networks, :through => :cloud_subnets
+  has_many :network_routers, -> { distinct }, :through => :cloud_subnets
+  has_many :public_networks, -> { distinct }, :through => :cloud_subnets
 end

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network/public.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network/public.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
-  has_many :vms, :through => :network_routers
+  has_many :vms, -> { distinct }, :through => :network_routers
   has_many :network_routers, :foreign_key => :cloud_network_id
-  has_many :private_networks, :through => :network_routers, :source => :cloud_networks
+  has_many :private_networks, -> { distinct }, :through => :network_routers, :source => :cloud_networks
 end

--- a/app/models/manageiq/providers/openstack/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/security_group.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::SecurityGroup
-  has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
+  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 end

--- a/app/models/mixins/cloud_network_private_mixin.rb
+++ b/app/models/mixins/cloud_network_private_mixin.rb
@@ -3,7 +3,7 @@ module CloudNetworkPrivateMixin
 
   included do
     has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
-    has_many :network_routers, :through => :cloud_subnets
-    has_many :public_networks, :through => :cloud_subnets
+    has_many :network_routers, -> { distinct }, :through => :cloud_subnets
+    has_many :public_networks, -> { distinct }, :through => :cloud_subnets
   end
 end

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -18,7 +18,7 @@ class NetworkPort < ApplicationRecord
   has_many :floating_ips
   has_many :cloud_subnet_network_ports
   has_many :cloud_subnets, :through => :cloud_subnet_network_ports
-  has_many :network_routers, :through => :cloud_subnets
+  has_many :network_routers, -> { distinct }, :through => :cloud_subnets
 
   # Use for virtual columns, mainly for modeling array and hash types, we get from the API
   serialize :extra_attributes

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/network_manager/security_group.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/network_manager/security_group.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup < ::SecurityGroup
-  has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
+  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 end


### PR DESCRIPTION
We need a certain relations to be distinct, since the result could
repeat there, then the relation in UI shows different number
than there is a number of the table items, when we click on the
relation.

Example vm can have many subnets connected to the same router,
then vm.network_routers has to show 1 router.