### PR TITLE
Remove possible `miq_ae_service_` prefix from image paths in simulate

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -343,7 +343,7 @@ Methods updated/added: %{method_stats}") % stat_options)
       e_node[:icon] = ActionController::Base.helpers.image_path("100/#{el.name.underscore}.png")
     else
       e_node[:title] = el.name
-      e_node[:icon] = ActionController::Base.helpers.image_path("100/#{e_node[:title].underscore}.png")
+      e_node[:icon] = ActionController::Base.helpers.image_path("100/#{e_node[:title].underscore.sub(/^miq_ae_service_/, '')}.png")
       el.attributes.each_pair do |k, v|
         a_node = {}
         a_node[:key] = "a_#{@idx}"


### PR DESCRIPTION
**Before:**
![screenshot from 2016-04-27 17-25-57](https://cloud.githubusercontent.com/assets/649130/14857603/30460304-0c9d-11e6-8242-591c9c6777cb.png)

**After:**
![screenshot from 2016-04-27 17-25-13](https://cloud.githubusercontent.com/assets/649130/14857607/3584e484-0c9d-11e6-8c74-b3c3725c39a4.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1331039