### PR TITLE
Improve the query that determines the tables in a replication set

### DIFF
--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -254,7 +254,13 @@ class PgLogicalRaw
   # @param set_name [String] replication set name
   # @return [Array<String>] names of the tables in the given set
   def tables_in_replication_set(set_name)
-    typed_exec("SELECT relname FROM pglogical.tables WHERE set_name = $1", set_name).values.flatten
+    typed_exec(<<-SQL, set_name).values.flatten
+      SELECT set_reloid
+      FROM pglogical.replication_set_table
+      JOIN pglogical.replication_set
+        USING (set_id)
+      WHERE set_name = $1
+    SQL
   end
 
   private


### PR DESCRIPTION
Previously this query was passing tests, but did not work properly on an appliance. Before this change MiqPglogical#included_tables would always return an empty array on an appliance.

@gtanzillo 