### PR TITLE
Handle gracefully when cloud -> network relation gets deleted

### DIFF
--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -131,6 +131,6 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.name}
+    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.try(:name)}
   end
 end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -108,7 +108,8 @@ class ExtManagementSystem < ApplicationRecord
            :port=,
            :security_protocol,
            :security_protocol=,
-           :to => :default_endpoint
+           :to => :default_endpoint,
+           :allow_nil => true
 
   alias_method :address, :hostname # TODO: Remove all callers of address
 

--- a/app/models/mixins/virtual_total_mixin.rb
+++ b/app/models/mixins/virtual_total_mixin.rb
@@ -16,7 +16,7 @@ module VirtualTotalMixin
     #
     def virtual_total(name, relation)
       define_method(name) do
-        send(relation).count
+        send(relation).try(:size) || 0
       end
 
       # allow this attribute to be sorted in the database

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -94,7 +94,7 @@ class NetworkTopologyService < TopologyService
     when Vm
       entity.power_state.capitalize
     when ManageIQ::Providers::NetworkManager
-      entity.authentications.empty? ? 'Unknown' : entity.authentications.first.status.capitalize
+      entity.authentications.blank? ? 'Unknown' : entity.authentications.first.status.try(:capitalize)
     when NetworkRouter, CloudSubnet, CloudNetwork, FloatingIp
       entity.status ? entity.status.downcase.capitalize : 'Unknown'
     when CloudTenant

--- a/app/views/layouts/listnav/_ems_cloud.html.haml
+++ b/app/views/layouts/listnav/_ems_cloud.html.haml
@@ -40,7 +40,7 @@
             :tables        => 'flavor',
             :controller    => 'ems_cloud')
         - if role_allows(:feature => "security_group_show_list")
-          = li_link(:count => @record.number_of(:security_groups),
+          = li_link(:count => @record.security_groups && @record.number_of(:security_groups),
             :record        => @record,
             :display       => 'security_groups',
             :tables        => 'security_group',


### PR DESCRIPTION
Handle gracefully when CloudManager -> NetworkManager relation
gets deleted. This should not happened since both creation
and deletion of cloud_manager is always packed with network
manager in a transaction. And yet, I had reported this occurred.

Which would probably point to some lowlevel consistency bug.
It has not been reproduced yet.

This PR allows us to display and delete disconnected CloudManager
and NetworkManager, without presenting any 500 error to the
user.