### PR TITLE
Changed error message when trying to log in with incorrect password or username

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -884,7 +884,7 @@ function miqAjaxAuth(url) {
     // TODO API.autorenew is called on (non-login) page load - when?
   })
   .then(null, function() {
-    add_flash(__("API Authentication failed"), 'error');
+    add_flash(__("Incorrect username or password"), 'error');
 
     miqEnableLoginFields(true);
     miqSparkleOff();


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1329937

Updated string  "API Authentication failed"  to "Incorrect username or password"
in app/assets/javascripts/miq_application.js

/cc @gtanzillo 