### PR TITLE
Eval the Gems Pending gemfile after the Gemfile gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
-
 #
 # VMDB specific gems
 #
@@ -139,4 +137,5 @@ dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
 eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 
 # Load other additional Gemfiles
+eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 Dir.glob("bundler.d/*.rb").each { |f| eval_gemfile(File.expand_path(f, __dir__)) }


### PR DESCRIPTION
With bundler 1.12.0 we're seeing:

$ bundle
Fetching git://github.com/rails/rails.git
Checking out files: 100% (3167/3167), done.
Fetching git://github.com/ManageIQ/handsoap.git
Fetching git://github.com/ManageIQ/rubywbem.git
Fetching git://github.com/Fryguy/config.git
Fetching git://github.com/Fryguy/deep_merge.git
The path `~/manageiq/gems/pending/gems` does not exist.