### PR TITLE
Clear cluster when ems is cleared

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -8,7 +8,7 @@ class EmsCluster < ApplicationRecord
 
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many    :hosts, :dependent => :nullify
-  has_many    :vms_and_templates
+  has_many    :vms_and_templates, :dependent => :nullify
   has_many    :miq_templates, :inverse_of => :ems_cluster
   has_many    :vms, :inverse_of => :ems_cluster
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -654,6 +654,7 @@ class Host < ApplicationRecord
       _log.info "Disconnecting Host [#{name}] id [#{id}]#{log_text}"
 
       self.ext_management_system = nil
+      self.ems_cluster = nil
       self.state = "unknown"
       save
     end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -702,6 +702,7 @@ class VmOrTemplate < ApplicationRecord
       _log.info "Disconnecting Vm [#{name}] id [#{id}]#{log_text}"
 
       self.ext_management_system = nil
+      self.ems_cluster = nil
       self.raw_power_state = "unknown"
       save
     end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -349,4 +349,24 @@ describe Host do
       expect(subject.current_tenant).to eq(Tenant.root_tenant)
     end
   end
+
+  describe "#disconnect_ems" do
+    let(:ems) { FactoryGirl.build(:ext_management_system) }
+    let(:host) do
+      FactoryGirl.build(:host,
+                        :ext_management_system => ems,
+                        :ems_cluster           => FactoryGirl.build(:ems_cluster))
+    end
+    it "clears ems and cluster" do
+      host.disconnect_ems(ems)
+      expect(host.ext_management_system).to be_nil
+      expect(host.ems_cluster).to be_nil
+    end
+
+    it "doesnt clear the wrong ems" do
+      host.disconnect_ems(FactoryGirl.build(:ext_management_system))
+      expect(host.ext_management_system).not_to be_nil
+      expect(host.ems_cluster).not_to be_nil
+    end
+  end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -609,4 +609,25 @@ describe VmOrTemplate do
       expect(vm.v_host_vmm_product).to eq("Hyper-V")
     end
   end
+
+  describe "#disconnect_ems" do
+    let(:ems) { FactoryGirl.build(:ext_management_system) }
+    let(:vm) do
+      FactoryGirl.build(:vm_or_template,
+                        :ext_management_system => ems,
+                        :ems_cluster           => FactoryGirl.build(:ems_cluster))
+    end
+
+    it "clears ems and cluster" do
+      vm.disconnect_ems(ems)
+      expect(vm.ext_management_system).to be_nil
+      expect(vm.ems_cluster).to be_nil
+    end
+
+    it "doesnt clear the wrong ems" do
+      vm.disconnect_ems(FactoryGirl.build(:ext_management_system))
+      expect(vm.ext_management_system).not_to be_nil
+      expect(vm.ems_cluster).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1331803

When an ems is orphaned, clear out the ems_cluser as well.

**before:**

This was causing issues when cap&u tried to rollup vms that had no ems. It blew up while figuring out the ems's queue name (since there was no ems).

**after:**

The vm will not be returned when cap&u discovers vms that need performance rollups. So it will no longer blow up perf capture rollups

/cc @gtanzillo thanks for all the help