### PR TITLE
Fix url for ems_infra hosts in GTL views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -208,6 +208,9 @@ module ApplicationHelper
       if controller == "ems_cloud" && action == "show"
         return ems_clouds_path
       end
+      if controller == "ems_infra" && action == "show"
+        return ems_infras_path
+      end
       if parent && parent.class.base_model.to_s == "MiqCimInstance" && ["CimBaseStorageExtent", "SniaLocalFileSystem"].include?(view.db)
         return url_for(:controller => controller, :action => action, :id => parent.id) + "?show="
       else


### PR DESCRIPTION
This is to fix an error when clicking on Compute -> Infra -> Providers (GTL mode == list) -> [Provider]:

```
Started GET "/ems_infra/show/10r21"
ActionController::RoutingError (No route matches [GET]
"/ems_infra/show/10r21"):
```

https://bugzilla.redhat.com/show_bug.cgi?id=1331741

@himdel Please review :-)