### PR TITLE
replace a number of virtual_total columns

### DIFF
--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -4,6 +4,7 @@ class AvailabilityZone < ApplicationRecord
   include Metric::CiMixin
   include EventMixin
   include ProviderObjectMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
@@ -17,9 +18,7 @@ class AvailabilityZone < ApplicationRecord
   has_many   :vim_performance_states, :as => :resource
   has_many   :ems_events
 
-  acts_as_miq_taggable
-
-  virtual_column :total_vms, :type => :integer, :uses => :vms
+  virtual_total :total_vms, :vms
 
   def self.available
     where(arel_table[:type].not_eq("ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull"))
@@ -29,10 +28,6 @@ class AvailabilityZone < ApplicationRecord
 
   def perf_rollup_parents(interval_name = nil)
     [ext_management_system].compact unless interval_name == 'realtime'
-  end
-
-  def total_vms
-    vms.size
   end
 
   def my_zone

--- a/app/models/cloud_database_flavor.rb
+++ b/app/models/cloud_database_flavor.rb
@@ -1,17 +1,14 @@
 class CloudDatabaseFlavor < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   has_many   :cloud_databases
 
-  virtual_column :total_cloud_databases, :type => :integer, :uses => :cloud_databases
+  virtual_total :total_cloud_databases, :cloud_databases
 
   default_value_for :enabled, true
-
-  def total_cloud_databases
-    cloud_databases.size
-  end
 end

--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -1,6 +1,7 @@
 class CloudNetwork < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
@@ -40,10 +41,7 @@ class CloudNetwork < ApplicationRecord
     end
   end
 
-  def total_vms
-    vms.size
-  end
-  virtual_column :total_vms, :type => :integer, :uses => :vms
+  virtual_total :total_vms, :vms
 
   private
 

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -1,6 +1,7 @@
 class CloudSubnet < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
@@ -44,10 +45,7 @@ class CloudSubnet < ApplicationRecord
   end
   virtual_column :dns_nameservers_show, :type => :string, :uses => :dns_nameservers
 
-  def total_vms
-    vms.size
-  end
-  virtual_column :total_vms, :type => :integer, :uses => :vms
+  virtual_total :total_vms, :vms
 
   private
 

--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -1,6 +1,7 @@
 class CloudTenant < ApplicationRecord
   include ReportableMixin
   include NewWithTypeStiMixin
+  include VirtualTotalMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::CloudManager"
   has_many   :security_groups
@@ -23,13 +24,9 @@ class CloudTenant < ApplicationRecord
 
   acts_as_miq_taggable
 
-  virtual_column :total_vms, :type => :integer, :uses => :vms
+  virtual_total :total_vms, :vms
 
   def all_cloud_networks
     direct_cloud_networks + shared_cloud_networks
-  end
-
-  def total_vms
-    vms.size
   end
 end

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -1,6 +1,7 @@
 class CloudVolumeSnapshot < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
@@ -9,9 +10,5 @@ class CloudVolumeSnapshot < ApplicationRecord
   belongs_to :cloud_volume
   has_many   :based_volumes, :class_name => 'CloudVolume'
 
-  virtual_column :total_based_volumes, :type => :integer, :uses => :based_volumes
-
-  def total_based_volumes
-    based_volumes.size
-  end
+  virtual_total :total_based_volumes, :based_volumes
 end

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -3,6 +3,7 @@ class EmsCluster < ApplicationRecord
   include_concern 'CapacityPlanning'
   include ReportableMixin
   include EventMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
@@ -25,9 +26,10 @@ class EmsCluster < ApplicationRecord
   virtual_column :v_parent_datacenter, :type => :string,  :uses => :all_relationships
   virtual_column :v_qualified_desc,    :type => :string,  :uses => :all_relationships
   virtual_column :last_scan_on,        :type => :time,    :uses => :last_drift_state_timestamp
-  virtual_column :total_vms,           :type => :integer, :uses => :all_relationships
-  virtual_column :total_miq_templates, :type => :integer, :uses => :all_relationships
-  virtual_column :total_hosts,         :type => :integer, :uses => :all_relationships
+  virtual_total  :total_vms,           :vms,              :uses => :all_relationships
+  virtual_total  :total_miq_templates, :miq_templates,    :uses => :all_relationships
+  virtual_total  :total_vms_and_templates, :vms_and_templates, :uses => :all_relationships
+  virtual_total  :total_hosts,         :hosts,            :uses => :all_relationships
 
   virtual_has_many :storages,       :uses => {:hosts => :storages}
   virtual_has_many :resource_pools, :uses => :all_relationships
@@ -177,19 +179,6 @@ class EmsCluster < ApplicationRecord
 
   def total_direct_vms_and_templates
     total_direct_vms + total_direct_miq_templates
-  end
-
-  # All VMs under this Cluster
-  def total_vms
-    vms.size
-  end
-
-  def total_miq_templates
-    miq_templates.size
-  end
-
-  def total_vms_and_templates
-    vms_and_templates.size
   end
 
   # Resource Pool relationship methods

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -122,10 +122,10 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :last_refresh_status,     :type => :string
   virtual_total  :total_vms_and_templates, :vms_and_templates
   virtual_total  :total_vms,               :vms
-  virtual_column :total_miq_templates,     :type => :integer
-  virtual_column :total_hosts,             :type => :integer
+  virtual_total  :total_miq_templates,     :miq_templates
+  virtual_total  :total_hosts,             :hosts
   virtual_column :total_storages,          :type => :integer
-  virtual_column :total_clusters,          :type => :integer
+  virtual_total  :total_clusters,          :clusters
   virtual_column :zone_name,               :type => :string, :uses => :zone
   virtual_column :total_vms_on,            :type => :integer
   virtual_column :total_vms_off,           :type => :integer

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -1,19 +1,16 @@
 class Flavor < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   has_many   :vms
 
-  virtual_column :total_vms, :type => :integer, :uses => :vms
+  virtual_total :total_vms, :vms
 
   default_value_for :enabled, true
-
-  def total_vms
-    vms.size
-  end
 
   def name_with_details
     details = if cpus == 1

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -1,6 +1,7 @@
 class NetworkRouter < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
@@ -34,10 +35,7 @@ class NetworkRouter < ApplicationRecord
     end
   end
 
-  def total_vms
-    vms.size
-  end
-  virtual_column :total_vms, :type => :integer, :uses => :vms
+  virtual_total :total_vms, :vms
 
   private
 

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -1,6 +1,7 @@
 class SecurityGroup < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
+  include VirtualTotalMixin
 
   acts_as_miq_taggable
 
@@ -16,10 +17,7 @@ class SecurityGroup < ApplicationRecord
   has_and_belongs_to_many :vms
   has_and_belongs_to_many :network_ports
 
-  def total_vms
-    vms.size
-  end
-  virtual_column :total_vms, :type => :integer, :uses => :vms
+  virtual_total :total_vms, :vms
 
   def self.non_cloud_network
     where(:cloud_network_id => nil)

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -1,23 +1,42 @@
 describe VirtualTotalMixin do
-  describe "ems" do
-    # virtual_total :total_vms, :vms
+  describe ".virtual_total (with real relation ems#total_vms)" do
+    let(:base_model) { ExtManagementSystem }
     it "sorts by total" do
-      ems0 = ems_with_vms(0)
-      ems2 = ems_with_vms(2)
-      ems1 = ems_with_vms(1)
+      ems0 = model_with_children(0)
+      ems2 = model_with_children(2)
+      ems1 = model_with_children(1)
 
-      expect(ExtManagementSystem.order(ExtManagementSystem.arel_attribute(:total_vms)).pluck(:id))
+      expect(base_model.order(base_model.arel_attribute(:total_vms)).pluck(:id))
         .to eq([ems0, ems1, ems2].map(&:id))
     end
 
     it "calculates totals locally" do
-      expect(ems_with_vms(0).total_vms).to eq(0)
-      expect(ems_with_vms(2).total_vms).to eq(2)
+      expect(model_with_children(0).total_vms).to eq(0)
+      expect(model_with_children(2).total_vms).to eq(2)
     end
 
-    def ems_with_vms(count)
+    def model_with_children(count)
       FactoryGirl.create(:ext_management_system).tap do |ems|
         FactoryGirl.create_list(:vm, count, :ext_management_system => ems) if count > 0
+      end
+    end
+  end
+
+  describe ".virtual_total (with virtual relation (resource_pool#total_vms)" do
+    let(:base_model) { ResourcePool }
+    # it can not sort by virtual
+
+    it "calculates totals locally" do
+      expect(model_with_children(0).total_vms).to eq(0)
+      expect(model_with_children(2).total_vms).to eq(2)
+    end
+
+    def model_with_children(count)
+      FactoryGirl.create(:resource_pool).tap do |pool|
+        count.times do |_i|
+          vm = FactoryGirl.create(:vm)
+          vm.with_relationship_type("ems_metadata") { vm.set_parent pool }
+        end
       end
     end
   end

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -46,6 +46,7 @@ describe ResourcePool do
     it "should return the correct values for v_direct_vms and v_total_vms" do
       expect(@rp1.v_direct_vms).to eq(5)
       expect(@rp1.v_total_vms).to eq(15)
+      expect(@rp1.total_vms).to eq(15)
 
       expect(@rp2.v_direct_vms).to eq(10)
       expect(@rp2.v_total_vms).to eq(10)


### PR DESCRIPTION
Use `virtual_total` for all fields that are simply a counter.
If a report sorts by this counter, it will be sortable.

This is a followup to #8393

/cc @gtanzillo 