### PR TITLE
Add option to turn off calling Rbac in MiqRequestWorkflow.

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -550,8 +550,7 @@ module ApplicationController::MiqRequestMethods
 
   def validate_fields # This doesn't run validations, it creates flash messages for errors found in MiqRequestWorkflow#validate
     @edit[:wf].get_dialog_order.each do |d|
-      @edit[:wf].get_all_fields(d).keys.each do |f|
-        field = @edit[:wf].get_field(f, d)
+      @edit[:wf].get_all_fields(d, false).each do |f, field|
         unless field[:error].blank?
           @error_div ||= "#{d}"
           add_flash(field[:error], :error)
@@ -562,8 +561,7 @@ module ApplicationController::MiqRequestMethods
 
   def validate_preprov
     @edit[:wf].get_dialog_order.each do |d|
-      @edit[:wf].get_all_fields(d).keys.each do |f|
-        field = @edit[:wf].get_field(f, d)
+      @edit[:wf].get_all_fields(d, false).each do |f, field|
         @edit[:wf].validate(@edit[:new])
         unless field[:error].nil?
           @error_div ||= "#{d}"

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -550,7 +550,7 @@ module ApplicationController::MiqRequestMethods
 
   def validate_fields # This doesn't run validations, it creates flash messages for errors found in MiqRequestWorkflow#validate
     @edit[:wf].get_dialog_order.each do |d|
-      @edit[:wf].get_all_fields(d, false).each do |f, field|
+      @edit[:wf].get_all_fields(d, false).each do |_f, field|
         unless field[:error].blank?
           @error_div ||= "#{d}"
           add_flash(field[:error], :error)
@@ -561,7 +561,7 @@ module ApplicationController::MiqRequestMethods
 
   def validate_preprov
     @edit[:wf].get_dialog_order.each do |d|
-      @edit[:wf].get_all_fields(d, false).each do |f, field|
+      @edit[:wf].get_all_fields(d, false).each do |_f, field|
         @edit[:wf].validate(@edit[:new])
         unless field[:error].nil?
           @error_div ||= "#{d}"

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -291,8 +291,7 @@ class MiqRequestController < ApplicationController
       @edit[:wf].init_from_dialog(@edit[:new])    # Create a new provision workflow for this edit session
       @edit[:buttons] = @edit[:wf].get_buttons
       @edit[:wf].get_dialog_order.each do |d|                           # Go thru all dialogs, in order that they are displayed
-        @edit[:wf].get_all_fields(d).keys.each do |f|                 # Go thru all field
-          field = @edit[:wf].get_field(f, d)
+        @edit[:wf].get_all_fields(d).each do |f, field|                 # Go thru all field
           unless field[:error].blank?
             @error_div ||= "#{d}_div"
             add_flash(field[:error], :error)

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -291,7 +291,7 @@ class MiqRequestController < ApplicationController
       @edit[:wf].init_from_dialog(@edit[:new])    # Create a new provision workflow for this edit session
       @edit[:buttons] = @edit[:wf].get_buttons
       @edit[:wf].get_dialog_order.each do |d|                           # Go thru all dialogs, in order that they are displayed
-        @edit[:wf].get_all_fields(d).each do |f, field|                 # Go thru all field
+        @edit[:wf].get_all_fields(d).each do |_f, field|                # Go thru all field
           unless field[:error].blank?
             @error_div ||= "#{d}_div"
             add_flash(field[:error], :error)

--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -243,9 +243,9 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
     values[:ws_ems_custom_attributes] = p.ws_values(options.ems_custom_attributes, :parse_ws_string, :modify_key_name => false)
     values[:ws_miq_custom_attributes] = p.ws_values(options.miq_custom_attributes, :parse_ws_string, :modify_key_name => false)
 
-    p.validate_values(values)
-
-    p.create_request(values, nil, values[:auto_approve])
+    p.create_request(values, nil, values[:auto_approve]).tap do |request|
+      p.raise_validate_errors if request == false
+    end
   rescue => err
     _log.error "<#{err}>"
     raise err

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -1133,9 +1133,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     values[:ws_ems_custom_attributes] = p.ws_values(options.ems_custom_attributes, :parse_ws_string, :modify_key_name => false)
     values[:ws_miq_custom_attributes] = p.ws_values(options.miq_custom_attributes, :parse_ws_string, :modify_key_name => false)
 
-    p.validate_values(values)
-
-    p.create_request(values, nil, values[:auto_approve])
+    p.create_request(values, nil, values[:auto_approve]).tap do |request|
+      p.raise_validate_errors if request == false
+    end
   rescue => err
     _log.error "<#{err}>"
     raise err

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -994,11 +994,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
   def ws_environment_fields(values, data)
     # do not parse environment data unless :placement_auto is false
-    if data[:placement_auto].to_s != "false"
-      values[:placement_auto] = [true, 1]
-      return
-    end
+    return unless data[:placement_auto].to_s == "false"
 
+    values[:placement_auto] = [false, 0]
     return if (dlg_fields = get_ws_dialog_fields(dialog_name = :environment)).nil?
 
     data.keys.each { |key| set_ws_field_value(values, key, data, dialog_name, dlg_fields) if dlg_fields.key?(key) }
@@ -1119,6 +1117,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     raise _("Source template [%{name}] was not found") % {:name => src_name} if src.nil?
     # Allow new workflow class to determine dialog name instead of using the stored value from the first call.
     values.delete(:miq_request_dialog_name)
+    values[:placement_auto] = [true, 1]
     p = class_for_source(src.id).new(values, user, init_options)
 
     # Populate required fields

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -284,34 +284,34 @@ class MiqRequestWorkflow
     tab_list
   end
 
-  def get_all_dialogs
-    @dialogs[:dialogs].each_key { |d| get_dialog(d) }
+  def get_all_dialogs(refresh_values = true)
+    @dialogs[:dialogs].each_key { |d| get_dialog(d, refresh_values) }
     @dialogs[:dialogs]
   end
 
-  def get_dialog(dialog_name)
+  def get_dialog(dialog_name, refresh_values = true)
     dialog = @dialogs.fetch_path(:dialogs, dialog_name.to_sym)
     return {} unless dialog
 
-    get_all_fields(dialog_name)
+    get_all_fields(dialog_name, refresh_values)
     dialog
   end
 
-  def get_all_fields(dialog_name)
+  def get_all_fields(dialog_name, refresh_values = true)
     dialog = @dialogs.fetch_path(:dialogs, dialog_name.to_sym)
     return {} unless dialog
 
-    dialog[:fields].each_key { |f| get_field(f, dialog_name) }
+    dialog[:fields].each_key { |f| get_field(f, dialog_name, refresh_values) }
     dialog[:fields]
   end
 
-  def get_field(field_name, dialog_name = nil)
+  def get_field(field_name, dialog_name = nil, refresh_values = true)
     field_name = field_name.to_sym
     dialog_name = find_dialog_from_field_name(field_name) if dialog_name.nil?
     field = @dialogs.fetch_path(:dialogs, dialog_name.to_sym, :fields, field_name)
     return {} unless field
 
-    if field.key?(:values_from)
+    if field.key?(:values_from) && refresh_values
       options = field[:values_from][:options] || {}
       options[:prov_field_name] = field_name
       field[:values] = send(field[:values_from][:method], options)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -181,11 +181,11 @@ class MiqRequestWorkflow
     # Update @dialogs adding error keys to fields that don't validate
     valid = true
 
-    get_all_dialogs.each do |d, dlg|
+    get_all_dialogs(false).each do |d, dlg|
       # Check if the entire dialog is ignored or disabled and check while processing the fields
       dialog_disabled = !dialog_active?(d, dlg, values)
 
-      get_all_fields(d).each do |f, fld|
+      get_all_fields(d, false).each do |f, fld|
         fld[:error] = nil
 
         # Check the disabled flag here so we reset the "error" value on each field

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1514,14 +1514,12 @@ class MiqRequestWorkflow
     data.keys.each { |key| set_ws_field_value(values, key, data, dialog_name, dlg_fields) if dlg_keys.include?(key) }
   end
 
-  def validate_values(values)
-    if validate(values) == false
-      errors = []
-      fields { |_fn, f, _dn, _d| errors << f[:error] unless f[:error].nil? }
-      err_text = "Provision failed for the following reasons:\n#{errors.join("\n")}"
-      _log.error "<#{err_text}>"
-      raise _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
-    end
+  def raise_validate_errors
+    errors = []
+    fields { |_fn, f, _dn, _d| errors << f[:error] unless f[:error].nil? }
+    err_text = "Provision failed for the following reasons:\n#{errors.join("\n")}"
+    _log.error "<#{err_text}>"
+    raise _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
   end
 
   private

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -60,6 +60,24 @@ describe MiqRequestWorkflow do
     end
   end
 
+  context "#get_field" do
+    let(:dialog) { workflow.instance_variable_get(:@dialogs) }
+    before do
+      values = {:values_from => {:method => :allowed_clusters}}
+      dialog.store_path(:dialogs, :environment, :fields, :placement_cluster_name, values)
+    end
+
+    it "refreshes value by default" do
+      expect(workflow).to receive(:allowed_clusters).once
+      workflow.get_field(:placement_cluster_name, :environment)
+    end
+
+    it "not refresh value when specified" do
+      expect(workflow).not_to receive(:allowed_clusters)
+      workflow.get_field(:placement_cluster_name, :environment, false)
+    end
+  end
+
   describe "#init_from_dialog" do
     let(:dialogs) { workflow.instance_variable_get(:@dialogs) }
     let(:init_values) { {} }


### PR DESCRIPTION
During validate_values and create_request, MiqReqestWorkflow does not need to call Rbac which may take a while to get back with result for a large DB.

https://bugzilla.redhat.com/show_bug.cgi?id=1318825