### PR TITLE
pluggable providers: remove coupling from miq_provision

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -75,6 +75,7 @@ class ExtManagementSystem < ApplicationRecord
   include EmsRefresh::Manager
   include TenancyMixin
   include AvailabilityMixin
+  include SupportsFeatureMixin
 
   after_destroy { |record| $log.info "MIQ(ExtManagementSystem.after_destroy) Removed EMS [#{record.name}] id [#{record.id}]" }
 

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -42,6 +42,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   before_validation :ensure_managers
 
   supports :discovery
+  supports :provisioning
 
   def ensure_managers
     build_network_manager unless network_manager

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -3,6 +3,7 @@ module ManageIQ::Providers
     require_nested :Refresher
 
     include SupportsFeatureMixin
+    supports_not :provisioning # via automate
 
     def self.metrics_collector_queue_name
       self::MetricsCollectorWorker.default_queue_name

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -34,6 +34,8 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
 
   before_validation :ensure_managers
 
+  supports :provisioning
+
   def ensure_managers
     build_network_manager unless network_manager
     network_manager.name            = "#{name} Network Manager"

--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -10,6 +10,8 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
 
   include_concern "Powershell"
 
+  supports :provisioning
+
   def self.ems_type
     @ems_type ||= "scvmm".freeze
   end

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -24,6 +24,8 @@ class ManageIQ::Providers::Openstack::CloudManager < EmsCloud
   include ManageIQ::Providers::Openstack::ManagerMixin
   include HasManyCloudNetworksMixin
 
+  supports :provisioning
+
   def self.ems_type
     @ems_type ||= "openstack".freeze
   end

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -14,6 +14,8 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   require_nested :Template
   require_nested :Vm
 
+  supports :provisioning
+
   def self.ems_type
     @ems_type ||= "rhevm".freeze
   end

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -20,6 +20,8 @@ module ManageIQ::Providers
     before_save :stop_event_monitor_queue_on_change
     before_destroy :stop_event_monitor
 
+    supports :provisioning
+
     def self.ems_type
       @ems_type ||= "vmwarews".freeze
     end

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -31,13 +31,6 @@ class MiqProvision < MiqProvisionTask
 
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
-  SUPPORTED_EMS_CLASSES = %w( ManageIQ::Providers::Vmware::InfraManager
-                              ManageIQ::Providers::Redhat::InfraManager
-                              ManageIQ::Providers::Amazon::CloudManager
-                              ManageIQ::Providers::Openstack::CloudManager
-                              ManageIQ::Providers::Microsoft::InfraManager
-                              ManageIQ::Providers::Google::CloudManager
-                              ManageIQ::Providers::Azure::CloudManager)
 
   def self.base_model
     MiqProvision

--- a/app/models/miq_provision/options_helper.rb
+++ b/app/models/miq_provision/options_helper.rb
@@ -36,7 +36,7 @@ module MiqProvision::OptionsHelper
             _("%{class_name} [%{name}] is not attached to a Management System") % {:class_name => source.class.name,
                                                                                    :name       => source.name}
     end
-    unless MiqProvision::SUPPORTED_EMS_CLASSES.include?(ems.class.name)
+    unless ems.supports_provisioning?
       raise MiqException::MiqProvisionError,
             _("%{class_name} [%{name}] is attached to <%{ems_class_name}: %{ems_name}> that does not support Provisioning") %
               {:class_name     => source.class.name,


### PR DESCRIPTION
removed hardcoded classes that support provisioning from miq_provision

Managers of providers answer the question wether they support
provisioning via automate or not. The BaseManager does not by default.

@miq-bot add_labels refactoring, providers