### PR TITLE
Remove last miqBrowserSizeTimeout mention

### DIFF
--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -124,7 +124,6 @@
 :javascript
   miqGetTZO();
   miqGetBrowserInfo();
-  miqBrowserSizeTimeout();
   miqClearTreeState();
 
 - auto_login  = session[:auto_login]  # Set to false via dashboard/logout


### PR DESCRIPTION
Fixes "Uncaught ReferenceError: miqBrowserSizeTimeout is not defined" on the login screen

The function was removed in #8072, this bit was forgotten..