### PR TITLE
Metrics auth should use C&U endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem "net-ssh",                        "~>2.9.2",   :require => false
 gem "omniauth",                       "~>1.3.1",   :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",   :require => false
-gem "ovirt_metrics",                  :git => "git://github.com/matthewd/ovirt_metrics.git", :branch => "rails5", :require => false # https://github.com/ManageIQ/ovirt_metrics/pull/8
+gem "ovirt_metrics",                  "~>1.2.0",   :require => false
 gem "ruby_parser",                    "~>3.7",     :require => false
 gem "ruby-progressbar",               "~>1.7.0",   :require => false
 gem "rufus-scheduler",                "~>3.1.3",   :require => false

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -116,7 +116,9 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def rhevm_metrics_connect_options(options = {})
-    server   = options[:hostname] || hostname
+    server   = options[:hostname] || connection_configuration_by_role('metrics')
+                                       .try(:endpoint)
+                                       .try(:hostname)
     username = options[:user] || authentication_userid(:metrics)
     password = options[:pass] || authentication_password(:metrics)
     database = options[:database]

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -116,9 +116,10 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def rhevm_metrics_connect_options(options = {})
-    server   = options[:hostname] || connection_configuration_by_role('metrics')
-                                       .try(:endpoint)
-                                       .try(:hostname)
+    metrics_hostname = connection_configuration_by_role('metrics')
+      .try(:endpoint)
+      .try(:hostname)
+    server   = options[:hostname] || metrics_hostname || hostname
     username = options[:user] || authentication_userid(:metrics)
     password = options[:pass] || authentication_password(:metrics)
     database = options[:database]

--- a/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Redhat::InfraManager::MetricsCapture < ManageIQ::Prov
     username, password = target.ext_management_system.auth_user_pwd(:metrics)
 
     conn_info = {
-      :host     => target.ext_management_system.hostname,
+      :host     => target.ext_management_system.connection_configuration_by_role('metrics').endpoint.hostname,
       :database => target.ext_management_system.history_database_name,
       :username => username,
       :password => password

--- a/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
@@ -7,9 +7,13 @@ class ManageIQ::Providers::Redhat::InfraManager::MetricsCapture < ManageIQ::Prov
     raise "no metrics credentials defined" unless target.ext_management_system.has_authentication_type?(:metrics)
 
     username, password = target.ext_management_system.auth_user_pwd(:metrics)
+    metrics_hostname = target.ext_management_system.connection_configuration_by_role('metrics')
+      .try(:endpoint)
+      .try(:hostname)
+    host = metrics_hostname || target.ext_management_system.hostname
 
     conn_info = {
-      :host     => target.ext_management_system.connection_configuration_by_role('metrics').endpoint.hostname,
+      :host     => host,
       :database => target.ext_management_system.history_database_name,
       :username => username,
       :password => password

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -14,14 +14,14 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     end
   end
 
-  it "rhevm_metrics_connect_options" do
-    h = FactoryGirl.create(:ems_redhat, :hostname => "h")
-    expect(h.rhevm_metrics_connect_options[:host]).to eq("h")
-  end
+  describe "rhevm_metrics_connect_options" do
+    let(:ems) { FactoryGirl.create(:ems_redhat, :hostname => "some.thing.tld") }
 
-  it "rhevm_metrics_connect_options overrides" do
-    h = FactoryGirl.create(:ems_redhat, :hostname => "h")
-    expect(h.rhevm_metrics_connect_options(:hostname => "i")[:host]).to eq("i")
+    it "rhevm_metrics_connect_options fetches configuration and allows overrides" do
+      expect(ems.rhevm_metrics_connect_options[:host]).to eq("some.thing.tld")
+      expect(ems.rhevm_metrics_connect_options({:hostname => "different.tld"})[:host])
+        .to eq("different.tld")
+    end
   end
 
   context "#vm_reconfigure" do


### PR DESCRIPTION
Combined with https://github.com/ManageIQ/ovirt_metrics/pull/10, this fixes metrics capturing for Rails 5 <3

Note that ideally I'd like to replace the connections by role API to make it betterer, but for now it would be lovely if we could just get metrics working first to eliminate this release blocker.