### PR TITLE
Removed unused part of toolbar_builder spec

### DIFF
--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1799,13 +1799,6 @@ describe ApplicationHelper do
       end
     end
 
-    it "when with 'history_1' and x_tree_history.length < 2" do
-      # setup for x_tree_history
-      @sb = {:history     => {:testing => %w(something)},
-             :active_tree => :testing}
-      expect(build_toolbar_disable_button('history_1')).to be_truthy
-    end
-
     ['button_add', 'button_save', 'button_reset'].each do |b|
       it "when with #{b} and not changed" do
         @changed = false


### PR DESCRIPTION
This part was removed in PR #6078:
https://github.com/ManageIQ/manageiq/commit/a7e6f5e6e6a956532cf408995fc4a2a02b1f9d18#diff-7ae614daa2bb6b8fb8409c6f36995139L1727

and again added by mistake in my PR #5884:
https://github.com/ManageIQ/manageiq/pull/5884/commits/8b8bcc1d65358443e65ab892f3ceb80d10678a34#diff-7ae614daa2bb6b8fb8409c6f36995139R1729

@h-kataria @martinpovolny please review