### PR TITLE
Print error if user did not complete filtering section in container project chargeback

### DIFF
--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -241,7 +241,7 @@ module ReportController::Reports
       end
     end
 
-    if @edit[:new][:model] == "Chargeback"
+    if @edit[:new][:model].to_s.starts_with?("Chargeback")
       unless @edit[:new][:cb_show_typ]
         add_flash(_("Show Costs by must be selected"), :error)
         active_tab = "edit_3"
@@ -263,6 +263,11 @@ module ReportController::Reports
               add_flash(_("A Tag must be selected"), :error)
               active_tab = "edit_3"
             end
+          end
+        elsif @edit[:new][:cb_show_typ] == "entity"
+          unless @edit[:new][:cb_entity_id]
+            add_flash(_("A specific #{ui_lookup(:model => @edit[:new][:cb_model])} or all must be selected"), :error)
+            active_tab = "edit_3"
           end
         end
       end
@@ -316,6 +321,7 @@ module ReportController::Reports
                  when "owner" then @edit[:new][:cb_owner_id]
                  when "tenant" then @edit[:new][:cb_tenant_id]
                  when "tag" then @edit[:new][:cb_tag_cat] && @edit[:new][:cb_tag_value]
+                 when "entity" then @edit[:new][:cb_entity_id]
                  end
     end
     is_valid

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -72,9 +72,9 @@
       - elsif @edit[:new][:cb_show_typ] == "entity"
         .form-group
           %label.control-label.col-md-2
-            = _(@edit[:new][:cb_model].to_s)
+            = ui_lookup(:model => @edit[:new][:cb_model])
           .col-md-8
-            - opts = [["<#{_('Choose %{entity}')}>" % {:entity => ui_lookup(:table => @edit[:new][:cb_model].to_s)}, nil], [_("All #{ui_lookup(:tables => @edit[:new][:cb_model].to_s)}"), :all]]
+            - opts = [["<#{_('Choose %{entity}')}>" % {:entity => ui_lookup(:model => @edit[:new][:cb_model])}, nil], [_("All #{ui_lookup(:tables => @edit[:new][:cb_model].to_s)}"), :all]]
             - opts += Array(@edit[:cb_all_entities_of_type][@edit[:new][:cb_model].to_sym].invert).sort_by { |a| a.first.downcase } if @edit[:cb_all_entities_of_type][@edit[:new][:cb_model].to_sym].present?
             = select_tag('cb_entity_id',
               options_for_select(opts, @edit[:new][:cb_entity_id]),

--- a/spec/controllers/miq_report_controller/reports_spec.rb
+++ b/spec/controllers/miq_report_controller/reports_spec.rb
@@ -77,4 +77,21 @@ describe ReportController, "::Reports" do
     #   FactoryGirl.create(:miq_widget, :resource => report)
     # end
   end
+
+  describe "#verify is_valid? flash messages" do
+    it "show flash message when show cost by entity is selected but no entity_id chosen" do
+      model = "ChargebackContainerProject"
+      controller.instance_variable_set(:@edit, :new => {:model       => model,
+                                                        :fields      => [["Date Created"]],
+                                                        :cb_show_typ => "entity",
+                                                        :cb_model    => "ContainerProject"})
+      controller.instance_variable_set(:@sb, {})
+      rpt = FactoryGirl.create(:miq_report_chargeback)
+      controller.send(:valid_report?, rpt)
+      flash_messages = assigns(:flash_array)
+      flash_str = "A specific Project or all must be selected"
+      expect(flash_messages.first[:message]).to eq(flash_str)
+      expect(flash_messages.first[:level]).to eq(:error)
+    end
+  end
 end

--- a/spec/factories/miq_report.rb
+++ b/spec/factories/miq_report.rb
@@ -23,4 +23,14 @@ FactoryGirl.define do
   factory :miq_report_with_results, :parent => :miq_report do
     miq_report_results { [FactoryGirl.create(:miq_report_result)] }
   end
+
+  factory :miq_report_chargeback, :parent => :miq_report do
+    sequence(:name) { |n| "Test Report #{seq_padded_for_sorting(n)}" }
+    db              'ChargebackVm'
+    title           'some title'
+    rpt_type        'Default'
+    template_type   'report'
+    rpt_group       'Custom'
+    association     :miq_group
+  end
 end


### PR DESCRIPTION
This will prevent users from adding incomplete-broken chargeback reports

![screencapture-localhost-3000-report-explorer-1461251372764](https://cloud.githubusercontent.com/assets/11256940/14714122/727192d0-07ec-11e6-91f1-e70bdfc61ab5.png)


@h-kataria @dclarizio Please review
cc @simon3z @amaurygonzalez 

@miq-bot add_label chargeback, ui