### PR TITLE
Show a storage's cluster datastores

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -353,7 +353,7 @@ module ApplicationController::MiqRequestMethods
       "name"            => _("Name"),
       "free_space"      => _("Free Space"),
       "total_space"     => _("Total Space"),
-      "storage_cluster" => _("Storage Cluster"),
+      "storage_clusters" => _("Storage Clusters"),
     }
 
     integer_fields = %w(free_space total_space)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1055,9 +1055,9 @@ class MiqRequestWorkflow
   end
 
   def storage_to_hash_struct(ci)
-    storage_cluster = ci.storage_clusters.detect { |cluster| cluster.ems_id == get_source_and_targets[:ems].try(:id) }
+    storage_clusters = ci.storage_clusters.blank? ? nil : ci.storage_clusters.collect(&:name).join(', ')
     build_ci_hash_struct(ci, [:name, :free_space, :total_space, :storage_domain_type]).tap do |hs|
-      hs.storage_cluster = storage_cluster.try(:name)
+      hs.storage_clusters = storage_clusters
     end
   end
 

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -427,11 +427,12 @@ describe MiqRequestWorkflow do
       storage_cluster2 = FactoryGirl.create(:storage_cluster, :name => 'test_storage_cluster2', :ems_id => ems.id + 1)
       storage_cluster1.add_child(storage)
       storage_cluster2.add_child(storage)
-      expect(workflow.storage_to_hash_struct(storage).storage_cluster).to eq(storage_cluster1.name)
+      clusters = workflow.storage_to_hash_struct(storage).storage_clusters.split(', ')
+      expect(clusters).to match_array([storage_cluster1.name, storage_cluster2.name])
     end
 
     it 'says nil if not a storage_cluster' do
-      expect(workflow.storage_to_hash_struct(storage).storage_cluster).to be_nil
+      expect(workflow.storage_to_hash_struct(storage).storage_clusters).to be_nil
     end
   end
 end


### PR DESCRIPTION
QE reported the service workflow page won't come back.  Thanks to @gmcculloug that he found out that the logic of retrieving the ems ID of a storage will go into infinite loop if the result has not previously been cached. In further discussion with GM, we decide to simply the logic by displaying all the storage clusters a storage may be participating. It is rare that a storage will be configured to participate in different storage cluster in different provider. So even admin decides to do that, the displaying of all the clusters a storage is participating will be good enough.

https://bugzilla.redhat.com/show_bug.cgi?id=1329757