### PR TITLE
Fix  links to datastores from other summary pages

### DIFF
--- a/app/views/layouts/quadicon/_storage.html.haml
+++ b/app/views/layouts/quadicon/_storage.html.haml
@@ -29,7 +29,7 @@
     %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}
 - else
   .flobj
-    -if @explorer
+    - if @explorer
       - if !@embedded || @showlinks
         = link_to(image_tag(image_path("#{size}/reflection.png"), :width => size, :height => size, :title => h(item.name)),
         {:action => 'x_show', :id => to_cid(item.id)},
@@ -40,7 +40,7 @@
       - else
         %a{:title => _("Name: %s | %s Type: %s") % [h(item.name), ui_lookup(:table => "storages"), h(item.store_type)]}
           %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}
-    -else
+    - else
       - if !@embedded || @showlinks
         %a{:href => url_for_record(item), :title => _("Name: %s | %s Type: %s") % [h(item.name), ui_lookup(:table => "storages"), h(item.store_type)]}
           %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}

--- a/app/views/layouts/quadicon/_storage.html.haml
+++ b/app/views/layouts/quadicon/_storage.html.haml
@@ -29,13 +29,21 @@
     %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}
 - else
   .flobj
-    - if !@embedded || @showlinks
-      = link_to(image_tag(image_path("#{size}/reflection.png"), :width => size, :height => size, :title => h(item.name)),
+    -if @explorer
+      - if !@embedded || @showlinks
+        = link_to(image_tag(image_path("#{size}/reflection.png"), :width => size, :height => size, :title => h(item.name)),
         {:action => 'x_show', :id => to_cid(item.id)},
         "data-miq_sparkle_on"  => true,
         "data-miq_sparkle_off" => true,
         "data-method"          => :post,
         :remote                => true)
-    - else
-      %a{:title => _("Name: %s | %s Type: %s") % [h(item.name), ui_lookup(:table => "storages"), h(item.store_type)]}
-        %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}
+      - else
+        %a{:title => _("Name: %s | %s Type: %s") % [h(item.name), ui_lookup(:table => "storages"), h(item.store_type)]}
+          %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}
+    -else
+      - if !@embedded || @showlinks
+        %a{:href => url_for_record(item), :title => _("Name: %s | %s Type: %s") % [h(item.name), ui_lookup(:table => "storages"), h(item.store_type)]}
+          %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}
+      - else
+        %a{:title => _("Name: %s | %s Type: %s") % [h(item.name), ui_lookup(:table => "storages"), h(item.store_type)]}
+          %img{:src => image_path("#{size}/reflection.png"), :width => size, :height => size}

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -232,9 +232,9 @@ describe HostController do
                                           ])
     end
 
-    it "renders show_item datastore" do
+    it "shows associated datastores" do
       controller.instance_variable_set(:@breadcrumbs, [])
-      get :show, :params => { :id => @host.id, :display => 'storages' }
+      get :show, :params => {:id => @host.id, :display => 'storages'}
       expect(response.status).to eq(200)
       expect(response).to render_template('host/show')
       expect(assigns(:breadcrumbs)).to eq([{:name => "#{@host.name} (All Datastores)",

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -215,6 +215,8 @@ describe HostController do
       EvmSpecHelper.create_guid_miq_server_zone
       @host = FactoryGirl.create(:host)
       @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
+      @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @datastore.parent = @host
     end
 
     it "renders show_item" do
@@ -228,6 +230,15 @@ describe HostController do
                                            {:name => "foo",
                                             :url  => "/host/guest_applications/#{@host.id}?show=#{@guest_application.id}"}
                                           ])
+    end
+
+    it "renders show_item datastore" do
+      controller.instance_variable_set(:@breadcrumbs, [])
+      get :show, :params => { :id => @host.id, :display => 'storages' }
+      expect(response.status).to eq(200)
+      expect(response).to render_template('host/show')
+      expect(assigns(:breadcrumbs)).to eq([{:name => "#{@host.name} (All Datastores)",
+                                            :url => "/host/show/#{@host.id}?display=storages"}])
     end
 
     it "renders show_details" do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -252,6 +252,19 @@ describe EmsInfraController do
         is_expected.to render_template(:partial => "layouts/listnav/_ems_infra")
       end
     end
+
+    it "shows associated datastores" do
+      @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @datastore.parent = @ems
+      controller.instance_variable_set(:@breadcrumbs, [])
+      get :show, :params => {:id => @ems.id, :display => 'storages'}
+      expect(response.status).to eq(200)
+      expect(response).to render_template('ems_infra/show')
+      expect(assigns(:breadcrumbs)).to eq([{:name=>"Infrastructure Providers",
+                                            :url=>"/ems_infra/show_list?page=&refresh=y"},
+                                           {:name=>"#{@ems.name} (All Managed Datastores)",
+                                            :url=>"/ems_infra/#{@ems.id}?display=storages"}])
+    end
   end
 
   describe "#show_list" do

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -158,9 +158,9 @@ describe HostController do
       expect(assigns(:devices)).to be_kind_of(Array)
     end
 
-    it "renders show delete for datastore" do
+    it "shows associated datastores" do
       controller.instance_variable_set(:@breadcrumbs, [])
-      get :show, :params => { :id => @host.id, :display => 'storages' }
+      get :show, :params => {:id => @host.id, :display => 'storages'}
       expect(response.status).to eq(200)
       expect(response).to render_template('host/show')
       expect(assigns(:breadcrumbs)).to eq([{:name => "#{@host.name} (All Datastores)",

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -141,11 +141,13 @@ describe HostController do
   context "#show_association" do
     before(:each) do
       set_user_privileges
-      @host = FactoryGirl.create(:host)
+      @host = FactoryGirl.create(:host, :name =>'hostname1')
       @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
+      @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @datastore.parent = @host
     end
 
-    it "renders show_details" do
+    it "renders show_details for guest applications" do
       controller.instance_variable_set(:@breadcrumbs, [])
       allow(controller).to receive(:get_view)
       get :guest_applications, :params => { :id => @host.id }
@@ -154,6 +156,15 @@ describe HostController do
       expect(assigns(:breadcrumbs)).to eq([{:name => "#{@host.name} (Packages)",
                                             :url  => "/host/guest_applications/#{@host.id}"}])
       expect(assigns(:devices)).to be_kind_of(Array)
+    end
+
+    it "renders show delete for datastore" do
+      controller.instance_variable_set(:@breadcrumbs, [])
+      get :show, :params => { :id => @host.id, :display => 'storages' }
+      expect(response.status).to eq(200)
+      expect(response).to render_template('host/show')
+      expect(assigns(:breadcrumbs)).to eq([{:name => "#{@host.name} (All Datastores)",
+                                            :url => "/host/show/#{@host.id}?display=storages"}])
     end
   end
 

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -77,6 +77,17 @@ describe VmOrTemplateController do
       expect(response).to redirect_to(:controller => "dashboard", :action => 'show')
       expect(assigns(:flash_array).first[:message]).to include("is not authorized to access")
     end
+
+    it "renders show_item datastore" do
+      set_user_privileges
+      feature = MiqProductFeature.find_all_by_identifier(["vandt_accord", "vms_filter_accord", "storages"])
+      login_as FactoryGirl.create(:user, :features => feature)
+      datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @vm.storage_id = datastore.id
+      controller.instance_variable_set(:@breadcrumbs, [])
+      get :show, :params => { :id => @vm.id, :display => 'storages' }
+      expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')
+    end
   end
 
   describe '#console_after_task' do

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -77,17 +77,6 @@ describe VmOrTemplateController do
       expect(response).to redirect_to(:controller => "dashboard", :action => 'show')
       expect(assigns(:flash_array).first[:message]).to include("is not authorized to access")
     end
-
-    it "shows associated datastores" do
-      set_user_privileges
-      feature = MiqProductFeature.find_all_by_identifier(["vandt_accord", "vms_filter_accord", "storages"])
-      login_as FactoryGirl.create(:user, :features => feature)
-      datastore = FactoryGirl.create(:storage, :name => 'storage_name')
-      @vm.storage_id = datastore.id
-      controller.instance_variable_set(:@breadcrumbs, [])
-      get :show, :params => {:id => @vm.id, :display => 'storages'}
-      expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')
-    end
   end
 
   describe '#console_after_task' do

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -78,14 +78,14 @@ describe VmOrTemplateController do
       expect(assigns(:flash_array).first[:message]).to include("is not authorized to access")
     end
 
-    it "renders show_item datastore" do
+    it "shows associated datastores" do
       set_user_privileges
       feature = MiqProductFeature.find_all_by_identifier(["vandt_accord", "vms_filter_accord", "storages"])
       login_as FactoryGirl.create(:user, :features => feature)
       datastore = FactoryGirl.create(:storage, :name => 'storage_name')
       @vm.storage_id = datastore.id
       controller.instance_variable_set(:@breadcrumbs, [])
-      get :show, :params => { :id => @vm.id, :display => 'storages' }
+      get :show, :params => {:id => @vm.id, :display => 'storages'}
       expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')
     end
   end


### PR DESCRIPTION
Handle explorer and non-explorer links for datstores from other summary pages

https://bugzilla.redhat.com/show_bug.cgi?id=1329651
https://bugzilla.redhat.com/show_bug.cgi?id=1330718