### PR TITLE
SCVMM - Handle exception raised when 'VMCheckpoints' are not present

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -331,6 +331,12 @@ module ManageIQ::Providers::Microsoft
 
     def process_snapshots(p)
       result = []
+
+      if p[:VMCheckpoints].nil?
+        $scvmm_log.info("No snapshot information available for #{p[:Name]}")
+        return result
+      end
+
       p[:VMCheckpoints].each do |snapshot_hash|
         s = snapshot_hash[:Props]
         new_result = {


### PR DESCRIPTION
As described in the BZ, we have been unable to reproduce this exception so I took an educated guess at the cause. The exception message in the log file is as follows:

`----] E, [2016-01-13T16:14:15.454712 #3064:6c398c] ERROR -- : [NoMethodError]: undefined method each' for nil:NilClass  Method:[rescue in block in refresh]
[----] E, [2016-01-13T16:14:15.454828 #3064:6c398c] ERROR -- : /var/www/miq/vmdb/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb:324:in process_snapshots`


**the fix:**
This usually indicates an attempt was made to read a hash key that is not present. In this PR I check if the `VMCheckpoints` key is present before trying to read it to gather a list of snapshots.


**spec test**
I am open to ideas on how to write a test for this. The refresher spec tests read from the database after a refresh has completed. I could butcher the output of loading the static YML file of inventory in the `before` method so a VM's properties hash has no `VMCheckpoints` key: 
https://github.com/ManageIQ/manageiq/blob/master/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb#L10
.. but i do not love that approach.

https://bugzilla.redhat.com/show_bug.cgi?id=1298325

@miq-bot add_label darga/yes