### PR TITLE
Respect local overrides when serializing ActiveRecord to json

### DIFF
--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -19,7 +19,7 @@ class ApiController
       end
 
       attrs.each do |k|
-        value =  normalize_direct(type, k, obj[k])
+        value =  normalize_direct(type, k, obj.kind_of?(ActiveRecord::Base) ? obj.try(k) : obj[k])
         result[k] = value unless value.nil?
       end
       result

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -254,8 +254,8 @@ describe ApiController do
     it "supports multiple resource edits" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      p1 = FactoryGirl.create(:ext_management_system, :name => "name1")
-      p2 = FactoryGirl.create(:ext_management_system, :name => "name2")
+      p1 = FactoryGirl.create(:ems_redhat, :name => "name1")
+      p2 = FactoryGirl.create(:ems_redhat, :name => "name2")
 
       run_post(providers_url, gen_request(:edit,
                                           [{"href" => providers_url(p1.id), "name" => "updated name1"},


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1328265

Some models override default accessors like Tenant#name does. When
serializing these models to json, we should respect the overrides. That
way we ensure that webui and api present consistent data.

@miq-bot add_label bug, tenancy, wip