### PR TITLE
Empty VM annotation doesn't clear VM/Container/Notes field

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -843,7 +843,7 @@ module ManageIQ::Providers
           result[:cpu_sockets]          = result[:cpu_total_cores] / result[:cpu_cores_per_socket]
         end
 
-        result[:annotation] = inv["annotation"] unless inv["annotation"].blank?
+        result[:annotation] = inv["annotation"].present? ? inv["annotation"] : nil
         result[:memory_mb] = inv["memorySizeMB"] unless inv["memorySizeMB"].blank?
         result[:virtual_hw_version] = config['version'].to_s.split('-').last if config && config['version']
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
@@ -24,5 +24,19 @@ describe ManageIQ::Providers::Vmware::InfraManager::RefreshParser do
         expect(result[:cpu_total_cores]).to      eq(total)
       end
     end
+
+    context "properly set annotation field" do
+      let(:inv) do
+        {"summary" => {"config" => {"name" => "a"}},
+         "config"  => {"annotation" => {}}}
+      end
+
+      it "with empty annotation" do
+        result = described_class.vm_inv_to_hardware_hash(inv)
+
+        expect(result.keys).to include(:annotation)
+        expect(result[:annotation]).to be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
When you clear the VM Notes field of a VM instead of setting hardware[:annotation] to nil we leave it unset so it the value in the database isn't cleared out.

To fix this set the hardware[:annotation] field to nil explicitly if the config.annotation property is blank.

https://bugzilla.redhat.com/show_bug.cgi?id=1326866