### PR TITLE
Metrics does not show information for pods/containers

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -44,7 +44,12 @@ module ManageIQ::Providers
       _log.info("Collecting metrics for #{target_name} [#{interval_name}] " \
                 "[#{start_time}] [#{end_time}]")
 
-      context = CaptureContext.new(target, start_time, end_time, INTERVAL)
+      begin
+        context = CaptureContext.new(target, start_time, end_time, INTERVAL)
+      rescue TargetValidationError => e
+        _log.error("#{target_name} is not valid: #{e.message}")
+        return [{}, {}]
+      end
 
       Benchmark.realtime_block(:collect_data) do
         begin

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
@@ -128,7 +128,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
           resource,
           :starts         => (@start_time - @interval).to_i.in_milliseconds,
           :bucketDuration => "#{@interval}s"))
-    rescue SystemCallError => e
+    rescue SystemCallError, SocketError, OpenSSL::SSL::SSLError => e
       raise CollectionFailure, e.message
     end
 
@@ -138,7 +138,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
           resource,
           :starts         => @start_time.to_i.in_milliseconds,
           :bucketDuration => "#{@interval}s"))
-    rescue SystemCallError => e
+    rescue SystemCallError, SocketError, OpenSSL::SSL::SSLError => e
       raise CollectionFailure, e.message
     end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -25,22 +25,19 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
   end
 
   context "#perf_collect_metrics" do
-    it "raises an error when no ems is defined" do
+    it "fails quietly when no ems is defined" do
       @node.ext_management_system = nil
-      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(
-        described_class::TargetValidationError)
+      expect(@node.perf_collect_metrics('interval_name')).to eq([{}, {}])
     end
 
-    it "raises an error when no cpu cores are defined" do
+    it "fails quietly when no cpu cores are defined" do
       @node.hardware.cpu_total_cores = nil
-      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(
-        described_class::TargetValidationError)
+      expect(@node.perf_collect_metrics('interval_name')).to eq([{}, {}])
     end
 
-    it "raises an error when memory is not defined" do
+    it "fails quietly when memory is not defined" do
       @node.hardware.memory_mb = nil
-      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(
-        described_class::TargetValidationError)
+      expect(@node.perf_collect_metrics('interval_name')).to eq([{}, {}])
     end
 
     # TODO: include also sort_and_normalize in the tests


### PR DESCRIPTION
_Description_:
While using a list to collect metrics, for testing, metric collection for the invalid node _and all nodes after it_ in list fails, should fail only for the invalid node and continue.

https://bugzilla.redhat.com/show_bug.cgi?id=1301861

_Screenshots_:
dummy node:
![screenshot-2016-04-26-14-40-51](https://cloud.githubusercontent.com/assets/2181522/14821434/6aa45d54-0bd3-11e6-80d0-e80aada9d15b.png)




