### PR TITLE
Introduced application.rb variable for setting digest class (FIPS compliance)

### DIFF
--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -15,7 +15,7 @@ class BinaryBlob < ApplicationRecord
     unless size.nil? || size == data.bytesize
       raise _("size of %{name} id [%{number}] is incorrect") % {:name => self.class.name, :number => id}
     end
-    unless md5.nil? || md5 == Digest::MD5.hexdigest(data)
+    unless md5.nil? || md5 == Rails.application.config.digest_class.hexdigest(data)
       raise _("md5 of %{name} id [%{number}] is incorrect") % {:name => self.class.name, :number => id}
     end
     data
@@ -28,7 +28,7 @@ class BinaryBlob < ApplicationRecord
     return self if data.bytesize == 0
 
     self.part_size ||= BinaryBlobPart.default_part_size
-    self.md5 = Digest::MD5.hexdigest(data)
+    self.md5 = Rails.application.config.digest_class.hexdigest(data)
     self.size = data.bytesize
 
     until data.bytesize == 0
@@ -43,7 +43,7 @@ class BinaryBlob < ApplicationRecord
   # Write binary file from the database into a file
   def dump_binary(path_or_io)
     dump_size = 0
-    hasher = Digest::MD5.new
+    hasher = Rails.application.config.digest_class.new
 
     begin
       fd = path_or_io.respond_to?(:write) ? path_or_io : File.open(path_or_io, "wb")
@@ -76,7 +76,7 @@ class BinaryBlob < ApplicationRecord
     self.md5 = nil
     self.size = 0
 
-    hasher = Digest::MD5.new
+    hasher = Rails.application.config.digest_class.new
 
     File.open(path, "rb") do |f|
       until f.eof?

--- a/app/models/binary_blob_part.rb
+++ b/app/models/binary_blob_part.rb
@@ -19,7 +19,7 @@ class BinaryBlobPart < ApplicationRecord
     unless size.nil? || size == val.bytesize
       raise _("size of %{name} id [%{number}] is incorrect") % {:name => self.class.name, :number => id}
     end
-    unless md5.nil? || md5 == Digest::MD5.hexdigest(val)
+    unless md5.nil? || md5 == Rails.application.config.digest_class.hexdigest(val)
       raise _("md5 of %{name} id [%{number}] is incorrect") % {:name => self.class.name, :number => id}
     end
     val
@@ -28,7 +28,7 @@ class BinaryBlobPart < ApplicationRecord
   def data=(val)
     raise ArgumentError, "data cannot be set to nil" if val.nil?
     write_attribute(:data, val)
-    self.md5 = Digest::MD5.hexdigest(val)
+    self.md5 = Rails.application.config.digest_class.hexdigest(val)
     self.size = val.bytesize
     self
   end

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -153,7 +153,7 @@ class OrchestrationTemplate < ApplicationRecord
   end
 
   def self.calc_md5(text)
-    Digest::MD5.hexdigest(text) if text
+    Rails.application.config.digest_class.hexdigest(text) if text
   end
 
   def calc_md5(text)

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,8 @@ module Vmdb
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
 
+    # Configure digest class
+    config.digest_class = Digest::MD5
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password, :verify, :data, :_pwd, :__protected]
 

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
@@ -209,7 +209,7 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
   "Id": "#{queue_arn}/SQSDefaultPolicy",
   "Statement": [
     {
-      "Sid": "#{Digest::MD5.hexdigest(queue_arn)}",
+      "Sid": "#{Rails.application.config.digest_class.hexdigest(queue_arn)}",
       "Effect": "Allow",
       "Principal": {
         "AWS": "*"

--- a/gems/pending/blackbox/VmBlackBox.rb
+++ b/gems/pending/blackbox/VmBlackBox.rb
@@ -25,9 +25,9 @@ module Manageiq
 
       # Get path to local data directory
       if ost.config && ost.config.dataDir
-        @localDataDir = File.join(ost.config.dataDir, Digest::MD5.hexdigest(@config_name))
+        @localDataDir = File.join(ost.config.dataDir, Rails.application.config.digest_class.hexdigest(@config_name))
       elsif $miqHostCfg && $miqHostCfg.dataDir
-        @localDataDir = File.join($miqHostCfg.dataDir, Digest::MD5.hexdigest(@config_name))
+        @localDataDir = File.join($miqHostCfg.dataDir, Rails.application.config.digest_class.hexdigest(@config_name))
       else
         @localDataDir = "/tmp"
       end

--- a/gems/pending/disk/modules/AzureBlobDisk.rb
+++ b/gems/pending/disk/modules/AzureBlobDisk.rb
@@ -72,7 +72,7 @@ module AzureBlobDisk
     ret = @storage_acct.get_blob_raw(@container, @blob, key, options)
 
     content_md5  = ret.headers[:content_md5].unpack("m0").first.unpack("H*").first
-    returned_md5 = Digest::MD5.hexdigest(ret.body)
+    returned_md5 = Rails.application.config.digest_class.hexdigest(ret.body)
     raise "Checksum error: #{range_str}, blob: #{@container}/#{@blob}" unless content_md5 == returned_md5
 
     ret.body

--- a/gems/pending/metadata/ScanProfile/modules/HostScanItemNteventlog.rb
+++ b/gems/pending/metadata/ScanProfile/modules/HostScanItemNteventlog.rb
@@ -72,7 +72,7 @@ module HostScanItemNteventlog
         :level     => level,
         :source    => source,
         :message   => message,
-        :uid       => Digest::MD5.hexdigest("#{generated} #{name} #{level} #{source} #{message}")
+        :uid       => Rails.application.config.digest_class.hexdigest("#{generated} #{name} #{level} #{source} #{message}")
       }
 
       rec_count += 1

--- a/gems/pending/metadata/util/win32/Win32EventLog.rb
+++ b/gems/pending/metadata/util/win32/Win32EventLog.rb
@@ -525,7 +525,7 @@ class Win32EventLog
     # Put the needed fields in the node_rec, and collect them for md5 hashing to
     #   verify that this record is unique
     md5 = NODE_REC_KEYS.collect { |k| node_rec[k] = rec[k] }.join(' ')
-    md5 = Digest::MD5.hexdigest(md5)
+    md5 = Rails.application.config.digest_class.hexdigest(md5)
     return false if @dup_check.key?(md5)
     @dup_check[md5] = nil
 

--- a/gems/pending/metadata/util/win32/Win32Software.rb
+++ b/gems/pending/metadata/util/win32/Win32Software.rb
@@ -265,7 +265,7 @@ module MiqWin32
             # Access application icons
             # peData = PEheader.new(fh)
             # if peData.icons.length > 0
-            #  ie = e1.add_element("image",{"file"=>fileName, "count"=>peData.icons.length.to_s, "md5"=>Digest::MD5.hexdigest(peData.icons[0])})
+            #  ie = e1.add_element("image",{"file"=>fileName, "count"=>peData.icons.length.to_s, "md5"=>Rails.application.config.digest_class.hexdigest(peData.icons[0])})
             #  addIconData(ie, peData, iconNode)
             # end
           rescue Exception => err

--- a/gems/pending/metadata/util/win32/fleece_hives.rb
+++ b/gems/pending/metadata/util/win32/fleece_hives.rb
@@ -159,7 +159,7 @@ class FleeceHives
           end
 
         #     if peData.icons.length > 0
-        #     ie = e1.add_element("image",{"file"=>fileName, "count"=>peData.icons.length.to_s, "md5"=>Digest::MD5.hexdigest(peData.icons[0])})
+        #     ie = e1.add_element("image",{"file"=>fileName, "count"=>peData.icons.length.to_s, "md5"=>Rails.application.config.digest_class.hexdigest(peData.icons[0])})
         #     addIconData(ie, peData, iconNode)
         #     end
         rescue Exception => e

--- a/gems/pending/test/extract/tc_registry.rb
+++ b/gems/pending/test/extract/tc_registry.rb
@@ -123,7 +123,7 @@ module Extract
     end
 
     def generateMD5(xml)
-      md5Sig = Digest::MD5.new
+      md5Sig = Rails.application.config.digest_class.new
       xmlFormatted = ""
       xml.write(xmlFormatted, 0)
       md5Sig << xmlFormatted

--- a/gems/pending/util/xml/xml_diff.rb
+++ b/gems/pending/util/xml/xml_diff.rb
@@ -83,7 +83,7 @@ module MiqXmlDiff
 
     # Add items to delta xml file
     path = srcPath.get_path
-    path_md5 = Digest::MD5.hexdigest(action.to_s + (path.nil? ? "root=>true" : path.to_s))
+    path_md5 = Rails.application.config.digest_class.hexdigest(action.to_s + (path.nil? ? "root=>true" : path.to_s))
 
     # Check if we have already added an item node for this action and path, if so
     # just add the data node(s) to it.  Otherwise create a new item node.

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -148,7 +148,7 @@ describe OrchestrationTemplate do
   describe ".find_with_content" do
     it "avoids content comparison but through content hash value comparison" do
       existing_template = FactoryGirl.create(:orchestration_template)
-      allow(Digest::MD5).to receive(:hexdigest).and_return(existing_template.md5)
+      allow(Rails.application.config.digest_class).to receive(:hexdigest).and_return(existing_template.md5)
 
       result = OrchestrationTemplate.find_with_content("#{existing_template.content} content changed")
       expect(result).to eq(existing_template)


### PR DESCRIPTION
#8163 Setting of Digest::MD5 as the default implementation will prevent clients from breaking if this PR is merged.  There is some work that will need to follow to update methods named 'md5' and 'generateMD5' (among potentially others) to be renamed into more generic methods such as 'generateDigest'