### PR TITLE
Inproper context of 'this' in onchange event of select (set ownership screen) 

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1272,14 +1272,19 @@ function miqSelectPickerEvent(element, url, options) {
   $('#' + element).on('change', function() {
     var selected = $(this).val();
     var finalUrl = url + (firstarg ? '?' : '&') + element + '=' + escape(selected);
-    if($(this).attr('data-miq_sparkle_on') == 'true') {
+    var is_sparkle_on = $(this).attr('data-miq_sparkle_on') == 'true'
+    var is_sparkle_off = $(this).attr('data-miq_sparkle_off') == 'true'
+
+    if (is_sparkle_on) {
       miqSparkleOn();
     }
+
     miqJqueryRequest(finalUrl, options).done(function() {
       if (options.callback) {
         options.callback();
       }
-      if($(this).attr('data-miq_sparkle_off') == 'true') {
+
+      if (is_sparkle_off) {
         miqSparkleOff();
       }
     });


### PR DESCRIPTION
it was causing that spinner (sparkle) was still visible.

one of test scenario (but it seems it is global thing)
1. got to VM summary and open set ownership screen
2. Select any group
3. sparkle was still visible

thanks @himdel @PanSpagetka 

@miq-bot add_label ui, bug


