### PR TITLE
Removed fieldset from Report views

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -1,156 +1,157 @@
 - url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
-%fieldset
-  %h3
-    = _('Chargeback Filters')
-  .form-horizontal
-    - if @edit[:cb_users]
-      .form-group
-        %label.control-label.col-md-2
-          = _('Show Costs by')
-        .col-md-8
-          - opts = [["<#{_('Choose')}>", nil]]
-          - if @edit[:new][:model] == "ChargebackContainerProject"
-            - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"]]
-          - elsif @edit[:new][:model] == "ChargebackVm"
-            - opts += [[_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"], [_('Tenant'), "tenant"]]
-          - else
-            - opts += [[_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"], [_(@edit[:new][:cb_model].to_s), "entity"]]
-          = select_tag("cb_show_typ",
-            options_for_select(opts, @edit[:new][:cb_show_typ]),
-            :class                 => "selectpicker")
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('cb_show_typ', '#{url}', {beforeSend: true, complete: true});
-      - if @edit[:new][:cb_show_typ] == "owner"
-        .form-group
-          %label.control-label.col-md-2
-            = _('Owner')
-          .col-md-8
-            - opts = [["<#{_('Choose an Owner')}>", nil]] + Array(@edit[:cb_users].invert).sort_by { |a| a.first.downcase }
-            = select_tag("cb_owner_id",
-              options_for_select(opts, @edit[:new][:cb_owner_id]),
-              :class                 => "selectpicker")
-            :javascript
-              miqInitSelectPicker();
-              miqSelectPickerEvent('cb_owner_id', '#{url}', {beforeSend: true, complete: true});
-      - elsif @edit[:new][:cb_show_typ] == "tenant"
-        .form-group
-          %label.control-label.col-md-2
-            = _('Tenant')
-          .col-md-8
-            - opts = [["<#{_('Choose a tenant')}>", nil]] + Array(@edit[:cb_tenant].invert).sort_by { |a| a.first.downcase }
-            = select_tag("cb_tenant_id",
-              options_for_select(opts, @edit[:new][:cb_tenant_id]),
-              :class                 => "selectpicker")
-            :javascript
-              miqInitSelectPicker();
-              miqSelectPickerEvent('cb_tenant_id', '#{url}', {beforeSend: true, complete: true});
-      - elsif @edit[:new][:cb_show_typ] == "tag"
-        .form-group
-          %label.control-label.col-md-2
-            = _('Tag Category')
-          .col-md-8
-            - opts = [["<#{_('Choose a Category')}>", nil]] + Array(@edit[:cb_cats].invert).sort_by { |a| a.first.downcase }
-            = select_tag("cb_tag_cat",
-              options_for_select(opts, @edit[:new][:cb_tag_cat]),
-              :class                 => "selectpicker")
-            :javascript
-              miqInitSelectPicker();
-              miqSelectPickerEvent('cb_tag_cat', '#{url}', {beforeSend: true, complete: true});
-        - if @edit[:new][:cb_tag_cat]
-          .form-group
-            %label.control-label.col-md-2
-              = _('Tag')
-            .col-md-8
-              - opts = [["<#{_('Choose a Value')}>", nil]] + Array(@edit[:cb_tags].invert).sort_by { |a| a.first.downcase }
-              = select_tag("cb_tag_value",
-                options_for_select(opts, @edit[:new][:cb_tag_value]),
-                :class                 => "selectpicker")
-              :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent('cb_tag_value', '#{url}', {beforeSend: true, complete: true});
-      - elsif @edit[:new][:cb_show_typ] == "entity"
-        .form-group
-          %label.control-label.col-md-2
-            = ui_lookup(:model => @edit[:new][:cb_model])
-          .col-md-8
-            - opts = [["<#{_('Choose %{entity}')}>" % {:entity => ui_lookup(:model => @edit[:new][:cb_model])}, nil], [_("All #{ui_lookup(:tables => @edit[:new][:cb_model].to_s)}"), :all]]
-            - opts += Array(@edit[:cb_all_entities_of_type][@edit[:new][:cb_model].to_sym].invert).sort_by { |a| a.first.downcase } if @edit[:cb_all_entities_of_type][@edit[:new][:cb_model].to_sym].present?
-            = select_tag('cb_entity_id',
-              options_for_select(opts, @edit[:new][:cb_entity_id]),
-              :class                 => "selectpicker")
-            :javascript
-              miqInitSelectPicker();
-              miqSelectPickerEvent('cb_entity_id', '#{url}', {beforeSend: true, complete: true});
-    - else
-      .form-group
-        %label.control-label.col-md-2
-          = _('Owner')
-        .col-md-8
-          = h(@edit[:cb_owner_name])
-    .form-group
-      %label.control-label.col-md-2
-        = _('Group by')
-      .col-md-8
-        = select_tag("cb_groupby",
-          options_for_select([["#{_('Date')}", "date"], ["#{_('VM/Instance/Project')}", "vm"]], @edit[:new][:cb_groupby]),
-          :class                 => "selectpicker")
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('cb_groupby', '#{url}', {beforeSend: true, complete: true});
-
-%fieldset
-  %h3
-    = _('Chargeback Interval')
-  .form-horizontal
+%h3
+  = _('Chargeback Filters')
+.form-horizontal
+  - if @edit[:cb_users]
     .form-group
       %label.control-label.col-md-2
         = _('Show Costs by')
       .col-md-8
-        = select_tag("cb_interval",
-          options_for_select([[_("Day"), "daily"], [_("Week"), "weekly"], [_("Month"), "monthly"]], @edit[:new][:cb_interval]),
+        - opts = [["<#{_('Choose')}>", nil]]
+        - if @edit[:new][:model] == "ChargebackContainerProject"
+          - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"]]
+        - elsif @edit[:new][:model] == "ChargebackVm"
+          - opts += [[_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"], [_('Tenant'), "tenant"]]
+        - else
+          - opts += [[_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"], [_(@edit[:new][:cb_model].to_s), "entity"]]
+        = select_tag("cb_show_typ",
+          options_for_select(opts, @edit[:new][:cb_show_typ]),
           :class                 => "selectpicker")
         :javascript
           miqInitSelectPicker();
-          miqSelectPickerEvent('cb_interval', '#{url}', {beforeSend: true, complete: true});
+          miqSelectPickerEvent('cb_show_typ', '#{url}', {beforeSend: true, complete: true});
+    - if @edit[:new][:cb_show_typ] == "owner"
+      .form-group
+        %label.control-label.col-md-2
+          = _('Owner')
+        .col-md-8
+          - opts = [["<#{_('Choose an Owner')}>", nil]] + Array(@edit[:cb_users].invert).sort_by { |a| a.first.downcase }
+          = select_tag("cb_owner_id",
+            options_for_select(opts, @edit[:new][:cb_owner_id]),
+            :class                 => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('cb_owner_id', '#{url}', {beforeSend: true, complete: true});
+    - elsif @edit[:new][:cb_show_typ] == "tenant"
+      .form-group
+        %label.control-label.col-md-2
+          = _('Tenant')
+        .col-md-8
+          - opts = [["<#{_('Choose a tenant')}>", nil]] + Array(@edit[:cb_tenant].invert).sort_by { |a| a.first.downcase }
+          = select_tag("cb_tenant_id",
+            options_for_select(opts, @edit[:new][:cb_tenant_id]),
+            :class                 => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('cb_tenant_id', '#{url}', {beforeSend: true, complete: true});
+    - elsif @edit[:new][:cb_show_typ] == "tag"
+      .form-group
+        %label.control-label.col-md-2
+          = _('Tag Category')
+        .col-md-8
+          - opts = [["<#{_('Choose a Category')}>", nil]] + Array(@edit[:cb_cats].invert).sort_by { |a| a.first.downcase }
+          = select_tag("cb_tag_cat",
+            options_for_select(opts, @edit[:new][:cb_tag_cat]),
+            :class                 => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('cb_tag_cat', '#{url}', {beforeSend: true, complete: true});
+      - if @edit[:new][:cb_tag_cat]
+        .form-group
+          %label.control-label.col-md-2
+            = _('Tag')
+          .col-md-8
+            - opts = [["<#{_('Choose a Value')}>", nil]] + Array(@edit[:cb_tags].invert).sort_by { |a| a.first.downcase }
+            = select_tag("cb_tag_value",
+              options_for_select(opts, @edit[:new][:cb_tag_value]),
+              :class                 => "selectpicker")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('cb_tag_value', '#{url}', {beforeSend: true, complete: true});
+    - elsif @edit[:new][:cb_show_typ] == "entity"
+      .form-group
+        %label.control-label.col-md-2
+          = ui_lookup(:model => @edit[:new][:cb_model])
+        .col-md-8
+          - opts = [["<#{_('Choose %{entity}')}>" % {:entity => ui_lookup(:model => @edit[:new][:cb_model])},
+                                                                          nil],
+                    [_("All #{ui_lookup(:tables => @edit[:new][:cb_model].to_s)}"), :all]]
+          - if @edit[:cb_all_entities_of_type][@edit[:new][:cb_model].to_sym].present?
+            - opts += Array(@edit[:cb_all_entities_of_type][@edit[:new][:cb_model].to_sym].invert).sort_by { |a| a.first.downcase }
+          = select_tag('cb_entity_id',
+            options_for_select(opts, @edit[:new][:cb_entity_id]),
+            :class                 => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('cb_entity_id', '#{url}', {beforeSend: true, complete: true});
+  - else
     .form-group
       %label.control-label.col-md-2
-        = _("%s  Ending with") % @edit[:new][:cb_interval].capitalize
+        = _('Owner')
       .col-md-8
-        - case @edit[:new][:cb_interval]
-        - when "daily"
-          - opts = [[_("Today (partial)"), 0], [_("Yesterday"), 1]] + (2..6).map { |i| [_("%s Days Ago") % i, i] } + [[_("1 Week Ago"), 7]]
-        - when "weekly"
-          - opts = [[_("This Week (partial)"), 0], [_("Last Week"), 1]] + (2..4).map { |i| [_("%d Weeks Ago") % i, i] }
-        - when "monthly"
-          - opts = [[_("This Month (partial)"), 0], ["Last Month", 1]] + (2..3).map { |i| [_("%d Months Ago") % i, i] }
-        = select_tag("cb_end_interval_offset",
-          options_for_select(opts, @edit[:new][:cb_end_interval_offset]),
-          :class                 => "selectpicker")
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('cb_end_interval_offset', '#{url}', {beforeSend: true, complete: true});
-        = _("going back")
-        - case @edit[:new][:cb_interval]
-        - when "daily"
-          - opts = (1..6).map { |i| [n_('%s Day', '%s Days', i) % i, i] } + (1..4).map { |i| [n_('%s Week', '%s Weeks', i) % i, i * 7] }
-        - when "weekly"
-          - opts = [1, 2, 3, 4, 8, 12].map! { |i| [n_('%s Week', '%s Weeks', i) % i, i] }
-        - when "monthly"
-          - opts = [1, 2, 3, 6, 9, 12].map! { |i| [n_('%s Month', '%s Months', i) % i, i] }
-        = select_tag("cb_interval_size",
-          options_for_select(opts, @edit[:new][:cb_interval_size]),
-          :class                 => "selectpicker")
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('cb_interval_size', '#{url}', {beforeSend: true, complete: true});
-    .form-group
-      %label.control-label.col-md-2
-        = _('Time Zone')
-      .col-md-8
-        = select_tag('chosen_tz',
-          options_for_select(ALL_TIMEZONES, @edit[:new][:tz]),
-          :class => "selectpicker")
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('chosen_tz', '#{url}')
+        = h(@edit[:cb_owner_name])
+  .form-group
+    %label.control-label.col-md-2
+      = _('Group by')
+    .col-md-8
+      = select_tag("cb_groupby",
+        options_for_select([["#{_('Date')}", "date"], ["#{_('VM/Instance/Project')}", "vm"]], @edit[:new][:cb_groupby]),
+        :class                 => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('cb_groupby', '#{url}', {beforeSend: true, complete: true});
+
+%h3
+  = _('Chargeback Interval')
+.form-horizontal
+  .form-group
+    %label.control-label.col-md-2
+      = _('Show Costs by')
+    .col-md-8
+      = select_tag("cb_interval",
+        options_for_select([[_("Day"), "daily"], [_("Week"), "weekly"], [_("Month"), "monthly"]], @edit[:new][:cb_interval]),
+        :class                 => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('cb_interval', '#{url}', {beforeSend: true, complete: true});
+  .form-group
+    %label.control-label.col-md-2
+      = _("%s  Ending with") % @edit[:new][:cb_interval].capitalize
+    .col-md-8
+      - case @edit[:new][:cb_interval]
+      - when "daily"
+        - opts = [[_("Today (partial)"), 0], [_("Yesterday"), 1]] + (2..6).map { |i| [_("%s Days Ago") % i, i] } + [[_("1 Week Ago"), 7]]
+      - when "weekly"
+        - opts = [[_("This Week (partial)"), 0], [_("Last Week"), 1]] + (2..4).map { |i| [_("%d Weeks Ago") % i, i] }
+      - when "monthly"
+        - opts = [[_("This Month (partial)"), 0], ["Last Month", 1]] + (2..3).map { |i| [_("%d Months Ago") % i, i] }
+      = select_tag("cb_end_interval_offset",
+        options_for_select(opts, @edit[:new][:cb_end_interval_offset]),
+        :class                 => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('cb_end_interval_offset', '#{url}', {beforeSend: true, complete: true});
+      = _("going back")
+      - case @edit[:new][:cb_interval]
+      - when "daily"
+        - opts = (1..6).map { |i| [n_('%s Day', '%s Days', i) % i, i] } + (1..4).map { |i| [n_('%s Week', '%s Weeks', i) % i, i * 7] }
+      - when "weekly"
+        - opts = [1, 2, 3, 4, 8, 12].map! { |i| [n_('%s Week', '%s Weeks', i) % i, i] }
+      - when "monthly"
+        - opts = [1, 2, 3, 6, 9, 12].map! { |i| [n_('%s Month', '%s Months', i) % i, i] }
+      = select_tag("cb_interval_size",
+        options_for_select(opts, @edit[:new][:cb_interval_size]),
+        :class                 => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('cb_interval_size', '#{url}', {beforeSend: true, complete: true});
+  .form-group
+    %label.control-label.col-md-2
+      = _('Time Zone')
+    .col-md-8
+      = select_tag('chosen_tz',
+        options_for_select(ALL_TIMEZONES, @edit[:new][:tz]),
+        :class => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('chosen_tz', '#{url}')

--- a/app/views/report/_form_filter_performance.html.haml
+++ b/app/views/report/_form_filter_performance.html.haml
@@ -1,44 +1,44 @@
 - url = url_for(:action => 'form_field_changed', :id => "#{@edit[:rpt_id] || 'new'}")
-%fieldset
-  %h3
-    = _('Performance Timeframe')
-  .form-horizontal
-    .form-group
-      %label.control-label.col-md-2
-        - if @edit[:new][:perf_interval]
-          = _("Show hourly data from")
-        - else
-          = _("Show daily data from")
-      .col-md-8
-        = select_tag('chosen_end',
-          options_for_select(@edit[:end_array], @edit[:new][:perf_end]),
-          :multiple          => false,
-          :class             => "selectpicker")
+%h3
+  = _('Performance Timeframe')
+.form-horizontal
+  .form-group
+    %label.control-label.col-md-2
+      - if @edit[:new][:perf_interval]
+        = _("Show hourly data from")
+      - else
+        = _("Show daily data from")
+    .col-md-8
+      = select_tag('chosen_end',
+        options_for_select(@edit[:end_array], @edit[:new][:perf_end]),
+        :multiple => false,
+        :class => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('chosen_end', '#{url}')
+      = _('going back')
+      = select_tag('chosen_start',
+        options_for_select(@edit[:start_array], @edit[:new][:perf_start]),
+        :multiple => false,
+        :class => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('chosen_start', '#{url}')
+  .form-group
+    %label.control-label.col-md-2
+      = _('Time Profile')
+    .col-md-8
+      - if session[:time_profiles].blank?
+        = _('No Time Profiles found')
+      - elsif session[:time_profiles].length == 1
+        -# Only 1 choice, show the value
+        = session[:time_profiles][@edit[:new][:time_profile].to_i]
+      - else
+        = select_tag('chosen_time_profile',
+          options_for_select(Array(session[:time_profiles].invert).sort_by(&:first),
+                             @edit[:new][:time_profile]),
+          :class => "selectpicker")
         :javascript
           miqInitSelectPicker();
-          miqSelectPickerEvent('chosen_end', '#{url}')
-        = _('going back')
-        = select_tag('chosen_start',
-          options_for_select(@edit[:start_array], @edit[:new][:perf_start]),
-          :multiple          => false,
-          :class             => "selectpicker")
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('chosen_start', '#{url}')
-    .form-group
-      %label.control-label.col-md-2
-        = _('Time Profile')
-      .col-md-8
-        - if session[:time_profiles].blank?
-          = _('No Time Profiles found')
-        - elsif session[:time_profiles].length == 1
-          -# Only 1 choice, show the value
-          = session[:time_profiles][@edit[:new][:time_profile].to_i]
-        - else
-          = select_tag('chosen_time_profile',
-            options_for_select(Array(session[:time_profiles].invert).sort_by(&:first), @edit[:new][:time_profile]),
-            :class => "selectpicker")
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('chosen_time_profile', '#{url}')
-  = _("Note: Only Time Profiles with 'Roll Up Performance' set are shown.")
+          miqSelectPickerEvent('chosen_time_profile', '#{url}')
+= _("Note: Only Time Profiles with 'Roll Up Performance' set are shown.")


### PR DESCRIPTION
Before:
![screencapture-localhost-3000-report-explorer-1462280409801](https://cloud.githubusercontent.com/assets/1187051/14983907/43202782-1140-11e6-8d22-4adb4cc78647.png)
After:
![screencapture-localhost-3000-report-explorer-1462280334783](https://cloud.githubusercontent.com/assets/1187051/14983908/443eeffe-1140-11e6-8f0e-ece82438f20b.png)
___

Before:
![screencapture-localhost-3000-report-explorer-1462280194640](https://cloud.githubusercontent.com/assets/1187051/14983911/452ec574-1140-11e6-8dbe-31ba6732d701.png)
After:
![screencapture-localhost-3000-report-explorer-1462280174541](https://cloud.githubusercontent.com/assets/1187051/14983912/4635765c-1140-11e6-92dd-d8b5cc47828a.png)

___

Note: There are more:
```
$ ag '%fieldset'
_form_filter.html.haml
37:      %fieldset

_form_tl_sample.html.haml
3:    %fieldset

_form_tl_settings.html.haml
3:  %fieldset
8:        %fieldset
59:          %fieldset

_role_list.html.haml
8:            %fieldset.role_list

_form_preview.html.haml
4:      %fieldset
14:      %fieldset
25:      %fieldset
30:    %fieldset

_menu_form2.html.haml
4:    %fieldset{:style => "height: 450px;"}

_form_sort.html.haml
133:    %fieldset

_menu_form1.html.haml
3:  %fieldset
77:  %fieldset{:style => "width: 300px; height: 450px;"}

show_saved.html.haml
5:    %fieldset

_form_chart_sample.html.haml
3:    %fieldset
```

@epwinchell please review