### PR TITLE
Lock down webmock until tests can be updated appropriately

### DIFF
--- a/gems/manageiq_foreman/manageiq_foreman.gemspec
+++ b/gems/manageiq_foreman/manageiq_foreman.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "vcr", "~> 2.6"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock", "~> 1.24.2"
 
   spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
[webmock 2.0.0](https://rubygems.org/gems/webmock/versions/2.0.0) was released yesterday.