### PR TITLE
Fix 0 items count in pagination control

### DIFF
--- a/app/views/layouts/_pagingcontrols.html.haml
+++ b/app/views/layouts/_pagingcontrols.html.haml
@@ -85,7 +85,7 @@
 
               %li
                 %span
-                  - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
+                  - start_number = pages[:items] > 0 ? (pages[:perpage] * pages[:current]) - pages[:perpage] + 1 : 0
                   - end_number = pages[:perpage] * pages[:current]
                   - if start_number == pages[:items]
                     = _("(Item %{start_number} of %{total_items})") % {:start_number => start_number, :total_items => pages[:items]}


### PR DESCRIPTION
When was zero items in list table, it has showed 1 instead of 0

https://bugzilla.redhat.com/show_bug.cgi?id=1328879