### PR TITLE
Find LDAP user in DB using userprincipalname

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -54,7 +54,7 @@ module Authenticator
           else
             # If role_mode == database we will only use the external system for authentication. Also, the user must exist in our database
             # otherwise we will fail authentication
-            user_or_taskid = User.find_by_userid(username)
+            user_or_taskid = lookup_by_identity(username)
             user_or_taskid ||= autocreate_user(username)
 
             unless user_or_taskid

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -27,7 +27,7 @@ module Authenticator
 
     def find_or_create_by_ldap(username)
       username = miq_ldap.fqusername(username)
-      user = User.find_by_userid(username)
+      user = userprincipal_for(username)
       return user unless user.nil?
 
       raise _("Unable to auto-create user because LDAP bind credentials are not configured") unless authorize?
@@ -84,6 +84,11 @@ module Authenticator
       _log.debug("User obj from LDAP: #{lobj.inspect}")
 
       lobj
+    end
+
+    def userprincipal_for(username)
+      lobj = find_external_identity(username)
+      User.find_by_userid(userid_for(lobj, username))
     end
 
     def userid_for(lobj, username)

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -113,6 +113,7 @@ describe Authenticator::Ldap do
       end
 
       it "refuses users that don't exist in LDAP" do
+        expect(subject).to receive(:userprincipal_for)
         expect(-> { subject.lookup_by_identity('carol') }).to raise_error(/credentials are not configured/)
       end
     end
@@ -147,6 +148,7 @@ describe Authenticator::Ldap do
       end
 
       it "refuses users that don't exist in LDAP" do
+        expect(subject).to receive(:userprincipal_for)
         expect(-> { subject.lookup_by_identity('carol') }).to raise_error(/no data for user/)
       end
     end
@@ -159,6 +161,10 @@ describe Authenticator::Ldap do
 
     let(:username) { 'alice' }
     let(:password) { 'secret' }
+
+    before do
+      allow(subject).to receive(:find_or_create_by_ldap)
+    end
 
     context "when using LDAP" do
       let(:config) { super().merge(:ldap_role => true) }
@@ -340,6 +346,11 @@ describe Authenticator::Ldap do
 
           it "succeeds" do
             expect(authenticate).to be_a(User)
+          end
+
+          it "looks in ldap" do
+            expect(subject).to receive(:find_or_create_by_ldap)
+            authenticate
           end
 
           it "records two successful audit entries" do

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -30,6 +30,7 @@ describe Authenticator::Ldap do
 
     it "user exists" do
       user = FactoryGirl.create(:user_admin, :userid => @fqusername)
+      allow(@auth).to receive(:userprincipal_for).and_return(user)
       expect(current_user).to eq(user)
     end
 
@@ -49,6 +50,7 @@ describe Authenticator::Ldap do
       init_ldap_setup
       setup_to_get_fqdn
     end
+
     subject { @auth.authenticate("username", @password, nil) }
 
     it "password is blank" do
@@ -82,6 +84,7 @@ describe Authenticator::Ldap do
 
         context "with default group for users enabled" do
           it "group exists" do
+            allow(@auth).to receive(:find_or_create_by_ldap)
             group = create_super_admin_group
             setup_to_create_user(group)
             @auth_config[:authentication][:default_group_for_users] = group.description


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1302345

The LDAP user is stored in the database using the LDAP userprincipalname. This PR
ensures the userprincipalname is used to retrieve it.