### PR TITLE
Fix host name collision incrementing every refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -155,9 +155,15 @@ module EmsRefresh::SaveInventoryInfra
           #   Keep the previous hostname unless it's nil or it's an ip address
           h[:hostname] = found.hostname unless found.hostname.nil? || (found.hostname =~ ip_whole)
 
-          #   Update the name to the hostname if the new name has an ip address,
-          #   and the new hostname is not an ip address
-          h[:name] = h[:hostname] if h[:name] =~ ip_part && !(h[:hostname] =~ ip_whole)
+          if found.name =~ /#{h[:name]} - \d+$/
+            # Update the name to be found.name if it has the same ems_ref and the name
+            # already has a '- int' suffix to work around duplicate hostnames
+            h[:name] = found.name
+          elsif h[:name] =~ ip_part && h[:hostname] !~ ip_whole
+            # Update the name to the hostname if the new name has an ip address,
+            # and the new hostname is not an ip address
+            h[:name] = h[:hostname]
+          end
 
           h.delete(:type)
 

--- a/spec/models/ems_refresh/save_inventory_infra_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_infra_spec.rb
@@ -131,5 +131,16 @@ describe EmsRefresh::SaveInventoryInfra do
       hosts = Host.all
       expect(hosts.length).to eq(data.length)
     end
+
+    it "should not change the name of a host every refresh if there are duplicate names" do
+      FactoryGirl.create(:host, :ems_id => nil,     :ems_ref => "host-1", :name => "localhost",     :hostname => "localhost")
+      FactoryGirl.create(:host, :ems_id => @ems.id, :ems_ref => "host-2", :name => "localhost - 2", :hostname => "localhost")
+
+      data = [{:name => 'localhost', :hostname => 'localhost', :ems_ref => "host-2"}]
+
+      EmsRefresh.save_hosts_inventory(@ems, data)
+
+      expect(Host.where(:ems_ref => "host-2").first.name).to eq("localhost - 2")
+    end
   end
 end


### PR DESCRIPTION
When saving a host that has a duplicate hostname, we increment `found.name` until the save succeeds.
When re-saving the host it will try with the read hostname again, fail to save, and increment the `found.name`.

This means if you originally had
```
:name => 'localhost',     :hostname => 'localhost', :ems_ref => 'host-1'
:name => 'localhost - 2', :hostname => 'localhost', :ems_ref => 'host-2'
```
When you run `ems_refresh` again, you will end up with
```
:name => 'localhost',     :hostname => 'localhost', :ems_ref => 'host-1'
:name => 'localhost - 3', :hostname => 'localhost', :ems_ref => 'host-2'
```

This fix checks to see if `found.name` == `h[:name] - "some integer"` and if so uses the name already found in the database.

https://bugzilla.redhat.com/show_bug.cgi?id=1328145