### PR TITLE
Fix variable name

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -48,7 +48,7 @@ module EmsRefresh::SaveInventoryContainer
   end
 
   def save_container_quotas_inventory(ems, hashes, target = nil)
-    return if hash.nil?
+    return if hashes.nil?
     target = ems if target.nil?
 
     ems.container_quotas.reset


### PR DESCRIPTION
This line of code and all other 24 x ```if hashes.nil?``` do not have any effect because of the way we [parse inventory items](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb#L119) but it is still wrong and might cause problems in case we ever support a partial refresh