### PR TITLE
JS specs - fail on error - output exception also on the console

### DIFF
--- a/spec/javascripts/helpers/fail-on-error.js
+++ b/spec/javascripts/helpers/fail-on-error.js
@@ -15,6 +15,15 @@ window.addEventListener('error', function(err) {
 
 describe("Parse errors", function() {
   it("shouldn't happen", function() {
-    expect(window.was_syntax_error).toEqual(null);
+    var err = window.was_syntax_error;
+    expect(err).toEqual(null);
+
+    if (err) {
+      // just in case the error happens only in `test:javascript` and not `environment jasmine`
+      // and since we have no other way to output to console from there..
+      expect("message").toEqual(err.message)
+      expect("filename").toEqual(err.filename);
+      expect("lineno").toEqual(err.lineno);
+    }
   });
 });


### PR DESCRIPTION
`fail-on-error.js` logs any parse errors during tests to the browser console, which works fine when run under `rake environment jasmine`

however, if such a failure happens only under `rake test:javascript`, there's no easy way to output it to the console

Thus this, in the spirit of test-driven debugging, adds a bunch of failing test cases to output the useful fields if that exception happens - we output `err.message`, `.filename` and `.lineno`.


Example output (from #8356):

```
Failures:
          Parse errors shouldn't happen

          Expected [object ErrorEvent] to equal null.
          Error: Expected [object ErrorEvent] to equal null.
    at stack (http://localhost:36097/__jasmine__/jasmine.js:1577)
    at buildExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:1547)
    at http://localhost:36097/__jasmine__/jasmine.js:638
    at http://localhost:36097/__jasmine__/jasmine.js:330
    at addExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:588)
    at http://localhost:36097/__jasmine__/jasmine.js:1508

-- these are the new ones:

          Expected 'message' to equal 'TypeError: 'undefined' is not a function (evaluating '$(document).setupVerticalTertiaryNavigation(true)')'.
          Error: Expected 'message' to equal 'TypeError: 'undefined' is not a function (evaluating '$(document).setupVerticalTertiaryNavigation(true)')'.
    at stack (http://localhost:36097/__jasmine__/jasmine.js:1577)
    at buildExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:1547)
    at http://localhost:36097/__jasmine__/jasmine.js:638
    at http://localhost:36097/__jasmine__/jasmine.js:330
    at addExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:588)
    at http://localhost:36097/__jasmine__/jasmine.js:1508

          Expected 'filename' to equal 'http://localhost:36097/assets/miq_application.self-75d785db2821094acb1e65dcaf2defefb0c76ddc9578279cd359c240d89b9f41.js?body=1?body=true'.
          Error: Expected 'filename' to equal 'http://localhost:36097/assets/miq_application.self-75d785db2821094acb1e65dcaf2defefb0c76ddc9578279cd359c240d89b9f41.js?body=1?body=true'.
    at stack (http://localhost:36097/__jasmine__/jasmine.js:1577)
    at buildExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:1547)
    at http://localhost:36097/__jasmine__/jasmine.js:638
    at http://localhost:36097/__jasmine__/jasmine.js:330
    at addExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:588)
    at http://localhost:36097/__jasmine__/jasmine.js:1508

          Expected 'lineno' to equal 1589.
          Error: Expected 'lineno' to equal 1589.
    at stack (http://localhost:36097/__jasmine__/jasmine.js:1577)
    at buildExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:1547)
    at http://localhost:36097/__jasmine__/jasmine.js:638
    at http://localhost:36097/__jasmine__/jasmine.js:330
    at addExpectationResult (http://localhost:36097/__jasmine__/jasmine.js:588)
    at http://localhost:36097/__jasmine__/jasmine.js:1508
```

(Yes, this is a very contrived way to find out that "undefined is not a function" happened in "miq_application.js" on line 1589, but.. better than nothing :).)