### PR TITLE
Do not save credentials on a Validate

### DIFF
--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -240,7 +240,7 @@ describe EmsCloudController do
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
       expect(mocked_ems).to receive(:supports_authentication?).with(:auth_key)
-      expect(controller.send(:build_credentials, mocked_ems)).to eq(:default => default_creds, :amqp => amqp_creds)
+      expect(controller.send(:build_credentials, mocked_ems, :validate)).to eq(:default => default_creds.merge!(:save => false), :amqp => amqp_creds.merge!(:save => false))
     end
 
     it "uses the stored passwords for validation if passwords dont exist in params" do
@@ -252,20 +252,20 @@ describe EmsCloudController do
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
       expect(mocked_ems).to receive(:supports_authentication?).with(:auth_key)
-      expect(controller.send(:build_credentials, mocked_ems)).to eq(:default => default_creds, :amqp => amqp_creds)
+      expect(controller.send(:build_credentials, mocked_ems, :validate)).to eq(:default => default_creds.merge!(:save => false), :amqp => amqp_creds.merge!(:save => false))
     end
   end
 
   context "#update_ems_button_validate" do
     let(:mocked_ems) { double(ManageIQ::Providers::Openstack::CloudManager, :id => 1) }
-    it "calls authentication_check with save = true if validation is done for an existing record" do
+    it "calls authentication_check with save = false if validation is done for an existing record" do
       allow(controller).to receive(:set_ems_record_vars)
       allow(controller).to receive(:render)
       controller.instance_variable_set(:@_params,
                                        :button    => "validate",
                                        :id        => mocked_ems.id,
                                        :cred_type => "default")
-      expect(mocked_ems).to receive(:authentication_check).with("default", :save => true)
+      expect(mocked_ems).to receive(:authentication_check).with("default", :save => false)
       controller.send(:update_ems_button_validate, mocked_ems)
     end
 

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -343,9 +343,9 @@ describe EmsInfraController do
         expect(@ems).to receive(:supports_authentication?).with(:ssh_keypair).and_return(true)
         expect(@ems).to receive(:supports_authentication?).with(:oauth)
         expect(@ems).to receive(:supports_authentication?).with(:auth_key)
-        expect(controller.send(:build_credentials, @ems)).to eq(:default     => default_creds,
-                                                                :amqp        => amqp_creds,
-                                                                :ssh_keypair => ssh_keypair_creds)
+        expect(controller.send(:build_credentials, @ems, :validate)).to eq(:default     => default_creds.merge!(:save => false),
+                                                                           :amqp        => amqp_creds.merge!(:save => false),
+                                                                           :ssh_keypair => ssh_keypair_creds.merge!(:save => false))
       end
 
       it "uses the stored passwords for validation if passwords dont exist in params" do
@@ -360,9 +360,9 @@ describe EmsInfraController do
         expect(@ems).to receive(:supports_authentication?).with(:ssh_keypair).and_return(true)
         expect(@ems).to receive(:supports_authentication?).with(:oauth)
         expect(@ems).to receive(:supports_authentication?).with(:auth_key)
-        expect(controller.send(:build_credentials, @ems)).to eq(:default     => default_creds,
-                                                                :amqp        => amqp_creds,
-                                                                :ssh_keypair => ssh_keypair_creds)
+        expect(controller.send(:build_credentials, @ems, :validate)).to eq(:default     => default_creds.merge!(:save => false),
+                                                                           :amqp        => amqp_creds.merge!(:save => false),
+                                                                           :ssh_keypair => ssh_keypair_creds.merge!(:save => false))
       end
     end
   end


### PR DESCRIPTION
`Validate` should only perform validation and should not save the credentials for an `ems` record.