### PR TITLE
Fixed db for filters in Workloads explorer.

### DIFF
--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
   def tree_init_options(_tree_name)
-    super.update(:leaf => 'ManageIQ::Providers::InfraManager::Template')
+    super.update(:leaf => 'MiqTemplate')
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
   def tree_init_options(_tree_name)
-    super.update(:leaf => 'ManageIQ::Providers::CloudManager::Vm')
+    super.update(:leaf => 'Vm')
   end
 
   def set_locals_for_render


### PR DESCRIPTION
Fixed value of db to be used for filter trees in Workloads explorer to match with db value in miq_searches.yml

https://bugzilla.redhat.com/show_bug.cgi?id=1328225

workload default filters:
![workloads_filters](https://cloud.githubusercontent.com/assets/3450808/14833275/6cd8bd42-0bcc-11e6-9705-e39529d7d54d.png)

before
![before_vm_instances_tree](https://cloud.githubusercontent.com/assets/3450808/14833310/9e9c09c4-0bcc-11e6-8d03-fc9bcb415ea3.png)

![before_templates_images_tree](https://cloud.githubusercontent.com/assets/3450808/14833314/a1b90dc8-0bcc-11e6-9c70-87c602c4a682.png)

after
![vms_instances_filters](https://cloud.githubusercontent.com/assets/3450808/14833282/715cf0d6-0bcc-11e6-9415-229c06adb306.png)

![template_images_filters](https://cloud.githubusercontent.com/assets/3450808/14833287/75d5b6a2-0bcc-11e6-87f3-2e745dc0293c.png)


@dclarizio please review.
