### PR TITLE
refactor GenericObject

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -15,8 +15,12 @@ class GenericObjectDefinition < ApplicationRecord
   has_one   :picture, :dependent => :destroy, :as => :resource
   has_many  :generic_objects
 
-  def defined_attributes
+  def defined_property_attributes
     properties[:attributes]
+  end
+
+  def property_attribute_defined?(attr)
+    defined_property_attributes.try(:key?, attr.to_s)
   end
 
   def properties=(props)
@@ -31,6 +35,6 @@ class GenericObjectDefinition < ApplicationRecord
   end
 
   def type_cast(attr_name, value)
-    TYPE_MAP.fetch(defined_attributes[attr_name]).cast(value)
+    TYPE_MAP.fetch(defined_property_attributes[attr_name]).cast(value)
   end
 end

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -15,6 +15,8 @@ class GenericObjectDefinition < ApplicationRecord
   has_one   :picture, :dependent => :destroy, :as => :resource
   has_many  :generic_objects
 
+  before_destroy :check_not_in_use
+
   def defined_property_attributes
     properties[:attributes]
   end
@@ -36,5 +38,13 @@ class GenericObjectDefinition < ApplicationRecord
 
   def type_cast(attr_name, value)
     TYPE_MAP.fetch(defined_property_attributes[attr_name]).cast(value)
+  end
+
+  private
+
+  def check_not_in_use
+    return true if generic_objects.empty?
+    errors[:base] << "Cannot delete the definition while it is referenced by some generic objects"
+    throw :abort
   end
 end

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -34,4 +34,15 @@ describe GenericObjectDefinition do
       expect(definition.type_cast('max_number', '100')).to eq(100)
     end
   end
+
+  describe '#destroy' do
+    let(:generic_object) do
+      FactoryGirl.build(:generic_object, :generic_object_definition => definition, :name => 'test')
+    end
+
+    it 'raises an error if the definition is in use' do
+      generic_object.save!
+      expect { definition.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+    end
+  end
 end

--- a/spec/models/generic_object_spec.rb
+++ b/spec/models/generic_object_spec.rb
@@ -90,7 +90,7 @@ describe GenericObject do
     end
 
     context "without generic_object_definition" do
-      let (:empty_go) { FactoryGirl.create(:generic_object) }
+      let(:empty_go) { FactoryGirl.create(:generic_object) }
 
       it "raises an error when set a property attribute" do
         expect { empty_go.max_number = max_number }.to raise_error(NoMethodError)


### PR DESCRIPTION
It fixes a few bugs. The major refactoring includes
1. `GenericObject#name` does not need to be unique
2. Do not do validation before save, rather check whether a property attribute is defined when it is accessed.
3. `GenericObjectDefinition` cannot be deleted if some generic objects are still referencing to it.