### PR TITLE
Mark an exited worker as aborted

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -431,17 +431,17 @@ class MiqWorker < ApplicationRecord
   def status_update
     begin
       pinfo = MiqProcess.processInfo(pid)
+    rescue Errno::ESRCH
+      update(:status => STATUS_ABORTED)
+      _log.warn("No such process [#{friendly_name}] with PID=[#{pid}], aborting worker.")
     rescue => err
-      # Calling ps on Linux with a pid that does not exist fails with a RuntimeError containing an empty message.
-      # We will ignore this since we may be asking for the status of a worker who has exited.
-      _log.warn("#{self.class.name}: #{err.message}, while requesting process info for [#{friendly_name}] with PID=[#{pid}]") unless err.message.blank?
-      return
+      _log.warn("Unexpected error: #{err.message}, while requesting process info for [#{friendly_name}] with PID=[#{pid}]")
+    else
+      # Ensure the hash only contains the values we want to store in the table
+      pinfo.keep_if { |k, _v| self.class::PROCESS_INFO_FIELDS.include?(k) }
+      pinfo[:os_priority] = pinfo.delete(:priority)
+      update_attributes!(pinfo)
     end
-
-    # Ensure the hash only contains the values we want to store in the table
-    pinfo.keep_if { |k, _v| self.class::PROCESS_INFO_FIELDS.include?(k) }
-    pinfo[:os_priority] = pinfo.delete(:priority)
-    update_attributes!(pinfo)
   end
 
   def log_status(level = :info)

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -438,7 +438,7 @@ class MiqWorker < ApplicationRecord
       _log.warn("Unexpected error: #{err.message}, while requesting process info for [#{friendly_name}] with PID=[#{pid}]")
     else
       # Ensure the hash only contains the values we want to store in the table
-      pinfo.keep_if { |k, _v| self.class::PROCESS_INFO_FIELDS.include?(k) }
+      pinfo.slice!(*PROCESS_INFO_FIELDS)
       pinfo[:os_priority] = pinfo.delete(:priority)
       update_attributes!(pinfo)
     end

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -341,6 +341,19 @@ describe MiqWorker do
         require 'miq-process'
       end
 
+      it "no such process" do
+        allow(MiqProcess).to receive(:processInfo).with(123).and_raise(Errno::ESRCH)
+        described_class.status_update
+        @worker.reload
+        expect(@worker.status).to eq MiqWorker::STATUS_ABORTED
+      end
+
+      it "a StandardError" do
+        allow(MiqProcess).to receive(:processInfo).with(123).and_raise(StandardError.new("LOLRUBY"))
+        expect($log).to receive(:warn).with(/LOLRUBY/)
+        described_class.status_update
+      end
+
       it "updates expected values" do
         values = {
           :pid                   => 123,


### PR DESCRIPTION
We launch UI/Web Service/Web Socket workers using puma.
Puma has it's own signal handlers, so if a puma based worker gets a SIGINT/etc,
puma will handle it and exit cleanly without running our normal worker signal
handling, which cleans up the worker row to say it's exited cleanly.

Before this change, we'd wait for the exited process' worker row heartbeat timeout
to be reached before we marked it as not responding and eventually restart a
replacement.

Since we check the worker's status each iteration of monitor_workers, marking the
worker as aborted based on a Errno:ESRCH (No Such Process) exception greatly
speeds up the process of starting a replacement worker.

Note: processInfo should raise Errno::ESRCH for "No such process"

The handling of a RuntimeError with an empty message for ps on a missing process
was added in def8f129976f11c22 back in 2008.  That was probably on ruby 1.8.x
on ubuntu.  This should not happen in 2016 with ruby 2.2+ / CentOS 7+ / Fedora /
OSX.  We'll treat any StandardError exceptions as unexpected, catch and log them
but not abort the worker.

@Fryguy @gtanzillo Please review, the middle commit is the primary one.  Reviewing commit by commit is much easier to follow.  The first and third commit is related code cleanup.

cc @mkanoor @abellotti @skateman @imtayadeway (in case you have seen this behavior locally)

@mkanoor I saw this while digging into the worker issue you're seeing where puma workers are sticking around (not exiting cleanly)... it's not the issue but certainly a bug.