### PR TITLE
removed not used parameter input from calls to Condition.subst in miq_expression_spec and in condition_spec

### DIFF
--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -20,42 +20,42 @@ describe Condition do
 
       it "valid expression" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to be_truthy
+        expect(Condition.subst(expr, @cluster)).to be_truthy
       end
 
       it "has_one support" do
         expr = "<find><search><value ref=vm, type=string>/virtual/host/name</value> == 'XXX'</search><check mode=count><count> == 1</check></find>"
-        expect(Condition.subst(expr, @vm1, nil)).to be_truthy
+        expect(Condition.subst(expr, @vm1)).to be_truthy
       end
 
       it "invalid expression should not raise security error because it is now parsed and not evaluated" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2; system('ls /etc')</check></find>"
-        expect { Condition.subst(expr, @cluster, nil) }.not_to raise_error
+        expect { Condition.subst(expr, @cluster) }.not_to raise_error
       end
 
       it "tests all allowed operators in find/check expression clause" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> == 0</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to eq('false')
+        expect(Condition.subst(expr, @cluster)).to eq('false')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> > 0</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to eq('true')
+        expect(Condition.subst(expr, @cluster)).to eq('true')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 0</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to eq('true')
+        expect(Condition.subst(expr, @cluster)).to eq('true')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'true'</search><check mode=count><count> < 0</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to eq('false')
+        expect(Condition.subst(expr, @cluster)).to eq('false')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> <= 0</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to eq('false')
+        expect(Condition.subst(expr, @cluster)).to eq('false')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> != 0</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to eq('true')
+        expect(Condition.subst(expr, @cluster)).to eq('true')
       end
 
       it "rejects and expression with an illegal operator" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> !! 0</check></find>"
-        expect { expect(Condition.subst(expr, @cluster, nil)).to eq('false') }.to raise_error(RuntimeError, "Illegal operator, '!!'")
+        expect { expect(Condition.subst(expr, @cluster)).to eq('false') }.to raise_error(RuntimeError, "Illegal operator, '!!'")
       end
     end
 
@@ -68,12 +68,12 @@ describe Condition do
 
       it "string type registry key data is single quoted" do
         expr = "<registry>#{@reg_string.name}</registry>"
-        expect(Condition.subst(expr, @vm, nil)).to eq('"y"')
+        expect(Condition.subst(expr, @vm)).to eq('"y"')
       end
 
       it "numerical type registry key data is single quoted" do
         expr = "<registry>#{@reg_num.name}</registry>"
-        expect(Condition.subst(expr, @vm, nil)).to eq('"0"')
+        expect(Condition.subst(expr, @vm)).to eq('"0"')
       end
     end
   end

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -542,7 +542,7 @@ describe MiqExpression do
         expect(filter.to_ruby).to eq("<value ref=vm, type=text>/virtual/registry_items/data</value> =~ /\\$foo/")
 
         data = {"registry_items.data" => "C:\\Documents and Users\\O'Neill, April\\", "/virtual/registry_items/data" => "C:\\Documents and Users\\O'Neill, April\\"}
-        expect(Condition.subst(filter.to_ruby, data, {})).to eq("\"C:\\\\Documents and Users\\\\O'Neill, April\\\\\" =~ /\\$foo/")
+        expect(Condition.subst(filter.to_ruby, data)).to eq("\"C:\\\\Documents and Users\\\\O'Neill, April\\\\\" =~ /\\$foo/")
       end
 
       it "should test context hash" do
@@ -556,7 +556,7 @@ describe MiqExpression do
         context_type: hash
         '
         expect(filter.to_ruby).to eq("<value type=string>guest_applications.name</value> == \"VMware Tools\"")
-        expect(Condition.subst(filter.to_ruby, data, {})).to eq("\"VMware Tools\" == \"VMware Tools\"")
+        expect(Condition.subst(filter.to_ruby, data)).to eq("\"VMware Tools\" == \"VMware Tools\"")
 
         filter = YAML.load '--- !ruby/object:MiqExpression
         exp:
@@ -566,7 +566,7 @@ describe MiqExpression do
         context_type: hash
         '
         expect(filter.to_ruby).to eq("<value type=string>guest_applications.vendor</value> =~ /^[^.]*ware.*$/")
-        expect(Condition.subst(filter.to_ruby, data, {})).to eq('"VMware, Inc." =~ /^[^.]*ware.*$/')
+        expect(Condition.subst(filter.to_ruby, data)).to eq('"VMware, Inc." =~ /^[^.]*ware.*$/')
       end
     end
 


### PR DESCRIPTION
Refactoring MiqExpression - #7751

Currently calls to Condition.subst passing nil( or {}) ) as last parameter.
However this parameter is not used in implementation of Condition.subst - #7788

Next step would be removing not used parameter from callers of Condition.subst and from method signature

/cc @gtanzillo @Fryguy  
@miq-bot add-label test, core