### PR TITLE
Fix event_monitor_example.rb script

### DIFF
--- a/gems/pending/openstack/test/event_monitor_example.rb
+++ b/gems/pending/openstack/test/event_monitor_example.rb
@@ -36,15 +36,16 @@ OPENSTACK_RDU_DEV_PORT   = ""
 OPENSTACK_RDU_USERNAME   = ""
 OPENSTACK_RDU_PASSWORD   = ""
 
-os_monitor = OpenstackEventMonitor.new(:hostname => OPENSTACK_RDU_DEV_SERVER,
-                                       :username => OPENSTACK_RDU_USERNAME,
-                                       :password => OPENSTACK_RDU_PASSWORD,
-                                       :topics   => {"nova"    => "notifications.*",
-                                                     "glance"  => "notifications.*",
-                                                     "cinder"  => "notifications.*",
-                                                     "heat"    => "notifications.*",
-                                                     "quantum" => "notifications.*",
-                                                     "neutron" => "notifications.*"})
+os_monitor = OpenstackEventMonitor.new(:events_monitor => :amqp,
+                                       :hostname       => OPENSTACK_RDU_DEV_SERVER,
+                                       :username       => OPENSTACK_RDU_USERNAME,
+                                       :password       => OPENSTACK_RDU_PASSWORD,
+                                       :topics         => {"nova"    => "notifications.*",
+                                                           "glance"  => "notifications.*",
+                                                           "cinder"  => "notifications.*",
+                                                           "heat"    => "notifications.*",
+                                                           "quantum" => "notifications.*",
+                                                           "neutron" => "notifications.*"})
 
 Signal.trap("INT") { os_monitor.stop }
 


### PR DESCRIPTION
We need to pass :events_monitor => :amqp to the event_monitor
builder.