### PR TITLE
Add stub for MiqAlert in migration add_read_only_to_miq_alert.rb

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -742,6 +742,7 @@ class MiqAlert < ApplicationRecord
         guid = alert_hash["guid"] || alert_hash[:guid]
         rec = find_by_guid(guid)
         if rec.nil?
+          alert_hash[:read_only] = true
           alert = create(alert_hash)
           _log.info("Added sample Alert: #{alert.description}")
           if action

--- a/db/migrate/20160418141210_add_read_only_to_miq_alert.rb
+++ b/db/migrate/20160418141210_add_read_only_to_miq_alert.rb
@@ -1,6 +1,9 @@
 class AddReadOnlyToMiqAlert < ActiveRecord::Migration[5.0]
+  class MiqAlert < ActiveRecord::Base; end
+
   def up
     add_column :miq_alerts, :read_only, :boolean
+
     say_with_time('Add read only parameter to MiqAlert with true for OOTB alerts') do
       guids = YAML.load_file(Rails.root.join("db/fixtures/miq_alerts.yml")).map { |h| h["guid"] || h[:guid] }
       MiqAlert.where(:guid => guids).update(:read_only => true)

--- a/db/migrate/20160418141210_add_read_only_to_miq_alert.rb
+++ b/db/migrate/20160418141210_add_read_only_to_miq_alert.rb
@@ -1,12 +1,25 @@
 class AddReadOnlyToMiqAlert < ActiveRecord::Migration[5.0]
   class MiqAlert < ActiveRecord::Base; end
 
+  MIQ_ALERT_GUIDS = ["9bc0d572-40bd-11de-bd12-005056a170fa", "fc2ae066-44b8-11de-900a-005056a170fa",
+                     "8a6d32a8-44b8-11de-900a-005056a170fa", "a9532172-44a5-11de-b543-005056a170fa",
+                     "1bb81254-44a6-11de-b543-005056a170fa", "ce2f8846-44a5-11de-b543-005056a170fa",
+                     "fb73af80-40bd-11de-bd12-005056a170fa", "e750cdcc-447c-11de-aaba-005056a170fa",
+                     "d59185a4-40bc-11de-bd12-005056a170fa", "c2fc477a-44a5-11de-b543-005056a170fa",
+                     "fbe4b5ee-447e-11de-aaba-005056a170fa", "3cfbb5ce-40be-11de-bd12-005056a170fa",
+                     "731da3b2-40bc-11de-bd12-005056a170fa", "5cd2b880-be53-11de-8d65-000c290de4f9",
+                     "8261bf0a-be54-11de-8d65-000c290de4f9", "fdee2784-bf2c-11de-b3b4-000c290de4f9",
+                     "9b61fd9e-bf35-11de-b3b4-000c290de4f9", "561d023c-bf36-11de-b3b4-000c290de4f9",
+                     "82f853b0-bf36-11de-b3b4-000c290de4f9", "58e8a372-bff9-11de-b3b4-000c290de4f9",
+                     "f8b870d0-c23d-11de-a3be-000c290de4f9", "eb88f942-c23e-11de-a3be-000c290de4f9",
+                     "196868de-c23f-11de-a3be-000c290de4f9", "4077943a-c240-11de-a3be-000c290de4f9",
+                     "89db0be8-c240-11de-a3be-000c290de4f9"].freeze
+
   def up
     add_column :miq_alerts, :read_only, :boolean
 
     say_with_time('Add read only parameter to MiqAlert with true for OOTB alerts') do
-      guids = YAML.load_file(Rails.root.join("db/fixtures/miq_alerts.yml")).map { |h| h["guid"] || h[:guid] }
-      MiqAlert.where(:guid => guids).update(:read_only => true)
+      MiqAlert.where(:guid => MIQ_ALERT_GUIDS).update(:read_only => true)
     end
   end
 

--- a/spec/migrations/20160418141210_add_read_only_to_miq_alert_spec.rb
+++ b/spec/migrations/20160418141210_add_read_only_to_miq_alert_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe AddReadOnlyToMiqAlert do
+  let(:miq_alert_stub) { migration_stub(:MiqAlert) }
+
+  let(:guids) { described_class::MIQ_ALERT_GUIDS }
+
+  migration_context :up do
+    it 'sets read_only to true value in for all records with guid from yaml file' do
+      guids.each { |guid| miq_alert_stub.create!(:guid => guid) }
+
+      migrate
+
+      guids.each { |guid| expect(miq_alert_stub.where(:guid => guid).first.reload.read_only).to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
- added stub for MiqAlert and spec
- Hardcode guids of MiqAlerts from current existing yaml file 
- mark new MiqAlerts with read_only=true in seed method

cc @jrafanie @Fryguy 

fyi @skateman - it is your migration
