### PR TITLE
Maintain VMware class hierarchy

### DIFF
--- a/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -1720,10 +1720,16 @@ class MiqVimInventory < MiqVimClientBase
     return(@dvSwithces) if @dvSwitches
 
     $vim_log.info "MiqVimInventory.dvSwitches_locked: loading DV Switch cache for #{@connId}"
+
+    base_class    = 'DistributedVirtualSwitch'.freeze
+    child_classes = VimType.child_classes(base_class)
+
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
-      ra = getMoPropMulti(inventoryHash_locked['DistributedVirtualSwitch'], @propMap[:DistributedVirtualSwitch][:props])
+      moref_array = child_classes.collect { |klass| inventoryHash_locked[klass] }.flatten.compact
+
+      ra = getMoPropMulti(moref_array, @propMap[base_class.to_sym][:props])
 
       @dvSwitches      = {}
       @dvSwitchesByMor = {}

--- a/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -548,7 +548,7 @@ class MiqVimInventory < MiqVimClientBase
   #
   def addObjByMor(objMor)
     raise "addObjByMor: exclusive cache lock not held"      unless @cacheLock.sync_exclusive?
-    objType = objMor.vimType.to_sym
+    objType = objMor.vimBaseType.to_sym
     raise "addObjByMor: Unknown VIM object type: #{objType}"  unless (pmap = @propMap[objType])
 
     objHash = getMoProp_local(objMor, pmap[:props])
@@ -560,7 +560,7 @@ class MiqVimInventory < MiqVimClientBase
 
   def removeObjByMor(objMor)
     raise "removeObjByMor: exclusive cache lock not held"   unless @cacheLock.sync_exclusive?
-    objType = objMor.vimType.to_sym
+    objType = objMor.vimBaseType.to_sym
     raise "removeObjByMor: Unknown VIM object type: #{objType}" unless (pmap = @propMap[objType])
 
     baseName  = pmap[:baseName]

--- a/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -1722,7 +1722,7 @@ class MiqVimInventory < MiqVimClientBase
     $vim_log.info "MiqVimInventory.dvSwitches_locked: loading DV Switch cache for #{@connId}"
 
     base_class    = 'DistributedVirtualSwitch'.freeze
-    child_classes = VimType.child_classes(base_class)
+    child_classes = VimClass.child_classes(base_class)
 
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)

--- a/gems/pending/VMwareWebService/MiqVimUpdate.rb
+++ b/gems/pending/VMwareWebService/MiqVimUpdate.rb
@@ -185,7 +185,7 @@ module MiqVimUpdate
     # Look up root hash of object in the <objType>ByMor hash and pass it
     # to the prop update routines: add, remove, assign.
     #
-    objType = objUpdate.obj.vimType.to_sym
+    objType = objUpdate.obj.vimBaseType.to_sym
     unless (pm = @propMap[objType])
       # We don't cache this type of object
       return
@@ -264,10 +264,12 @@ module MiqVimUpdate
   end
 
   def addObject(objUpdate, initialUpdate)
-    objType = objUpdate.obj.vimType
+    objType     = objUpdate.obj.vimType
+    objBaseType = objUpdate.obj.vimBaseType
+
     # always log additions to the inventory.
     $vim_log.info "MiqVimUpdate.addObject (#{@connId}): #{objType}: #{objUpdate.obj}"
-    return unless (pm = @propMap[objType.to_sym])  # not an object type we cache
+    return unless (pm = @propMap[objBaseType.to_sym])  # not an object type we cache
     $vim_log.info "MiqVimUpdate.addObject (#{@connId}): Adding object #{objType}: #{objUpdate.obj}"
 
     #
@@ -292,7 +294,7 @@ module MiqVimUpdate
       obj['MOR'] = objUpdate.obj
       propUpdate(obj, objUpdate.changeSet)
 
-      addObjHash(objType.to_sym, obj)
+      addObjHash(objBaseType.to_sym, obj)
 
       #
       # Call the notify callback if enabled, defined and we are past the initial update
@@ -321,10 +323,12 @@ module MiqVimUpdate
   end
 
   def deleteObject(objUpdate, initialUpdate = false)
-    objType = objUpdate.obj.vimType
+    objType     = objUpdate.obj.vimType
+    objBaseType = objUpdate.obj.vimBaseType
+
     # always log deletions from the inventory.
     $vim_log.info "MiqVimUpdate.deleteObject (#{@connId}): #{objType}: #{objUpdate.obj}"
-    return unless (pm = @propMap[objType.to_sym])      # not an object type we cache
+    return unless (pm = @propMap[objBaseType.to_sym])      # not an object type we cache
     $vim_log.info "MiqVimUpdate.deleteObject (#{@connId}): Deleting object: #{objType}: #{objUpdate.obj}"
 
     ia = @inventoryHash[objType]

--- a/gems/pending/VMwareWebService/VimTypes.rb
+++ b/gems/pending/VMwareWebService/VimTypes.rb
@@ -1,7 +1,31 @@
 require 'VMwareWebService/VimConstants'
 autoload :VimMappingRegistry, 'VMwareWebService/VimMappingRegistry'
 
+module VimType
+  def vimType
+    @vimType.nil? ? nil : @vimType.to_s
+  end
+
+  def vimType=(val)
+    @vimType = val.nil? ? nil : val.to_sym
+  end
+
+  def vimBaseType
+    VimClass.base_class(vimType)
+  end
+
+  def xsiType
+    @xsiType.nil? ? nil : @xsiType.to_s
+  end
+
+  def xsiType=(val)
+    @xsiType = val.nil? ? nil : val.to_sym
+  end
+end
+
 class VimHash < Hash
+  include VimType
+
   undef_method(:id)   if method_defined?(:id)
   undef_method(:type) if method_defined?(:type)
   undef_method(:size) if method_defined?(:size)
@@ -23,26 +47,6 @@ class VimHash < Hash
     end
   end
 
-  def vimType
-    @vimType.nil? ? nil : @vimType.to_s
-  end
-
-  def vimType=(val)
-    @vimType = val.nil? ? nil : val.to_sym
-  end
-
-  def vimBaseType
-    VimType.base_class(vimType)
-  end
-
-  def xsiType
-    @xsiType.nil? ? nil : @xsiType.to_s
-  end
-
-  def xsiType=(val)
-    @xsiType = val.nil? ? nil : val.to_sym
-  end
-
   def method_missing(sym, *args)
     key = sym.to_s
     if key[-1, 1] == '='
@@ -54,35 +58,19 @@ class VimHash < Hash
 end
 
 class VimArray < Array
+  include VimType
+
   def initialize(xsiType = nil, vimType = nil)
     self.xsiType = xsiType
     self.vimType = vimType
     super()
     yield(self) if block_given?
   end
-
-  def vimType
-    @vimType.nil? ? nil : @vimType.to_s
-  end
-
-  def vimType=(val)
-    @vimType = val.nil? ? nil : val.to_sym
-  end
-
-  def vimBaseType
-    VimType.base_class(vimType)
-  end
-
-  def xsiType
-    @xsiType.nil? ? nil : @xsiType.to_s
-  end
-
-  def xsiType=(val)
-    @xsiType = val.nil? ? nil : val.to_sym
-  end
 end
 
 class VimString < String
+  include VimType
+
   #
   # vimType and xsiType arg positions are switched here because
   # most strings are MORs, and this makes it easier to set the
@@ -93,26 +81,6 @@ class VimString < String
     self.vimType = vimType
     super(val)
     yield(self) if block_given?
-  end
-
-  def vimType
-    @vimType.nil? ? nil : @vimType.to_s
-  end
-
-  def vimType=(val)
-    @vimType = val.nil? ? nil : val.to_sym
-  end
-
-  def vimBaseType
-    VimType.base_class(vimType)
-  end
-
-  def xsiType
-    @xsiType.nil? ? nil : @xsiType.to_s
-  end
-
-  def xsiType=(val)
-    @xsiType = val.nil? ? nil : val.to_sym
   end
 end
 
@@ -125,7 +93,7 @@ class VimFault < RuntimeError
   end
 end
 
-class VimType
+class VimClass
   # Default to a sparse 1:1 mapping
   @class_hierarchy = Hash.new { |hash, key| hash[key] = Set[key] }
   @base_class      = Hash.new { |hash, key| hash[key] = key }

--- a/gems/pending/VMwareWebService/VimTypes.rb
+++ b/gems/pending/VMwareWebService/VimTypes.rb
@@ -31,6 +31,10 @@ class VimHash < Hash
     @vimType = val.nil? ? nil : val.to_sym
   end
 
+  def vimBaseType
+    VimType.base_class(vimType)
+  end
+
   def xsiType
     @xsiType.nil? ? nil : @xsiType.to_s
   end
@@ -65,6 +69,10 @@ class VimArray < Array
     @vimType = val.nil? ? nil : val.to_sym
   end
 
+  def vimBaseType
+    VimType.base_class(vimType)
+  end
+
   def xsiType
     @xsiType.nil? ? nil : @xsiType.to_s
   end
@@ -95,6 +103,10 @@ class VimString < String
     @vimType = val.nil? ? nil : val.to_sym
   end
 
+  def vimBaseType
+    VimType.base_class(vimType)
+  end
+
   def xsiType
     @xsiType.nil? ? nil : @xsiType.to_s
   end
@@ -110,5 +122,23 @@ class VimFault < RuntimeError
   def initialize(vimObj)
     @vimFaultInfo = vimObj
     super(@vimFaultInfo.localizedMessage)
+  end
+end
+
+class VimType
+  # Default to a sparse 1:1 mapping
+  @class_hierarchy = Hash.new { |hash, key| hash[key] = Set[key] }
+  @base_class      = Hash.new { |hash, key| hash[key] = key }
+
+  # Add VmwareDistributedVirtualSwitch as a child class of DistributedVirtualSwitch
+  @class_hierarchy["DistributedVirtualSwitch"]  << "VmwareDistributedVirtualSwitch"
+  @base_class["VmwareDistributedVirtualSwitch"] =  "DistributedVirtualSwitch"
+
+  def self.child_classes(vim_type)
+    @class_hierarchy[vim_type]
+  end
+
+  def self.base_class(vim_type)
+    @base_class[vim_type]
   end
 end


### PR DESCRIPTION
VMware extends some classes to denote the type of object, for example [DistributedVirtualSwitch](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.DistributedVirtualSwitch.html) is extended by [VmwareDistributedVirtualSwitch](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.dvs.VmwareDistributedVirtualSwitch.html).

DVSwitches created by VMware will have type `VmwareDistributedVirtualSwitch` while DVSwitches created by third parties (i.e.: Cisco Nexus 1000V) will have the base class type, so we need to be able to handle both.

This change maintains a class mapping so that you can pass in a vimType (e.g.: `HostSystem` or `VirtualMachine`) and find out its base class as well as all extended classes.  This lets us maintain the correct vimType for all objects while still being able to access the propMap using just the base class name.