### PR TITLE
removed MiqExpression.subst - not needed proxy  for calling Condition.subst

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1021,7 +1021,7 @@ class MiqExpression
   def self.evaluate(expression, obj, inputs = {}, tz = nil)
     ruby_exp = expression.kind_of?(Hash) ? new(expression).to_ruby(tz) : expression.to_ruby(tz)
     _log.debug("Expression before substitution: #{ruby_exp}")
-    subst_expr = subst(ruby_exp, obj, inputs)
+    subst_expr = Condition.subst(ruby_exp, obj, inputs)
     _log.debug("Expression after substitution: #{subst_expr}")
     result = eval(subst_expr) ? true : false
     _log.debug("Expression evaluation result: [#{result}]")
@@ -1049,10 +1049,6 @@ class MiqExpression
       end
     end
     exp
-  end
-
-  def self.subst(ruby_exp, obj, inputs)
-    Condition.subst(ruby_exp, obj, inputs)
   end
 
   def self.operands2humanvalue(ops, options = {})


### PR DESCRIPTION
Refactoring MiqExpression - #7751

MiqExpression,subst implementation is just call to Condition.subst 
Removed method MiqExpression.subst and in single place where it used replaced by direct call to Condition.subst 

/cc @gtanzillo @imtayadeway 
@miq-bot add-label core, refactoring
