### PR TITLE
Refactor ansible tower service provisioning state machine methods

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
@@ -1,32 +1,68 @@
 #
 # Description: This method checks to see if the job has been provisioned
-#   and whether the refresh has completed
+# and refresh the job when it completes at the provider
 #
-task = $evm.root["service_template_provision_task"]
-raise "service_template_provision_task not found" unless task
 
-service = task.destination
-raise "service is not a type of AnsibleTower" unless service.respond_to?(:job)
+class AnsibleTowerCheckProvisioned
+  def initialize(handle)
+    @handle = handle
+  end
 
-# check whether the AnsibleTower job completed
-job = service.job
-status, reason = job.normalized_live_status
-case status.downcase
-when 'create_complete'
-  $evm.root['ae_result'] = 'ok'
-when /failed$/, /canceled$/
-  $evm.root['ae_result'] = 'error'
-  $evm.root['ae_reason'] = reason
-else
-  # deployment not done yet in provider
-  $evm.root['ae_result']         = 'retry'
-  $evm.root['ae_retry_interval'] = '1.minute'
+  def main
+    @handle.log("info", "Starting Ansible Tower Provisioning")
+    check_provisioned(task, service)
+  end
+
+  private
+
+  def check_provisioned(task, service)
+    # check whether the AnsibleTower job completed
+    job = service.job
+
+    if job.nil?
+      @handle.root['ae_result'] = 'error'
+      @handle.root['ae_reason'] = 'job was not created'
+    else
+      check_status(job)
+    end
+
+    unless @handle.root['ae_result'] == 'retry'
+      @handle.log("info", "AnsibleTower job finished. Status: #{@handle.root['ae_result']}, reason: #{@handle.root['ae_reason']}")
+      @handle.log("info", "Please examine job console output for more details") if @handle.root['ae_result'] == 'error'
+
+      job.refresh_ems
+      task.miq_request.user_message = @handle.root['ae_reason'].truncate(255) unless @handle.root['ae_reason'].blank?
+    end
+  end
+
+  def check_status(job)
+    status, reason = job.normalized_live_status
+    case status.downcase
+    when 'create_complete'
+      @handle.root['ae_result'] = 'ok'
+    when /failed$/, /canceled$/
+      @handle.root['ae_result'] = 'error'
+      @handle.root['ae_reason'] = reason
+    else
+      # job not done yet in provider
+      @handle.root['ae_result']         = 'retry'
+      @handle.root['ae_retry_interval'] = '1.minute'
+    end
+  end
+
+  def task
+    @handle.root["service_template_provision_task"].tap do |task|
+      raise "service_template_provision_task not found" unless task
+    end
+  end
+
+  def service
+    task.destination.tap do |service|
+      raise "service is not of type AnsibleTower" unless service.respond_to?(:job_template)
+    end
+  end
 end
 
-unless $evm.root['ae_result'] == 'retry'
-  $evm.log("info", "AnsibleTower job finished. Status: #{$evm.root['ae_result']}, reason: #{$evm.root['ae_reason']}")
-  # $evm.log("info", "Please examine job resources for more details") if $evm.root['ae_result'] == 'error'
-
-  job.refresh_ems
-  task.miq_request.user_message = $evm.root['ae_reason'].truncate(255) unless $evm.root['ae_reason'].blank?
+if __FILE__ == $PROGRAM_NAME
+  AnsibleTowerCheckProvisioned.new($evm).main
 end

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
@@ -1,17 +1,36 @@
 #
 # Description: This method examines the AnsibleTower job provisioned
 #
-$evm.log("info", "Starting Ansible Tower Post-Provisioning")
+class AnsibleTowerPostProvision
+  def initialize(handle)
+    @handle = handle
+  end
 
-task = $evm.root["service_template_provision_task"]
-raise "service_template_provision_task not found" unless task
+  def main
+    @handle.log("info", "Starting Ansible Tower Post-Provisioning")
+    # job = service.job
 
-service = task.destination
-raise "service is not of type AnsibleTower" unless service.respond_to?(:job)
+    # You can add logic to process the job object in VMDB
+    # For example, dump all outputs from the job
+    #
+    # dump_job_outputs(job)
+  end
 
-#job = service.job
+  private
 
-# You can add logic to process the job object in VMDB
-# For example, dump all outputs from the job
-#
-# dump_job_outputs(job)
+  def task
+    @handle.root["service_template_provision_task"].tap do |task|
+      raise "service_template_provision_task not found" unless task
+    end
+  end
+
+  def service
+    task.destination.tap do |service|
+      raise "service is not of type AnsibleTower" unless service.respond_to?(:job_template)
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  AnsibleTowerPostProvision.new($evm).main
+end

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision.rb
@@ -2,26 +2,51 @@
 # Description: This method prepares arguments and parameters for a job template
 #
 
-$evm.log("info", "Starting Ansible Tower Pre-Provisioning")
+class AnsibleTowerPreprovision
+  def initialize(handle)
+    @handle = handle
+  end
 
-task = $evm.root["service_template_provision_task"]
-raise "service_template_provision_task not found" unless task
+  def main
+    @handle.log("info", "Starting Ansible Tower Pre-Provisioning")
+    examine_request(service)
+    # modify_job_options(service)
+  end
 
-service = task.destination
-raise "service is not of type AnsibleTower" unless service.respond_to?(:job_template)
+  def task
+    @handle.root["service_template_provision_task"].tap do |task|
+      raise "service_template_provision_task not found" unless task
+    end
+  end
 
-# Through service you can examine the job template, configuration manager (i.e., provider)
-# and options to start a job
-# You can also override these selections through service
-# $evm.log("info", "manager = #{service.configuration_manager.name}")
-# $evm.log("info", "template = #{service.job_template.name}")
+  def service
+    task.destination.tap do |service|
+      raise "service is not of type AnsibleTower" unless service.respond_to?(:job_template)
+    end
+  end
 
-# Caution: job options may contain passwords.
-# $evm.log("info", "job options = #{service.job_options.inspect}")
+  # Through service you can examine the job template, configuration manager (i.e., provider)
+  # and options to start a job
+  def examine_request(service)
+    @handle.log("info", "manager = #{service.configuration_manager.name}")
+    @handle.log("info", "template = #{service.job_template.name}")
 
-# Example how to programmatically modify job options:
-# job_options = service.job_options
-# job_options[:limit] = 'someHost'
-# job_options[:extra_vars]['flavor'] = 'm1.small'
-# # Important: set stack_options
-# service.job_options = job_options
+    # Caution: job options may contain passwords.
+    # @handle.log("info", "job options = #{service.job_options.inspect}")
+  end
+
+  # You can also override job options through service
+  def modify_job_options(service)
+    # Example how to programmatically modify job options:
+    job_options = service.job_options
+    job_options[:limit] = 'someHost'
+    job_options[:extra_vars]['flavor'] = 'm1.small'
+
+    # Important: set stack_options
+    service.job_options = job_options
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  AnsibleTowerPreprovision.new($evm).main
+end

--- a/spec/automation/unit/method_validation/ansible_tower_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/ansible_tower_check_provisioned_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned').to_s
+require Rails.root.join('spec/support/miq_ae_mock_service').to_s
+
+describe AnsibleTowerCheckProvisioned do
+  let(:admin) { FactoryGirl.create(:user_admin) }
+  let(:request) { FactoryGirl.create(:service_template_provision_request, :requester => admin) }
+  let(:service_ansible_tower) { FactoryGirl.create(:service_ansible_tower) }
+  let(:task) { FactoryGirl.create(:service_template_provision_task, :destination => service_ansible_tower, :miq_request => request) }
+  let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(task.id) }
+  let(:root_object) { MiqAeMockObject.new('service_template_provision_task' => svc_task) }
+  let(:ae_service) { MiqAeMockService.new(root_object) }
+  let(:job_class) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_Job }
+  let(:job) { FactoryGirl.create(:ansible_tower_job) }
+
+  describe 'check provision status' do
+    before { allow_any_instance_of(ServiceAnsibleTower).to receive(:job).and_return(job) }
+
+    context 'ansible tower job completed' do
+      before { allow_any_instance_of(job_class).to receive(:normalized_live_status).and_return(['create_complete', 'ok']) }
+      it "refreshes the job status" do
+        expect(job).to receive(:refresh_ems)
+        described_class.new(ae_service).main
+        expect(ae_service.root['ae_result']).to eq('ok')
+      end
+    end
+
+    context 'ansible tower job is running' do
+      before { allow_any_instance_of(job_class).to receive(:normalized_live_status).and_return(['running', 'ok']) }
+      it "retries the step" do
+        described_class.new(ae_service).main
+        expect(ae_service.root['ae_result']).to eq('retry')
+      end
+    end
+
+    context 'ansible tower job failed' do
+      before { allow_any_instance_of(job_class).to receive(:normalized_live_status).and_return(['create_failed', 'bad']) }
+      it "signals error" do
+        expect(job).to receive(:refresh_ems)
+        described_class.new(ae_service).main
+        expect(ae_service.root['ae_result']).to eq('error')
+        expect(ae_service.root['ae_reason']).to eq('bad')
+      end
+    end
+  end
+end

--- a/spec/automation/unit/method_validation/ansible_tower_preprovision_spec.rb
+++ b/spec/automation/unit/method_validation/ansible_tower_preprovision_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision').to_s
+require Rails.root.join('spec/support/miq_ae_mock_service').to_s
+
+describe AnsibleTowerPreprovision do
+  let(:ansible_tower_manager) { FactoryGirl.create(:configuration_manager) }
+  let(:job_template) { FactoryGirl.create(:ansible_configuration_script, :manager => ansible_tower_manager) }
+  let(:service_ansible_tower) { FactoryGirl.create(:service_ansible_tower, :job_template => job_template) }
+  let(:task) { FactoryGirl.create(:service_template_provision_task, :destination => service_ansible_tower) }
+  let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(task.id) }
+  let(:root_object) { MiqAeMockObject.new('service_template_provision_task' => svc_task) }
+  let(:ae_service) { MiqAeMockService.new(root_object) }
+
+  it "examines request configuration" do
+    expect_any_instance_of(ServiceAnsibleTower).to receive(:configuration_manager).and_return(ansible_tower_manager)
+    expect_any_instance_of(ServiceAnsibleTower).to receive(:job_template).at_least(1).times.and_return(job_template)
+    described_class.new(ae_service).main
+  end
+
+  it "modifies job options" do
+    test = described_class.new(ae_service)
+    test.send(:modify_job_options, test.service)
+    service_ansible_tower.reload
+    expect(service_ansible_tower.job_options).to have_attributes(:limit => 'someHost', :extra_vars => {'flavor' => 'm1.small'})
+  end
+end

--- a/spec/automation/unit/method_validation/ansible_tower_provision_spec.rb
+++ b/spec/automation/unit/method_validation/ansible_tower_provision_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/provision').to_s
+require Rails.root.join('spec/support/miq_ae_mock_service').to_s
+
+describe AnsibleTowerProvision do
+  let(:admin) { FactoryGirl.create(:user_admin) }
+  let(:request) { FactoryGirl.create(:service_template_provision_request, :requester => admin) }
+  let(:job_class) { ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job }
+  let(:ansible_tower_manager) { FactoryGirl.create(:configuration_manager) }
+  let(:job_template) { FactoryGirl.create(:ansible_configuration_script, :manager => ansible_tower_manager) }
+  let(:service_ansible_tower) { FactoryGirl.create(:service_ansible_tower, :job_template => job_template) }
+  let(:job) { FactoryGirl.create(:ansible_tower_job) }
+  let(:task) { FactoryGirl.create(:service_template_provision_task, :destination => service_ansible_tower, :miq_request => request) }
+  let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(task.id) }
+  let(:root_object) { MiqAeMockObject.new('service_template_provision_task' => svc_task) }
+  let(:ae_service) { MiqAeMockService.new(root_object) }
+
+  it "launches an Ansible Tower job" do
+    expect(job_class).to receive(:create_job).and_return(job)
+    described_class.new(ae_service).main
+  end
+
+  it "fails the step when job launching fails" do
+    expect(job_class).to receive(:create_job).and_raise('provider error')
+    described_class.new(ae_service).main
+    expect(ae_service.root['ae_result']).to eq('error')
+    expect(ae_service.root['ae_reason']).to eq('provider error')
+  end
+end

--- a/spec/automation/unit/method_validation/wait_for_completion_spec.rb
+++ b/spec/automation/unit/method_validation/wait_for_completion_spec.rb
@@ -16,29 +16,29 @@ describe WaitForCompletion do
   let(:service) { MiqAeMockService.new(MiqAeMockObject.new({}), persist_state_hash) }
 
   it "job status successful" do
-    expect_any_instance_of(MiqAeMethodService::MiqAeServiceOrchestrationStack).to receive(:normalized_live_status).with(no_args).and_return(%w(create_complete ok))
+    expect_any_instance_of(job_class).to receive(:normalized_live_status).with(no_args).and_return(%w(create_complete ok))
     expect_any_instance_of(job_class).to receive(:refresh_ems).with(no_args).and_return(nil)
-    WaitForCompletion.new(service).main
+    described_class.new(service).main
     expect(service.root['ae_result']).to eq('ok')
   end
 
   it "job status running" do
-    expect_any_instance_of(MiqAeMethodService::MiqAeServiceOrchestrationStack).to receive(:normalized_live_status).with(no_args).and_return(%w(transient ok))
-    WaitForCompletion.new(service).main
+    expect_any_instance_of(job_class).to receive(:normalized_live_status).with(no_args).and_return(%w(transient ok))
+    described_class.new(service).main
     expect(service.root['ae_result']).to eq('retry')
   end
 
   it "job status failed" do
-    expect_any_instance_of(MiqAeMethodService::MiqAeServiceOrchestrationStack).to receive(:normalized_live_status).with(no_args).and_return(%w(failed ok))
+    expect_any_instance_of(job_class).to receive(:normalized_live_status).with(no_args).and_return(%w(failed ok))
     expect_any_instance_of(job_class).to receive(:refresh_ems).with(no_args).and_return(nil)
-    WaitForCompletion.new(service).main
+    described_class.new(service).main
     expect(service.root['ae_result']).to eq('error')
   end
 
   it "job status canceled" do
-    expect_any_instance_of(MiqAeMethodService::MiqAeServiceOrchestrationStack).to receive(:normalized_live_status).with(no_args).and_return(%w(create_canceled ok))
+    expect_any_instance_of(job_class).to receive(:normalized_live_status).with(no_args).and_return(%w(create_canceled ok))
     expect_any_instance_of(job_class).to receive(:refresh_ems).with(no_args).and_return(nil)
-    WaitForCompletion.new(service).main
+    described_class.new(service).main
     expect(service.root['ae_result']).to eq('error')
   end
 end

--- a/spec/factories/service_template_provision_task.rb
+++ b/spec/factories/service_template_provision_task.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
   factory :service_template_provision_task do
+    state        'pending'
+    status       'Ok'
+    request_type 'clone_to_service'
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
@@ -11,7 +11,7 @@ module MiqAeServiceServiceTemplateProvisionTaskSpec
       @user          = FactoryGirl.create(:user_with_group)
       @ae_result_key = 'foo'
       @options       = {}
-      @service_template_provision_task = FactoryGirl.create(:service_template_provision_task,  :state => 'pending', :status => 'Ok', :request_type => "clone_to_service", :options => @options)
+      @service_template_provision_task = FactoryGirl.create(:service_template_provision_task, :options => @options)
     end
 
     def invoke_ae

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -9,9 +9,6 @@ describe MiqProvisionRequestTemplate do
   let(:service_template_request) { FactoryGirl.create(:service_template_provision_request, :requester => user) }
   let(:service_task) do
     FactoryGirl.create(:service_template_provision_task,
-                       :status       => 'Ok',
-                       :state        => 'pending',
-                       :request_type => 'clone_to_service',
                        :miq_request  => service_template_request,
                        :options      => {:service_resource_id => service_resource.id})
   end

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -2,12 +2,12 @@ describe ServiceTemplateProvisionRequest do
   let(:admin) { FactoryGirl.create(:user_admin) }
   context "with multiple tasks" do
     before(:each) do
-      @request   = FactoryGirl.create(:service_template_provision_request, :description => 'Service Request', :requester => admin)
+      @request  = FactoryGirl.create(:service_template_provision_request, :description => 'Service Request', :requester => admin)
 
-      @task_1    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1', :userid => admin.userid, :status => "Ok", :state => "pending", :miq_request_id => @request.id, :request_type => "clone_to_service")
-      @task_1_1  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1 - 1', :userid => admin.userid, :status => "Ok", :state => "pending", :miq_request_id => @request.id, :request_type => "clone_to_service")
-      @task_2    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 2', :userid => admin.userid, :status => "Ok", :state => "pending", :miq_request_id => @request.id, :request_type => "clone_to_service")
-      @task_2_1  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 2 - 1', :userid => admin.userid, :status => "Ok", :state => "pending", :miq_request_id => @request.id, :request_type => "clone_to_service")
+      @task_1   = FactoryGirl.create(:service_template_provision_task, :description => 'Task 1',     :userid => admin.userid, :miq_request_id => @request.id)
+      @task_1_1 = FactoryGirl.create(:service_template_provision_task, :description => 'Task 1 - 1', :userid => admin.userid, :miq_request_id => @request.id)
+      @task_2   = FactoryGirl.create(:service_template_provision_task, :description => 'Task 2',     :userid => admin.userid, :miq_request_id => @request.id)
+      @task_2_1 = FactoryGirl.create(:service_template_provision_task, :description => 'Task 2 - 1', :userid => admin.userid, :miq_request_id => @request.id)
 
       @task_1.miq_request_tasks << @task_1_1
       @task_2.miq_request_tasks << @task_2_1

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -34,10 +34,8 @@ describe ServiceTemplateProvisionTask do
       FactoryGirl.create(:service_template_provision_task,
                          :description    => description,
                          :userid         => @admin.userid,
-                         :status         => "Ok",
                          :state          => state,
                          :miq_request_id => @request.id,
-                         :request_type   => "clone_to_service",
                          :options        => options)
     end
 


### PR DESCRIPTION
Refactor ansible tower service provisioning state machine methods with the new style to start with a complete class definition
    
Add spec tests for these methods

During this work a bug fixed in #8336 was discovered.