### PR TITLE
fix sort by virtual columns blowing up

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -55,6 +55,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource # Destroy will be handled by purger
   has_many :miq_events,             :as => :target, :dependent => :destroy
+  has_many :cloud_subnets, :foreign_key => :ems_id, :dependent => :destroy
 
   validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
   validates :hostname, :presence => true, :if => :hostname_required?
@@ -97,6 +98,7 @@ class ExtManagementSystem < ApplicationRecord
   include AuthenticationMixin
   include Metric::CiMixin
   include AsyncDeleteMixin
+  include VirtualTotalMixin
 
   delegate :ipaddress,
            :ipaddress=,
@@ -130,6 +132,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_unknown,       :type => :integer
   virtual_column :total_vms_never,         :type => :integer
   virtual_column :total_vms_suspended,     :type => :integer
+  virtual_total  :total_subnets,           :cloud_subnets
 
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
   alias_attribute :to_s, :name

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -118,8 +118,8 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :emstype,                 :type => :string
   virtual_column :emstype_description,     :type => :string
   virtual_column :last_refresh_status,     :type => :string
-  virtual_column :total_vms_and_templates, :type => :integer
-  virtual_column :total_vms,               :type => :integer
+  virtual_total  :total_vms_and_templates, :vms_and_templates
+  virtual_total  :total_vms,               :vms
   virtual_column :total_miq_templates,     :type => :integer
   virtual_column :total_hosts,             :type => :integer
   virtual_column :total_storages,          :type => :integer
@@ -465,14 +465,6 @@ class ExtManagementSystem < ApplicationRecord
 
   def event_where_clause(assoc = :ems_events)
     ["#{events_table_name(assoc)}.ems_id = ?", id]
-  end
-
-  def total_vms_and_templates
-    vms_and_templates.size
-  end
-
-  def total_vms
-    vms.size
   end
 
   def total_miq_templates

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -7,10 +7,6 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
 
   has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
 
-  delegate :url, :to => :default_endpoint
-
-  virtual_column :url, :type => :string, :uses => :endpoints
-
   before_validation :ensure_managers
 
   validates :name, :presence => true, :uniqueness => true

--- a/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
@@ -3,46 +3,6 @@ class ManageIQ::Providers::CloudManager::OrchestrationStack < ::OrchestrationSta
   belongs_to :orchestration_template
   belongs_to :cloud_tenant
 
-  has_many   :direct_vms,             :class_name => "ManageIQ::Providers::CloudManager::Vm"
-  has_many   :direct_security_groups, :class_name => "SecurityGroup"
-  has_many   :direct_cloud_networks,  :class_name => "CloudNetwork"
-
-  virtual_has_many :vms, :class_name => "ManageIQ::Providers::CloudManager::Vm"
-  virtual_has_many :security_groups
-  virtual_has_many :cloud_networks
-
-  virtual_column :total_vms,             :type => :integer
-  virtual_column :total_security_groups, :type => :integer
-  virtual_column :total_cloud_networks,  :type => :integer
-
-  def total_vms
-    vms.size
-  end
-
-  def indirect_vms
-    MiqPreloader.preload_and_map(children, :direct_vms)
-  end
-
-  def total_security_groups
-    security_groups.size
-  end
-
-  def total_cloud_networks
-    cloud_networks.size
-  end
-
-  def vms
-    directs_and_indirects(:direct_vms)
-  end
-
-  def security_groups
-    directs_and_indirects(:direct_security_groups)
-  end
-
-  def cloud_networks
-    directs_and_indirects(:direct_cloud_networks)
-  end
-
   def self.create_stack(orchestration_manager, stack_name, template, options = {})
     klass = orchestration_manager.class::OrchestrationStack
     ems_ref = klass.raw_create_stack(orchestration_manager, stack_name, template, options)

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -8,16 +8,10 @@ module ManageIQ::Providers
     has_many :floating_ips,    :foreign_key => :ems_id, :dependent => :destroy
     has_many :security_groups, :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_networks,  :foreign_key => :ems_id, :dependent => :destroy
-    has_many :cloud_subnets,   :foreign_key => :ems_id, :dependent => :destroy
     has_many :network_ports,   :foreign_key => :ems_id, :dependent => :destroy
     has_many :network_routers, :foreign_key => :ems_id, :dependent => :destroy
     has_many :network_groups,  :foreign_key => :ems_id, :dependent => :destroy
 
     alias all_cloud_networks cloud_networks
-
-    def total_subnets
-      cloud_subnets.size
-    end
-    virtual_column :total_subnets, :type => :integer, :uses => :cloud_subnets
   end
 end

--- a/app/models/mixins/virtual_total_mixin.rb
+++ b/app/models/mixins/virtual_total_mixin.rb
@@ -1,0 +1,37 @@
+module VirtualTotalMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    private
+
+    # define an attribute to calculating the total of a child
+    #   virtual_total :total_vms, :vms
+    #
+    #   def total_vms
+    #     vms.count
+    #   end
+    #   virtual_attribute :total_vms, :integer, :uses => :vms
+    #
+    #   It also defines the necessary arel so it will sort by the total in the database
+    #
+    def virtual_total(name, relation)
+      define_method(name) do
+        send(relation).count
+      end
+
+      # allow this attribute to be sorted in the database
+      if (reflection = reflect_on_association(relation))
+        foreign_table = reflection.klass.arel_table
+        local_key = reflection.active_record_primary_key
+        foreign_key = reflection.foreign_key
+        virtual_attribute name, :integer, :uses => relation, :arel => (lambda do |t|
+          # assuming has_many
+          Arel::Nodes::Grouping.new(foreign_table.project(Arel.star.count)
+                                                 .where(t[local_key].eq(foreign_table[foreign_key])))
+        end)
+      else
+        virtual_attribute name, :integer
+      end
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -15,6 +15,7 @@ class Provider < ApplicationRecord
   delegate :verify_ssl,
            :verify_ssl=,
            :verify_ssl?,
+           :url,
            :to => :default_endpoint
 
   virtual_column :verify_ssl,        :type => :integer

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -1,0 +1,24 @@
+describe VirtualTotalMixin do
+  describe "ems" do
+    # virtual_total :total_vms, :vms
+    it "sorts by total" do
+      ems0 = ems_with_vms(0)
+      ems2 = ems_with_vms(2)
+      ems1 = ems_with_vms(1)
+
+      expect(ExtManagementSystem.order(ExtManagementSystem.arel_attribute(:total_vms)).pluck(:id))
+        .to eq([ems0, ems1, ems2].map(&:id))
+    end
+
+    it "calculates totals locally" do
+      expect(ems_with_vms(0).total_vms).to eq(0)
+      expect(ems_with_vms(2).total_vms).to eq(2)
+    end
+
+    def ems_with_vms(count)
+      FactoryGirl.create(:ext_management_system).tap do |ems|
+        FactoryGirl.create_list(:vm, count, :ext_management_system => ems) if count > 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reporting has trouble accessing virtual attributes defined in STI descendant classes.

```
[----] F, [2016-04-21T17:35:31.419070 #3166:1323a9c] FATAL -- : Error caught: [PG::UndefinedColumn] ERROR:  column orchestration_stacks.total_security_groups does not exist
LINE 1: ...WHERE (orchestration_stacks.id IN (1,2)) ORDER BY "orchestra...
                                                             ^
activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:68:in `select_all'
activerecord/lib/active_record/relation/finder_methods.rb:389:in `find_with_associations'
lib/extensions/ar_virtual.rb:323:in `find_with_associations'
activerecord/lib/active_record/relation.rb:256:in `to_a'
app/models/miq_report/generator.rb:353:in `build_table'
app/models/miq_report/search.rb:118:in `paged_view_search'
app/controllers/application_controller.rb:1592:in `get_view'
app/controllers/ems_common.rb:114:in `view_setup_helper'
app/controllers/ems_common.rb:77:in `show'
```

- I fixed the report.
- Proactively fixed all virtual attributes defined in child classes.
- Introduced `virtual_total` to shorten the common pattern of defining a virtual attribute that is just a count of a dependent table.
- As a bonus, improved performance for "total" columns as they will now be sorted in the database and not in memory.

https://bugzilla.redhat.com/show_bug.cgi?id=1329422
fixes #7382

/cc @mzazrivec took this one from you
/cc @Fryguy 