### PR TITLE
TimeProfiles are unique per region

### DIFF
--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -3,7 +3,7 @@ class TimeProfile < ApplicationRecord
   ALL_HOURS = (0...24).to_a.freeze
   DEFAULT_TZ = "UTC"
 
-  validates_uniqueness_of :description
+  validates_uniqueness_of :description, :conditions => -> { where(region_to_conditions(my_region_number)) }
 
   serialize :profile
   default_value_for :days,  ALL_DAYS
@@ -26,7 +26,7 @@ class TimeProfile < ApplicationRecord
   end
 
   def self.seed
-    default_time_profile || create!(
+    in_my_region.rollup_daily_metrics.find_all_with_entire_tz.detect { |tp| tp.tz_or_default == DEFAULT_TZ } || create!(
       :description          => DEFAULT_TZ,
       :tz                   => DEFAULT_TZ,
       :profile_type         => "global",


### PR DESCRIPTION
**before**
Booting up an appliance in a region with replication enabled blows up when running seeds.

```
activerecord/lib/active_record/validations.rb:78:in `raise_validation_error'
activerecord/lib/active_record/validations.rb:50:in `save!'
activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
activerecord/lib/active_record/transactions.rb:324:in `block in save!'
activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
activerecord/lib/active_record/transactions.rb:211:in `transaction'
activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
activerecord/lib/active_record/transactions.rb:324:in `save!'
activerecord/lib/active_record/suppressor.rb:45:in `save!'
activerecord/lib/active_record/persistence.rb:51:in `create!'
app/models/time_profile.rb:29:in `seed'
lib/evm_database.rb:71:in `block (2 levels) in seed'
lib/evm_database.rb:60:in `each'
lib/evm_database.rb:60:in `block in seed'
lib/extensions/ar_table_lock.rb:21:in `block (2 levels) in with_lock'
lib/extensions/ar_table_lock.rb:21:in `block in with_lock'
activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:234:in `block in transaction'
activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:234:in `transaction'
activerecord/lib/active_record/transactions.rb:211:in `transaction'
lib/extensions/ar_table_lock.rb:15:in `with_lock'
lib/evm_database.rb:59:in `seed'
lib/evm_database.rb:47:in `seed_last'
app/models/miq_server.rb:260:in `start'
lib/workers/evm_server.rb:65:in `start'
lib/workers/evm_server.rb:92:in `start'
lib/workers/bin/evm_server.rb:4:in `<main>'
activerecord/lib/active_record/validations.rb:78:in `raise_validation_error': Validation failed: Description has already been taken (ActiveRecord::RecordInvalid)
```

**after:**
A time profile is created in the local region, but the descriptions are only made unique per region.

/cc @Fryguy @jdeubel This is my take of the problem