### PR TITLE
Don't pass the html message from the provider.

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -25,7 +25,7 @@ module ManageIQ::Providers
         # we verify the credentials via an actual operation
         connect(options).list_feeds
       rescue => err
-        raise MiqException::MiqInvalidCredentialsError, err.message
+        raise MiqException::MiqInvalidCredentialsError, 'Invalid credentials'
       end
 
       true


### PR DESCRIPTION
Hawkular's underlying app server returns authentication errors always as html data, which must not end up in the UI.
Provide a static message instead. Fixes #8239