### PR TITLE
Fix resize_vm() cancel and submission errors

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -38,6 +38,7 @@ class VmCloudController < ApplicationController
 
   def resize_vm
     assert_privileges("instance_resize")
+    load_edit("vm_resize__#{params[:id]}")
     flavor_id = @edit[:new][:flavor]
     flavor = find_by_id_filtered(Flavor, flavor_id)
     @record = VmOrTemplate.find_by_id(params[:id])
@@ -82,7 +83,7 @@ class VmCloudController < ApplicationController
     return unless load_edit("vm_resize__#{params[:id]}")
     @edit ||= {}
     @edit[:new] ||= {}
-    @edit[:new][:flavor] = params[:id]
+    @edit[:new][:flavor] = params[:flavor]
     render :update do |page|
       page << javascript_prologue
       page.replace_html("main_div",

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -74,6 +74,7 @@ describe VmCloudController do
 
     it 'can resize an instance' do
       flavor = FactoryGirl.create(:flavor_openstack)
+      allow(controller).to receive(:load_edit).and_return(true)
       controller.instance_variable_set(:@edit,
                                        :new      => {:flavor => flavor.id},
                                        :explorer => true)


### PR DESCRIPTION
This is to fix the following error when submiting / canceling vm resize:

```
Error caught: [NoMethodError] undefined method `[]' for nil:NilClass
app/controllers/vm_cloud_controller.rb:41:in `resize_vm'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1331052