### PR TITLE
Remove $watch from angular controllers

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -3,6 +3,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
   $scope.formId = cloudVolumeFormId;
   $scope.afterGet = false;
   $scope.modelCopy = angular.copy( $scope.cloudVolumeModel );
+  $scope.model = "cloudVolumeModel";
 
   ManageIQ.angular.scope = $scope;
 
@@ -19,10 +20,6 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
         miqService.sparkleOff();
       });
    }
-
-  $scope.$watch("cloudVolumeModel.name", function() {
-    $scope.form = $scope.angularForm;
-  });
 
   $scope.addClicked = function() {
     miqService.sparkleOn();

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -134,11 +134,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       });
     }
     $scope.currentTab = "default";
-
-    $scope.$watch("emsCommonModel.name", function() {
-      $scope.form = $scope.angularForm;
-      $scope.model = "emsCommonModel";
-    });
   };
 
   $scope.changeAuthTab = function(id) {

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -30,6 +30,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
     $scope.formFieldsUrl = $attrs.formFieldsUrl;
     $scope.createUrl = $attrs.createUrl;
     $scope.updateUrl = $attrs.updateUrl;
+    $scope.model = "hostModel";
     ManageIQ.angular.scope = $scope;
 
     if (hostFormId == 'new') {
@@ -95,11 +96,6 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
     }
 
      $scope.currentTab = "default";
-
-    $scope.$watch("hostModel.name", function() {
-      $scope.form = $scope.angularForm;
-      $scope.model = "hostModel";
-    });
   };
 
   $scope.changeAuthTab = function(id) {

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -20,11 +20,6 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
     $scope.model = 'diagnosticsDatabaseModel';
 
     ManageIQ.angular.scope = $scope;
-
-    $scope.$watch("diagnosticsDatabaseModel.depot_name", function() {
-        $scope.form = $scope.angularForm;
-        $scope.miqDBBackupService = miqDBBackupService;
-    });
   };
 
   $scope.backupScheduleTypeChanged = function() {

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -52,11 +52,6 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
         miqService.sparkleOff();
       });
     }
-
-    $scope.$watch("logCollectionModel.depot_name", function() {
-      $scope.form = $scope.angularForm;
-      $scope.miqDBBackupService = miqDBBackupService;
-    });
   };
 
   $scope.logProtocolChanged = function() {

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -26,10 +26,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController',['$http', '
       $scope.modelCopy = angular.copy( $scope.pglogicalReplicationModel );
       miqService.sparkleOff();
     });
-
-    $scope.$watch("pglogicalReplicationModel.subscriptions", function() {
-      $scope.form = $scope.angularForm;
-    });
   };
 
   var pglogicalManageSubscriptionsButtonClicked = function(buttonName, serializeFields) {

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -10,6 +10,7 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       $scope.formId = tenantFormId;
       $scope.afterGet = false;
       $scope.modelCopy = angular.copy( $scope.tenantModel );
+      $scope.model = "tenantModel";
 
       ManageIQ.angular.scope = $scope;
 
@@ -39,11 +40,6 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
           miqService.sparkleOff();
         });
       }
-
-      $scope.$watch("tenantModel.name", function() {
-        $scope.form = $scope.angularForm;
-        $scope.model = "tenantModel";
-      });
     };
 
 

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -7,6 +7,7 @@ ManageIQ.angular.app.controller('tenantQuotaFormController',['$http', '$scope', 
     $scope.formId = tenantQuotaFormId;
     $scope.afterGet = false;
     $scope.modelCopy = angular.copy( $scope.tenantQuotaModel );
+    $scope.model = "tenantQuotaModel";
 
     ManageIQ.angular.scope = $scope;
     $scope.newRecord = false;
@@ -34,11 +35,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController',['$http', '$scope', 
       $scope.afterGet = true;
       $scope.modelCopy = angular.copy( $scope.tenantQuotaModel );
       miqService.sparkleOff();
-    });
-
-    $scope.$watch("tenantQuotaModel", function() {
-      $scope.form = $scope.angularForm;
-      $scope.model = "tenantQuotaModel";
     });
   };
 

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -52,10 +52,6 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
           miqService.sparkleOff();
         });
       }
-
-      $scope.$watch("providerForemanModel.name", function() {
-        $scope.form = $scope.angularForm;
-      });
     };
 
     $scope.canValidateBasicInfo = function () {

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -61,10 +61,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
         miqService.sparkleOff();
       });
-
-      $scope.$watch("reconfigureModel.memory", function() {
-        $scope.form = $scope.angularForm;
-      });
     };
 
     $scope.canValidateBasicInfo = function () {

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -25,6 +25,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     $scope.afterGet = false;
     $scope.validateClicked = miqService.validateWithAjax;
     $scope.modelCopy = angular.copy( $scope.scheduleModel );
+    $scope.model = "scheduleModel";
 
     ManageIQ.angular.scope = $scope;
 
@@ -97,11 +98,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     }
 
     miqService.buildCalendar(oneMonthAgo.year, parseInt(oneMonthAgo.month) + 1, oneMonthAgo.date);
-
-    $scope.$watch("scheduleModel.name", function() {
-      $scope.form = $scope.angularForm;
-      $scope.model = "scheduleModel";
-    });
   };
 
   var buildFilterList = function(data) {

--- a/app/assets/javascripts/controllers/service/service_form_controller.js
+++ b/app/assets/javascripts/controllers/service/service_form_controller.js
@@ -21,11 +21,6 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
         $scope.modelCopy = angular.copy( $scope.serviceModel );
         miqService.sparkleOff();
       });
-
-      // need this in order to get Abandon Changes? prompt when leaving form without saving
-      $scope.$watch("serviceModel.name", function() {
-        $scope.form  = $scope.angularForm;
-     });
     };
 
     var serviceEditButtonClicked = function(buttonName, serializeFields) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -291,7 +291,7 @@ function miqDimDiv(divname, status) {
 // Check for changes and prompt
 function miqCheckForChanges() {
   if (ManageIQ.angular.scope) {
-    if (ManageIQ.angular.scope.form.$dirty) {
+    if (angular.isDefined(ManageIQ.angular.scope.angularForm) && ManageIQ.angular.scope.angularForm.$dirty) {
       var answer = confirm(__("Abandon changes?"));
       if (answer) {
         ManageIQ.angular.scope.form.$setPristine(true);


### PR DESCRIPTION
The `'dirty'` state of the form can be monitored by `ManageIQ.angular.scope.angularForm` which means we do not need the `$watch` in some of the angular controllers