### PR TITLE
Correct "html hover" on chargeback tables

### DIFF
--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -21,7 +21,7 @@
       - if @cur_group != detail[:group]
         - @cur_group = detail[:group]
         %tr
-          %td.active{:colspan => "10"} &nbsp;
+          %td{:colspan => "10", :style => "background-color: #f5f5f5;"} &nbsp;
       - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
 
       %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}
@@ -88,3 +88,12 @@
                                       :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
                                                                             :index => "#{detail_index}-#{tier_index}",
                                                                             :button => "remove")}');")
+
+    :javascript
+      $('tbody tr.rdetail').hover(
+        function () {
+          $("tr[id^='"+this.id.slice(0,-2)+"']").addClass("active");
+        }, function() {
+          $("tr[id^='"+this.id.slice(0,-2)+"']").removeClass("active");
+        }
+      );

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -68,7 +68,7 @@
           = @edit[:new][:code_currency]
       - (1..num_tiers.to_i - 1).each do |tier_index|
         - tier = @edit[:new][:tiers][detail_index][tier_index]
-        %tr{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
+        %tr.rdetail{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
           %td
             - tier_val = (tier[:start].to_s.eql? "Infinity") ? "" : tier[:start]
             = text_field_tag("start_#{detail_index}_#{tier_index}", tier_val,
@@ -90,10 +90,10 @@
                                                                             :button => "remove")}');")
 
     :javascript
-      $('tbody tr.rdetail').hover(
-        function () {
-          $("tr[id^='"+this.id.slice(0,-2)+"']").addClass("active");
-        }, function() {
-          $("tr[id^='"+this.id.slice(0,-2)+"']").removeClass("active");
-        }
-      );
+      $('tbody tr.rdetail').hover( function(){hoverRowIn(this)}, function(row){hoverRowOut(this)});
+      function hoverRowIn(row) {
+        $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").addClass("active");
+      }
+      function hoverRowOut(row) {
+        $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").removeClass("active");
+      }

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -28,15 +28,15 @@
     %tbody
       /Currency code is the same for all the chargeback_rate_details
       - code_currency = @record.chargeback_rate_details.first.detail_currency.code
-      - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each do |detail|
+      - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each_with_index do |detail, detail_index|
       - tiers = detail.chargeback_tiers.order(:start)
         - @cur_group = detail[:group] if @cur_group.nil?
         - if @cur_group != detail[:group]
           - @cur_group = detail[:group]
           %tr
-            %td.active{:colspan => "9"} &nbsp;
+            %td.active{:colspan => "9", :style => "background-color: #f5f5f5;"} &nbsp;
         - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : tiers.to_a.length.to_s
-        %tr
+        %tr.rdetail{:id => "rate_detail_row_#{detail_index}"}
           %td{:rowspan => num_tiers}
             = h(rate_detail_group(detail[:group]))
           %td{:rowspan => num_tiers}
@@ -54,7 +54,7 @@
             = detail.show_rates(code_currency)
         - (1..num_tiers.to_i - 1).each do |tier_index|
           - tier = tiers.to_a[tier_index]
-          %tr
+          %tr.rdetail{:id => "rate_detail_row_#{detail_index}"}
             %td
               = tier.start
             %td
@@ -65,3 +65,12 @@
               = tier.variable_rate
         %tr
           %td{:colspan => "9"}
+
+    :javascript
+      $('tbody tr.rdetail').hover(
+        function () {
+          $("tr[id$='"+this.id+"']").addClass("active");
+        }, function() {
+          $("tr[id$='"+this.id+"']").removeClass("active");
+        }
+      );

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -69,8 +69,8 @@
     :javascript
       $('tbody tr.rdetail').hover(
         function () {
-          $("tr[id$='"+this.id+"']").addClass("active");
+          $("tr[id = '"+this.id+"']").addClass("active");
         }, function() {
-          $("tr[id$='"+this.id+"']").removeClass("active");
+          $("tr[id = '"+this.id+"']").removeClass("active");
         }
       );

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -47,11 +47,3 @@
   /Show the code of the currency selected by the user
   %td{:id => "column_currency_#{i}", :rowspan => n.to_s}
     = code_currency
-:javascript
-  $('tbody tr.rdetail').hover(
-    function () {
-      $("tr[id^='"+this.id.slice(0,-2)+"']").addClass("active");
-    }, function() {
-      $("tr[id^='"+this.id.slice(0,-2)+"']").removeClass("active");
-    }
-  );

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -47,3 +47,11 @@
   /Show the code of the currency selected by the user
   %td{:id => "column_currency_#{i}", :rowspan => n.to_s}
     = code_currency
+:javascript
+  $('tbody tr.rdetail').hover(
+    function () {
+      $("tr[id^='"+this.id.slice(0,-2)+"']").addClass("active");
+    }, function() {
+      $("tr[id^='"+this.id.slice(0,-2)+"']").removeClass("active");
+    }
+  );

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -31,10 +31,4 @@
         $('.new_tier').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();
         $('.new_tier').addClass('new_tier_off').removeClass('new_tier');
     });
-    $('tbody tr.rdetail').hover(
-      function () {
-        $("tr[id^='"+this.id.slice(0,-2)+"']").addClass("active");
-      }, function() {
-        $("tr[id^='"+this.id.slice(0,-2)+"']").removeClass("active");
-      }
-    );
+    $('tbody tr.rdetail').hover( function(){hoverRowIn(this)}, function(row){hoverRowOut(this)});

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -31,3 +31,10 @@
         $('.new_tier').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();
         $('.new_tier').addClass('new_tier_off').removeClass('new_tier');
     });
+    $('tbody tr.rdetail').hover(
+      function () {
+        $("tr[id^='"+this.id.slice(0,-2)+"']").addClass("active");
+      }, function() {
+        $("tr[id^='"+this.id.slice(0,-2)+"']").removeClass("active");
+      }
+    );


### PR DESCRIPTION
This PR adds some js code to the view to permit a correct hover on html tables. The current tables with tiers on the metrics, do that the table-hover class of patternfly does not works correctly. With this change the user can understand better the table makink a hover.
![hover](https://cloud.githubusercontent.com/assets/14124243/14816938/0760b202-0bb4-11e6-807c-cdb83e82dc70.png)

