### PR TITLE
Do not show items not marked to be displayed in Catalog in tree

### DIFF
--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -25,7 +25,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   end
 
   def x_get_tree_stc_kids(object, count_only)
-    objects = rbac_filtered_objects(object.service_templates.sort_by { |o| o.name.downcase })
+    objects = rbac_filtered_objects(object.service_templates.select(&:display))
     count_only_or_objects(count_only, objects, 'name')
   end
 

--- a/spec/presenters/tree_builder_service_catalog_spec.rb
+++ b/spec/presenters/tree_builder_service_catalog_spec.rb
@@ -1,0 +1,27 @@
+describe TreeBuilderServiceCatalog do
+  include CompressedIds
+  before do
+    Tenant.seed
+    @catalog = FactoryGirl.create(:service_template_catalog, :name => "My Catalog")
+    FactoryGirl.create(:service_template,
+                       :name                     => "Display in Catalog",
+                       :service_template_catalog => @catalog,
+                       :display                  => true)
+    FactoryGirl.create(:service_template,
+                       :name                     => "Do not Display in Catalog",
+                       :service_template_catalog => @catalog,
+                       :display                  => false)
+    @tree = TreeBuilderServiceCatalog.new(:svccat_tree, "svccat", {})
+  end
+
+  it "#x_get_tree_roots" do
+    roots = @tree.send(:x_get_tree_roots, false, {})
+    expect(roots.first.name).to eq(@catalog.name)
+  end
+
+  it "#x_get_tree_stc_kids returns items that are set to be displayed in catalog" do
+    items = @tree.send(:x_get_tree_stc_kids, @catalog, false)
+    expect(items.size).to eq(1)
+    expect(items.first.name).to eq("Display in Catalog")
+  end
+end


### PR DESCRIPTION
Fixed Service Catalogs tree to not show items that are not marked to display in catalog. List on the right right side was already working correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1326090

@dclarizio please review.

Catalog summary screen
![catalog_item_show](https://cloud.githubusercontent.com/assets/3450808/14868918/49caa176-0c9e-11e6-9148-0ba672343eb6.png)

before:
![before](https://cloud.githubusercontent.com/assets/3450808/14868934/5d999086-0c9e-11e6-8195-f3c0661b8a4f.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/14868940/60e1e914-0c9e-11e6-9499-426a0acd3e4f.png)
