### PR TITLE
Clean-up mechanism for creation of child nodes of TreeBuilder

### DIFF
--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -10,16 +10,16 @@ module Sandbox
     @sb[:history][x_active_tree]
   end
 
-  def x_tree_init(name, type, leaf, values = {})
+  def x_tree_init(name, type, leaf)
     return if @sb.has_key_path?(:trees, name)
 
-    values = values.reverse_merge(
+    values = {
       :tree       => name,
       :type       => type,
       :leaf       => leaf,
       :add_root   => true,
       :open_nodes => []
-    )
+    }
 
     @sb.store_path(:trees, name, values)
   end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -352,7 +352,7 @@ class TreeBuilder
                           # * TreeBuilderReportReports         - options[:tree]
                           # * TreeBuilderVandt - the whole options hash is passed to TreeBuilderVmsAndTemplates constructor
                           # * All the rest 30+ ancestors ignore options hash.
-                          x_get_tree_roots(count_only, options.dup)
+                          x_get_tree_roots(count_only, options)
                         when AvailabilityZone    then x_get_tree_az_kids(parent, count_only)
                         when Compliance          then x_get_compliance_kids(parent, count_only)
                         when ComplianceDetail    then x_get_compliance_detail_kids(parent, count_only, parents)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -340,29 +340,6 @@ class TreeBuilder
     children_or_count || (count_only ? 0 : [])
   end
 
-  def x_get_tree_guest_device_kids(_parent, count_only)
-    count_only ? 0 : []
-  end
-
-  def x_get_tree_lun_kids(_parent, count_only)
-    count_only ? 0 : []
-  end
-
-  def x_get_tree_host_kids(_parent, count_only)
-    count_only ? 0 : []
-  end
-
-  def x_get_resource_pool_kids(_parent, count_only)
-    count_only ? 0 : []
-  end
-
-  def x_get_compliance_kids(_parent, count_only)
-    count_only ? 0 : []
-  end
-
-  def x_get_compliance_detail_kids(_parent, count_only, _parents)
-    count_only ? 0 : []
-  end
   # Return a tree node for the passed in object
   def x_build_node(object, pid, options)    # Called with object, tree node parent id, tree options
     parents = pid.to_s.split('_')

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -1,5 +1,7 @@
 class TreeBuilder
   include CompressedIds
+  include TreeKids
+
   attr_reader :name, :type, :tree_nodes
 
   def node_builder
@@ -333,82 +335,8 @@ class TreeBuilder
     [{:key => 'root', :children => child_nodes, :expand => true}]
   end
 
-  # Get objects (or count) to put into a tree under a parent node.
-  # TODO: Perhaps push the object sorting down to SQL, if possible -- no point where there are few items.
-  # parent  --- Parent object for which we need child tree nodes returned
-  # options --- Options:
-  #   :count_only           # Return only the count if true -- remove this
-  #   :leaf                 # Model name of leaf nodes, i.e. "Vm"
-  #   :open_all             # if true open all node (no autoload)
-  #   :load_children
-  # parents --- an Array of parent object ids, starting from tree root + 1, ending with parent's parent; only available when full_ids and not lazy
   def x_get_tree_objects(parent, options, count_only, parents)
-    children_or_count = case parent
-                        when nil                 then
-                          # options are only required for the following TreeBuilder ancestors:
-                          # * TreeBuilderCatalogsClass         - options[:type]
-                          # * TreeBuilderChargebackAssignments - options[:type]
-                          # * TreeBuilderChargebackRates       - options[:type]
-                          # * TreeBuilderReportReports         - options[:tree]
-                          # * TreeBuilderVandt - the whole options hash is passed to TreeBuilderVmsAndTemplates constructor
-                          # * All the rest 30+ ancestors ignore options hash.
-                          x_get_tree_roots(count_only, options)
-                        when AvailabilityZone    then x_get_tree_az_kids(parent, count_only)
-                        when Compliance          then x_get_compliance_kids(parent, count_only)
-                        when ComplianceDetail    then x_get_compliance_detail_kids(parent, count_only, parents)
-                        when ManageIQ::Providers::Foreman::ConfigurationManager then
-                          x_get_tree_cmf_kids(parent, count_only)
-                        when ManageIQ::Providers::AnsibleTower::ConfigurationManager then
-                          x_get_tree_cmat_kids(parent, count_only)
-                        when ConfigurationProfile then x_get_tree_cpf_kids(parent, count_only)
-                        when CustomButtonSet     then x_get_tree_aset_kids(parent, count_only)
-                        when Dialog              then x_get_tree_dialog_kids(parent, count_only, options[:type])
-                        when DialogGroup         then x_get_tree_dialog_group_kids(parent, count_only, options[:type])
-                        when DialogTab           then x_get_tree_dialog_tab_kids(parent, count_only, options[:type])
-                        when ExtManagementSystem then x_get_tree_ems_kids(parent, count_only)
-                        when Datacenter          then x_get_tree_datacenter_kids(parent, count_only, options[:type])
-                        when EmsFolder           then x_get_tree_folder_kids(parent, count_only, options[:type])
-                        when EmsCluster          then x_get_tree_cluster_kids(parent, count_only)
-                        when GuestDevice         then x_get_tree_guest_device_kids(parent, count_only)
-                        when Hash                then
-                          # TreeBuilderAlertProfile - :type
-                          # TreeBuilderArchived - :leaf
-                          # TreeBuilderCondition - :type
-                          # TreeBuilderContainersFilter - :leaf
-                          # TreeBuilderForemanConfiguredSystems - :leaf
-                          # TreeBuilderPolicy - :type
-                          # TreeBuilderReportDashboards - :type
-                          # TreeBuilderVmsFilter - :leaf
-                          x_get_tree_custom_kids(parent, count_only, options)
-                        when Host                then try(:x_get_tree_host_kids, parent, count_only)
-                        when IsoDatastore        then x_get_tree_iso_datastore_kids(parent, count_only)
-                        when LdapRegion          then x_get_tree_lr_kids(parent, count_only)
-                        when MiqAeClass          then x_get_tree_class_kids(parent, count_only, options[:type])
-                        when MiqAeNamespace      then x_get_tree_ns_kids(parent, count_only, options[:type])
-                        when MiqGroup            then options[:tree] == :db_tree ?
-                                                    x_get_tree_g_kids(parent, count_only) : nil
-                        when MiqRegion           then x_get_tree_region_kids(parent, count_only)
-                        when MiqReport           then x_get_tree_r_kids(parent, count_only)
-                        when PxeServer           then x_get_tree_pxe_server_kids(parent, count_only)
-                        when ResourcePool        then x_get_resource_pool_kids(parent, count_only)
-                        when Service             then x_get_tree_service_kids(parent, count_only)
-                        when ServiceTemplateCatalog
-                                                 then x_get_tree_stc_kids(parent, count_only)
-                        when ServiceTemplate     then x_get_tree_st_kids(parent, count_only, options[:type])
-                        when Tenant              then x_get_tree_tenant_kids(parent, count_only)
-                        when VmdbTableEvm        then x_get_tree_vmdb_table_kids(parent, count_only)
-                        when Zone                then x_get_tree_zone_kids(parent, count_only)
-
-                        when MiqPolicySet        then x_get_tree_pp_kids(parent, count_only)
-                        when MiqAction           then x_get_tree_ac_kids(parent, count_only)
-                        when MiqAlert            then x_get_tree_al_kids(parent, count_only)
-                        when MiqAlertSet         then x_get_tree_ap_kids(parent, count_only)
-                        when Condition           then x_get_tree_co_kids(parent, count_only)
-                        when MiqEventDefinition  then x_get_tree_ev_kids(parent, count_only, parents)
-                        when MiqPolicy           then x_get_tree_po_kids(parent, count_only)
-                        when MiqScsiLun          then x_get_tree_lun_kids(parent, count_only)
-                        when MiqScsiTarget       then x_get_tree_target_kids(parent, count_only)
-                        end
+    children_or_count = parent.nil? ? x_get_tree_roots(count_only, options) : x_get_tree_kids(parent, count_only, options, parents)
     children_or_count || (count_only ? 0 : [])
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -408,8 +408,6 @@ class TreeBuilder
                         when MiqPolicy           then x_get_tree_po_kids(parent, count_only)
                         when MiqScsiLun          then x_get_tree_lun_kids(parent, count_only)
                         when MiqScsiTarget       then x_get_tree_target_kids(parent, count_only)
-                        when MiqSearch           then nil
-                        when ManageIQ::Providers::Openstack::CloudManager::Vm         then nil
                         end
     children_or_count || (count_only ? 0 : [])
   end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -380,7 +380,7 @@ class TreeBuilder
                           # TreeBuilderReportDashboards - :type
                           # TreeBuilderVmsFilter - :leaf
                           x_get_tree_custom_kids(parent, count_only, options)
-                        when Host                then x_get_tree_host_kids(parent, count_only)
+                        when Host                then try(:x_get_tree_host_kids, parent, count_only)
                         when IsoDatastore        then x_get_tree_iso_datastore_kids(parent, count_only)
                         when LdapRegion          then x_get_tree_lr_kids(parent, count_only)
                         when MiqAeClass          then x_get_tree_class_kids(parent, count_only, options[:type])

--- a/app/presenters/tree_builder_action.rb
+++ b/app/presenters/tree_builder_action.rb
@@ -21,9 +21,4 @@ class TreeBuilderAction < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     count_only_or_objects(count_only, MiqAction.all, :description)
   end
-
-  # level 2 - nothing
-  def x_get_tree_ac_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
-  end
 end

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -1,4 +1,7 @@
 class TreeBuilderAeClass < TreeBuilder
+  has_kids_for MiqAeClass, [:x_get_tree_class_kids, :type]
+  has_kids_for MiqAeNamespace, [:x_get_tree_ns_kids, :type]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_alert.rb
+++ b/app/presenters/tree_builder_alert.rb
@@ -21,9 +21,4 @@ class TreeBuilderAlert < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     count_only_or_objects(count_only, MiqAlert.all, :description)
   end
-
-  # level 2 - nothing
-  def x_get_tree_al_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
-  end
 end

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -1,4 +1,6 @@
 class TreeBuilderAlertProfile < TreeBuilder
+  has_kids_for MiqAlertSet, [:x_get_tree_ap_kids]
+
   private
 
   def tree_init_options(_tree_name)
@@ -50,10 +52,5 @@ class TreeBuilderAlertProfile < TreeBuilder
     count_only_or_objects(count_only,
                           parent.miq_alerts,
                           :description)
-  end
-
-  # level 4 - nothing
-  def x_get_tree_al_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
   end
 end

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -1,4 +1,6 @@
 class TreeBuilderButtons < TreeBuilderAeCustomization
+  has_kids_for CustomButtonSet, [:x_get_tree_aset_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -1,4 +1,7 @@
 class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
+  has_kids_for ServiceTemplateCatalog, [:x_get_tree_stc_kids]
+  has_kids_for ServiceTemplate, [:x_get_tree_st_kids, :type]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_catalogs.rb
+++ b/app/presenters/tree_builder_catalogs.rb
@@ -12,8 +12,4 @@ class TreeBuilderCatalogs < TreeBuilderCatalogsClass
       :autoload  => 'true',
     )
   end
-
-  def x_get_tree_stc_kids(_object, count_only)
-    count_only_or_objects(count_only, [], nil)
-  end
 end

--- a/app/presenters/tree_builder_catalogs_class.rb
+++ b/app/presenters/tree_builder_catalogs_class.rb
@@ -1,4 +1,6 @@
 class TreeBuilderCatalogsClass < TreeBuilder
+  has_kids_for CustomButtonSet, [:x_get_tree_aset_kids]
+
   private
 
   def x_get_tree_roots(count_only, options)

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -1,4 +1,7 @@
 class TreeBuilderComplianceHistory < TreeBuilder
+  has_kids_for Compliance, [:x_get_compliance_kids]
+  has_kids_for ComplianceDetail, [:x_get_compliance_detail_kids, :parents]
+
   def node_builder
     TreeNodeBuilderComplianceHistory
   end

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -37,9 +37,4 @@ class TreeBuilderCondition < TreeBuilder
 
     count_only_or_objects(count_only, objects, :description)
   end
-
-  # level 3 - nothing
-  def x_get_tree_co_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
-  end
 end

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -1,4 +1,8 @@
 class TreeBuilderConfigurationManager < TreeBuilder
+  has_kids_for ManageIQ::Providers::Foreman::ConfigurationManager, [:x_get_tree_cmf_kids]
+  has_kids_for ManageIQ::Providers::AnsibleTower::ConfigurationManager, [:x_get_tree_cmat_kids]
+  has_kids_for ConfigurationProfile, [:x_get_tree_cpf_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -1,4 +1,10 @@
 class TreeBuilderDatacenter < TreeBuilder
+  has_kids_for Host, [:x_get_tree_host_kids]
+  has_kids_for Datacenter, [:x_get_tree_datacenter_kids, :type]
+  has_kids_for EmsFolder, [:x_get_tree_folder_kids, :type]
+  has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
+  has_kids_for ResourcePool, [:x_get_resource_pool_kids]
+
   def node_builder
     TreeNodeBuilderDatacenter
   end

--- a/app/presenters/tree_builder_event.rb
+++ b/app/presenters/tree_builder_event.rb
@@ -21,9 +21,4 @@ class TreeBuilderEvent < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     count_only_or_objects(count_only, MiqPolicy.all_policy_events, :description)
   end
-
-  # level 2 - nothing
-  def x_get_tree_ev_kids(_parent, count_only, _parents)
-    count_only_or_objects(count_only, [])
-  end
 end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -1,4 +1,6 @@
 class TreeBuilderImages < TreeBuilder
+  has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
+
   def tree_init_options(_tree_name)
     {
       :leaf => "ManageIQ::Providers::CloudManager::Template"

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -1,4 +1,7 @@
 class TreeBuilderInstances < TreeBuilder
+  has_kids_for AvailabilityZone, [:x_get_tree_az_kids]
+  has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
+
   def tree_init_options(_tree_name)
     {
       :leaf => 'VmCloud'

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -1,4 +1,6 @@
 class TreeBuilderIsoDatastores < TreeBuilder
+  has_kids_for IsoDatastore, [:x_get_tree_iso_datastore_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_ops.rb
+++ b/app/presenters/tree_builder_ops.rb
@@ -1,5 +1,7 @@
 class TreeBuilderOps < TreeBuilder
   # common methods for OPS subclasses
+  has_kids_for LdapRegion, [:x_get_tree_lr_kids]
+  has_kids_for Zone, [:x_get_tree_zone_kids]
 
   private
 

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -1,4 +1,6 @@
 class TreeBuilderOpsRbac < TreeBuilder
+  has_kids_for Tenant, [:x_get_tree_tenant_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -1,4 +1,6 @@
 class TreeBuilderOpsVmdb < TreeBuilderOps
+  has_kids_for VmdbTableEvm, [:x_get_tree_vmdb_table_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -1,4 +1,7 @@
 class TreeBuilderPolicy < TreeBuilder
+  has_kids_for MiqPolicy, [:x_get_tree_po_kids]
+  has_kids_for MiqEventDefinition, [:x_get_tree_ev_kids, :parents]
+
   private
 
   def tree_init_options(_tree_name)
@@ -95,15 +98,5 @@ class TreeBuilderPolicy < TreeBuilder
     success = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :success) : [])
     failure = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :failure) : [])
     success + failure
-  end
-
-  # level 5 - nothing under conditions
-  def x_get_tree_co_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
-  end
-
-  # level 6 - nothing under actions
-  def x_get_tree_ac_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
   end
 end

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -1,4 +1,8 @@
 class TreeBuilderPolicyProfile < TreeBuilder
+  has_kids_for MiqPolicySet, [:x_get_tree_pp_kids]
+  has_kids_for MiqPolicy, [:x_get_tree_po_kids]
+  has_kids_for MiqEventDefinition, [:x_get_tree_ev_kids, :parents]
+
   private
 
   def tree_init_options(_tree_name)
@@ -45,15 +49,5 @@ class TreeBuilderPolicyProfile < TreeBuilder
     success = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :success) : [])
     failure = count_only_or_objects(count_only, pol_rec ? pol_rec.actions_for_event(parent, :failure) : [])
     success + failure
-  end
-
-  # level 4 - nothing under conditions
-  def x_get_tree_co_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
-  end
-
-  # level 5 - nothing under actions
-  def x_get_tree_ac_kids(_parent, count_only)
-    count_only_or_objects(count_only, [])
   end
 end

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -1,4 +1,6 @@
 class TreeBuilderPxeServers < TreeBuilder
+  has_kids_for PxeServer, [:x_get_tree_pxe_server_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_region.rb
+++ b/app/presenters/tree_builder_region.rb
@@ -1,4 +1,6 @@
 class TreeBuilderRegion < TreeBuilder
+  has_kids_for MiqRegion, [:x_get_tree_region_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -1,4 +1,6 @@
 class TreeBuilderReportDashboards < TreeBuilder
+  has_kids_for MiqGroup, [:x_get_tree_g_kids]
+
   private
 
   def tree_init_options(tree_name)

--- a/app/presenters/tree_builder_report_reports_class.rb
+++ b/app/presenters/tree_builder_report_reports_class.rb
@@ -1,4 +1,6 @@
 class TreeBuilderReportReportsClass < TreeBuilder
+  has_kids_for MiqReport, [:x_get_tree_r_kids]
+
   private
 
   def x_get_tree_r_kids(object, count_only)

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -1,4 +1,7 @@
 class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
+  has_kids_for Dialog, [:x_get_tree_dialog_kids, :type]
+  has_kids_for ServiceTemplateCatalog, [:x_get_tree_stc_kids]
+
   private
 
   def tree_init_options(_tree_name)
@@ -27,9 +30,5 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   def x_get_tree_stc_kids(object, count_only)
     objects = rbac_filtered_objects(object.service_templates.select(&:display))
     count_only_or_objects(count_only, objects, 'name')
-  end
-
-  def x_get_tree_st_kids(_object, count_only, _type)
-    count_only ? 0 : []
   end
 end

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -1,4 +1,7 @@
 class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
+  has_kids_for DialogGroup, [:x_get_tree_dialog_group_kids, :type]
+  has_kids_for DialogTab, [:x_get_tree_dialog_tab_kids, :type]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -1,4 +1,6 @@
 class TreeBuilderServices < TreeBuilder
+  has_kids_for Service, [:x_get_tree_service_kids]
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -1,4 +1,7 @@
 class TreeBuilderStorageAdapters < TreeBuilder
+  has_kids_for GuestDevice, [:x_get_tree_guest_device_kids]
+  has_kids_for MiqScsiTarget, [:x_get_tree_target_kids]
+
   def initialize(name, type, sandbox, build = true, root = nil)
     sandbox[:sa_root] = root if root
     @root = sandbox[:sa_root]
@@ -39,9 +42,5 @@ class TreeBuilderStorageAdapters < TreeBuilder
 
   def x_get_tree_target_kids(parent, count_only)
     count_only_or_objects(count_only, parent.miq_scsi_luns)
-  end
-
-  def x_get_tree_lun_kids(_parent, count_only)
-    count_only ? 0 : []
   end
 end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -1,4 +1,9 @@
 class TreeBuilderUtilization < TreeBuilderRegion
+  has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
+  has_kids_for Datacenter, [:x_get_tree_datacenter_kids, :type]
+  has_kids_for EmsFolder, [:x_get_tree_folder_kids, :type]
+  has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
+
   private
 
   def x_get_tree_ems_kids(object, count_only)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -10,7 +10,7 @@ class TreeBuilderVandt < TreeBuilder
       objects.length + 2
     else
       objects = objects.to_a
-      objects.collect! { |o| TreeBuilderVmsAndTemplates.new(o, options).tree }
+      objects.collect! { |o| TreeBuilderVmsAndTemplates.new(o, options.dup).tree }
       objects + [
         {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived VMs and Templates")},
         {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned VMs and Templates")}

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -1,4 +1,7 @@
 class TreeBuilderVat < TreeBuilderDatacenter
+  has_kids_for Datacenter, [:x_get_tree_datacenter_kids, :type]
+  has_kids_for EmsFolder, [:x_get_tree_folder_kids, :type]
+
   def initialize(name, type, sandbox, build = true, root = nil, vat = nil)
     sandbox[:vat] = vat unless vat.nil?
     @vat = sandbox[:vat]

--- a/app/presenters/tree_kids.rb
+++ b/app/presenters/tree_kids.rb
@@ -6,7 +6,7 @@ module TreeKids
     end
 
     def kids_generators
-      @kids_generators ||= {
+      @kids_generators ||= superclass.try(:kids_generators).try(:dup) || {
         Hash => [:x_get_tree_custom_kids, :options],
       }
     end

--- a/app/presenters/tree_kids.rb
+++ b/app/presenters/tree_kids.rb
@@ -1,47 +1,17 @@
 module TreeKids
-  KIDS_GENERATORS = {
-    AvailabilityZone       => [:x_get_tree_az_kids],
-    ConfigurationProfile   => [:x_get_tree_cpf_kids],
-    Compliance             => [:x_get_compliance_kids],
-    ComplianceDetail       => [:x_get_compliance_detail_kids, :parents],
-    ManageIQ::Providers::Foreman::ConfigurationManager => [:x_get_tree_cmf_kids],
-    ManageIQ::Providers::AnsibleTower::ConfigurationManager => [:x_get_tree_cmat_kids],
-    CustomButtonSet        => [:x_get_tree_aset_kids],
-    Dialog                 => [:x_get_tree_dialog_kids, :type],
-    DialogGroup            => [:x_get_tree_dialog_group_kids, :type],
-    DialogTab              => [:x_get_tree_dialog_tab_kids, :type],
-    ExtManagementSystem    => [:x_get_tree_ems_kids],
-    Datacenter             => [:x_get_tree_datacenter_kids, :type],
-    EmsFolder              => [:x_get_tree_folder_kids, :type],
-    EmsCluster             => [:x_get_tree_cluster_kids],
-    GuestDevice            => [:x_get_tree_guest_device_kids],
-    Hash                   => [:x_get_tree_custom_kids, :options],
-    Host                   => [:x_get_tree_host_kids],
-    IsoDatastore           => [:x_get_tree_iso_datastore_kids],
-    LdapRegion             => [:x_get_tree_lr_kids],
-    MiqAeClass             => [:x_get_tree_class_kids, :type],
-    MiqAeNamespace         => [:x_get_tree_ns_kids, :type],
-    MiqGroup               => [:x_get_tree_g_kids],
-    MiqRegion              => [:x_get_tree_region_kids],
-    MiqReport              => [:x_get_tree_r_kids],
-    PxeServer              => [:x_get_tree_pxe_server_kids],
-    ResourcePool           => [:x_get_resource_pool_kids],
-    Service                => [:x_get_tree_service_kids],
-    ServiceTemplateCatalog => [:x_get_tree_stc_kids],
-    ServiceTemplate        => [:x_get_tree_st_kids, :type],
-    Tenant                 => [:x_get_tree_tenant_kids],
-    VmdbTableEvm           => [:x_get_tree_vmdb_table_kids],
-    Zone                   => [:x_get_tree_zone_kids],
-    MiqPolicySet           => [:x_get_tree_pp_kids],
-    MiqAction              => [:x_get_tree_ac_kids],
-    MiqAlert               => [:x_get_tree_al_kids],
-    MiqAlertSet            => [:x_get_tree_ap_kids],
-    Condition              => [:x_get_tree_co_kids],
-    MiqEventDefinition     => [:x_get_tree_ev_kids, :parents],
-    MiqPolicy              => [:x_get_tree_po_kids],
-    MiqScsiLun             => [:x_get_tree_lun_kids],
-    MiqScsiTarget          => [:x_get_tree_target_kids],
-  }
+  extend ActiveSupport::Concern
+  module ClassMethods
+    def has_kids_for(klass, method_and_arguments)
+      kids_generators[klass] = method_and_arguments
+    end
+
+    def kids_generators
+      @kids_generators ||= {
+        Hash => [:x_get_tree_custom_kids, :options],
+      }
+    end
+  end
+
   # Get objects (or count) to [put into a tree under a parent node.
   # TODO: Perhaps push the object sorting down to SQL, if possible -- no point where there are few items.
   # parent  --- Parent object for which we need child tree nodes returned
@@ -52,7 +22,7 @@ module TreeKids
   #   :load_children
   # parents --- an Array of parent object ids, starting from tree root + 1, ending with parent's parent; only available when full_ids and not lazy
   def x_get_tree_kids(parent, count_only, options, parents)
-    generator = KIDS_GENERATORS.detect { |k, v| v if parent.kind_of? k }
+    generator = self.class.kids_generators.detect { |k, v| v if parent.kind_of? k }
     return nil unless generator
     method = generator[1][0]
     attributes = generator[1][1..-1].collect do |attribute_name|
@@ -63,9 +33,5 @@ module TreeKids
       end
     end
     send(method, *([parent, count_only] + attributes))
-  end
-
-  def x_get_tree_g_kids(_, _)
-    nil # FIXME: temp until I am done
   end
 end

--- a/app/presenters/tree_kids.rb
+++ b/app/presenters/tree_kids.rb
@@ -1,0 +1,71 @@
+module TreeKids
+  KIDS_GENERATORS = {
+    AvailabilityZone       => [:x_get_tree_az_kids],
+    ConfigurationProfile   => [:x_get_tree_cpf_kids],
+    Compliance             => [:x_get_compliance_kids],
+    ComplianceDetail       => [:x_get_compliance_detail_kids, :parents],
+    ManageIQ::Providers::Foreman::ConfigurationManager => [:x_get_tree_cmf_kids],
+    ManageIQ::Providers::AnsibleTower::ConfigurationManager => [:x_get_tree_cmat_kids],
+    CustomButtonSet        => [:x_get_tree_aset_kids],
+    Dialog                 => [:x_get_tree_dialog_kids, :type],
+    DialogGroup            => [:x_get_tree_dialog_group_kids, :type],
+    DialogTab              => [:x_get_tree_dialog_tab_kids, :type],
+    ExtManagementSystem    => [:x_get_tree_ems_kids],
+    Datacenter             => [:x_get_tree_datacenter_kids, :type],
+    EmsFolder              => [:x_get_tree_folder_kids, :type],
+    EmsCluster             => [:x_get_tree_cluster_kids],
+    GuestDevice            => [:x_get_tree_guest_device_kids],
+    Hash                   => [:x_get_tree_custom_kids, :options],
+    Host                   => [:x_get_tree_host_kids],
+    IsoDatastore           => [:x_get_tree_iso_datastore_kids],
+    LdapRegion             => [:x_get_tree_lr_kids],
+    MiqAeClass             => [:x_get_tree_class_kids, :type],
+    MiqAeNamespace         => [:x_get_tree_ns_kids, :type],
+    MiqGroup               => [:x_get_tree_g_kids],
+    MiqRegion              => [:x_get_tree_region_kids],
+    MiqReport              => [:x_get_tree_r_kids],
+    PxeServer              => [:x_get_tree_pxe_server_kids],
+    ResourcePool           => [:x_get_resource_pool_kids],
+    Service                => [:x_get_tree_service_kids],
+    ServiceTemplateCatalog => [:x_get_tree_stc_kids],
+    ServiceTemplate        => [:x_get_tree_st_kids, :type],
+    Tenant                 => [:x_get_tree_tenant_kids],
+    VmdbTableEvm           => [:x_get_tree_vmdb_table_kids],
+    Zone                   => [:x_get_tree_zone_kids],
+    MiqPolicySet           => [:x_get_tree_pp_kids],
+    MiqAction              => [:x_get_tree_ac_kids],
+    MiqAlert               => [:x_get_tree_al_kids],
+    MiqAlertSet            => [:x_get_tree_ap_kids],
+    Condition              => [:x_get_tree_co_kids],
+    MiqEventDefinition     => [:x_get_tree_ev_kids, :parents],
+    MiqPolicy              => [:x_get_tree_po_kids],
+    MiqScsiLun             => [:x_get_tree_lun_kids],
+    MiqScsiTarget          => [:x_get_tree_target_kids],
+  }
+  # Get objects (or count) to [put into a tree under a parent node.
+  # TODO: Perhaps push the object sorting down to SQL, if possible -- no point where there are few items.
+  # parent  --- Parent object for which we need child tree nodes returned
+  # options --- Options:
+  #   :count_only           # Return only the count if true -- remove this
+  #   :leaf                 # Model name of leaf nodes, i.e. "Vm"
+  #   :open_all             # if true open all node (no autoload)
+  #   :load_children
+  # parents --- an Array of parent object ids, starting from tree root + 1, ending with parent's parent; only available when full_ids and not lazy
+  def x_get_tree_kids(parent, count_only, options, parents)
+    generator = KIDS_GENERATORS.detect { |k, v| v if parent.kind_of? k }
+    return nil unless generator
+    method = generator[1][0]
+    attributes = generator[1][1..-1].collect do |attribute_name|
+      case attribute_name
+      when :options then options
+      when :type then options[:type]
+      when :parents then parents
+      end
+    end
+    send(method, *([parent, count_only] + attributes))
+  end
+
+  def x_get_tree_g_kids(_, _)
+    nil # FIXME: temp until I am done
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1034,23 +1034,6 @@ describe ApplicationHelper do
                                                    :add_root   => true,
                                                    :open_nodes => [])
       end
-
-      it "can override default values" do
-        helper.x_tree_init(:vm_filter_tree, :vm_filter, "Vm",
-                           :add_root   => false,
-                           :open_nodes => [:a],
-                           :open_all   => true,
-                           :full_ids   => true
-                          )
-
-        expect(@sb[:trees][:vm_filter_tree]).to eq(:tree       => :vm_filter_tree,
-                                                   :type       => :vm_filter,
-                                                   :leaf       => "Vm",
-                                                   :add_root   => false,
-                                                   :open_nodes => [:a],
-                                                   :open_all   => true,
-                                                   :full_ids   => true)
-      end
     end
 
     it "#x_tree_history" do

--- a/spec/presenters/tree_builder_storage_adapters_spec.rb
+++ b/spec/presenters/tree_builder_storage_adapters_spec.rb
@@ -33,13 +33,5 @@ describe TreeBuilderStorageAdapters do
       expect(kids.first).to be_a_kind_of(MiqScsiLun)
       expect(number_of_kids).to eq(3)
     end
-    it 'returns nothing as MiqScsiLun children' do
-      root = @sa_tree.send(:x_get_tree_roots, false).first
-      parent = @sa_tree.send(:x_get_tree_target_kids, root, false).first
-      number_of_kids = @sa_tree.send(:x_get_tree_lun_kids, parent, true)
-      kids = @sa_tree.send(:x_get_tree_lun_kids, parent, false)
-      expect(number_of_kids).to eq(0)
-      expect(kids).to eq([])
-    end
   end
 end


### PR DESCRIPTION
I have been fixing a bug, where we attempted to expand Host node on a page, where we shoud not. Then, I have discovered there has been 4 or 5 different workarounds already in place for similar cases. I felt like I need to do some more about this.

This pr removes hairy `case` statement from TreeBuilder base class. And puts the information to appropriate specific TreeBuilders. It also removes some of the workarounds that has sedimented over time.

@himdel, @martinpovolny, and @ZitaNemeckova, please take a look. We have been discussing this after yesterday meeting. Since then, I have rewritten this to declarative notation. 

The last commit is wip.

@miq-bot add_label ui, refactoring, wip