### PR TITLE
[WIP] update cap&u only if new task is added

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -126,7 +126,7 @@ module Metric::Capture
     default_task_start_time = 1.hour.ago.utc.iso8601
 
     # Create a new task for each rollup parent
-    tasks_by_rollup_parent = targets_by_rollup_parent.keys.inject({}) do |h, pkey|
+    targets_by_rollup_parent.keys.each_with_object({}) do |pkey, h|
       name = "Performance rollup for #{pkey}"
       prev_task = MiqTask.where(:identifier => pkey).order("id DESC").first
       task_start_time = prev_task ? prev_task.context_data[:end] : default_task_start_time
@@ -148,10 +148,7 @@ module Metric::Capture
       )
       _log.info "Created task id: [#{task.id}] for: [#{pkey}] with targets: #{targets_by_rollup_parent[pkey].inspect} for time range: [#{task_start_time} - #{task_end_time}]"
       h[pkey] = task
-      h
     end
-
-    tasks_by_rollup_parent
   end
 
   def self.queue_captures(zone, targets, targets_by_rollup_parent, tasks_by_rollup_parent)


### PR DESCRIPTION
When I an running performance test I noticed that it resubmits the same realtime performance numbers.

This may not be a common case, and it may not be valid, but it seemed that we should not rerun the same numbers over and over again.

```ruby
Metric::Capture::perf_capture_timer
```

/cc @blomquisg is this even valid? Or possibly do we want to ensure that we DO resubmit the duplicate tasks?

**before:**

|        ms |  sql |    sqlms |  sqlrows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  34,654.0 |6,344 | 25,160.0 |   27,993 |`perf cu before-1`
|  28,365.7 |6,106 | 20,634.2 |   16,283 |`perf cu before-2`
|  28,718.3 |6,106 | 20,842.6 |   16,283 |`perf cu before-3`
|  30,044.2 |6,106 | 21,564.6 |   16,283 |`perf cu before-4`
|       ---:|  ---:|      ---:|      ---:| ---
|  29,042.7 |      | 21,013.8 |          |`avg`

**after:**

|        ms |  sql |    sqlms |  sqlrows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  36,748.8 |6,281 | 26,399.4 |   27,993 |`perf cu after-1`
|  30,424.5 |5,446 | 22,735.0 |   16,283 |`perf cu after-2`
|  31,857.5 |5,446 | 23,917.4 |   16,283 |`perf cu after-3`
|  32,098.6 |5,446 | 23,853.6 |   16,283 |`perf cu after-4`
|       ---:|  ---:|      ---:|      ---:| ---
|  31,460.2 |      | 23,502.0 |          |`avg`

|VmOrTemplate|Host|Storage|ExtManagementSystem|MiqRegion|Zone|
|-----------:|---:|------:|------------------:|--------:|---:|
|      10,000 |200 |   221 |                 1 |       1 |  1 |

