### PR TITLE
Decrease old sql heartbeat frequency to detect parent server exits faster

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -448,9 +448,9 @@ class MiqWorker::Runner
   end
 
   def ruby_object_usage
-    types = Hash.new { |h, k| h[k] = Hash.new(0) }
+    types = Hash.new { |h, k| h[k] = 0 }
     ObjectSpace.each_object do |obj|
-      types[obj.class][:count] += 1
+      types[obj.class.name] += 1
     end
     types
   end
@@ -464,7 +464,7 @@ class MiqWorker::Runner
 
     if (@last_ruby_object_usage + LOG_RUBY_OBJECT_USAGE_INTERVAL) < t
       types = ruby_object_usage
-      $log.info("Ruby Object Usage: #{types.sort_by { |_klass, h| h[:count] }.reverse[0, top].inspect}")
+      _log.info("Ruby Object Usage: #{types.sort_by { |_k, v| -v }.take(top).inspect}")
       @last_ruby_object_usage = t
     end
   end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -451,14 +451,6 @@ class MiqWorker::Runner
     types = Hash.new { |h, k| h[k] = Hash.new(0) }
     ObjectSpace.each_object do |obj|
       types[obj.class][:count] += 1
-      next if obj.kind_of?(DRbObject) || obj.kind_of?(WeakRef)
-      if obj.respond_to?(:length)
-        len = obj.length
-        if len.kind_of?(Numeric)
-          types[obj.class][:max]    = len if len > types[obj.class][:max]
-          types[obj.class][:total] += len
-        end
-      end
     end
     types
   end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -343,6 +343,7 @@ class MiqWorker::Runner
       end
 
       do_gc
+      log_ruby_object_usage(worker_settings[:top_ruby_object_classes_to_log].to_i)
       send(poll_method)
     end
   end
@@ -354,7 +355,6 @@ class MiqWorker::Runner
     @worker_monitor_drb ||= worker_monitor_drb
     messages = @worker_monitor_drb.worker_heartbeat(@worker.pid, @worker.class.name, @worker.queue_name)
     @last_hb = now
-    log_ruby_object_usage(worker_settings[:log_top_ruby_objects_on_heartbeat].to_i)
     messages.each { |msg, *args| process_message(msg, *args) }
     do_heartbeat_work
   rescue DRb::DRbError => err

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -455,10 +455,17 @@ class MiqWorker::Runner
     types
   end
 
+  LOG_RUBY_OBJECT_USAGE_INTERVAL = 60
   def log_ruby_object_usage(top = 20)
-    if top > 0
+    return unless top > 0
+
+    t = Time.now.utc
+    @last_ruby_object_usage ||= t
+
+    if (@last_ruby_object_usage + LOG_RUBY_OBJECT_USAGE_INTERVAL) < t
       types = ruby_object_usage
       $log.info("Ruby Object Usage: #{types.sort_by { |_klass, h| h[:count] }.reverse[0, top].inspect}")
+      @last_ruby_object_usage = t
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1394,7 +1394,6 @@
       :connection_pool_size: 5
       :memory_threshold: 1.gigabytes
       :nice_delta: 1
-      :poll: 60.seconds
     :vim_broker_worker:
       :memory_threshold: 2.gigabytes
       :nice_delta: 3
@@ -1408,9 +1407,7 @@
       :connection_pool_size: 5
       :memory_threshold: 1.gigabytes
       :nice_delta: 1
-      :poll: 60.seconds
     :websocket_worker:
        :connection_pool_size: 5
        :memory_threshold: 1.gigabytes
        :nice_delta: 1
-       :poll: 60.seconds

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1082,7 +1082,7 @@
     :defaults:
       :count: 1
       :gc_interval: 15.minutes
-      :heartbeat_freq: 60.seconds
+      :heartbeat_freq: 10.seconds
       :heartbeat_timeout: 2.minutes
       :memory_threshold: 200.megabytes
       :nice_delta: 10
@@ -1396,7 +1396,6 @@
       :nice_delta: 1
       :poll: 60.seconds
     :vim_broker_worker:
-      :heartbeat_freq: 15.seconds
       :memory_threshold: 2.gigabytes
       :nice_delta: 3
       :poll: 1.seconds


### PR DESCRIPTION
* We want to heartbeat more often for non-queue based workers so they can detect the server disappearing faster:  Some wait around 1 minute after the server exits before they exit, causing all sorts of oddities in development environments where the puma workers get a port already in use error. (ask @mkanoor)
* Queue based workers tend to detect an exited server process within "poll" (3) seconds because that's how often they poll for MiqQueue messages via DRb.  Dropping our heartbeat frequency to every 10 seconds shouldn't have much impact on the server process since it's already getting this 3 second poll for queue messages from the queue workers.

To do this we need to:

- [x] log_ruby_object_usage: determining the size of objects is problematic and not useful so remove it.  
- [x] log_ruby_object_usage: cleanup the output
- [x] log_ruby_object_usage: make them public class methods so it's easier to test
- [x] Move log_ruby_object_usage out of the heartbeat and allow it to only run every 60 seconds from the main loop.
- [x] Heartbeat every 10 seconds for all workers, limited by your poll value
- [x] Drop the UI/Web Service/Web Socket workers really high poll from 60 to the default of 3.


**Before**  (UI Worker takes ~ 1 minute after server exits before it exits)
```
[----] I, [2016-04-22T16:30:31.282669 #51403:3ffe5885e1fc]  INFO -- : MIQ(EvmServer) PID [51403] Interrupt signal (SIGTERM) received. Server exiting.
[----] E, [2016-04-22T16:30:32.005421 #51428:3ffe5885e1fc] ERROR -- : MIQ(MiqGenericWorker::Runner) ID [509000000000053] PID [51428] GUID [820681d4-08c7-11e6-8d50-3c15c2c9babc] Error communicating with WorkerMonitor because <druby://127.0.0.1:50108 - #<Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 50108>> Worker exiting.
[----] E, [2016-04-22T16:30:33.520601 #51430:3ffe5885e1fc] ERROR -- : MIQ(MiqReportingWorker::Runner) ID [509000000000054] PID [51430] GUID [8223dc3e-08c7-11e6-8d50-3c15c2c9babc] Error communicating with WorkerMonitor because <druby://127.0.0.1:50108 - #<Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 50108>> Worker exiting.
[----] E, [2016-04-22T16:31:27.193119 #51432:3ffe59598174] ERROR -- : MIQ(MiqUiWorker::Runner) ID [509000000000055] PID [51432] GUID [8231f210-08c7-11e6-8d50-3c15c2c9babc] Error heartbeating to MiqServer because DRb::DRbConnError: druby://127.0.0.1:50108 - #<Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 50108> Worker exiting.
```

**After**  (UI Worker exits within a few seconds after the server)

```
[----] I, [2016-04-22T15:42:58.242602 #50130:3fd394c5e200]  INFO -- : MIQ(EvmServer) PID [50130] Interrupt signal (SIGTERM) received. Server exiting.
[----] E, [2016-04-22T15:42:58.715365 #50156:3fd394c5e200] ERROR -- : MIQ(MiqReportingWorker::Runner) ID [509000000000051] PID [50156] GUID [48398398-08c2-11e6-bf6c-3c15c2c9babc] Error communicating with WorkerMonitor because <druby://127.0.0.1:49746 - #<Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 49746>> Worker exiting.
[----] E, [2016-04-22T15:43:00.285428 #50154:3fd394c5e200] ERROR -- : MIQ(MiqGenericWorker::Runner) ID [509000000000050] PID [50154] GUID [481dc40a-08c2-11e6-bf6c-3c15c2c9babc] Error heartbeating to MiqServer because DRb::DRbConnError: druby://127.0.0.1:49746 - #<Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 49746> Worker exiting.
[----] E, [2016-04-22T15:43:02.485672 #50159:3fd3951cd984] ERROR -- : MIQ(MiqUiWorker::Runner) ID [509000000000052] PID [50159] GUID [48464aec-08c2-11e6-bf6c-3c15c2c9babc] Error heartbeating to MiqServer because DRb::DRbConnError: druby://127.0.0.1:49746 - #<Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 49746> Worker exiting.
```

Note, the log ruby object usage, when enabled via advanced settings or console:
`Settings.workers.worker_base.top_ruby_object_classes_to_log = 20`

```
[----] I, [2016-04-26T16:54:00.496474 #97602:3fddc585e200]  INFO -- : Ruby Object Usage: [["String", 475660], ["Array", 97001], ["RubyVM::InstructionSequence", 50492], ["Hash", 25620], ["ActionDispatch::Journey::Nodes::Cat", 19628], ["Proc", 14402], ["RubyVM::Env", 12909], ["ActionDispatch::Journey::Format", 8462], ["ActionDispatch::Journey::Nodes::Slash", 8394], ["ActionDispatch::Journey::Nodes::Symbol", 5628], ["ActionDispatch::Journey::Format::Parameter", 5628], ["ActionDispatch::Journey::Nodes::Literal", 5611], ["ActionDispatch::Journey::Nodes::Group", 5610], ["Class", 4322], ["MIME::Types::Container", 3850], ["Gem::Requirement", 3518], ["Regexp", 3229], ["ActionDispatch::Journey::Path::Pattern", 2852], ["ActionDispatch::Journey::Route", 2852], ["ActionDispatch::Routing::RouteSet::Dispatcher", 2850]
```