### PR TITLE
Bind sortable properties to sortable-handle class

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -948,17 +948,17 @@ function miqEnableLoginFields(enabled) {
 // Initialize dashboard column jQuery sortables
 function miqInitDashboardCols() {
   if ($('#col1').length) {
-    $('#col1').sortable({connectWith: '#col2, #col3', handle: "h2"});
+    $('#col1').sortable({connectWith: '#col2, #col3', handle: ".sortable-handle"});
     $('#col1').off('sortupdate');
     $('#col1').on('sortupdate', miqDropComplete);
   }
   if ($('#col2').length) {
-    $('#col2').sortable({connectWith: '#col1, #col3', handle: "h2"});
+    $('#col2').sortable({connectWith: '#col1, #col3', handle: ".sortable-handle"});
     $('#col2').off('sortupdate');
     $('#col2').on('sortupdate', miqDropComplete);
   }
   if ($('#col3').length) {
-    $('#col3').sortable({connectWith: '#col1, #col2', handle: "h2"});
+    $('#col3').sortable({connectWith: '#col1, #col2', handle: ".sortable-handle"});
     $('#col3').off('sortupdate');
     $('#col3').on('sortupdate', miqDropComplete);
   }

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -3,7 +3,7 @@
 %div{:id => "w_#{presenter.widget.id}"}
   .card-pf
     .card-pf-heading
-      %h2.card-pf-title{:style => "cursor:move"}
+      %h2.card-pf-title.sortable-handle{:style => "cursor:move"}
         = h(presenter.widget.title)
         .dropdown.dropdown-kebab-pf.pull-right
           %button.btn.btn-link.dropdown-toggle{:type => "button", :id => "dropdownKebab", "data-toggle" => "dropdown"}

--- a/app/views/miq_ae_customization/_dialog_resource.html.haml
+++ b/app/views/miq_ae_customization/_dialog_resource.html.haml
@@ -5,7 +5,7 @@
 %div{:id => "t_#{curr_pos}|#{obj[:id]}", :title => _('Drag this Tab to a new location')}
   .panel.panel-default
     .panel-heading
-      %h3.panel-title{:style => "cursor: move;"}
+      %h3.panel-title.sortable-handle{:style => "cursor: move;"}
         %a{:class => "#{parent_id}_#{obj[:id]}box"}
         = render :partial => 'dialog_res_remove',
           :locals => {:obj => obj,

--- a/app/views/report/_db_widget.html.haml
+++ b/app/views/report/_db_widget.html.haml
@@ -9,7 +9,7 @@
 / .pointer{params}
 .panel.panel-default{params}
   .panel-heading
-    %h3.panel-title{:style => @edit && @edit[:current] ? "cursor: move;" : ""}
+    %h3.panel-title.sortable-handle{:style => @edit && @edit[:current] ? "cursor: move;" : ""}
       - case widget.content_type
       - when "chart"
         - glyphicon = "product product-chart"

--- a/app/views/report/_widget_form_menu.html.haml
+++ b/app/views/report/_widget_form_menu.html.haml
@@ -18,8 +18,8 @@
       -# :shortcuts is a hash of s.id => s.miq_widget_shortcut.description
       %div{:id => "s_#{s_id}", :title => _("Drag this Shortcut to a new location")}
         .panel.panel-default
-          .panel-header
-            %h3.panel-title{:style => @edit ? "cursor: move;" : ""}
+          .panel-heading
+            %h3.panel-title.sortable-handle{:style => @edit ? "cursor: move;" : ""}
               %a{:class => "#{@widget.content_type}box"}
               = link_to("",
                 {:controller => "report", :action => "widget_shortcut_remove", :id => @widget.id || "new", :shortcut => s_id},


### PR DESCRIPTION
We should not be binding the sortable properties to general elements, such as `h2`,
we should rather have our own class to bind the properties to.

This is to avoid situations, where drag & drop functionality in our UI will stop working
whenever we change `h2` to `h3` or vice versa.

https://bugzilla.redhat.com/show_bug.cgi?id=1330580

@himdel Review please :-)