### PR TITLE
Remove references to the never set pending_restart status

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -64,7 +64,6 @@ module MiqServer::WorkerManagement::Monitor
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)
       next unless w.is_stopped?
-      next if worker_get_monitor_status(w.pid) == :pending_restart
       _log.info("SQL Record for #{w.format_full_log_msg}, Status: [#{w.status}] is being deleted")
       processed_workers << w
       worker_delete(w.pid)

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -233,18 +233,6 @@ describe "MiqWorker Monitor" do
               MiqServer.monitor_class_names.each { |c| @miq_server.clean_worker_records(c) }
               expect(MiqWorker.count).to eq(0)
             end
-
-            context "but is waiting for restart" do
-              before(:each) do
-                allow(@miq_server).to receive(:worker_get_monitor_status).with(@worker1.pid).and_return(:pending_restart)
-              end
-
-              it "should not delete worker row after clean_worker_records" do
-                expect(MiqWorker.count).to eq(1)
-                MiqServer.monitor_class_names.each { |c| @miq_server.clean_worker_records(c) }
-                expect(MiqWorker.count).to eq(1)
-              end
-            end
           end
 
           context "because it aborted" do


### PR DESCRIPTION
Note:  This was found while researching some issues that @mkanoor was seeing with UI workers not exiting cleanly.  It doesn't solve his issue but gets in the way of following the code.  Also note, I was the one that failed to delete the pending_restart in the first place. 😢 

As of 250985c4b3ed pending_restart is never set, so don't look for it.

At some point before 250985c4b3ed, we would deal with stopping/killing a worker
and then immediately start a new one.  The pending_restart status was used in
that stop/start worker workflow.

We changed this behavior so that the stop/kill logic only handles stopping/killing
the worker and we let sync_workers deal with starting any desired workers.

@chessbyte @Fryguy @gtanzillo Could one of you please review?  🙇 