### PR TITLE
Moved call to get_node_info into import specific methods.

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -61,7 +61,7 @@ class MiqAeCustomizationController < ApplicationController
         add_flash(_("Error during upload: one of the DialogField types is not supported"), :error)
       end
     end
-
+    get_node_info
     replace_right_cell(x_node)
   end
 
@@ -79,7 +79,7 @@ class MiqAeCustomizationController < ApplicationController
       dialog_import_service.cancel_import(params[:import_file_upload_id])
       add_flash(_("Service dialog import cancelled"), :success)
     end
-
+    get_node_info
     replace_right_cell(x_node)
   end
 
@@ -218,7 +218,7 @@ class MiqAeCustomizationController < ApplicationController
       presenter[:clear_tree_cookies] = "edit_treeOpenStatex"
     end
     rebuild_toolbars(presenter)
-    get_node_info
+
     setup_presenter_based_on_active_tree(nodetype, presenter)
     set_right_cell_text(presenter)
     handle_bottom_cell(presenter)

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -476,4 +476,27 @@ describe MiqAeCustomizationController do
       end
     end
   end
+
+  context "#x_button" do
+    before :each do
+      controller.instance_variable_set(:@sb, :applies_to_class => "EmsCluster")
+      allow(controller).to receive(:role_allows).and_return(true)
+      session[:sandboxes] = {
+        "miq_ae_customization" => {
+          :applies_to_class => "EmsCluster",
+          :trees            => {
+            :ab_tree => {:active_node => "-ub-EmsCluster"}
+          },
+          :active_tree      => :ab_tree
+        }
+      }
+    end
+
+    it "it should not call get_node_info when building new group add screen" do
+      expect(controller).to_not receive(:get_node_info)
+      post :x_button, :params => {:pressed => "ab_group_new"}
+      expect(response.status).to eq(200)
+      expect(response.body).to include("main_div")
+    end
+  end
 end


### PR DESCRIPTION
Adding call to get_node_info in replace_right_cell was causing it to be called twice once from specific methods and once from replace_right_cell, this was also causing issues when going to add/edit screens in Buttons accordion. Issue was introduced in commit 46032b28ef05b3b74dbe3f1cab29378d9d1b64c4

Fixes #8195 

@mkanoor please test

@dclarizio please review.

before:
![before](https://cloud.githubusercontent.com/assets/3450808/14753546/144ae892-08a4-11e6-905e-90ffd9f79e60.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/14753549/18b3a0d6-08a4-11e6-9dc1-69c61be9b566.png)
