### PR TITLE
Expect an array due to API change

### DIFF
--- a/gems/pending/MiqVm/MiqVm.rb
+++ b/gems/pending/MiqVm/MiqVm.rb
@@ -42,7 +42,7 @@ class MiqVm
     elsif (@rhevm = @ost.miqRhevm)
       $log.debug "MiqVm::initialize: accessing VM through RHEVM server" if $log.debug?
       $log.debug "MiqVm::initialize: vmCfg = #{vmCfg}"
-      @rhevmVm = @rhevm.get_vm(vmCfg)
+      @rhevmVm = @rhevm.get_vm(vmCfg)[0]
       $log.debug "MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}" if $log.debug?
       @ost.miqRhevmVm = @rhevmVm
       @vmConfig = VmConfig.new(getCfg(@ost.snapId))


### PR DESCRIPTION
In [1] of ovirt gem, the returned value of
service.get_resource_by_ems_ref is changed from an object to
an array. Fetching a VM from rhevm should be adjusted by SSA
to expect an array and to extract the vm out of it.

[1] https://github.com/ManageIQ/ovirt/commit/7ddcf4e07fe30383ce7f2ea6ef3adc4b0bbe0a86#diff-9be2dde14cfe2ea852f52a1c2bc13398L105