### PR TITLE
[api] exposing vms as subcollection of services

### DIFF
--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -122,6 +122,12 @@ class ApiController
       end
     end
 
+    def attribute_selection_for(collection)
+      Array(attribute_selection).collect do |attr|
+        /\A#{collection}\.(?<name>.*)\z/.match(attr) { |m| m[:name] }
+      end.compact
+    end
+
     def render_attr(attr)
       as = attribute_selection
       as == "all" || as.include?(attr)

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -221,6 +221,9 @@ class ApiController
       scs.each do |sc|
         target = "#{sc}_query_resource"
         next unless expand_subcollection?(sc, target)
+        if Array(attribute_selection).include?(sc.to_s)
+          raise BadRequestError, "Cannot expand subcollection #{sc} by name and virtual attribute"
+        end
         expand_subcollection(json, sc, "#{type}/#{resource.id}/#{sc}", send(target, resource))
       end
     end

--- a/app/controllers/api_controller/vms.rb
+++ b/app/controllers/api_controller/vms.rb
@@ -1,5 +1,15 @@
 class ApiController
   module Vms
+    def vms_query_resource(object)
+      vm_attrs = attribute_selection_for("vms")
+      vm_attrs.blank? ? object.try(:vms) : Array(object.try(:vms)).collect do |vm|
+        add_hash = vm_attrs.each_with_object({}) do |attr, hash|
+          hash[attr] = vm.try(attr.to_sym) if vm.respond_to?(attr.to_sym)
+        end.compact
+        vm.as_json.merge(add_hash)
+      end
+    end
+
     def start_resource_vms(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
 

--- a/app/controllers/api_controller/vms.rb
+++ b/app/controllers/api_controller/vms.rb
@@ -4,7 +4,7 @@ class ApiController
       vm_attrs = attribute_selection_for("vms")
       vm_attrs.blank? ? object.try(:vms) : Array(object.try(:vms)).collect do |vm|
         add_hash = vm_attrs.each_with_object({}) do |attr, hash|
-          hash[attr] = vm.try(attr.to_sym) if vm.respond_to?(attr.to_sym)
+          hash[attr] = vm.public_send(attr.to_sym) if vm.respond_to?(attr.to_sym)
         end.compact
         vm.as_json.merge(add_hash)
       end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1042,6 +1042,7 @@
     :subcollections:
     - :tags
     - :service_dialogs
+    - :vms
     :collection_actions:
       :get:
       - :name: read

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -15,6 +15,11 @@
 #
 # - Reconfigure service         /api/services/:id     action "reconfigure"
 #
+# - Query vms subcollection     /api/services/:id/vms
+#                               /api/services/:id?expand=vms
+#   with subcollection
+#   virtual attribute:          /api/services/:id?expand=vms&attributes=vms.cpu_total_cores
+#
 describe ApiController do
   let(:svc)  { FactoryGirl.create(:service, :name => "svc",  :description => "svc description")  }
   let(:svc1) { FactoryGirl.create(:service, :name => "svc1", :description => "svc1 description") }
@@ -254,6 +259,56 @@ describe ApiController do
       run_post(services_url(svc1.id), gen_request(:reconfigure, "text1" => "updated_text"))
 
       expect_single_action_result(:success => true, :message => /reconfiguring/i, :href => services_url(svc1.id))
+    end
+  end
+
+  describe "Services" do
+    let(:hw1) { FactoryGirl.build(:hardware, :cpu_total_cores => 2) }
+    let(:vm1) { FactoryGirl.create(:vm_vmware, :hardware => hw1) }
+
+    let(:hw2) { FactoryGirl.build(:hardware, :cpu_total_cores => 4) }
+    let(:vm2) { FactoryGirl.create(:vm_vmware, :hardware => hw2) }
+
+    before do
+      api_basic_authorize(action_identifier(:services, :read, :resource_actions, :get))
+
+      svc1 << vm1
+      svc1 << vm2
+      svc1.save
+
+      @svc1_vm_list = ["#{services_url(svc1.id)}/vms/#{vm1.id}", "#{services_url(svc1.id)}/vms/#{vm2.id}"]
+    end
+
+    def expect_svc_with_vms
+      expect_single_resource_query("href" => services_url(svc1.id))
+      expect_result_resources_to_include_hrefs("vms", @svc1_vm_list)
+    end
+
+    it "can query vms as subcollection" do
+      run_get "#{services_url(svc1.id)}/vms"
+
+      expect_query_result(:vms, 2, 2)
+      expect_result_resources_to_include_hrefs("resources", @svc1_vm_list)
+    end
+
+    it "can query vms as subcollection via expand" do
+      run_get services_url(svc1.id), :expand => "vms"
+
+      expect_svc_with_vms
+    end
+
+    it "can query vms as subcollection via expand with additional virtual attributes" do
+      run_get services_url(svc1.id), :expand => "vms", :attributes => "vms.cpu_total_cores"
+
+      expect_svc_with_vms
+      expect_results_to_match_hash("vms", [{"id" => vm1.id, "cpu_total_cores" => 2},
+                                           {"id" => vm2.id, "cpu_total_cores" => 4}])
+    end
+
+    it "cannot query vms via both virtual attribute and subcollection" do
+      run_get services_url(svc1.id), :expand => "vms", :attributes => "vms"
+
+      expect_bad_request("Cannot expand subcollection vms by name and virtual attribute")
     end
   end
 end


### PR DESCRIPTION
- Provide ability to query vms via GET /api/services/:id/vms
- This allows us to expand vms as subcollection instead of just a reflection, so we can do:
      GET /api/services/:id?expand=vms
- Allows specification of subcollection specific attributes as follows:
      GET /api/services/:id?expand=vms&attributes=vms.num_cpu
