### PR TITLE
Hide "Phone" field on Azure provision dialog by default

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -13,7 +13,7 @@
         :owner_phone: 
           :description: Phone
           :required: false
-          :display: :show
+          :display: :hide
           :data_type: :string
         :owner_country: 
           :description: Country/Region


### PR DESCRIPTION
Changed to match all other vendor dialog default values.

https://bugzilla.redhat.com/show_bug.cgi?id=1330725