### PR TITLE
Show nice configuration manager provider type in reports

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -722,6 +722,8 @@ en:
       ManageIQ::Providers::BaseManager:                                     Provider
       #ManageIQ::Providers::BaseManager::VmOrTemplate: VM or Template
       #ManageIQ::Providers::BaseManager::Vm:           VM and Instance
+      ManageIQ::Providers::AnsibleTower::ConfigurationManager:              Configuration Manager (Ansible)
+      ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Foreman Configured System
       ManageIQ::Providers::CloudManager:                                    Cloud Provider

--- a/product/views/ManageIQ_Providers_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager.yaml
@@ -68,7 +68,7 @@ headers:
 col_formats:
 -
 -
--
+- :model_name
 -
 -
 -


### PR DESCRIPTION
Let's display a nice human readable name, rather than model name.