### PR TITLE
Fix toplevel constant warning in Azure refresh spec

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -147,7 +147,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
   def assert_specific_security_group
     name = 'miq-test-rhel1'
-    @sg = ManageIQ::Providers::Azure::CloudManager::SecurityGroup.where(:name => name).first
+    @sg = SecurityGroup.where(:name => name).first
 
     expect(@sg).to have_attributes(
       :name        => name,


### PR DESCRIPTION
@djberg96 @blomquisg @bronaghs Please review.

This fixes the following warning that appears in the refresh spec:

```text
/Users/jfrey/dev/manageiq/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb:150:
warning: toplevel constant SecurityGroup referenced by ManageIQ::Providers::Azure::CloudManager::SecurityGroup
```

