### PR TITLE
Using the fixed version of hawkular-client

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -25,7 +25,7 @@ gem "fog-openstack",           "~>0.1.2",           :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.1",           :require => false
 gem "kubeclient",              "=1.1.3",            :require => false
-gem "hawkular-client",         "~>0.2.1",           :require => false
+gem "hawkular-client",         "=0.2.2",            :require => false
 gem "linux_admin",             "~>0.16.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false


### PR DESCRIPTION
Using the `=0.2.2`, instead of  `~> 0.2.x`. 

(Semantic versioning is a good thing, but we want to make the updates of the gem more consciously.)

@miq-bot add_label providers/hawkular