### PR TITLE
OpenStack AMQP doesn't use endpoint data

### DIFF
--- a/gems/pending/openstack/openstack_event_monitor.rb
+++ b/gems/pending/openstack/openstack_event_monitor.rb
@@ -96,7 +96,7 @@ class OpenstackEventMonitor
   private
 
   def self.event_monitor_key(options)
-    options.values_at(:hostname, :username, :password)
+    options.values_at(:hostname, :port, :security_protocol, :username, :password)
   end
   private_class_method :event_monitor_key
 


### PR DESCRIPTION
OpenStack AMQP doesn't use endpoint data, whcih is being fixed.

Fixes Issue:
https://github.com/ManageIQ/manageiq/issues/8158