### PR TITLE
Clean-up interface of TimelineMessage

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -53,7 +53,6 @@ module ReportFormatter
     end
 
     def tl_event(tl_xml, row, col)
-      tl_message = TimelineMessage.new
       mri = options.mri
       tz = mri.get_time_zone(Time.zone.name)
       etime = row[col]
@@ -209,12 +208,13 @@ module ReportFormatter
       headers.delete(j)
       headers.push(j)
 
+      flags = {:ems_cloud     => ems_cloud,
+               :ems_container => ems_container,
+               :time_zone     => tz}
+      tl_message = TimelineMessage.new(row, rec, flags, mri.db)
       e_text = ''
       col_order.each_with_index do |co, co_idx|
-        flags = {:ems_cloud     => ems_cloud,
-                 :ems_container => ems_container,
-                 :time_zone     => tz}
-        val = tl_message.message_html(co, row, rec, flags, mri.db)
+        val = tl_message.message_html(co)
         e_text += "<b>#{headers[co_idx]}:</b> #{val}<br/>" unless val.to_s.empty? || co == "id"
       end
       e_text = e_text.chomp('<br/>')

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -3,50 +3,50 @@ module ReportFormatter
     include CompressedIds
 
     def vm_name
-      "<a href=\"/vm/show/#{to_cid(@event.vm_or_template_id)}\">#{@text}</a>" if @event.vm_or_template_id
+      "<a href=\"/vm/show/#{to_cid(@event.vm_or_template_id)}\">#{text}</a>" if @event.vm_or_template_id
     end
 
     def src_vm_name
-      "<a href=\"/vm/show/#{to_cid(@event.src_vm_or_template.id)}\">#{@text}</a>" if @event.src_vm_or_template
+      "<a href=\"/vm/show/#{to_cid(@event.src_vm_or_template.id)}\">#{text}</a>" if @event.src_vm_or_template
     end
 
     def dest_vm_name
-      "<a href=\"/vm/show/#{to_cid(@event.dest_vm_or_template_id)}\">#{@text}</a>" if @event.dest_vm_or_template_id
+      "<a href=\"/vm/show/#{to_cid(@event.dest_vm_or_template_id)}\">#{text}</a>" if @event.dest_vm_or_template_id
     end
 
     def host_name
-      "<a href=\"/host/show/#{to_cid(@event.host_id)}\">#{@text}</a>" if @event.host_id
+      "<a href=\"/host/show/#{to_cid(@event.host_id)}\">#{text}</a>" if @event.host_id
     end
 
     def dest_host_name
-      "<a href=\"/host/show/#{to_cid(@event.dest_host_id)}\">#{@text}</a>" if @event.dest_host_id
+      "<a href=\"/host/show/#{to_cid(@event.dest_host_id)}\">#{text}</a>" if @event.dest_host_id
     end
 
     def ems_cluster_name
-      "<a href=\"/ems_cluster/show/#{to_cid(@event.ems_cluster_id)}\">#{@text}</a>" if @event.ems_cluster_id
+      "<a href=\"/ems_cluster/show/#{to_cid(@event.ems_cluster_id)}\">#{text}</a>" if @event.ems_cluster_id
     end
 
     def availability_zone_name
       if @event.availability_zone_id
-        "<a href=\"/availability_zone/show/#{to_cid(@event.availability_zone_id)}\">#{@text}</a>"
+        "<a href=\"/availability_zone/show/#{to_cid(@event.availability_zone_id)}\">#{text}</a>"
       end
     end
 
     def container_node_name
-      "<a href=\"/container_node/show/#{to_cid(@event.container_node_id)}\">#{@text}</a>" if @event.container_node_id
+      "<a href=\"/container_node/show/#{to_cid(@event.container_node_id)}\">#{text}</a>" if @event.container_node_id
     end
 
     def container_group_name
-      "<a href=\"/container_group/show/#{to_cid(@event.container_group_id)}\">#{@text}</a>" if @event.container_group_id
+      "<a href=\"/container_group/show/#{to_cid(@event.container_group_id)}\">#{text}</a>" if @event.container_group_id
     end
 
     def container_name
-      "<a href=\"/container/tree_select/?id=cnt-#{to_cid(@event.container_id)}\">#{@text}</a>" if @event.container_id
+      "<a href=\"/container/tree_select/?id=cnt-#{to_cid(@event.container_id)}\">#{text}</a>" if @event.container_id
     end
 
     def container_replicator_name
       if @event.container_replicator_id
-        "<a href=\"/container_replicator/show/#{to_cid(@event.container_replicator_id)}\">#{@text}</a>"
+        "<a href=\"/container_replicator/show/#{to_cid(@event.container_replicator_id)}\">#{text}</a>"
       end
     end
 
@@ -55,11 +55,11 @@ module ReportFormatter
         provider_id = @event.ext_management_system.id
         if @ems_cloud
           # restful route is used for cloud provider unlike infrastructure provider
-          "<a href=\"/ems_cloud/#{provider_id}\">#{@text}</a>"
+          "<a href=\"/ems_cloud/#{provider_id}\">#{text}</a>"
         elsif @ems_container
-          "<a href=\"/ems_container/#{to_cid(provider_id)}\">#{@text}</a>"
+          "<a href=\"/ems_container/#{to_cid(provider_id)}\">#{text}</a>"
         else
-          "<a href=\"/ems_infra/#{to_cid(provider_id)}\">#{@text}</a>"
+          "<a href=\"/ems_infra/#{to_cid(provider_id)}\">#{text}</a>"
         end
       end
     end
@@ -80,18 +80,26 @@ module ReportFormatter
     def set_parameters(column, row, event, flags, db)
       @event, @ems_cloud, @ems_container = event, flags[:ems_cloud], flags[:ems_container]
       @db   = db
-      @text = if row[column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(column)
-                format_timezone(Time.parse(row[column].to_s).utc, flags[:time_zone], "gtl")
-              else
-                row[column].to_s
-              end
+      @column = column
+      @row = row
+      @flags = flags
     end
 
     def message_html(column, row, event, flags, db)
       set_parameters(column, row, event, flags, db)
 
       field = column.tr('.', '_').to_sym
-      respond_to?(field) ? send(field).to_s : @text
+      respond_to?(field) ? send(field).to_s : text
+    end
+
+    private
+
+    def text
+      if @row[@column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(@column)
+        format_timezone(Time.parse(@row[@column].to_s).utc, @flags[:time_zone], "gtl")
+      else
+        @row[@column].to_s
+      end
     end
   end
 end

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -4,7 +4,6 @@ module ReportFormatter
 
     def initialize(row, event, flags, db)
       @row, @event, @flags, @db = row, event, flags, db
-      @ems_cloud, @ems_container = flags[:ems_cloud], flags[:ems_container]
     end
 
     def vm_name
@@ -58,10 +57,10 @@ module ReportFormatter
     def ext_management_system_name
       if @event.ext_management_system && @event.ext_management_system.id
         provider_id = @event.ext_management_system.id
-        if @ems_cloud
+        if ems_cloud
           # restful route is used for cloud provider unlike infrastructure provider
           "<a href=\"/ems_cloud/#{provider_id}\">#{text}</a>"
-        elsif @ems_container
+        elsif ems_container
           "<a href=\"/ems_container/#{to_cid(provider_id)}\">#{text}</a>"
         else
           "<a href=\"/ems_infra/#{to_cid(provider_id)}\">#{text}</a>"
@@ -71,7 +70,7 @@ module ReportFormatter
 
     def resource_name
       if @db == 'BottleneckEvent'
-        db = if @ems_cloud && @event.resource_type == 'ExtManagementSystem'
+        db = if ems_cloud && @event.resource_type == 'ExtManagementSystem'
                'ems_cloud'
              elsif @event.resource_type == 'ExtManagementSystem'
                'ems_infra'
@@ -96,6 +95,14 @@ module ReportFormatter
       else
         @row[@column].to_s
       end
+    end
+
+    def ems_cloud
+      @flags[:ems_cloud]
+    end
+
+    def ems_container
+      @flags[:ems_container]
     end
   end
 end

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -6,6 +6,14 @@ module ReportFormatter
       @row, @event, @flags, @db = row, event, flags, db
     end
 
+    def message_html(column)
+      @column = column
+      field = column.tr('.', '_').to_sym
+      respond_to?(field, true) ? send(field).to_s : text
+    end
+
+    private
+
     def vm_name
       "<a href=\"/vm/show/#{to_cid(@event.vm_or_template_id)}\">#{text}</a>" if @event.vm_or_template_id
     end
@@ -80,14 +88,6 @@ module ReportFormatter
         "<a href=\"/#{db}/#{to_cid(@event.resource_id)}\">#{@event.resource_name}</a>"
       end
     end
-
-    def message_html(column)
-      @column = column
-      field = column.tr('.', '_').to_sym
-      respond_to?(field) ? send(field).to_s : text
-    end
-
-    private
 
     def text
       if @row[@column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(@column)

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -2,6 +2,11 @@ module ReportFormatter
   class TimelineMessage
     include CompressedIds
 
+    def initialize(row, event, flags, db)
+      @row, @event, @flags, @db = row, event, flags, db
+      @ems_cloud, @ems_container = flags[:ems_cloud], flags[:ems_container]
+    end
+
     def vm_name
       "<a href=\"/vm/show/#{to_cid(@event.vm_or_template_id)}\">#{text}</a>" if @event.vm_or_template_id
     end
@@ -77,17 +82,8 @@ module ReportFormatter
       end
     end
 
-    def set_parameters(column, row, event, flags, db)
-      @event, @ems_cloud, @ems_container = event, flags[:ems_cloud], flags[:ems_container]
-      @db   = db
+    def message_html(column)
       @column = column
-      @row = row
-      @flags = flags
-    end
-
-    def message_html(column, row, event, flags, db)
-      set_parameters(column, row, event, flags, db)
-
       field = column.tr('.', '_').to_sym
       respond_to?(field) ? send(field).to_s : text
     end

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -54,7 +54,7 @@ describe ReportFormatter::TimelineMessage do
     tests.each do |column, href|
       it "Evaluate column #{column} content" do
         row[column] = 'test timeline'
-        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags, 'EmsEvent')
+        val = ReportFormatter::TimelineMessage.new(row, event, flags, 'EmsEvent').message_html(column)
         expect(val).to eq(href)
       end
     end
@@ -79,7 +79,7 @@ describe ReportFormatter::TimelineMessage do
     tests.each do |column, href|
       it "Evaluate column #{column} content" do
         row[column] = 'test timeline'
-        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags, 'EmsEvent')
+        val = ReportFormatter::TimelineMessage.new(row, event, flags, 'EmsEvent').message_html(column)
         expect(val).to eq(href)
       end
     end
@@ -102,7 +102,7 @@ describe ReportFormatter::TimelineMessage do
     tests.each do |column, href|
       it "Evaluate column #{column} content" do
         row[column] = 'MemoryUsage'
-        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, {}, 'BottleneckEvent')
+        val = ReportFormatter::TimelineMessage.new(row, event, {}, 'BottleneckEvent').message_html(column)
         expect(val).to eq(href)
       end
     end


### PR DESCRIPTION
Addressing UI failure on the Bottleneck page after
328e129c22dd881ab4e45a9af60d6636e4f5a9f3. (#7857)
```
Error caught: [NameError] undefined local variable or method `mri' for #<ReportFormatter::TimelineMessage:0x007f9129ab2c70>
lib/report_formatter/timeline_message.rb:68:in `resource_name'
lib/report_formatter/timeline_message.rb:93:in `message_html'
lib/report_formatter/timeline.rb:217:in `block in tl_event'
lib/report_formatter/timeline.rb:213:in `each'
lib/report_formatter/timeline.rb:213:in `each_with_index'
lib/report_formatter/timeline.rb:213:in `tl_event'
lib/report_formatter/timeline.rb:37:in `block in build_document_body'
lib/report_formatter/timeline.rb:36:in `each'
lib/report_formatter/timeline.rb:36:in `each_with_index'
lib/report_formatter/timeline.rb:36:in `build_document_body'
```

Reproducer: Have some bottleneck events and go to the Bottleneck page.

@miq-bot add_label ui, bug
