### PR TITLE
Production migration fail due to cached schema for model

### DIFF
--- a/db/migrate/20160226092911_separate_openstack_network_manager_from_openstack_cloud_manager.rb
+++ b/db/migrate/20160226092911_separate_openstack_network_manager_from_openstack_cloud_manager.rb
@@ -33,6 +33,8 @@ class SeparateOpenstackNetworkManagerFromOpenstackCloudManager < ActiveRecord::M
 
   def up
     # Separate NetworkManager from CloudManager and move network models under NetworkManager
+    ExtManagementSystem.connection.schema_cache.clear!
+    ExtManagementSystem.reset_column_information
     ExtManagementSystem
       .joins('left join ext_management_systems as network_manager on network_manager.parent_ems_id = ext_management_systems.id')
       .where(:ext_management_systems => {:type          => ['ManageIQ::Providers::Openstack::CloudManager',


### PR DESCRIPTION
Production migration fails due to cached schema for model. Model
contains old schema, so the field parent_ems_id, that we created
couple of migrations back, will not be in the model
ExtManagementSystem and it will fail on create!. Seems like
this appears only on production env, where the schema is not
reloaded. Also this occurs only when we do e.g. upgrade, so
when migration has some data, before we continue with other
migrations. This migration is data migration touching OpenStack.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1329137