### PR TITLE
Handle lack of diskSizeGB property in Azure for inventory collection

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -247,7 +247,7 @@ module ManageIQ::Providers
       def populate_hardware_hash_with_disks(hardware_disks_array, instance)
         data_disks = instance.properties.storage_profile.data_disks
         data_disks.each do |disk|
-          disk_size      = disk.disk_size_gb * 1.gigabyte
+          disk_size      = disk.respond_to?(:disk_size_gb) ? disk.disk_size_gb * 1.gigabyte : 0
           disk_name      = disk.name
           disk_location  = disk.vhd.uri
 


### PR DESCRIPTION
It's apparently possible to attach a data disk that doesn't actually have a size set yet. This causes the refresher to blow up when attempting to get the disk_size_gb property on the Disk object.

This fix just checks for the property and, if not found, sets it to 0.