### PR TITLE
make vm#is_controllable? conditions positive

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1135,8 +1135,7 @@ class VmOrTemplate < ApplicationRecord
 
   # TODO: Vmware specfic
   def is_controllable?
-    return false if !self.runnable? || self.template? || !host.control_supported?
-    true
+    runnable? && !template? && host && host.control_supported?
   end
 
   def self.refresh_ems(vm_ids)


### PR DESCRIPTION
I've gone over this logic a number of times, the double negatives get me confused every time


```ruby
return false if !self.runnable? || self.template? || !host.control_supported?
true
# return true not false
return true if !(!self.runnable? || self.template? || !host.control_supported?)
# no return needed
!(!self.runnable? || self.template? || !host.control_supported?)
# distributive property: ! every element, and || => &&
!!self.runnable? && !self.template? && !!host.control_supported?
# remove double !!
self.runnable? && !self.template? && host.control_supported?
# remove self
runnable? && !template? && host.control_supported?
# add host for safety
runnable? && !template? && host && host.control_supported?
```

low risk - but not pressing either