### PR TITLE
API w/ decorators & VmOrTemplate - supports_console? via a decorator

### DIFF
--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -114,6 +114,16 @@ class ApiController
       expand_param ? expand_param.include?(what.to_s) : false
     end
 
+    def decorator_selection
+      params['decorators'].to_s.split(",")
+    end
+
+    def decorator_selection_for(collection)
+      decorator_selection.collect do |attr|
+        /\A#{collection}\.(?<name>.*)\z/.match(attr) { |m| m[:name] }
+      end.compact
+    end
+
     def attribute_selection
       if params['attributes'] || @req[:additional_attributes]
         params['attributes'].to_s.split(",") | Array(@req[:additional_attributes]) | ID_ATTRS

--- a/app/controllers/api_controller/vms.rb
+++ b/app/controllers/api_controller/vms.rb
@@ -1,12 +1,29 @@
 class ApiController
   module Vms
     def vms_query_resource(object)
+      vms = object.try(:vms) || []
+
       vm_attrs = attribute_selection_for("vms")
-      vm_attrs.blank? ? object.try(:vms) : Array(object.try(:vms)).collect do |vm|
-        add_hash = vm_attrs.each_with_object({}) do |attr, hash|
+      vm_decorators = decorator_selection_for("vms")
+
+      return vms if vm_attrs.blank? && vm_decorators.blank?
+
+      vms.collect do |vm|
+        decorated = vm.decorator_class? ? vm.decorate : nil
+
+        attributes_hash = vm_attrs.each_with_object({}) do |attr, hash|
           hash[attr] = vm.public_send(attr.to_sym) if vm.respond_to?(attr.to_sym)
         end.compact
-        vm.as_json.merge(add_hash)
+
+        decorators_hash = vm_decorators.each_with_object({}) do |name, hash|
+          hash[name] = vm.decorate.public_send(name.to_sym) if decorated.respond_to?(name.to_sym)
+        end.compact unless decorated.nil?
+
+        conflictless_hash = attributes_hash.merge(decorators_hash || {}) do |key, _, _|
+          raise BadRequestError, "Requested both an attribute and a decorator of the same name: #{key}"
+        end
+
+        vm.as_json.merge(conflictless_hash)
       end
     end
 

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -8,4 +8,8 @@ class VmOrTemplateDecorator < Draper::Decorator
   def listicon_image
     "svg/vendor-#{vendor.downcase}.svg"
   end
+
+  def supports_console?
+    console_supported?('spice') || console_supported?('vnc')
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -21,10 +21,13 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
     end
 
     def remote_console_acquire_ticket(userid, console_type)
+      # FIXME: a temporary work-around for #8151 (provider_object being an Array)
+      provider = provider_object.kind_of?(Array) ? provider_object.first : provider_object
+
       validate_remote_console_acquire_ticket(console_type)
 
-      parsed_ticket = Nokogiri::XML(provider_object.ticket)
-      display = provider_object.attributes[:display]
+      parsed_ticket = Nokogiri::XML(provider.ticket)
+      display = provider.attributes[:display]
 
       SystemConsole.where(:vm_id => id).each(&:destroy)
       # TODO: non-blocking SSL support in the proxy

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -62,6 +62,9 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   #
   # VNC
   #
+  def remote_console_html5_acquire_ticket(userid)
+    remote_console_vnc_acquire_ticket(userid)
+  end
 
   def remote_console_vnc_acquire_ticket(userid)
     validate_remote_console_acquire_ticket("vnc")

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -305,6 +305,14 @@ describe ApiController do
                                            {"id" => vm2.id, "cpu_total_cores" => 4}])
     end
 
+    it "can query vms as subcollection via decorators with additional decorators" do
+      run_get services_url(svc1.id), :expand => "vms", :attributes => "", :decorators => "vms.supports_console?"
+
+      expect_svc_with_vms
+      expect_results_to_match_hash("vms", [{"id" => vm1.id, "supports_console?" => true},
+                                           {"id" => vm2.id, "supports_console?" => true}])
+    end
+
     it "cannot query vms via both virtual attribute and subcollection" do
       run_get services_url(svc1.id), :expand => "vms", :attributes => "vms"
 


### PR DESCRIPTION
This is intended to replace https://github.com/ManageIQ/manageiq/pull/8289 moving the `supports_console` method to decorators.

It also includes a bunch of small fixes for consoles, including a workaround for #8151.


Essentially what I'm trying to do is add some rudimentary decorators support to the API, and change the `vms_query_resources` method to use those as well. So this is not yet generic decorators support for the API, but it does let us use decorators on demand for that particular problem.

Instead of adding `?attributes=vms.supports_console`, you add `?decorators=vms.supports_console?` ..and the result should be the same as before, but supports_console no longer needs to be a virtual column :).