### PR TITLE
Configure connection pool size since puma creates 5 threads by itself

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1256,7 +1256,6 @@
         :poll_method: :normal
         :queue_timeout: 120.minutes
     :replication_worker:
-      :connection_pool_size: 5
       :poll: 1.seconds
       :replication:
         :destination:
@@ -1385,7 +1384,6 @@
       :storage_file_collection_time_utc: 21600
       :vm_retired_interval: 10.minutes
     :smis_refresh_worker:
-      :connection_pool_size: 5
       :memory_threshold: 1.gigabytes
       :nice_delta: 3
       :poll: 15.seconds

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1393,7 +1393,7 @@
       :stats_update_period: 10.minutes
       :status_update_period: 5.minutes
     :ui_worker:
-      :connection_pool_size: 5
+      :connection_pool_size: 8
       :memory_threshold: 1.gigabytes
       :nice_delta: 1
       :poll: 60.seconds
@@ -1408,12 +1408,12 @@
       :vim_broker_max_wait: 60
       :vim_broker_max_objects: 250
     :web_service_worker:
-      :connection_pool_size: 5
+      :connection_pool_size: 8
       :memory_threshold: 1.gigabytes
       :nice_delta: 1
       :poll: 60.seconds
     :websocket_worker:
-       :connection_pool_size: 5
+       :connection_pool_size: 8
        :memory_threshold: 1.gigabytes
        :nice_delta: 1
        :poll: 60.seconds


### PR DESCRIPTION
**Increase connection pool to allow for 5 puma + worker threads.**
Threads:
config/puma.rb 5
main worker thread
main worker heartbeat thread

Related: #8275

From that PR, we frequently have 5 connections in the pool with 2 threads
waiting for connections.  8 should give us enough connections so the 7 known puma
and main worker threads aren't competing with each other.

`MIQ(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#log_after_checkout) pool_size: 5, connections: 5, in use: 5, waiting_in_queue: 2`

**There's no need to set connection_pool_size 5 since the default in database.yml is 5.**