### PR TITLE
Bottlenecks timelines fix

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -214,7 +214,7 @@ module ReportFormatter
         flags = {:ems_cloud     => ems_cloud,
                  :ems_container => ems_container,
                  :time_zone     => tz}
-        val = tl_message.message_html(co, row, rec, flags)
+        val = tl_message.message_html(co, row, rec, flags, mri.db)
         e_text += "<b>#{headers[co_idx]}:</b> #{val}<br/>" unless val.to_s.empty? || co == "id"
       end
       e_text = e_text.chomp('<br/>')

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -65,20 +65,21 @@ module ReportFormatter
     end
 
     def resource_name
-      if mri.db == 'BottleneckEvent'
+      if @db == 'BottleneckEvent'
         db = if @ems_cloud && @event.resource_type == 'ExtManagementSystem'
                'ems_cloud'
              elsif @event.resource_type == 'ExtManagementSystem'
                'ems_infra'
              else
-               @event.resource_type.underscore
+               "#{@event.resource_type.underscore}/show"
              end
         "<a href=\"/#{db}/#{to_cid(@event.resource_id)}\">#{@event.resource_name}</a>"
       end
     end
 
-    def set_parameters(column, row, event, flags)
+    def set_parameters(column, row, event, flags, db)
       @event, @ems_cloud, @ems_container = event, flags[:ems_cloud], flags[:ems_container]
+      @db   = db
       @text = if row[column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(column)
                 format_timezone(Time.parse(row[column].to_s).utc, flags[:time_zone], "gtl")
               else
@@ -86,8 +87,8 @@ module ReportFormatter
               end
     end
 
-    def message_html(column, row, event, flags)
-      set_parameters(column, row, event, flags)
+    def message_html(column, row, event, flags, db)
+      set_parameters(column, row, event, flags, db)
 
       field = column.tr('.', '_').to_sym
       respond_to?(field) ? send(field).to_s : @text

--- a/spec/factories/bottleneck_event.rb
+++ b/spec/factories/bottleneck_event.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :bottleneck_event, :class => "BottleneckEvent" do
+  end
+end

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -54,7 +54,7 @@ describe ReportFormatter::TimelineMessage do
     tests.each do |column, href|
       it "Evaluate column #{column} content" do
         row[column] = 'test timeline'
-        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags)
+        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags, 'EmsEvent')
         expect(val).to eq(href)
       end
     end
@@ -79,7 +79,30 @@ describe ReportFormatter::TimelineMessage do
     tests.each do |column, href|
       it "Evaluate column #{column} content" do
         row[column] = 'test timeline'
-        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags)
+        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, flags, 'EmsEvent')
+        expect(val).to eq(href)
+      end
+    end
+  end
+
+  describe '#message_html on bottleneck event' do
+    row = {}
+    let(:ems_cluster) { FactoryGirl.create(:ems_cluster, :id => 42, :name => 'Test Cluster') }
+    let(:event) do
+      FactoryGirl.create(:bottleneck_event,
+                         :event_type    => 'MemoryUsage',
+                         :resource_id   => 42,
+                         :resource_name => ems_cluster.name,
+                         :resource_type => 'EmsCluster')
+    end
+
+    tests = {'event_type'    => 'MemoryUsage',
+             'resource_name' => '<a href="/ems_cluster/show/42">Test Cluster</a>'}
+
+    tests.each do |column, href|
+      it "Evaluate column #{column} content" do
+        row[column] = 'MemoryUsage'
+        val = ReportFormatter::TimelineMessage.new.message_html(column, row, event, {}, 'BottleneckEvent')
         expect(val).to eq(href)
       end
     end


### PR DESCRIPTION
Pass in mri.db to message_html method to fix an undefined variable error. Fixed link to a resource in event bubble, needed to append "/show" in the link for non-restful controllers.

Fixed 2 issues introduced in commit 328e129c22dd881ab4e45a9af60d6636e4f5a9f3, when going to Optimize/Bottlenecks screen, getting an error

1. undefined local variable or method `mri' for #<ReportFormatter::TimelineMessage:0x000000094cb2e8> [miq_capacity/bottlenecks] 

2. Further after passing in the db, clicking on link to Cluster in Bottlenecks event bubble blows up 
[----] F, [2016-05-02T12:49:01.155662 #19185:926312c] FATAL -- :   
[----] F, [2016-05-02T12:49:01.155879 #19185:926312c] FATAL -- : ActionController::RoutingError (No route matches [GET] "/ems_cluster/1r1"):
[----] F, [2016-05-02T12:49:01.156050 #19185:926312c] FATAL -- :   
[----] F, [2016-05-02T12:49:01.156222 #19185:926312c] FATAL -- : /home/hkataria/.rvm/gems/ruby-2.2.3/bundler/gems/rails-afc4976cc73d/actionpack/lib/action_dispatch/middle
