### PR TITLE
Removed not used parameter from Condition.subst and from all callers

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -77,7 +77,7 @@ class Condition < ApplicationRecord
 
       MiqPolicy.logger.debug("MIQ(condition-eval): Name: #{name}, Expression before substitution: [#{expr.gsub(/\n/, " ")}]")
 
-      subst(expr, rec, inputs)
+      subst(expr, rec)
 
       MiqPolicy.logger.debug("MIQ(condition-eval): Name: #{name}, Expression after substitution: [#{expr.gsub(/\n/, " ")}]")
       result = do_eval(expr)
@@ -90,7 +90,7 @@ class Condition < ApplicationRecord
     eval(expr) ? true : false
   end
 
-  def self.subst(expr, rec, _inputs = nil)
+  def self.subst(expr, rec)
     findexp = /<find>(.+?)<\/find>/im
     if expr =~ findexp
       expr = expr.gsub!(findexp) { |_s| _subst_find(rec, $1.strip) }

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1016,10 +1016,10 @@ class MiqExpression
     Metric::Rollup.excluded_col_for_expression?(col.to_sym)
   end
 
-  def self.evaluate(expression, obj, inputs = {}, tz = nil)
+  def self.evaluate(expression, obj, _inputs = {}, tz = nil)
     ruby_exp = expression.kind_of?(Hash) ? new(expression).to_ruby(tz) : expression.to_ruby(tz)
     _log.debug("Expression before substitution: #{ruby_exp}")
-    subst_expr = Condition.subst(ruby_exp, obj, inputs)
+    subst_expr = Condition.subst(ruby_exp, obj)
     _log.debug("Expression after substitution: #{subst_expr}")
     result = eval(subst_expr) ? true : false
     _log.debug("Expression evaluation result: [#{result}]")

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -10,7 +10,7 @@ module ReportableMixin
       find(count, :conditions => conditions, :include => get_include_for_find(options[:include])).each do|obj|
         if filter
           expression = self.filter.to_ruby
-          expr = Condition.subst(expression, obj, inputs)
+          expr = Condition.subst(expression, obj)
           next unless eval(expr)
         end
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -559,7 +559,7 @@ module Rbac
     return true if filter.nil?
     expression = filter.to_ruby(tz)
     return true if expression.nil?
-    substituted_expression = Condition.subst(expression, obj, {})
+    substituted_expression = Condition.subst(expression, obj)
     return true if Condition.do_eval(substituted_expression)
     false
   end


### PR DESCRIPTION
Refactoring MiqExpression - #7751

This PR is the next step after #8169 and #7788 
Parameter 'input is not used in implementation of Condition.subst and removed from method declaration and from all callers: MiqExpression, ReportableMixin, Rbac.
 
/cc @gtanzillo @imtayadeway  
@miq-bot add-label core, refactoring 