### PR TITLE
[api] VM power operations are not queued properly

### DIFF
--- a/app/controllers/api_controller/action.rb
+++ b/app/controllers/api_controller/action.rb
@@ -26,6 +26,8 @@ class ApiController
         :role        => options[:role] || nil,
       }
 
+      queue_options[:zone] = object.my_zone if %w(ems_operations smartstate).include?(options[:role])
+
       MiqTask.generic_action_with_callback(task_options, queue_options)
     end
   end

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -177,6 +177,19 @@ describe ApiController do
       expect_single_action_result(:success => true, :message => "starting", :href => :vm_url, :task => true)
     end
 
+    it "starting a vm queues it properly" do
+      api_basic_authorize action_identifier(:vms, :start)
+      update_raw_power_state("poweredOff", vm)
+
+      run_post(vm_url, gen_request(:start))
+
+      expect_single_action_result(:success => true, :message => "starting", :href => :vm_url, :task => true)
+      expect(MiqQueue.where(:class_name  => vm.class.name,
+                            :instance_id => vm.id,
+                            :method_name => "start",
+                            :zone        => zone.name).count).to eq(1)
+    end
+
     it "starts multiple vms" do
       api_basic_authorize action_identifier(:vms, :start)
       update_raw_power_state("poweredOff", vm1, vm2)


### PR DESCRIPTION
When queueing VM power or smartstate operations, the zone was not getting
specified for the queue so in environments with providers in different zones,
those providers were not getting the task to perform on those VMs.

This fixes: #7998

https://bugzilla.redhat.com/show_bug.cgi?id=1326955