### PR TITLE
New angular directive to detect spaces in input fields

### DIFF
--- a/app/assets/javascripts/directives/detect_spaces.js
+++ b/app/assets/javascripts/directives/detect_spaces.js
@@ -1,0 +1,28 @@
+ManageIQ.angular.app.directive('detectSpaces', function() {
+  return {
+    require: 'ngModel',
+    link: function (scope, elem, attrs, ctrl) {
+      scope.$watch(attrs.ngModel, function() {
+        if((ctrl.$modelValue != undefined)) {
+          setValidityForSpaces(ctrl, ctrl.$modelValue);
+        }
+      });
+      ctrl.$parsers.push(function(value) {
+        setValidityForSpaces(ctrl, value);
+        return value;
+      });
+
+      var setValidityForSpaces = function(ctrl, value) {
+        if(hasWhiteSpace(value)) {
+          ctrl.$setValidity("detectedSpaces", false);
+        } else {
+          ctrl.$setValidity("detectedSpaces", true);
+        }
+      };
+
+      var hasWhiteSpace = function(s) {
+        return /\s/g.test(s);
+      }
+    }
+  }
+});

--- a/app/assets/javascripts/directives/detect_spaces.js
+++ b/app/assets/javascripts/directives/detect_spaces.js
@@ -2,25 +2,14 @@ ManageIQ.angular.app.directive('detectSpaces', function() {
   return {
     require: 'ngModel',
     link: function (scope, elem, attrs, ctrl) {
-      scope.$watch(attrs.ngModel, function() {
-        if((ctrl.$modelValue != undefined)) {
-          setValidityForSpaces(ctrl, ctrl.$modelValue);
+      ctrl.$validators.detectedSpaces = function (modelValue, viewValue) {
+        if (angular.isDefined(viewValue) && !detectedSpaces(viewValue)) {
+          return true;
         }
-      });
-      ctrl.$parsers.push(function(value) {
-        setValidityForSpaces(ctrl, value);
-        return value;
-      });
-
-      var setValidityForSpaces = function(ctrl, value) {
-        if(hasWhiteSpace(value)) {
-          ctrl.$setValidity("detectedSpaces", false);
-        } else {
-          ctrl.$setValidity("detectedSpaces", true);
-        }
+        return false;
       };
 
-      var hasWhiteSpace = function(s) {
+      var detectedSpaces = function(s) {
         return /\s/g.test(s);
       }
     }

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -18,7 +18,7 @@
 
 %div{"ng-controller" => "credentialsController"}
   %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
-    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$error.required}"}
+    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$invalid}"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
         = userid_label
       .col-md-4
@@ -28,9 +28,13 @@
                             "ng-disabled"         => userid_disabled,
                             "name"                => "#{prefix}_userid",
                             "ng-model"            => "#{ng_model}.#{prefix}_userid",
-                            "checkchange"         => ""}
+                            "checkchange"         => "",
+                            "ng-trim"             => false,
+                            "detect_spaces"       => ""}
         %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.required"}
           = _("Required")
+        %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.detectedSpaces"}
+          = _("Spaces are prohibited")
         .note
           {{note}}
 

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -65,7 +65,7 @@
                        "ng-change"                   => "scvmmSecurityProtocolChanged()",
                        "selectpicker-for-select-tag" => "")
 .form-group{"ng-class" => "{'has-error': angularForm.realm.$invalid}",
-            "ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.security_protocol == 'kerberos'"}
+            "ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.default_security_protocol == 'kerberos'"}
   %label.col-md-2.control-label{"for" => "textInput-markup"}
     = _('Realm')
   .col-md-8

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -6,15 +6,19 @@
     %label.col-md-2.control-label{"for" => "textInput-markup"}
       = _('Hostname (or IPv4 or IPv6 address)')
     .col-md-8
-      %input.form-control{"type"        => "text",
-                          "id"          => "textInput-markup",
-                          "name"        => "#{prefix}_hostname",
-                          "ng-model"    => "#{ng_model}.#{prefix}_hostname",
-                          "maxlength"   => "#{MAX_NAME_LEN}",
-                          "required"    => defined?(hostname_not_required) ? false : true,
-                          "checkchange" => ""}
+      %input.form-control{"type"          => "text",
+                          "id"            => "textInput-markup",
+                          "name"          => "#{prefix}_hostname",
+                          "ng-model"      => "#{ng_model}.#{prefix}_hostname",
+                          "maxlength"     => "#{MAX_NAME_LEN}",
+                          "required"      => defined?(hostname_not_required) ? false : true,
+                          "ng-trim"       => false,
+                          "detect-spaces" => "",
+                          "checkchange"   => ""}
       %span.help-block{"ng-show" => "angularForm.#{prefix}_hostname.$error.required"}
         = _("Required")
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_hostname.$error.detectedSpaces"}
+        = _("Spaces are prohibited")
 
 %div{"ng-if" => defined?(apiport_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_api_port.$invalid}",
@@ -25,15 +29,19 @@
     %label.col-md-2.control-label{"for" => "textInput-markup"}
       = _('API Port')
     .col-md-8
-      %input.form-control{"type"        => "text",
-                          "id"          => "textInput-markup",
-                          "name"        => "#{prefix}_api_port",
-                          "ng-model"    => "#{ng_model}.#{prefix}_api_port",
-                          "maxlength"   => 15,
-                          "required"    => defined?(apiport_not_required) ? false : true,
-                          "checkchange" => ""}
+      %input.form-control{"type"          => "text",
+                          "id"            => "textInput-markup",
+                          "name"          => "#{prefix}_api_port",
+                          "ng-model"      => "#{ng_model}.#{prefix}_api_port",
+                          "maxlength"     => 15,
+                          "required"      => defined?(apiport_not_required) ? false : true,
+                          "checkchange"   => "",
+                          "ng-trim"       => false,
+                          "detect-spaces" => ""}
       %span.help-block{"ng-show" => "angularForm.#{prefix}_api_port.$error.required"}
         = _("Required")
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_api_port.$error.detectedSpaces"}
+        = _("Spaces are prohibited")
 
 %div{"ng-if" => defined?(security_protocol_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
@@ -61,13 +69,18 @@
   %label.col-md-2.control-label{"for" => "textInput-markup"}
     = _('Realm')
   .col-md-8
-    %input.form-control{"type"           => "text",
-                        "id"             => "textInput-markup",
-                        "name"           => "realm",
-                        "ng-model"       => "emsCommonModel.realm",
-                        "maxlength"      => "#{MAX_NAME_LEN}",
-                        "required"       => "",
-                        "checkchange"    => "",
-                        "auto-focus"     => ""}
+    %input.form-control{"type"          => "text",
+                        "id"            => "textInput-markup",
+                        "name"          => "realm",
+                        "ng-model"      => "emsCommonModel.realm",
+                        "maxlength"     => "#{MAX_NAME_LEN}",
+                        "required"      => "",
+                        "checkchange"   => "",
+                        "auto-focus"    => "",
+                        "ng-trim"       => false,
+                        "detect-spaces" => ""}
     %span.help-block{"ng-show" => "angularForm.realm.$error.required"}
       = _("Required")
+    %span.help-block{"ng-show" => "angularForm.realm.$error.detectedSpaces"}
+      = _("Spaces are prohibited")
+

--- a/spec/javascripts/directives/detect_spaces_spec.js
+++ b/spec/javascripts/directives/detect_spaces_spec.js
@@ -1,0 +1,32 @@
+describe('detectSpaces initialization', function() {
+  var $scope, form;
+  beforeEach(module('ManageIQ'));
+  beforeEach(inject(function($compile, $rootScope) {
+    $scope = $rootScope;
+    $scope.model = "hostModel";
+    var element = angular.element(
+      '<form name="angularForm">' +
+      '<input type="text" ng-trim=false detect-spaces ng-model="emsCommonModel.hostname" name="hostname"/>' +
+      '</form>'
+    );
+    $compile(element)($scope);
+    $scope.$digest();
+    angularForm = $scope.angularForm;
+  }));
+
+  describe('detect-spaces', function() {
+    it('sets the form to invalid if hostname has spaces in it', function() {
+      $scope.emsCommonModel = {'hostname': ''};
+      angularForm.hostname.$setViewValue('test.com ');
+      expect(angularForm.hostname.$valid).toBeFalsy();
+      expect(angularForm.$invalid).toBeTruthy();
+    });
+
+    it('sets the form to valid if hostname does not have spaces in it', function() {
+      $scope.emsCommonModel = {'hostname': ''};
+      angularForm.hostname.$setViewValue('test.com');
+      expect(angularForm.hostname.$valid).toBeTruthy();
+      expect(angularForm.$invalid).toBeFalsy();
+    });
+  });
+});

--- a/spec/javascripts/directives/detect_spaces_spec.js
+++ b/spec/javascripts/directives/detect_spaces_spec.js
@@ -16,15 +16,15 @@ describe('detectSpaces initialization', function() {
 
   describe('detect-spaces', function() {
     it('sets the form to invalid if hostname has spaces in it', function() {
-      $scope.emsCommonModel = {'hostname': ''};
-      angularForm.hostname.$setViewValue('test.com ');
+      angularForm.hostname.$setViewValue('test. com');
+      expect(angularForm.hostname.$error.detectedSpaces).toBeDefined();
       expect(angularForm.hostname.$valid).toBeFalsy();
       expect(angularForm.$invalid).toBeTruthy();
     });
 
     it('sets the form to valid if hostname does not have spaces in it', function() {
-      $scope.emsCommonModel = {'hostname': ''};
       angularForm.hostname.$setViewValue('test.com');
+      expect(angularForm.hostname.$error.detectedSpaces).not.toBeDefined();
       expect(angularForm.hostname.$valid).toBeTruthy();
       expect(angularForm.$invalid).toBeFalsy();
     });


### PR DESCRIPTION
Added a new angular directive that detects spaces in input fields.
The primary use case is to prevent the user from submitting the form if certain input fields like hostname, username have spaces in them.
This is a preferred approach that can be cleanly implemented in Angular. 
Other advantage is that we can avoid using `.strip` like methods at the backend that involve touching/modifying the original input fields.

https://bugzilla.redhat.com/show_bug.cgi?id=1318762

![screen shot 2016-05-02 at 1 50 45 pm](https://cloud.githubusercontent.com/assets/1538216/14967588/f91d0a52-106c-11e6-9018-c9f7fd56a908.png)
