### PR TITLE
Hack: Reset rails' column cache for Entitlement for now. :confused:

### DIFF
--- a/db/migrate/20160414123914_add_filters_to_entitlements.rb
+++ b/db/migrate/20160414123914_add_filters_to_entitlements.rb
@@ -1,5 +1,12 @@
 class AddFiltersToEntitlements < ActiveRecord::Migration[5.0]
+  class Entitlement < ActiveRecord::Base; end
+
   def change
     add_column :entitlements, :filters, :text
+
+    # HACK, this shouldn't be required, figure out why. :cry:
+    # Without this, migrate fails when you go from "latest schema" down to:
+    # 20160317194215_remove_miq_user_role_from_miq_groups.rb
+    Entitlement.reset_column_information
   end
 end


### PR DESCRIPTION
Caused by #8102

Without this, migrate fails when you go from "latest schema" down to:
20160317194215_remove_miq_user_role_from_miq_groups.rb:

`PG::UndefinedColumn: ERROR:  column entitlements.filters does not exist`

Clearly, this isn't the right fix because then we'd have to reset column
information everytime we add/remove a column in case "some other migration" tries
to use that table's stub model.  That would be bad. :cry: