### PR TITLE
Display flash message after snapshot creation

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -173,7 +173,7 @@ module VmCommon
   end
 
   def show(id = nil)
-    @flash_array = [] if params[:display]
+    @flash_array = [] if params[:display] && params[:display] != "snapshot_info"
     @sb[:action] = params[:display]
 
     return if perfmenu_click?

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -428,4 +428,13 @@ describe VmInfraController do
     get :explorer
     expect(response.status).to eq(200)
   end
+
+  it "render creation snapshot flash message" do
+    session[:edit] = {:explorer => true}
+    post :snap_vm, :params => {:name        => "test",
+                               :description => "test",
+                               :button      => "create",
+                               :id          => vm_vmware.id}
+    expect(assigns(:flash_array).first[:message]).to include("Create Snapshot")
+  end
 end


### PR DESCRIPTION
This PR is fixing flash message to be displayed after snapshot creation.

https://bugzilla.redhat.com/show_bug.cgi?id=1211456