### PR TITLE
OpenStack make Keystone V3 domain ID configurable

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -36,6 +36,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       emstype_vm: false,
       ems_common: true,
       azure_tenant_id: '',
+      keystone_v3_domain_id: '',
       subscription: '',
       host_default_vnc_port_start: '',
       host_default_vnc_port_end: '',
@@ -105,6 +106,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
         $scope.emsCommonModel.service_account                 = data.service_account;
         $scope.emsCommonModel.azure_tenant_id                 = data.azure_tenant_id;
+        $scope.emsCommonModel.keystone_v3_domain_id           = data.keystone_v3_domain_id;
         $scope.emsCommonModel.subscription                    = data.subscription;
 
         $scope.emsCommonModel.host_default_vnc_port_start     = data.host_default_vnc_port_start;

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module EmsCloudHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(provider_region hostname ipaddress type port guid)
+    %i(provider_region hostname ipaddress type port guid keystone_v3_domain_id)
   end
 
   def textual_group_relationships
@@ -30,6 +30,12 @@ module EmsCloudHelper::TextualSummary
     return nil if @ems.provider_region.nil?
     label_val = (@ems.type.include? "Google") ? _("Preferred Region") : _("Region")
     {:label => label_val, :value => @ems.description}
+  end
+
+  def textual_keystone_v3_domain_id
+    return nil if !@ems.respond_to?(:keystone_v3_domain_id) || @ems.keystone_v3_domain_id.nil?
+    label_val = _("Keystone V3 Domain ID")
+    {:label => label_val, :value => @ems.keystone_v3_domain_id}
   end
 
   def textual_hostname

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -1,6 +1,7 @@
 module ManageIQ::Providers::Openstack::ManagerMixin
   extend ActiveSupport::Concern
 
+  alias_attribute :keystone_v3_domain_id, :uid_ems
   #
   # OpenStack interactions
   #
@@ -38,6 +39,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
         :ssl_ca_path    => vmdb_config.fetch_path(:ssl, :ssl_ca_path),
         :ssl_cert_store => OpenSSL::X509::Store.new
       }
+      extra_options[:domain_id] = keystone_v3_domain_id
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -118,6 +118,17 @@
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")
 
+    .form-group{"ng-class" => "{'has-error': angularForm.keystone_v3_domain_id.$invalid}", "ng-if" => "emsCommonModel.api_version == 'v3' && (emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra')"}
+      %label.col-md-2.control-label{"for" => "textInput-markup"}
+        = _('Keystone V3 Domain ID')
+      .col-md-8
+        %input.form-control{"type"        => "text",
+                            "id"          => "textInput-markup",
+                            "name"        => "keystone_v3_domain_id",
+                            "ng-model"    => "emsCommonModel.keystone_v3_domain_id",
+                            "required"    => true,
+                            "checkchange" => ""}
+
     .form-group{"ng-class" => "{'has-error': angularForm.provider_id.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' && emsCommonModel.openstack_infra_providers_exist"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
         = _("Openstack Infra Provider")

--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -127,6 +127,10 @@ module OpenstackHandle
       @ssl_options
     end
 
+    def domain_id
+      @extra_options[:domain_id]
+    end
+
     def browser_url
       "http://#{address}/dashboard"
     end
@@ -135,8 +139,7 @@ module OpenstackHandle
       opts     = options.dup
       service  = (opts.delete(:service) || "Compute").to_s.camelize
       tenant   = opts.delete(:tenant_name)
-      # TODO(lsmola) figure out from where to take the project name and domain name
-      domain   = opts.delete(:domain_name) || 'admin_domain'
+      domain   = domain_id
 
       # Do not send auth_type to fog, it throws warning
       opts.delete(:auth_type)
@@ -151,7 +154,8 @@ module OpenstackHandle
         # For identity ,there is only domain scope, with project_name nil
         opts[:openstack_project_name] = @project_name = tenant
       end
-      opts[:openstack_domain_name]  = domain
+      
+      opts[:openstack_domain_id] = domain
 
       svc_cache = (@connection_cache[service] ||= {})
       svc_cache[tenant] ||= begin

--- a/gems/pending/openstack/openstack_handle/identity_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/identity_delegate.rb
@@ -23,7 +23,9 @@ module OpenstackHandle
     end
 
     def visible_tenants_v3
-      projects.all
+      # Huge inconsistency in Keystone v3, we actually need to provide domain_id both in token and query param, but only
+      # for keystone. This rule is defined in policy.json
+      projects.all(:domain_id => @os_handle.domain_id)
     end
 
     #

--- a/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
+++ b/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
@@ -55,7 +55,7 @@ describe OpenstackHandle::Handle do
                                            "Compute",
                                            {:openstack_tenant       => "admin",
                                             :openstack_project_name => "admin",
-                                            :openstack_domain_name  => "admin_domain",
+                                            :openstack_domain_id    => nil,
                                             :connection_options     => {:ssl_verify_peer => false}})
                                            .once do |_, _, address|
         expect(address).to eq(auth_url)
@@ -76,7 +76,7 @@ describe OpenstackHandle::Handle do
                                            "Compute",
                                            {:openstack_tenant       => "admin",
                                             :openstack_project_name => "admin",
-                                            :openstack_domain_name  => "admin_domain",
+                                            :openstack_domain_id    => nil,
                                             :connection_options     => {}})
                                            .once do |_, _, address|
         expect(address).to eq(auth_url)
@@ -97,7 +97,7 @@ describe OpenstackHandle::Handle do
                                            "Compute",
                                            {:openstack_tenant       => "admin",
                                             :openstack_project_name => "admin",
-                                            :openstack_domain_name  => "admin_domain",
+                                            :openstack_domain_id    => nil,
                                             :connection_options     => {:ssl_verify_peer => false}}) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
@@ -118,7 +118,7 @@ describe OpenstackHandle::Handle do
                                            "Compute",
                                            {:openstack_tenant       => "admin",
                                             :openstack_project_name => "admin",
-                                            :openstack_domain_name  => "admin_domain",
+                                            :openstack_domain_id    => nil,
                                             :connection_options     => {:ssl_verify_peer => true}}) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
@@ -137,7 +137,7 @@ describe OpenstackHandle::Handle do
 
       expected_options = {:openstack_tenant       => "admin",
                           :openstack_project_name => "admin",
-                          :openstack_domain_name  => "admin_domain",
+                          :openstack_domain_id    => nil,
                           :connection_options     => {:ssl_verify_peer => true,
                                                       :ssl_ca_file     => "file",
                                                       :ssl_ca_path     => "path",


### PR DESCRIPTION
OpenStack make Keystone V3 domain ID configurable

Fixes GH issue:
https://github.com/ManageIQ/manageiq/issues/7342

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1228542

![image](https://cloud.githubusercontent.com/assets/1737058/14742185/1d18080a-089b-11e6-9f33-d5d087a1482a.png)

![image](https://cloud.githubusercontent.com/assets/1737058/14742208/36158b0c-089b-11e6-8605-5edab5c2e2b1.png)
