### PR TITLE
Use description to show full path to the ConfigurationProfile

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/provision_workflow.rb
@@ -23,7 +23,7 @@ class ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow < Mi
     @allowed_configuration_profiles ||= begin
       profiles = ::ConfiguredSystem.common_configuration_profiles_for_selected_configured_systems(@values[:src_configured_system_ids])
       profiles.each_with_object({}) do |cp, hash|
-        hash[cp.id] = cp.name
+        hash[cp.id] = cp.description
       end
     end
   end

--- a/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
@@ -6,16 +6,14 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
   let(:system)  { FactoryGirl.create(:configured_system_foreman, :manager => manager) }
 
   it "#allowed_configuration_profiles" do
-    cp       = FactoryGirl.build(:configuration_profile, :name => "test profile")
+    cp       = FactoryGirl.build(:configuration_profile, :name => "test", :description => "a/b/c/test")
     cs       = FactoryGirl.build(:configured_system_foreman)
     workflow = FactoryGirl.build(:miq_provision_configured_system_foreman_workflow)
 
     workflow.instance_variable_set(:@values, :src_configured_system_ids => [cs.id])
-    expect(ConfiguredSystem).to receive(:common_configuration_profiles_for_selected_configured_systems)
-      .with([cs.id])
-      .and_return([cp])
+    expect(ConfiguredSystem).to receive(:common_configuration_profiles_for_selected_configured_systems).with([cs.id]).and_return([cp])
 
-    expect(workflow.allowed_configuration_profiles).to eq(cp.id => cp.name)
+    expect(workflow.allowed_configuration_profiles).to eq(cp.id => cp.description)
   end
 
   describe "#make_request" do


### PR DESCRIPTION
In provisioning dialogs, the full path to the ConfigurationProfile
is much more useful in the drop-down selection.

https://bugzilla.redhat.com/show_bug.cgi?id=1328823