### PR TITLE
Rbac belongs to 2

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -524,17 +524,18 @@ module Rbac
     blist.flat_map do |bfilter|
       vcmeta_list = MiqFilter.belongsto2object_list(bfilter)
       next [] if vcmeta_list.empty?
+      # typically, this is the only one we want:
+      vcmeta = vcmeta_list.last
 
       if klass == Storage
         vcmeta = vcmeta_list.reverse.detect { |vcm| vcm.respond_to?(:storages) }
         vcmeta ? vcmeta.storages : []
       elsif klass == Host
-        get_belongsto_matches_for_host(vcmeta_list.last)
-      elsif vcmeta_list.last.kind_of?(Host) && klass <= VmOrTemplate
-        host = vcmeta_list.last
-        host.send(association_name).to_a
+        get_belongsto_matches_for_host(vcmeta)
+      elsif vcmeta.kind_of?(Host) && klass <= VmOrTemplate
+        vcmeta.send(association_name).to_a
       else
-        vcmeta_list.grep(klass) + vcmeta_list.last.descendants.grep(klass)
+        vcmeta_list.grep(klass) + vcmeta.descendants.grep(klass)
       end
     end.uniq
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -555,8 +555,6 @@ module Rbac
   def self.get_belongsto_matches_for_storage(blist, klass)
     blist.flat_map do |bfilter|
       vcmeta_list = MiqFilter.belongsto2object_list(bfilter)
-      next if vcmeta_list.empty?
-
       vcmeta = vcmeta_list.reverse.detect { |v| v.respond_to?(:storages) }
       vcmeta ? vcmeta.storages : []
     end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -526,12 +526,8 @@ module Rbac
       next if vcmeta_list.empty?
 
       if klass == Storage
-        vcmeta_list.reverse_each do |vcmeta|
-          if vcmeta.respond_to?(:storages)
-            results.concat(vcmeta.storages)
-            break
-          end
-        end
+        vcmeta = vcmeta_list.reverse.detect { |vcm| vcm.respond_to?(:storages) }
+        results.concat(vcmeta.storages) if vcmeta
       elsif klass == Host
         results.concat(get_belongsto_matches_for_host(vcmeta_list.last))
       elsif vcmeta_list.last.kind_of?(Host) && klass <= VmOrTemplate

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -535,8 +535,8 @@ module Rbac
         vms_and_templates = host.send(klass.base_model.to_s.tableize).to_a
         results.concat(vms_and_templates)
       else
-        vcmeta_list.each { |vcmeta| results.push(vcmeta) if vcmeta.kind_of?(klass) }
-        results.concat(vcmeta_list.last.descendants.select { |obj| obj.kind_of?(klass) })
+        results.push(vcmeta_list.grep(klass))
+        results.concat(vcmeta_list.last.descendants.grep(klass))
       end
     end
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -520,6 +520,7 @@ module Rbac
   end
 
   def self.get_belongsto_matches(blist, klass)
+    association_name = klass.base_model.to_s.tableize
     blist.flat_map do |bfilter|
       vcmeta_list = MiqFilter.belongsto2object_list(bfilter)
       next [] if vcmeta_list.empty?
@@ -531,7 +532,7 @@ module Rbac
         get_belongsto_matches_for_host(vcmeta_list.last)
       elsif vcmeta_list.last.kind_of?(Host) && klass <= VmOrTemplate
         host = vcmeta_list.last
-        host.send(klass.base_model.to_s.tableize).to_a
+        host.send(association_name).to_a
       else
         vcmeta_list.grep(klass) + vcmeta_list.last.descendants.grep(klass)
       end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -547,8 +547,7 @@ module Rbac
       clusters = subtree.grep(EmsCluster)
       hosts    = subtree.grep(Host)
 
-      MiqPreloader.preload(clusters, :hosts)
-      clusters.collect(&:hosts).flatten + hosts
+      MiqPreloader.preload_and_map(clusters, :hosts) + hosts
     end
   end
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -554,8 +554,7 @@ module Rbac
 
   def self.get_belongsto_matches_for_storage(blist, klass)
     blist.flat_map do |bfilter|
-      vcmeta_list = MiqFilter.belongsto2object_list(bfilter)
-      vcmeta = vcmeta_list.reverse.detect { |v| v.respond_to?(:storages) }
+      vcmeta = MiqFilter.belongsto2object_list(bfilter).reverse.detect { |v| v.respond_to?(:storages) }
       vcmeta ? vcmeta.storages : []
     end
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -539,16 +539,17 @@ module Rbac
   end
 
   def self.get_belongsto_matches_for_host(blist, klass)
-    blist.flat_map do |bfilter|
+    clusters = []
+    hosts = []
+    blist.each do |bfilter|
       vcmeta = MiqFilter.belongsto2object(bfilter)
       next unless vcmeta
 
       subtree  = vcmeta.subtree
-      clusters = subtree.grep(EmsCluster)
-      hosts    = subtree.grep(Host)
-
-      MiqPreloader.preload_and_map(clusters, :hosts) + hosts
+      clusters += subtree.grep(EmsCluster)
+      hosts    += subtree.grep(Host)
     end
+    MiqPreloader.preload_and_map(clusters, :hosts) + hosts
   end
 
   def self.get_belongsto_matches_for_storage(blist, klass)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -553,10 +553,10 @@ module Rbac
   end
 
   def self.get_belongsto_matches_for_storage(blist, klass)
-    blist.flat_map do |bfilter|
-      vcmeta = MiqFilter.belongsto2object_list(bfilter).reverse.detect { |v| v.respond_to?(:storages) }
-      vcmeta ? vcmeta.storages : []
-    end
+    sources = blist.map do |bfilter|
+      MiqFilter.belongsto2object_list(bfilter).reverse.detect { |v| v.respond_to?(:storages) }
+    end.select(&:present?)
+    MiqPreloader.preload_and_map(sources, :storages)
   end
 
   def self.matches_search_filters?(obj, filter, tz)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -542,8 +542,8 @@ module Rbac
 
   def self.get_belongsto_matches_for_host(vcmeta)
     subtree  = vcmeta.subtree
-    clusters = subtree.select { |obj| obj.kind_of?(EmsCluster) }
-    hosts    = subtree.select { |obj| obj.kind_of?(Host) }
+    clusters = subtree.grep(EmsCluster)
+    hosts    = subtree.grep(Host)
 
     MiqPreloader.preload(clusters, :hosts)
     clusters.collect(&:hosts).flatten + hosts


### PR DESCRIPTION
The end game is to convert the `belongsto` filters so it produces a single scope. This is step 4 of 4 in `Rbac.calc_filtered_ids`

`MiqFilter.belongsto2object` produces a list of objects that have a relationship to the objects in concern. This is nicely isolated on its own.

This reorganizes the belongs to filter in prep for returning a scope instead of records.
`preload_and_map` is being used to consolidate the calls, but the next step will be to remove this and join together the queries in a more AR style query. For this reason `klass` is being passed to each of the sub methods.

there are minimal performance improvements from this change

/cc @chessbyte we'll get there soon