### PR TITLE
Ensure dialog_options not nil for building stack options

### DIFF
--- a/app/models/service_ansible_tower.rb
+++ b/app/models/service_ansible_tower.rb
@@ -38,7 +38,7 @@ class ServiceAnsibleTower < Service
 
     raise _("job template was not set") if job_template.nil?
 
-    build_stack_options_from_dialog(options[:dialog])
+    build_stack_options_from_dialog(dialog_options)
   end
 
   def save_launch_options

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -86,7 +86,7 @@ class ServiceOrchestration < Service
     template_from_dialog = OptionConverter.get_template(dialog_options)
     self.orchestration_template = template_from_dialog if template_from_dialog
 
-    build_stack_options_from_dialog(options[:dialog])
+    build_stack_options_from_dialog(dialog_options)
   end
 
   def save_create_options


### PR DESCRIPTION
`dialog_options` is already based on `options[:dialog]` but guaranteed not `nil`

This bug was found when adding spec tests for ansible tower service provisioning, which are to be included in a following PR.