### PR TITLE
Fix "html5 protocol not enabled for this vm" when requesting console via API

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -10,7 +10,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
 
     def validate_remote_console_acquire_ticket(protocol, options = {})
       raise(MiqException::RemoteConsoleNotSupportedError,
-            "#{protocol} protocol not enabled for this vm") unless protocol == :html5
+            "#{protocol} protocol not enabled for this vm") unless protocol.to_sym == :html5
 
       raise(MiqException::RemoteConsoleNotSupportedError,
             "#{protocol} remote console requires the vm to be registered with a management system.") if ext_management_system.nil?


### PR DESCRIPTION
Protocol is passed to the API as string, but `validate_remote_console_acquire_ticket` only checks for `:html5` (symbol).

@skateman please review.. :)