### PR TITLE
Fix openstack keypair add throws un-comprehensive error message

### DIFF
--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -128,10 +128,10 @@ class AuthKeyPairCloudController < ApplicationController
             :model => ui_lookup(:table => 'auth_key_pair_cloud'),
             :name  => options[:name]})
         rescue => ex
-          add_flash(_("Unable to create %{model} %{name} %{error}") % {
+          add_flash(_("Unable to create %{model} %{name}. %{error}") % {
             :model => ui_lookup(:table => 'auth_key_pair_cloud'),
             :name  => options[:name],
-            :error => ex}, :error)
+            :error => get_error_message_from_fog(ex.to_s)}, :error)
         end
         @breadcrumbs.pop if @breadcrumbs
         session[:edit] = nil
@@ -298,5 +298,10 @@ class AuthKeyPairCloudController < ApplicationController
     session[:auth_key_pair_cloud_display]    = @display unless @display.nil?
     session[:auth_key_pair_cloud_filters]    = @filters
     session[:auth_key_pair_cloud_catinfo]    = @catinfo
+  end
+
+  def get_error_message_from_fog(ex)
+    matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
+    matched_message ? matched_message[1] : ex
   end
 end

--- a/spec/controllers/auth_key_pair_cloud_controller_spec.rb
+++ b/spec/controllers/auth_key_pair_cloud_controller_spec.rb
@@ -55,4 +55,18 @@ describe AuthKeyPairCloudController do
       expect(assigns(:edit)).to be_nil
     end
   end
+
+  context "#parse error messages" do
+    it "simplifies fog error message" do
+      raw_msg = "Expected(200) <=> Actual(400 Bad Request)\nexcon.error.response\n  :body          => "\
+                "\"{\\\"badRequest\\\": {\\\"message\\\": \\\"Keypair data is invalid: failed to generate "\
+                "fingerprint\\\", \\\"code\\\": 400}}\"\n  :cookies       => [\n  ]\n  :headers       => {\n "\
+                "\"Content-Length\"       => \"99\"\n    \"Content-Type\"         => \"application/json; "\
+                "charset=UTF-8\"\n    \"Date\"                 => \"Mon, 02 May 2016 08:15:51 GMT\"\n ..."\
+                ":reason_phrase => \"Bad Request\"\n  :remote_ip     => \"10....\"\n  :status        => 400\n  "\
+                ":status_line   => \"HTTP/1.1 400 Bad Request\\r\\n\"\n"
+      expect(subject.send(:get_error_message_from_fog, raw_msg)).to eq "Keypair data is invalid: failed to generate "\
+                                                                       "fingerprint"
+    end
+  end
 end


### PR DESCRIPTION
Openstack keypair throws long and complicated error message when
public key to be added has an invalid format.

Error message was shortened, so it should be more descriptive now.

https://bugzilla.redhat.com/show_bug.cgi?id=1328767