### PR TITLE
Update to version 0.9.1 of "ovirt" gem

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -36,7 +36,7 @@ gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=1.1.0",            :require => false
 gem "openscap",                "~>0.4.3",           :require => false
-gem "ovirt",                   "~>0.9.0",           :require => false
+gem "ovirt",                   "~>0.9.1",           :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false


### PR DESCRIPTION
This patch updates the system to use version 0.9.1 of the "ovirt" gem, as that
version works correctly with version 2.0.0.rc1 of the "rest-client" that is
used by the rest of the system.

Bug-Url: https://bugzilla.redhat.com/1328087
Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>