### PR TITLE
Fix C3 charts x axis tick label

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1559,6 +1559,9 @@ function add_expanding_icon(element){
 }
 
 function chartData(type, data, data2) {
+  if(_.isObject(data.axis) && _.isObject(data.axis.x) && data.axis.x.categories.length > 10 ){
+    data.axis.x.tick = {centered: true, count: 10};
+  }
   if (_.isObject(data.axis) && _.isObject(data.axis.y) && _.isObject(data.axis.y.tick) && _.isObject(data.axis.y.tick.format)) {
     var o = data.axis.y.tick.format;
     data.axis.y.tick.format = ManageIQ.charts.formatters[o.function].c3(o.options);

--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -50,4 +50,9 @@ function load_c3_chart(data, chart_id, height) {
   var chart = c3.generate(generate_args);
 
   ManageIQ.charts.c3[chart_id] = chart;
-}
+};
+
+ c3.chart.internal.fn.categoryName = function (i) {
+    var config = this.config, categoryIndex = Math.ceil(i);
+    return i < config.axis_x_categories.length ? config.axis_x_categories[categoryIndex] : i;
+};

--- a/app/assets/javascripts/miq_c3_config.js
+++ b/app/assets/javascripts/miq_c3_config.js
@@ -159,7 +159,7 @@
 
     Line: _.defaultsDeep(
       {
-        axis : {x:{type: 'category'}},
+        axis : {x:{type: 'category', tick: {centered: true}}},
         data : {type: 'line'},
       },c3mixins.pfColorPattern,
       $().c3ChartDefaults().getDefaultLineConfig()


### PR DESCRIPTION
Parrent issue #6627
Fix readability of X axis labels primary in CU charts. Using code from this open PR to C3 repo: https://github.com/masayuki0812/c3/pull/1641
Override function c3.chart.internal.fn.categoryName(), which C3 chart uses.
I set the tick count to 10 for now, but we can change it.

Before:
![screenshot from 2016-04-29 14-11-42](https://cloud.githubusercontent.com/assets/9535558/14915567/551e8854-0e14-11e6-9c32-37e065302182.png)

After:
![screenshot from 2016-04-29 14-10-34](https://cloud.githubusercontent.com/assets/9535558/14915538/30be4918-0e14-11e6-9c5f-ad53a6481543.png)
