### PR TITLE
Fix unused variable in MiqVimInventory#hashObj

### DIFF
--- a/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -425,7 +425,7 @@ class MiqVimInventory < MiqVimClientBase
   end
 
   def hashObj(type, props)
-    objType = objType.to_sym if objType.kind_of?(String)
+    type = type.to_sym if type.kind_of?(String)
     raise "hashObj: exclusive cache lock not held" unless @cacheLock.sync_exclusive?
     raise "Unknown VIM object type: #{type}" unless (pmap = @propMap[type])
 


### PR DESCRIPTION
In the method #hashObj the parameter type is intended to be converted to a symbol in-case it is passed in as a string, but a unknown variable objType is used.

Other methods in this file use the exact same line, so appears to be just a copy&paste issue.  ObjType is not used in the rest of the method.