### PR TITLE
Add db connection checkin/checkout debug logging.

### DIFF
--- a/lib/extensions/ar_adapter/ar_checkin_checkout_callbacks.rb
+++ b/lib/extensions/ar_adapter/ar_checkin_checkout_callbacks.rb
@@ -1,0 +1,22 @@
+ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
+  set_callback(:checkout, :after, :log_after_checkout)
+  set_callback(:checkin,  :after, :log_after_checkin)
+
+  def connection_info_for_logging
+    pool             = ActiveRecord::Base.connection_pool
+    pool_size        = pool.size
+    count            = pool.connections.count
+    in_use           = pool.connections.count(&:in_use?)
+    waiting_in_queue = pool.num_waiting_in_queue
+
+    "connection_pool: size: #{pool_size}, connections: #{count}, in use: #{in_use}, waiting_in_queue: #{waiting_in_queue}"
+  end
+
+  def log_after_checkin
+    logger.debug { "#{self.class.name.demodulize}##{__method__}, #{connection_info_for_logging}" } if logger && ActiveRecord::Base.connected?
+  end
+
+  def log_after_checkout
+    logger.debug { "#{self.class.name.demodulize}##{__method__}, #{connection_info_for_logging}" } if logger && ActiveRecord::Base.connected?
+  end
+end


### PR DESCRIPTION
Related to #7801

Now that we use puma, which handles requests in threads, and we have multiple
services making requests to puma, the ops UI, self service UI, and the REST API,
we need logging of connection pool usage to try to track down misconfiguration or
a bug.

For example, if we have need to configure the puma min/max thread count (config/puma.rb)
(5,5 currently) to work correctly with the rails connection pool size of 5,
we need a way to know if we have too many/few puma threads or connection pool size.

To enable this, you need to configure level_rails in advanced settings to debug.

```
[----] D, [2016-04-29T12:26:55.359811 #31844:3fc79545e204] DEBUG -- : PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 1, waiting_in_queue: 0
[----] D, [2016-04-29T12:26:59.263333 #31844:3fc79545e204] DEBUG -- : PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 1, in use: 0, waiting_in_queue: 0
```
This might need to be backported as it could be useful for debugging.

UPDATE:  It was too much hassle to use our _log logger in rails code so I put it back to the activerecord's logger if defined.  We'll see if it's a hassle seeing these messages in dev mode.