### PR TITLE
Fix error when creating control policy copy

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -106,8 +106,8 @@ module MiqPolicyController::Policies
                          :target_id    => new_pol.id,
                          :target_class => "MiqPolicy",
                          :userid       => session[:userid],
-                         :message      => _("New Policy ID %{new_id} was copied from Policy ID %{old_id}")) %
-                                            {:new_id => new_pol.id, :old_id => policy.id}
+                         :message      => "New Policy ID %{new_id} was copied from Policy ID %{old_id}" %
+                                          {:new_id => new_pol.id, :old_id => policy.id})
       add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqPolicy"), :name => new_desc})
       @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{to_cid(policy.id)}"
       get_node_info(@new_policy_node)


### PR DESCRIPTION
This is to address the following error:

```
Error caught: [NoMethodError] undefined method `%' for
app/controllers/miq_policy_controller/policies.rb:110:in `policy_copy'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1331297