### PR TITLE
Fix RHEVM Verify Creds error message

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -110,8 +110,9 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     connect(options).api
   rescue URI::InvalidURIError
     raise "Invalid URI specified for RHEV server."
+  rescue SocketError => err
+    raise "Error occurred attempted to connect to RHEV server.", err
   rescue => err
-    err = err.to_s.split('<html>').first.strip.chomp(':')
     raise MiqException::MiqEVMLoginError, err
   end
 


### PR DESCRIPTION
Stop trying to parse the error message.

Also, handle SocketError for RHEVM cred verification. Instead of saying that the credential verification failed, indicate that we had trouble connecting to RHEV on a SocketError.

https://bugzilla.redhat.com/show_bug.cgi?id=1331088