### PR TITLE
Fix toplevel constant warnings on aws/azure specs

### DIFF
--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -5,6 +5,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :CloudVolumeSnapshot
   require_nested :EventCatcher
   require_nested :EventParser
+  require_nested :Flavor
   require_nested :MetricsCapture
   require_nested :MetricsCollectorWorker
   require_nested :OrchestrationServiceOptionConverter

--- a/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -100,7 +100,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_specific_floating_ip
-    ip = ManageIQ::Providers::Amazon::CloudManager::FloatingIp.where(:address => "54.215.0.230").first
+    ip = ManageIQ::Providers::Amazon::NetworkManager::FloatingIp.where(:address => "54.215.0.230").first
     expect(ip).to have_attributes(
       :address            => "54.215.0.230",
       :ems_ref            => "54.215.0.230",
@@ -117,7 +117,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_specific_security_group
-    @sg = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-OtherRegion").first
+    @sg = ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-OtherRegion").first
     expect(@sg).to have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup-OtherRegion",
       :description => "EmsRefreshSpec-SecurityGroup-OtherRegion",

--- a/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
+++ b/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
@@ -122,7 +122,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_specific_floating_ip
-    @ip = ManageIQ::Providers::Amazon::CloudManager::FloatingIp.where(:address => "54.221.202.53").first
+    @ip = ManageIQ::Providers::Amazon::NetworkManager::FloatingIp.where(:address => "54.221.202.53").first
     expect(@ip).to have_attributes(
       :address            => "54.221.202.53",
       :ems_ref            => "54.221.202.53",
@@ -131,7 +131,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_specific_floating_ip_for_cloud_network
-    ip = ManageIQ::Providers::Amazon::CloudManager::FloatingIp.where(:address => "54.208.119.197").first
+    ip = ManageIQ::Providers::Amazon::NetworkManager::FloatingIp.where(:address => "54.208.119.197").first
     expect(ip).to have_attributes(
       :address            => "54.208.119.197",
       :ems_ref            => "54.208.119.197",
@@ -178,7 +178,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_specific_security_group
-    @sg = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup1").first
+    @sg = ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup1").first
     expect(@sg).to have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup1",
       :description => "EmsRefreshSpec-SecurityGroup1",
@@ -210,7 +210,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_specific_security_group_on_cloud_network
-    @sg_on_cn = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-VPC").first
+    @sg_on_cn = ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-VPC").first
     expect(@sg_on_cn).to have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup-VPC",
       :description => "EmsRefreshSpec-SecurityGroup-VPC",
@@ -313,7 +313,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(v.key_pairs).to eq([@kp])
     expect(v.cloud_network).to     be_nil
     expect(v.cloud_subnet).to      be_nil
-    sg_2 = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup
+    sg_2 = ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup
            .where(:name => "EmsRefreshSpec-SecurityGroup2").first
     expect(v.security_groups)
       .to match_array [sg_2, @sg]

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -147,7 +147,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
   def assert_specific_security_group
     name = 'miq-test-rhel1'
-    @sg = SecurityGroup.where(:name => name).first
+    @sg = ManageIQ::Providers::Azure::NetworkManager::SecurityGroup.where(:name => name).first
 
     expect(@sg).to have_attributes(
       :name        => name,


### PR DESCRIPTION
Before this there were warnings like

```shell
refresher_spec.rb:97: warning: toplevel constant Flavor referenced by ManageIQ::Providers::Amazon::CloudManager::Flavor
```
some where due to moving things to new NetworkManager and some because
require_nested was missing

cc #7749 #7364 