### PR TITLE
Fixed cleanup and socket hijacking issue when a TCP timeout happens

### DIFF
--- a/lib/websocket_proxy.rb
+++ b/lib/websocket_proxy.rb
@@ -49,8 +49,8 @@ class WebsocketProxy
 
   def cleanup
     @console.destroy unless @console.destroyed?
-    @sock.close unless @sock.closed?
-    @ws.close unless @ws.closed?
+    @sock.close if @sock && !@sock.closed?
+    @ws.close if @ws && !@ws.closed?
   end
 
   def descriptors


### PR DESCRIPTION
If a TCP timeout happens, the `@sock` instance variable will remain
as `nil`. This causes issues when calling WebsocketProxy#cleanup.
The `WebsocketServer#call` passed further the cleanup's `nil` value,
which is uninterpretable by Puma and the Rack middleware.