### PR TITLE
openstack live migrate button only for openstack instances

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -113,16 +113,12 @@ class VmCloudController < ApplicationController
   def live_migrate_form_fields
     assert_privileges("instance_live_migrate")
     @record = find_by_id_filtered(VmOrTemplate, params[:id])
-    clusters = []
-    hosts = []
-    @record.ext_management_system.find_filtered_children("ems_clusters").each do |c|
-      clusters << {:id => c.id, :name => c.name}
+    clusters = @record.ext_management_system.ems_clusters.map do |c|
+      {:id => c.id, :name => c.name}
     end
-    @record.ext_management_system.find_filtered_children("hosts").each do |h|
-      hosts << {:id => h.id, :name => h.name, :cluster_id => h.emd_cluster.id}
+    hosts = @record.ext_management_system.hosts.map do |h|
+      {:id => h.id, :name => h.name, :cluster_id => h.emd_cluster.id}
     end
-    clusters.sort
-    hosts.sort
     render :json => {
       :clusters => clusters,
       :hosts    => hosts

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -142,8 +142,7 @@ class VmCloudController < ApplicationController
         page.redirect_to(previous_breadcrumb_url)
       end
     when "submit"
-      valid, details = @record.validate_live_migrate
-      if valid
+      if @record.is_available?(:live_migrate)
         if params['auto_select_host'] == '1'
           hostname = nil
         else
@@ -170,7 +169,7 @@ class VmCloudController < ApplicationController
         add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
           :instance => ui_lookup(:table => 'vm_cloud'),
           :name     => @record.name,
-          :details  => details}, :error)
+          :details  => @record.is_available_now_error_message(:live_migrate)}, :error)
       end
       params[:id] = @record.id.to_s # reset id in params for show
       @record = nil

--- a/app/helpers/application_helper/button/instance_migrate.rb
+++ b/app/helpers/application_helper/button/instance_migrate.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::InstanceMigrate < ApplicationHelper::Button::Basic
+  def skip?
+    !@record.is_available?(:live_migrate)
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -104,6 +104,7 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           'product product-migrate fa-lg',
           t = N_('Migrate Instance'),
           t,
+          :klass     => ApplicationHelper::Button::InstanceMigrate,
           :url_parms => 'main_div')
       ]
     ),


### PR DESCRIPTION
only show migrate instance button for instances that support it
also refactor removed find_filtered_children method

https://bugzilla.redhat.com/show_bug.cgi?id=1331061