### PR TITLE
ignore nil containers when saving inventory

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -68,7 +68,7 @@ module EmsRefresh::SaveInventoryHelper
   def save_inventory_single(type, parent, hash, child_keys = [], extra_keys = [], disconnect = false)
     child = parent.send(type)
     if hash.blank?
-      disconnect ? child.disconnect_inv : child.try(:destroy)
+      disconnect ? child.try(:disconnect_inv) : child.try(:destroy)
       return
     end
 


### PR DESCRIPTION
Fixes #7915

Since we dont do partial refreshes for containers providers, theres no reason not to follow suit with all the other save_inventory methods. containers are deleted when their pod(container group) is deleted.

@simon3z 