### PR TITLE
Fix Accordion restful routes in ems_infra

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -395,7 +395,7 @@ module EmsCommon
       tag(model) if params[:pressed] == "#{@table_name}_tag"
       assign_policies(model) if params[:pressed] == "#{@table_name}_protect"
       edit_record if params[:pressed] == "#{@table_name}_edit"
-      if params[:pressed] == "ems_cloud_timeline" || "ems_infra_timeline"
+      if params[:pressed] == "ems_cloud_timeline" || params[:pressed] == "ems_infra_timeline"
         @showtype = "timeline"
         @record = find_by_id_filtered(model, params[:id])
         @timeline = @timeline_filter = true

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -395,7 +395,7 @@ module EmsCommon
       tag(model) if params[:pressed] == "#{@table_name}_tag"
       assign_policies(model) if params[:pressed] == "#{@table_name}_protect"
       edit_record if params[:pressed] == "#{@table_name}_edit"
-      if params[:pressed] == "ems_cloud_timeline"
+      if params[:pressed] == "ems_cloud_timeline" || "ems_infra_timeline"
         @showtype = "timeline"
         @record = find_by_id_filtered(model, params[:id])
         @timeline = @timeline_filter = true

--- a/app/helpers/application_helper/button/ems_infra_timeline.rb
+++ b/app/helpers/application_helper/button/ems_infra_timeline.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::EmsInfraTimeline < ApplicationHelper::Button::Basic
+  def skip?
+    !@record.is_available?(:timeline)
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -77,7 +77,7 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
           'product product-timeline fa-lg',
           N_('Show Timelines for this #{ui_lookup(:table=>"ems_infra")}'),
           N_('Timelines'),
-          :url       => "/show",
+          :klass     => ApplicationHelper::Button::EmsInfraTimeline,
           :url_parms => "?display=timeline"),
       ]
     ),

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -4,6 +4,8 @@ module ManageIQ::Providers
     require_nested :ProvisionWorkflow
     require_nested :Vm
 
+    include AvailabilityMixin
+
     class << model_name
       define_method(:route_key) { "ems_infras" }
       define_method(:singular_route_key) { "ems_infra" }
@@ -39,6 +41,10 @@ module ManageIQ::Providers
       read_timeout = read_timeout.to_i_with_method if read_timeout
       open_timeout = open_timeout.to_i_with_method if open_timeout
       [read_timeout, open_timeout]
+    end
+
+    def validate_timeline
+      {:available => true, :message => nil}
     end
   end
 end

--- a/app/views/layouts/listnav/_ems_cloud.html.haml
+++ b/app/views/layouts/listnav/_ems_cloud.html.haml
@@ -9,7 +9,7 @@
           = link_to_with_icon(_('Summary'), polymorphic_path(@record, :display => 'main'), :title => _("Show Summary"))
           = li_link(:if => (@record.has_events? || @record.has_events?(:policy_events)),
             :text       => _('Timelines'),
-            :record_i   => @record.id,
+            :record     => @record,
             :display    => 'timeline',
             :title      => _("Show Timelines"))
 

--- a/app/views/layouts/listnav/_ems_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_infra.html.haml
@@ -8,55 +8,53 @@
     = miq_accordion_panel(_("Properties"), false, "ems_prop") do
       %ul.nav.nav-pills.nav-stacked
         %li
-          = link_to(_('Summary'),
-            {:action => 'show', :id => @record, :display => 'main'},
-            :title => _("Show Summary"))
-        = li_link(:if => @record.has_events? || @record.has_events?(:policy_events),
-          :text       => _('Timelines'),
-          :record_id  => @record.id,
-          :display    => 'timeline',
-          :title      => _("Show Timelines"))
+          = link_to_with_icon(_('Summary'), polymorphic_path(@record, :display => 'main'), :title => _("Show Summary"))
+        = li_link(:if => (@record.has_events? || @record.has_events?(:policy_events)),
+            :text       => _('Timelines'),
+            :record     => @record,
+            :display    => 'timeline',
+            :title      => _("Show Timelines"))
 
     = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked
         = li_link(:if => !(@record.number_of(:ems_folders) == 0 || @record.ems_folder_root.nil?),
           :text       => _("%{hosts} & %{clusters}") % {:hosts => hosts_title, :clusters => clusters_title},
-          :record_id  => @record.id,
+          :record     => @record,
           :display    => 'ems_folders',
           :title      => _("Show %{hosts} & %{clusters}") % {:hosts => hosts_title, :clusters => clusters_title})
         = li_link(:if => !(@record.number_of(:ems_folders) == 0 || @record.ems_folder_root.nil?),
           :text       => _('VMs & Templates'),
-          :record_id  => @record.id,
+          :record     => @record,
           :display    => 'ems_folders',
           :vat        => true,
           :title      => _("Show VMs & Templates"))
         - if role_allows(:feature => "ems_cluster_show_list")
           = li_link(:count => @record.number_of(:ems_clusters),
             :text          => clusters_title,
-            :record_id     => @record.id,
+            :record        => @record,
             :display       => 'ems_clusters',
             :title         => _("Show all managed %{cluster}") % {:cluster => clusters_title})
         - if role_allows(:feature => "host_show_list")
           = li_link(:count => @record.number_of(:hosts),
             :text          => hosts_title,
-            :record_id     => @record.id,
+            :record        => @record,
             :display       => 'hosts',
             :title         => _("Show all managed %{hosts}") % {:hosts => hosts_title})
         - if role_allows(:feature => "storage_show_list")
           = li_link(:count => @record.number_of(:storages),
-            :record_id     => @record.id,
+            :record        => @record,
             :tables        => 'storages',
             :display       => 'storages',
             :title         => _("Show all managed %{storages}") % {:storages => ui_lookup(:tables => "storages")})
         - if role_allows(:feature => "vm_show_list")
           = li_link(:count => @record.number_of(:vms),
             :text          => _("VMs"),
-            :record_id     => @record.id,
+            :record        => @record,
             :display       => 'vms',
             :title         => _("Show all VMs"))
         - if role_allows(:feature => "miq_template_show_list")
           = li_link(:count => @record.number_of(:miq_templates),
             :text          => _("Templates"),
-            :record_id     => @record.id,
+            :record        => @record,
             :display       => 'miq_templates',
             :title         => _("Show all Templates"))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -965,6 +965,7 @@ Vmdb::Application.routes.draw do
         wait_for_task
         scaling
         scaledown
+        x_show
       ) +
                adv_search_post +
                compare_post +

--- a/spec/routing/ems_infra_routing_spec.rb
+++ b/spec/routing/ems_infra_routing_spec.rb
@@ -28,11 +28,22 @@ describe EmsInfraController do
     create
     form_field_changed
     listnav_search_selected
-    save_default_search
+    panel_control
+    protect
+    quick_search
+    sections_field_changed
+    show
     show_list
+    tag_edit_form_field_changed
+    tagging_edit
+    tl_chooser
     tree_autoload_dynatree
     tree_autoload_quads
     update
+    wait_for_task
+    scaling
+    scaledown
+    x_show
   ).each do |task|
     describe "##{task}" do
       it 'routes with POST' do


### PR DESCRIPTION
Most restful routes in `ems_infra` were addressed when `ems_infra` was converted to have restful routes for `new`, `edit` and `show` https://github.com/ManageIQ/manageiq/pull/7808
However, there were a few areas that were not addressed like the `Relationships` and `Timelines` routes in the Accordions. 
This PR addresses those areas.

https://bugzilla.redhat.com/show_bug.cgi?id=1329578
https://bugzilla.redhat.com/show_bug.cgi?id=1330230

Fixes https://github.com/ManageIQ/manageiq/issues/8201