### PR TITLE
Azure - Incorrect unit used for flavor memory size

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -171,7 +171,7 @@ module ManageIQ::Providers
           :name           => name,
           :cpus           => s.number_of_cores, # where are the virtual CPUs??
           :cpu_cores      => s.number_of_cores,
-          :memory         => s.memory_in_mb.to_f,
+          :memory         => s.memory_in_mb.megabytes,
           :root_disk_size => s.os_disk_size_in_mb * 1024,
           :swap_disk_size => s.resource_disk_size_in_mb * 1024
         }
@@ -288,7 +288,7 @@ module ManageIQ::Providers
       def populate_hardware_hash_with_series_attributes(hardware_hash, instance, series)
         return if series.nil?
         hardware_hash[:cpu_total_cores] = series[:cpus]
-        hardware_hash[:memory_mb]       = series[:memory]
+        hardware_hash[:memory_mb]       = series[:memory] / 1.megabyte
         hardware_hash[:disk_capacity]   = series[:root_disk_size] + series[:swap_disk_size]
 
         os_disk = instance.properties.storage_profile.os_disk

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -178,7 +178,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :enabled                  => true,
       :cpus                     => 1,
       :cpu_cores                => 1,
-      :memory                   => 768,
+      :memory                   => 768.megabytes,
       :supports_32_bit          => nil,
       :supports_64_bit          => nil,
       :supports_hvm             => nil,


### PR DESCRIPTION
In Azure, the flavor memory unit is displayed incorrectly (eg KB instead of GB). 

**the fix:**
The memory attribute of the flavor must be stored in bytes
The memory attribute of the instance must be stored in MB

https://bugzilla.redhat.com/show_bug.cgi?id=1317921