### PR TITLE
Removing non existent delegation to Amazon_handle

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -27,7 +27,6 @@ class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkM
            :authentications,
            :authentication_for_summary,
            :zone,
-           :Amazon_handle,
            :connect,
            :verify_credentials,
            :with_provider_connection,

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/network_manager.rb
@@ -23,7 +23,6 @@ class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::Network
            :authentications,
            :authentication_for_summary,
            :zone,
-           :Amazon_handle,
            :connect,
            :verify_credentials,
            :with_provider_connection,


### PR DESCRIPTION
Removing non existent delegation to Amazon_handle, brought
probably from openstack, mass renamed from openstack_handle