### PR TITLE
MiqPreload creates scopes not arrays

### DIFF
--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -13,4 +13,22 @@ module MiqPreloader
   def self.preload_and_map(records, association)
     Array.wrap(records).tap { |recs| MiqPreloader.preload(recs, association) }.flat_map(&association)
   end
+
+  # @param records [ActiveRecord::Base, Array<ActiveRecord::Base>, Object, Array<Object>]
+  # @param association [String] an association on records
+  def self.preload_and_scope(records, association_name)
+    records = Array.wrap(records) unless records.kind_of?(Enumerable)
+    active_record_klass = records.respond_to?(:klass) ? records.klass : records.first.class
+    association = active_record_klass.reflect_on_association(association_name)
+
+    return preload_and_map(records, association_name) unless association
+
+    target_klass = association.klass
+    if (inverse_association = association.inverse_of)
+      target_klass.where(inverse_association.name.to_sym => records).where(association.scope)
+    else # assume it is a belongs_to
+      join_key = association.join_keys(target_klass)
+      target_klass.where(join_key.key.to_sym => records.select(join_key.foreign_key.to_sym))
+    end
+  end
 end

--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -11,6 +11,6 @@ module MiqPreloader
   # use instead:
   #   preload_and_map(orchestration_stack.subtree, :direct_vms)
   def self.preload_and_map(records, association)
-    records.to_a.tap { |recs| MiqPreloader.preload(recs, association) }.flat_map(&association)
+    Array.wrap(records).tap { |recs| MiqPreloader.preload(recs, association) }.flat_map(&association)
   end
 end

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     raw_power_state "running"
   end
 
-  factory :template, :class => "Template", :parent => :vm_or_template do
+  factory :template, :class => "MiqTemplate", :parent => :vm_or_template do
     sequence(:name) { |n| "template_#{seq_padded_for_sorting(n)}" }
     template        true
     raw_power_state "never"

--- a/spec/lib/miq_preloader_spec.rb
+++ b/spec/lib/miq_preloader_spec.rb
@@ -49,4 +49,67 @@ describe MiqPreloader do
       MiqPreloader.preload_and_map(*args)
     end
   end
+
+  describe ".preload_and_scope" do
+    it "preloads (object).has_many" do
+      ems = FactoryGirl.create(:ems_infra)
+      FactoryGirl.create_list(:vm, 2, :ext_management_system => ems)
+
+      vms = nil
+      expect { vms = preload_and_scope(ems, :vms) }.to match_query_limit_of(0)
+      expect { expect(vms.count).to eq(2) }.to match_query_limit_of(1)
+    end
+
+    it "preloads (object.all).has_many" do
+      FactoryGirl.create_list(:vm, 2, :ext_management_system => FactoryGirl.create(:ems_infra))
+      FactoryGirl.create(:template, :ext_management_system => FactoryGirl.create(:ems_infra))
+
+      vms = nil
+      expect { vms = preload_and_scope(ExtManagementSystem.all, :vms_and_templates) }.to match_query_limit_of(0)
+      expect { expect(vms.count).to eq(3) }.to match_query_limit_of(1)
+    end
+
+    it "respects scopes (object.all).has_many {with scope}" do
+      FactoryGirl.create_list(:vm, 2, :ext_management_system => FactoryGirl.create(:ems_infra))
+      FactoryGirl.create(:template, :ext_management_system => FactoryGirl.create(:ems_infra))
+
+      expect { expect(preload_and_scope(ExtManagementSystem.all, :vms).count).to eq(2) }.to match_query_limit_of(1)
+    end
+
+    it "preloads (object.all).has_many.belongs_to" do
+      ems = FactoryGirl.create(:ems_infra)
+      FactoryGirl.create_list(:vm, 2,
+                              :ext_management_system => ems,
+                              :host                  => FactoryGirl.create(:host, :ext_management_system => ems))
+      FactoryGirl.create(:vm, :ext_management_system => ems,
+                              :host                  => FactoryGirl.create(:host, :ext_management_system => ems))
+
+      hosts = nil
+      vms = nil
+      expect { vms = preload_and_scope(ExtManagementSystem.all, :vms_and_templates) }.to match_query_limit_of(0)
+      expect { hosts = preload_and_scope(vms, :host) }.to match_query_limit_of(0)
+      expect { expect(hosts.count).to eq(2) }.to match_query_limit_of(1)
+    end
+
+    it "preloads (object.all).belongs_to.has_many" do
+      ems = FactoryGirl.create(:ems_infra)
+      host = FactoryGirl.create(:host, :ext_management_system => ems)
+      FactoryGirl.create_list(:vm, 2,
+                              :ext_management_system => ems,
+                              :host                  => host)
+      host = FactoryGirl.create(:host, :ext_management_system => ems)
+      FactoryGirl.create(:vm, :ext_management_system => ems,
+                              :host                  => host)
+
+      emses = nil
+      vms = nil
+      expect { emses = preload_and_scope(Host.all, :ext_management_system) }.to match_query_limit_of(0)
+      expect { vms = preload_and_scope(emses, :vms) }.to match_query_limit_of(0)
+      expect { expect(vms.count).to eq(3) }.to match_query_limit_of(1)
+    end
+
+    def preload_and_scope(*args)
+      MiqPreloader.preload_and_scope(*args)
+    end
+  end
 end

--- a/spec/lib/miq_preloader_spec.rb
+++ b/spec/lib/miq_preloader_spec.rb
@@ -1,0 +1,52 @@
+describe MiqPreloader do
+  describe ".preload" do
+    it "preloads once from an object" do
+      ems = FactoryGirl.create(:ems_infra)
+      expect(ems.vms).not_to be_loaded
+      expect { preload(ems, :vms) }.to match_query_limit_of(1)
+      expect(ems.vms).to be_loaded
+      expect { preload(ems, :vms) }.to match_query_limit_of(0)
+    end
+
+    it "preloads from an array" do
+      emses = FactoryGirl.create_list(:ems_infra, 2)
+      expect { preload(emses, :vms) }.to match_query_limit_of(1)
+      expect(emses[0].vms).to be_loaded
+    end
+
+    it "preloads from an association" do
+      ems = FactoryGirl.create(:ems_infra)
+      FactoryGirl.create_list(:vm, 2, :ext_management_system => ems)
+
+      emses = ExtManagementSystem.all
+      expect { preload(emses, :vms) }.to match_query_limit_of(2)
+    end
+
+    def preload(*args)
+      MiqPreloader.preload(*args)
+    end
+  end
+
+  describe ".preload_and_map" do
+    it "preloads from an object" do
+      ems = FactoryGirl.create(:ems_infra)
+      FactoryGirl.create_list(:vm, 2, :ext_management_system => ems)
+
+      vms = nil
+      expect { vms = preload_and_map(ems, :vms) }.to match_query_limit_of(1)
+      expect { expect(vms.size).to eq(2) }.to match_query_limit_of(0)
+    end
+
+    it "preloads from an association" do
+      ems = FactoryGirl.create(:ems_infra)
+      FactoryGirl.create_list(:vm, 2, :ext_management_system => ems)
+
+      emses = ExtManagementSystem.all
+      expect { preload_and_map(emses, :vms) }.to match_query_limit_of(2)
+    end
+
+    def preload_and_map(*args)
+      MiqPreloader.preload_and_map(*args)
+    end
+  end
+end

--- a/spec/support/custom_matchers/exceed_query_limit.rb
+++ b/spec/support/custom_matchers/exceed_query_limit.rb
@@ -12,4 +12,6 @@ RSpec::Matchers.define :exceed_query_limit do |expected|
   failure_message_when_negated do |_actual|
     "Expected maximum #{expected} queries, got #{@query_count}"
   end
+
+  supports_block_expectations
 end

--- a/spec/support/custom_matchers/match_query_limit_of.rb
+++ b/spec/support/custom_matchers/match_query_limit_of.rb
@@ -1,0 +1,21 @@
+# Derived from code found in http://stackoverflow.com/questions/5490411/counting-the-number-of-queries-performed
+#
+# Example usage:
+#   expect { MyModel.do_the_queries }.to match_query_limit_of(5)
+
+RSpec::Matchers.define :match_query_limit_of do |expected|
+  match do |block|
+    @query_count = QueryCounter.count(&block)
+    @query_count == expected
+  end
+
+  failure_message do |_actual|
+    "Expected #{expected} queries, got #{@query_count}"
+  end
+
+  description do
+    "expect the block to execute certain number of queries"
+  end
+
+  supports_block_expectations
+end


### PR DESCRIPTION
The goal is to not load all interim records when looking up an association.

So instead of loading all vms to get all their hosts, query hosts directly with an in clause and a subquery for the vms.

Most benefit is seen when this is multiple levels deep.

This has been kept separate from the standard MiqPreload - to avoid any possible side effects.

/cc @Fryguy @jrafanie feedback on possible edge cases would be great.