### PR TITLE
Reset column information after `includes` in migration

### DIFF
--- a/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
+++ b/db/migrate/20160317194215_remove_miq_user_role_from_miq_groups.rb
@@ -23,5 +23,6 @@ class RemoveMiqUserRoleFromMiqGroups < ActiveRecord::Migration[5.0]
       group.miq_user_role_id = group.entitlement.miq_user_role_id
       group.save!
     end
+    MiqGroup.reset_column_information
   end
 end


### PR DESCRIPTION
The `includes` here does not use the stubbed model in this file. The
filters column gets loaded into the cache and the next time our virtual
columns poke at it, it explodes due to being removed later.

r? @jrafanie