### PR TITLE
Service#direct_vms - compact to prevent API bug

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -93,7 +93,7 @@ class Service < ApplicationRecord
   Vmdb::Deprecation.deprecate_methods(self, :indirect_vms)
 
   def direct_vms
-    service_resources.where(:resource_type => 'VmOrTemplate').includes(:resource).collect(&:resource)
+    service_resources.where(:resource_type => 'VmOrTemplate').includes(:resource).collect(&:resource).compact
   end
 
   def all_vms


### PR DESCRIPTION
When accessing /api/services/10000000000115?attributes=aggregate_all_vm_cpus, you can get  an API error - NoMethodError - "undefined method `cpu_total_cores' for nil:NilClass"

That happens because `direct_vms` can return `[nil]`, which means `all_vms` will also return `[nil]`.

So fixing direct_vms to prevent nils..


@kbrock you've been fixing at least one similar bug .. any thoughts about a more general approach?