### PR TITLE
Support GlusterFS in SSA

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -286,7 +286,7 @@ class JobProxyDispatcher
         queue_signal(job, {:args => [:abort, msg, "error"]})
         return []
       else
-        unless %w(VSAN VMFS NAS NFS ISCSI DIR FCP CSVFS NTFS).include?(@vm.storage.store_type)
+        unless %w(VSAN VMFS NAS NFS ISCSI DIR FCP CSVFS NTFS GLUSTERFS).include?(@vm.storage.store_type)
           msg = "Vm storage type [#{@vm.storage.store_type}] unsupported [#{job.target_id}], aborting job [#{job.guid}]."
           queue_signal(job, {:args => [:abort, msg, "error"]})
           return []

--- a/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -10,6 +10,7 @@ require 'util/miq-uuid'
 class MiqGenericMountSession
   require 'util/mount/miq_nfs_session'
   require 'util/mount/miq_smb_session'
+  require 'util/mount/miq_glusterfs_session'
 
   attr_accessor :settings, :mnt_point, :logger
 
@@ -63,6 +64,8 @@ class MiqGenericMountSession
       MiqSmbSession
     when 'nfs'
       MiqNfsSession
+    when 'glusterfs'
+      MiqGlusterfsSession
     else
       raise "unsupported scheme #{scheme} from uri: #{uri}"
     end

--- a/gems/pending/util/mount/miq_glusterfs_session.rb
+++ b/gems/pending/util/mount/miq_glusterfs_session.rb
@@ -1,0 +1,37 @@
+require 'util/mount/miq_generic_mount_session'
+
+class MiqGlusterfsSession < MiqGenericMountSession
+  PORTS = [2049, 111].freeze
+
+  def initialize(log_settings)
+    super(log_settings.merge(:ports => PORTS))
+  end
+
+  def connect
+    _scheme, _userinfo, @host, _port, _registry, @mount_path, _opaque, _query, _fragment =
+      URI.split(URI.encode(@settings[:uri]))
+    super
+  end
+
+  def mount_share
+    super
+
+    log_header = "MIQ(#{self.class.name}-mount_share)"
+    logger.info(
+      "#{log_header} Connecting to host: [#{@host}], share: [#{@mount_path}] using mount point: [#{@mnt_point}]...")
+
+    mount = "mount"
+    mount << " -r" if settings_read_only?
+
+    # Quote the host:exported directory since the directory can have spaces in it
+    case Sys::Platform::IMPL
+    when :macosx
+      runcmd("sudo #{mount} -t glusterfs -o resvport '#{@host}:#{@mount_path}' #{@mnt_point}")
+    when :linux
+      runcmd("#{mount} -t glusterfs '#{@host}:#{@mount_path}' #{@mnt_point}")
+    else
+      raise "platform not supported"
+    end
+    logger.info("#{log_header} Connecting to host: [#{@host}], share: [#{@mount_path}]...Complete")
+  end
+end


### PR DESCRIPTION
Performing SSA for VM with disks located on GlusterFS data stores is supported with the suggested patch. There should be a refactor work to for the Miq[*]MountSession and for MiqRhevmVm, either for a strategy or other method to avoid the case-when statements by the storage type.

**NOTE:** This PR depends on https://github.com/ManageIQ/manageiq-appliance-build/pull/123
When porting to Darga, ensure that PR is ported before this one is.

