### PR TITLE
Differentiate between a stopped VM and a suspended VM for Azure

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -85,6 +85,12 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
+  def vm_suspend(vm, _options = {})
+    vm.suspend
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
   def vm_destroy(vm, _options = {})
     vm.vm_destroy
   rescue => err

--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -51,7 +51,9 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
     case raw_power_state.downcase
     when /running/, /starting/
       "on"
-    when /stopped/, /stopping/, /dealloc/
+    when /stopped/, /stopping/
+      "suspended"
+    when /dealloc/
       "off"
     else
       "unknown"

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -1,6 +1,7 @@
 module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
-  def validate_suspend
-    validate_unsupported(_("Suspend Operation"))
+  def raw_suspend
+    provider_service.stop(name, resource_group)
+    update_attributes!(:raw_power_state => "VM stopping")
   end
 
   def validate_pause
@@ -13,8 +14,8 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
   end
 
   def raw_stop
-    provider_service.stop(name, resource_group)
-    update_attributes!(:raw_power_state => "VM stopping")
+    provider_service.deallocate(name, resource_group)
+    update_attributes!(:raw_power_state => "VM deallocating")
   end
 
   def raw_restart

--- a/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Vm do
     let(:vm) { FactoryGirl.create(:vm_azure, :ext_management_system => ems, :host => host) }
 
     let(:power_state_on)  { "VM running" }
-    let(:power_state_off) { "VM stopped" }
+    let(:power_state_off) { "VM deallocated" }
     let(:power_state_suspended) { "VM stopping" }
 
     it "defines a resource_group method that returns the expected value based on uid_ems" do


### PR DESCRIPTION
This updates the power state support for Azure. It addresses this BZ:

https://bugzilla.redhat.com/show_bug.cgi?id=1316280

At the moment, the "stop" operation within the UI sends a power off message. This basically suspends the VM, but does not deallocate it. This is potentially confusing for people who are used to the new Azure portal, where the stop button actually deallocates the VM. One of the main differences between a VM that is suspended versus one that is deallocated is that the former still incurs billing charges, while the latter does not. For more information about the differences you can read:

https://blogs.technet.microsoft.com/uspartner_ts2team/2014/10/10/azure-virtual-machines-stopping-versus-stopping-deallocating/

So, long story short, this PR alters the "stop" operation to actually mimic the Azure portal and deallocates the VM, and also adds a "suspend" operation that just sends a poweroff request, and this will be reflected in the UI as well.
