### PR TITLE
deprecate_attribute no longer accesses db

### DIFF
--- a/app/models/mixins/deprecation_mixin.rb
+++ b/app/models/mixins/deprecation_mixin.rb
@@ -17,7 +17,7 @@ module DeprecationMixin
 
     def deprecate_attribute(old_attribute, new_attribute)
       deprecate_attribute_methods(old_attribute, new_attribute)
-      virtual_column(old_attribute, :type => type_for_attribute(new_attribute.to_s).type)
+      virtual_attribute(old_attribute, -> { type_for_attribute(new_attribute.to_s) })
     end
 
     def deprecate_attribute_methods(old_attribute, new_attribute)

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -209,9 +209,8 @@ module VirtualAttributes
       super
 
       virtual_attributes_to_define.each do |name, (type, options)|
-        if type.is_a?(Symbol)
-          type = ActiveRecord::Type.lookup(type, **options.except(:uses, :arel))
-        end
+        type = type.call if type.respond_to?(:call)
+        type = ActiveRecord::Type.lookup(type, **options.except(:uses, :arel)) if type.is_a?(Symbol)
 
         define_virtual_attribute(name, type, **options.slice(:uses, :arel))
       end


### PR DESCRIPTION
**before:**

The `Hardware` has deprecated attributes. Defining a deprecated attribute loads the target column's type and this causes a schema load.

Loading the database on class definition causes our build to fail.
Currently, deprecated attributes is only used in Hardware and Hardware is not a dependent class in our build.

**after:**

The column type is not looked up until later in the process. And the build is happy once again.

/cc @chessbyte this is a fix for problem 2 of 2 from our debugging session.