### PR TITLE
For Middleware/Hawkular hide non-applicable endpoints

### DIFF
--- a/app/views/layouts/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/_multi_auth_credentials.html.haml
@@ -18,7 +18,7 @@
         - if %w(openstack_infra).include?(@edit[:new][:emstype])
           = miq_tab_header('ssh_keypair') do
             = _("RSA key pair")
-      - else
+      - elsif !%w(ems_middleware).include?(params[:controller])
         = miq_tab_header('remote') do
           = _("Remote Login")
         = miq_tab_header('web') do


### PR DESCRIPTION
The Hawkular provider only supports login via username/password. No remote, webservices or ipmi.
So hide those.

Before:

![bildschirmfoto 2016-04-27 um 09 53 57](https://cloud.githubusercontent.com/assets/208246/14847350/7468a68e-0c68-11e6-80bf-ae387a72f42a.png)

After:

![bildschirmfoto 2016-04-27 um 11 06 01](https://cloud.githubusercontent.com/assets/208246/14847357/7c5d0600-0c68-11e6-9cc2-046123ef4273.png)

@miq-bot add_label ui, providers/hawkular
@abonas 