### PR TITLE
[DARGA] [api] Fix for services_spec.rb for Darga

### DIFF
--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -268,7 +268,7 @@ describe ApiController do
     let(:vm2) { FactoryGirl.create(:vm_vmware, :hardware => hw2) }
 
     before do
-      api_basic_authorize(action_identifier(:services, :read, :resource_actions, :get))
+      api_basic_authorize
 
       svc1 << vm1
       svc1 << vm2


### PR DESCRIPTION
GET identifier support is on master only, so needed to update how
we authorize in the tests for vms subcollection of services.