### PR TITLE
Fix an error that nil can't be coerced into Fixnum with VM Reconfigure

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -79,7 +79,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
     controller_key, unit_number = vim_obj.send(:getScsiCandU)
 
     # if there is no scsi controller
-    if controller_key.nil?
+    if controller_key.blank?
       controller_key, unit_number = [-99, 0]
       add_scsi_controller(vmcs, 0, controller_key)
     end

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -183,4 +183,26 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       expect(subject).to eq('independent_nonpersistent')
     end
   end
+
+  context '#add_disks' do
+    let(:vim)  { double("vim object") }
+    let(:vmcs) { double("VirtualMachineConfigSpec").as_null_object }
+    let(:disk) { {:disk_size_in_mb => 1024} }
+
+    it 'with valid controller key' do
+      allow(vim).to receive(:getScsiCandU).and_return([200, 1])
+
+      expect(vm).not_to receive(:add_scsi_controller)
+      expect(vm).to receive(:add_disk_config_spec).with(vmcs, disk).once
+      vm.add_disks(vim, vmcs, [disk])
+    end
+
+    it 'with no controller key' do
+      allow(vim).to receive(:getScsiCandU).and_return({})
+
+      expect(vm).to receive(:add_scsi_controller).with(vmcs, 0, -99).once
+      expect(vm).to receive(:add_disk_config_spec).with(vmcs, disk).once
+      vm.add_disks(vim, vmcs, [disk])
+    end
+  end
 end


### PR DESCRIPTION
getScsiCandU may return either an empty hash or an array of controller key and unit number.

https://bugzilla.redhat.com/show_bug.cgi?id=1331184