### PR TITLE
The vms method should not override the relation

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -151,10 +151,8 @@ class CloudVolumeController < ApplicationController
 
   def detach
     assert_privileges("cloud_volume_detach")
-    @vm_choice = {}
     @volume = find_by_id_filtered(CloudVolume, params[:id])
-    attached_vms = @volume.attachments.map { |disk| disk.hardware.vm }
-    attached_vms.each { |vm| @vm_choices[vm.name] = vm.id }
+    @vm_choices = @volume.vms.each_with_object({}) { |vm, hash| hash[vm.name] = vm.id }
 
     @in_a_form = true
     drop_breadcrumb(

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -15,10 +15,6 @@ class CloudVolume < ApplicationRecord
   has_many   :hardwares, :through => :attachments
   has_many   :vms, :through => :hardwares, :foreign_key => :vm_or_template_id
 
-  def vms
-    attachments.map { |disk| disk.hardware.vm }
-  end
-
   acts_as_miq_taggable
 
   def self.available


### PR DESCRIPTION
vms method was brought back as a regression in
https://github.com/ManageIQ/manageiq/pull/6176

now it causes failure when clicking at instances relation
in the cloud volume detail

also fixes volume detach exception 