### PR TITLE
[WIP] QE IDs - An experiment

### DIFF
--- a/app/views/layouts/_vertical_navbar.html.haml
+++ b/app/views/layouts/_vertical_navbar.html.haml
@@ -3,7 +3,7 @@
     - Menu::Manager.menu do |menu_section|
       - if menu_section.visible?
         %li.list-group-item.secondary-nav-item-pf{"data-target" => "#menu-#{menu_section.id}", :class => primary_nav_class(menu_section.id)}
-          %a{:href => menu_section.url, :onclick => 'return miqCheckForChanges()'}
+          %a{:href => menu_section.url, :onclick => 'return miqCheckForChanges()', :'data-qeid' => menu_section.id, :'data-qetype' => 'menu_top'}
             %span{:class => menu_section.icon}
             %span.list-group-item-value
               = h(_(menu_section.name))
@@ -19,13 +19,13 @@
                 - menu_section.items.each do |menu_item|
                   - if menu_item.visible? && menu_item.leaf?
                     %li.list-group-item{:class => tertiary_nav_class(menu_item)}
-                      %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}
+                      %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()', :'data-qeid' => menu_item.id, :'data-qetype' => 'menu_secondary_leaf'}
                         %span.list-group-item-value
                           = _(menu_item.name)
 
                   - elsif menu_item.visible?
                     %li.list-group-item.tertiary-nav-item-pf{"data-target" => "#menu-#{menu_item.id}", :class => secondary_nav_class(menu_item)}
-                      %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}
+                      %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()', :'data-qeid' => menu_item.id, :'data-qetype' => 'menu_secondary_collapse'}
                         %span.list-group-item-value
                           = _(menu_item.name)
                       .nav-pf-tertiary-nav
@@ -38,7 +38,7 @@
                           - menu_item.items.each do |menu_item_deep|
                             - if menu_item_deep.visible?
                               %li.list-group-item{:class => menu_item_deep.id == @layout ? 'active' : nil}
-                                %a{:href => menu_item_deep.url, :onclick => 'return miqCheckForChanges()'}
+                                %a{:href => menu_item_deep.url, :onclick => 'return miqCheckForChanges()', :'data-qeid' => menu_item_deep.id, :'data-qetype' => 'menu_tertiary'}
                                   %span.list-group-item-value
                                     = _(menu_item_deep.name)
 
@@ -52,6 +52,6 @@
                 - menu_section.items.each do |menu_item|
                   - if menu_item.visible?
                     %li.list-group-item{:class => tertiary_nav_class(menu_item)}
-                      %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}
+                      %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()', :'data-qeid' => menu_item.id, :'data-qetype' => 'menu_nosubsection'}
                         %span.list-group-item-value
                           = _(menu_item.name)


### PR DESCRIPTION
It would be beneficial if elements in the UI had some sort of permanent marking that keeps on even if the element location changes. This is an experiment that does it for the menu.

I must state that I am no expert in this area so I named the types just how it felt right from the branches in the menu logic. It adds the `data-qeid` and `data-qetype` attributes.

![menuid](https://cloud.githubusercontent.com/assets/2163040/14953953/b09a5918-106e-11e6-9537-c22f77f0b598.png)

I tried this patch on latest downstream built appliance (because I don't have the developer setup running) and it seems to work.
