### PR TITLE
Failing ems_network displaying of the form

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -216,7 +216,7 @@ module Mixins
                        :project                         => project ? project : "",
                        :emstype_vm                      => @ems.kind_of?(ManageIQ::Providers::Vmware::InfraManager),
                        :ems_controller                  => controller_name
-      } if controller_name == "ems_cloud"
+      } if controller_name == "ems_cloud" || controller_name == "ems_network"
 
       render :json => {:name                        => @ems.name,
                        :emstype                     => @ems.emstype,

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -46,6 +46,14 @@ describe EmsNetworkController do
         end
       end
 
+      describe "#ems_network_form_fields" do
+        it "renders ems_network_form_fields json" do
+          get :ems_network_form_fields, :params => {:id => @ems.id}
+          expect(response.status).to eq(200)
+          expect(response.body).to_not be_empty
+        end
+      end
+
       describe "#create" do
         it "adds a new provider" do
           controller.instance_variable_set(:@breadcrumbs, [])


### PR DESCRIPTION
There was a regression that removed ems_network from the
shared method for ems_form_fields.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1329553