### PR TITLE
PatternFly updated to 3.3.5 with tertiary navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ gem "jquery-hotkeys-rails"
 gem "jquery-rails",                   "~>4.0.4"
 gem "jquery-rjs",                     "=0.1.1",                       :git => "git://github.com/ManageIQ/jquery-rjs.git", :branch => "master"
 gem "lodash-rails",                   "~>3.10.0"
-# gem "patternfly-sass",                "~>3.3.4"
-gem 'patternfly-sass', :github => 'skateman/patternfly-sass', :branch => 'tertiary-nav-new'
+# gem "patternfly-sass",                "~>3.3.5"
+gem 'patternfly-sass', :github => 'skateman/patternfly-sass', :branch => '3.3.5-tertiary'
 gem "sass-rails"
 gem "sprockets-es6",                  "~>0.9.0",  :require => "sprockets/es6"
 

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "angular": "^1.5.3",
     "angular-animate": "^1.5.3",
     "angular-mocks": "^1.5.3",
-    "angular-patternfly-sass": "3.3.4",
+    "angular-patternfly-sass": "3.3.5",
     "angular-sanitize": "^1.5.3",
     "bootstrap-filestyle": "^1.2.1",
     "bootstrap-hover-dropdown": "^2.0.11",


### PR DESCRIPTION
As described in #8280, this should be backported to darga.