### PR TITLE
Fix traceback in instance reconfigure screen when nil size root disk

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1928,7 +1928,7 @@ module VmCommon
     when "resize"
       partial = "vm_common/resize"
       header = _("Reconfiguring %{vm_or_template} \"%{name}\"") %
-        {:vm_or_template => name, :model => ui_lookup(:table => table)}
+        {:vm_or_template => ui_lookup(:table => table), :name => name}
       action = "resize_vm"
     when "retire"
       partial = "shared/views/retire"

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -17,15 +17,23 @@ class Flavor < ApplicationRecord
 
   def name_with_details
     details = if cpus == 1
-                _("%{name} (%{num_cpus} CPU, %{memory_gigabytes} GB RAM, %{root_disk_gigabytes} GB Root Disk)")
+                if root_disk_size.nil?
+                  _("%{name} (%{num_cpus} CPU, %{memory_gigabytes} GB RAM, Unknown Size Root Disk)")
+                else
+                  _("%{name} (%{num_cpus} CPU, %{memory_gigabytes} GB RAM, %{root_disk_gigabytes} GB Root Disk)")
+                end
               else
-                _("%{name} (%{num_cpus} CPUs, %{memory_gigabytes} GB RAM, %{root_disk_gigabytes} GB Root Disk)")
+                if root_disk_size.nil?
+                  _("%{name} (%{num_cpus} CPUs, %{memory_gigabytes} GB RAM, Unknown Size Root Disk)")
+                else
+                  _("%{name} (%{num_cpus} CPUs, %{memory_gigabytes} GB RAM, %{root_disk_gigabytes} GB Root Disk)")
+                end
               end
     details % {
       :name                => name,
       :num_cpus            => cpus,
       :memory_gigabytes    => memory.bytes / 1.0.gigabytes,
-      :root_disk_gigabytes => root_disk_size.bytes / 1.0.gigabytes
+      :root_disk_gigabytes => root_disk_size.nil? ? nil : root_disk_size.bytes / 1.0.gigabytes
     }
   end
 end


### PR DESCRIPTION
Some instances (Amazon) do not seem to have the info about root disk size available.

Fixing the following error:

```
Error caught: [NoMethodError] undefined method `bytes' for nil:NilClass
app/models/flavor.rb:36:in `name_with_details'
app/views/vm_common/_resize.html.haml:13
```

https://bugzilla.redhat.com/show_bug.cgi?id=1331052