### PR TITLE
Fix build failure: pending gem failure on armrest

### DIFF
--- a/gems/pending/spec/spec_helper.rb
+++ b/gems/pending/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require_relative '../bundler_setup'
+require 'active_support/all'
 require 'azure-armrest'
 require 'vcr'
 


### PR DESCRIPTION
It looks like not all the active support files are required for
armrest to be properly instantiated.

This can be fixed in our gem or in armrest.

activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb:10:
in `<module:Compatibility>': undefined method `mattr_accessor'
for DateAndTime::Compatibility:Module (NoMethodError)

/cc @djberg96 not sure where you want to fix. I just put in to fix our build.
