### PR TITLE
Enforce that `name` and `ems_id` be present to submit AuthKeyPair creation form

### DIFF
--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -81,11 +81,12 @@ class AuthKeyPairCloudController < ApplicationController
   def form_field_changed
     return unless load_edit("auth_key_pair_cloud_edit__#{params[:id] || 'new'}")
     get_form_vars
-    @changed = (@edit[:new] != @edit[:current])
+    enable_buttons = (!@edit[:new][:name].blank? && !@edit[:new][:ems_id].blank?)
+
     render :update do |page|
       page << javascript_prologue
       page.replace(@refresh_div, :partial => @refresh_partial) if @refresh_div
-      page << javascript_for_miq_button_visibility(true)
+      page << javascript_for_miq_button_visibility(enable_buttons)
     end
   end
 

--- a/app/views/layouts/_edit_buttons.html.haml
+++ b/app/views/layouts/_edit_buttons.html.haml
@@ -40,11 +40,9 @@
       #buttons_off{:style => "display:#{@changed ? "none" : "display"};"}
         - if record_id.blank?
           = button_tag(_("Add"),
-                       :class   => 'btn btn-default',
+                       :class   => 'btn btn-default btn-disabled',
                        :alt     => t = _("Add"),
-                       :title   => t,
-                       :onclick => "miqAjaxButton('#{url_for(:action => action_url,
-                                                             :button => "add")}');")
+                       :title   => t)
         - else
           = button_tag(_("Save"), :class => "btn btn-primary btn-disabled")
           - unless noreset


### PR DESCRIPTION
Don't enable the Add button unless at least a name and ems_id
have been entered in the form. The key field remains optional.

This was not being enforced before, allowing invalid form
submissions.

cc @durandom https://bugzilla.redhat.com/show_bug.cgi?id=1329427