### PR TITLE
Fix displaying of the mode in Trusted Forest Settings

### DIFF
--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -36,7 +36,7 @@ module OpsController::Settings
   def forest_get_form_vars
     @edit = session[:edit]
     @ldap_info = {}
-    @ldap_info[:mode] = params[:user_proxies][:mode] if params[:user_proxies] && params[:user_proxies][:mode]
+    @ldap_info[:mode] = params[:user_proxies_mode] if params[:user_proxies] && params[:user_proxies_mode]
     @ldap_info[:ldaphost] = params[:user_proxies][:ldaphost] if params[:user_proxies] && params[:user_proxies][:ldaphost]
     @ldap_info[:ldapport] = params[:user_proxies][:ldapport] if params[:user_proxies] && params[:user_proxies][:ldapport]
     @ldap_info[:basedn] = params[:user_proxies][:basedn] if params[:user_proxies] && params[:user_proxies][:basedn]


### PR DESCRIPTION
New record in Trusted Forest didn't display the Mode. The problem was in different name of the parameter, that handles the Mode type.

https://bugzilla.redhat.com/show_bug.cgi?id=1215557