### PR TITLE
Quote the watchdog process name shell variable

### DIFF
--- a/gems/pending/util/system/evm_watchdog.rb
+++ b/gems/pending/util/system/evm_watchdog.rb
@@ -51,7 +51,7 @@ module EvmWatchdog
   end
 
   def self.ps_for_process(process_name)
-    `ps -ef --no-heading | grep #{process_name} | awk '{print $2}'`
+    `ps -ef --no-heading | grep "#{process_name}" | awk '{print $2}'`
   end
 
   def self.get_db_state


### PR DESCRIPTION
The name change in #8198 introduced a space which needs to be quoted for the shell.