### PR TITLE
Fix instance reconfigure button visibility

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -50,8 +50,8 @@ class VmCloudController < ApplicationController
       @record = @sb[:action] = nil
       replace_right_cell
     when "submit"
-      valid, details = @record.validate_resize
-      if valid
+      validation = @record.validate_resize
+      if validation[:available]
         begin
           old_flavor = @record.flavor
           @record.resize(flavor)
@@ -70,7 +70,7 @@ class VmCloudController < ApplicationController
         add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {
           :instance => ui_lookup(:table => 'vm_cloud'),
           :name     => @record.name,
-          :details  => details}, :error)
+          :details  => validation[:message]}, :error)
       end
       params[:id] = @record.id.to_s # reset id in params for show
       @record = nil

--- a/app/helpers/application_helper/button/instance_reconfigure.rb
+++ b/app/helpers/application_helper/button/instance_reconfigure.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::InstanceReconfigure < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self[:title] = @record.is_available_now_error_message(:resize) if disabled?
+  end
+
+  def disabled?
+    !@record.is_available?(:resize)
+  end
+end

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -46,7 +46,8 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           :instance_resize,
           'pficon pficon-edit fa-lg',
           t = N_('Reconfigure this Instance'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::InstanceReconfigure),
         button(
           :vm_right_size,
           'product product-custom-6 fa-lg',

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -58,7 +58,8 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           :instance_resize,
           'pficon pficon-edit fa-lg',
           t = N_('Reconfigure this Instance'),
-          t)
+          t,
+          :klass => ApplicationHelper::Button::InstanceReconfigure)
       ]
     ),
   ])

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -59,6 +59,10 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     {:available => true, :message => nil}
   end
 
+  def validate_resize
+    validate_unsupported(_("Resize"))
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
@@ -1,6 +1,9 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
   def validate_resize
-    %w(ACTIVE SHUTOFF).include? raw_power_state
+    msg = validate_vm_control
+    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    return {:available => true, :message => nil} if %w(ACTIVE SHUTOFF).include?(raw_power_state)
+    {:available => false, :message => _("The Instance cannot be resized, current state has to be active or shutoff.")}
   end
 
   def raw_resize(new_flavor)

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -134,7 +134,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
     it "initiate resize process" do
       service = double
       allow(ems).to receive(:connect).and_return(service)
-      expect(vm.validate_resize).to be true
+      expect(vm.validate_resize[:available]).to be_truthy
       expect(vm.validate_resize_confirm).to be false
       expect(service).to receive(:resize_server).with(vm.ems_ref, flavor.ems_ref)
       vm.resize(flavor)
@@ -144,7 +144,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       vm.raw_power_state = 'VERIFY_RESIZE'
       service = double
       allow(ems).to receive(:connect).and_return(service)
-      expect(vm.validate_resize).to be false
+      expect(vm.validate_resize[:available]).to be_falsey
       expect(vm.validate_resize_confirm).to be true
       expect(service).to receive(:confirm_resize_server).with(vm.ems_ref)
       vm.resize_confirm
@@ -154,7 +154,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       vm.raw_power_state = 'VERIFY_RESIZE'
       service = double
       allow(ems).to receive(:connect).and_return(service)
-      expect(vm.validate_resize).to be false
+      expect(vm.validate_resize[:available]).to be_falsey
       expect(vm.validate_resize_revert).to be true
       expect(service).to receive(:revert_resize_server).with(vm.ems_ref)
       vm.resize_revert


### PR DESCRIPTION
The 'Reconfigure this Instance' toolbar button should only be visible if the model supports
the resize operation.

https://bugzilla.redhat.com/show_bug.cgi?id=1331052

@Ladas 