### PR TITLE
JS add_flash - add optional id, ensure uniqueness when given

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -884,7 +884,7 @@ function miqAjaxAuth(url) {
     // TODO API.autorenew is called on (non-login) page load - when?
   })
   .then(null, function() {
-    add_flash(__("Incorrect username or password"), 'error');
+    add_flash(__("Incorrect username or password"), 'error', { id: 'auth_failed' });
 
     miqEnableLoginFields(true);
     miqSparkleOff();
@@ -893,8 +893,9 @@ function miqAjaxAuth(url) {
 
 // add a flash message to an existing #flash_msg_div
 // levels are error, warning, info, success
-function add_flash(msg, level) {
+function add_flash(msg, level, options) {
   level = level || 'success';
+  options = options || {};
   var cls = { alert: '', icon: '' };
 
   switch (level) {
@@ -930,6 +931,12 @@ function add_flash(msg, level) {
     text_div.remove();
   });
   text_div.append(alert_div);
+
+  // if options.id is provided, only one flash message with that id may exist
+  if (options.id) {
+    $('#' + options.id).filter('#flash_msg_div > *').remove();
+    text_div.attr('id', options.id);
+  }
 
   $('#flash_msg_div').append(text_div).show();
 }

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -136,6 +136,44 @@ describe('miq_application.js', function() {
     });
   });
 
+  describe('add_flash', function () {
+    beforeEach(function () {
+      var html = '<div id="flash_msg_div"></div>';
+      setFixtures(html);
+    });
+
+    it('creates a flash message', function () {
+      add_flash("foo", 'error');
+
+      var text = $('#flash_msg_div strong').text();
+      var klass = $('#flash_msg_div .alert').is('.alert-danger');
+      var count = $('#flash_msg_div > *').length;
+      expect(text).toEqual('foo');
+      expect(klass).toEqual(true);
+      expect(count).toEqual(1);
+    });
+
+    it('creates two flash messages', function () {
+      add_flash("bar", 'info');
+      add_flash("baz", 'success');
+
+      var count = $('#flash_msg_div > *').length;
+      expect(count).toEqual(2);
+    });
+
+    it('creates a unique flash message with id', function () {
+      add_flash("bar", 'info', { id: "unique" });
+      add_flash("baz", 'success', { id: "unique" });
+
+      var text = $('#flash_msg_div strong').text();
+      var klass = $('#flash_msg_div .alert').is('.alert-success');
+      var count = $('#flash_msg_div > *').length;
+      expect(text).toEqual('baz');
+      expect(klass).toEqual(true);
+      expect(count).toEqual(1);
+    });
+  });
+
   describe('miqUpdateElementsId', function () {
     beforeEach(function () {
       var html = '<div class="col-md-4 ui-sortable" id="col1"><div id="t_0|10000000000764" title="Drag this Tab to a new location"></div><div id="t_3|" title="Drag this Tab to a new location" class=""></div><div id="t_1|10000000000765" title="Drag this Tab to a new location"></div><div id="t_2|10000000000766" title="Drag this Tab to a new location"></div></div>'


### PR DESCRIPTION
The "authentication failed" message now gets an id of `auth_failed`, and `add_flash` removes the previous one if a new one with the same id is added.

https://bugzilla.redhat.com/show_bug.cgi?id=1327042