### PR TITLE
Allow the task state to be active when executing the queue

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -107,10 +107,14 @@ class MiqRequestTask < ApplicationRecord
     self.class.get_description(self)
   end
 
-  def task_check_on_execute
+  def task_check_on_delivery
     if request_class::ACTIVE_STATES.include?(state)
       raise _("%{task} request is already being processed") % {:task => request_class::TASK_DESCRIPTION}
     end
+    task_check_on_execute
+  end
+
+  def task_check_on_execute
     if state == "finished"
       raise _("%{task} request has already been processed") % {:task => request_class::TASK_DESCRIPTION}
     end
@@ -118,7 +122,7 @@ class MiqRequestTask < ApplicationRecord
   end
 
   def deliver_to_automate(req_type = request_type, zone = nil)
-    task_check_on_execute
+    task_check_on_delivery
 
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -111,7 +111,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
   end
 
   def deliver_to_automate(req_type = request_type, _zone = nil)
-    task_check_on_execute
+    task_check_on_delivery
 
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 


### PR DESCRIPTION
Allow the task state to be active when executing the queue
The state is still forbidden being active when delivering to automate

https://bugzilla.redhat.com/show_bug.cgi?id=1330190