### PR TITLE
Validate ChargebackRateDetail#chargeback_rate

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -6,7 +6,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   default_scope { order(:group => :asc, :description => :asc) }
 
-  validates :group, :source, :presence => true
+  validates :group, :source, :chargeback_rate, :presence => true
   validate :contiguous_tiers?
 
   FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric).freeze

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -171,7 +171,7 @@ describe ChargebackController do
 
     render_views
 
-    let(:chargeback_rate) { FactoryGirl.create(:chargeback_rate_with_details) }
+    let(:chargeback_rate) { FactoryGirl.create(:chargeback_rate_with_details, :description => "foo") }
 
     # this index represent first rate detail( "Allocated Memory in MB") chargeback_rate
     let(:index_to_rate_type) { "0" }

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :chargeback_rate do
-    guid        { MiqUUID.new_guid }
-    description 'foo'
-    rate_type 'Compute'
+    guid                   { MiqUUID.new_guid }
+    sequence(:description) { |n| "Chargeback Rate ##{n}" }
+    rate_type              'Compute'
   end
 
   factory :chargeback_rate_with_details, :parent => :chargeback_rate do

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :chargeback_rate_detail do
     group   "unknown"
     source  "unknown"
+    chargeback_rate
 
     trait :euro do
       detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency_EUR) }

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -1,4 +1,14 @@
 describe ChargebackRateDetail do
+  describe "#chargeback_rate" do
+    it "is invalid without a valid chargeback_rate" do
+      invalid_chargeback_rate_id = (ChargebackRate.maximum(:id) || -1) + 1
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail,
+                                                 :chargeback_rate_id => invalid_chargeback_rate_id)
+      expect(chargeback_rate_detail).to be_invalid
+      expect(chargeback_rate_detail.errors.messages).to include(:chargeback_rate => [/can't be blank/])
+    end
+  end
+
   it "#cost" do
     cvalue   = 42.0
     fixed_rate = 5.0
@@ -133,12 +143,9 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
   end
 
   it "#rate_type" do
-    cbd = FactoryGirl.build(:chargeback_rate_detail)
-    expect(cbd.rate_type).to be_nil
-
     rate_type = 'ad-hoc'
     cb = FactoryGirl.create(:chargeback_rate, :rate_type => rate_type)
-    cbd.chargeback_rate = cb
+    cbd = FactoryGirl.build(:chargeback_rate_detail, :chargeback_rate => cb)
     expect(cbd.rate_type).to eq(rate_type)
   end
 

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -72,13 +72,15 @@ RSpec.describe "chargebacks API" do
   context "with an appropriate role" do
     it "can create a new chargeback rate detail" do
       api_basic_authorize action_identifier(:rates, :create, :collection_actions)
+      chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
       expect do
         run_post rates_url,
-                 :description => "rate_0",
-                 :group       => "fixed",
-                 :source      => "used",
-                 :enabled     => true
+                 :description        => "rate_0",
+                 :group              => "fixed",
+                 :chargeback_rate_id => chargeback_rate.id,
+                 :source             => "used",
+                 :enabled            => true
       end.to change(ChargebackRateDetail, :count).by(1)
       expect_result_to_match_hash(response_hash["results"].first, "description" => "rate_0", "enabled" => true)
       expect_request_success


### PR DESCRIPTION
In the API chargeback rate details can be created successfully with an
invalid chargeback_rate_id. Adding this validation ensures that this
can't happen at the model level.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1328940

@miq-bot add-label bug, core