### PR TITLE
Move report loading from ApplicationController to MiqReport

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1686,11 +1686,11 @@ class ApplicationController < ActionController::Base
   end
 
   def get_db_view_yaml(filename)
-    @db_view_yaml ||= {}
-    @db_view_yaml.delete(filename) if Rails.env.development?
-    @db_view_yaml[filename] ||= begin
-      YAML.load_file(filename)
-    end
+    db_view_yaml_cache[filename] ||= YAML.load_file(filename)
+  end
+
+  def db_view_yaml_cache
+    Rails.env.development? ? {} : @db_view_yaml ||= {}
   end
 
   def render_or_redirect_partial(pfx)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1678,46 +1678,11 @@ class ApplicationController < ActionController::Base
   end
 
   def get_db_view(db, options = {})
-    view_yaml = view_yaml_filename(db, options)
+    view_yaml = MiqReport.view_yaml_filename(db, current_user, options)
     view      = MiqReport.new(get_db_view_yaml(view_yaml))
     view.db   = db if view_yaml.ends_with?("Vm__restricted.yaml")
     view.extras ||= {}                        # Always add in the extras hash
     view
-  end
-
-  def view_yaml_filename(db, options)
-    suffix = options[:association] || options[:view_suffix]
-    db = db.to_s
-
-    # Special code to build the view file name for users of VM restricted roles
-    if %w(ManageIQ::Providers::CloudManager::Template ManageIQ::Providers::InfraManager::Template ManageIQ::Providers::CloudManager::Vm ManageIQ::Providers::InfraManager::Vm VmOrTemplate).include?(db)
-      role = current_user.miq_user_role
-      if role && role.settings && role.settings.fetch_path(:restrictions, :vms)
-        viewfilerestricted = "#{VIEWS_FOLDER}/Vm__restricted.yaml"
-      end
-    end
-
-    db = db.gsub(/::/, '_')
-
-    current_role = current_user.try(:miq_user_role)
-    current_role = current_role.name.split("-").last if current_role.try(:read_only?)
-
-    # Build the view file name
-    if suffix
-      viewfile = "#{VIEWS_FOLDER}/#{db}-#{suffix}.yaml"
-      viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{suffix}-#{current_role}.yaml"
-    else
-      viewfile = "#{VIEWS_FOLDER}/#{db}.yaml"
-      viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{current_role}.yaml"
-    end
-
-    if viewfilerestricted && File.exist?(viewfilerestricted)
-      viewfilerestricted
-    elsif File.exist?(viewfilebyrole)
-      viewfilebyrole
-    else
-      viewfile
-    end
   end
 
   def get_db_view_yaml(filename)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1678,15 +1678,7 @@ class ApplicationController < ActionController::Base
   end
 
   def get_db_view(db, options = {})
-    view_yaml = MiqReport.view_yaml_filename(db, current_user, options)
-    view      = MiqReport.new(get_db_view_yaml(view_yaml))
-    view.db   = db if view_yaml.ends_with?("Vm__restricted.yaml")
-    view.extras ||= {}                        # Always add in the extras hash
-    view
-  end
-
-  def get_db_view_yaml(filename)
-    db_view_yaml_cache[filename] ||= YAML.load_file(filename)
+    MiqReport.load_from_view_options(db, current_user, options, db_view_yaml_cache)
   end
 
   def db_view_yaml_cache

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -23,7 +23,6 @@ module UiConstants
   MAX_DASHBOARD_COUNT = 10  # Default maximum count of Dashboard per group
 
   REPORTS_FOLDER = File.join(Rails.root, "product/reports")
-  VIEWS_FOLDER = File.join(Rails.root, "product/views")
   OPS_REPORTS_FOLDER = File.join(Rails.root, "product/ops/miq_reports")
   CHARTS_REPORTS_FOLDER = File.join(Rails.root, "product/charts/miq_reports")
   CHARTS_LAYOUTS_FOLDER = File.join(Rails.root, "product/charts/layouts")

--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -54,9 +54,10 @@ module MiqReport::ImportExport
       suffix = options[:association] || options[:view_suffix]
       db = db.to_s
 
+      role = current_user.try(:miq_user_role)
       # Special code to build the view file name for users of VM restricted roles
-      if %w(ManageIQ::Providers::CloudManager::Template ManageIQ::Providers::InfraManager::Template ManageIQ::Providers::CloudManager::Vm ManageIQ::Providers::InfraManager::Vm VmOrTemplate).include?(db)
-        role = current_user.miq_user_role
+      if %w(ManageIQ::Providers::CloudManager::Template ManageIQ::Providers::InfraManager::Template
+            ManageIQ::Providers::CloudManager::Vm ManageIQ::Providers::InfraManager::Vm VmOrTemplate).include?(db)
         if role && role.settings && role.settings.fetch_path(:restrictions, :vms)
           viewfilerestricted = "#{VIEWS_FOLDER}/Vm__restricted.yaml"
         end
@@ -64,16 +65,15 @@ module MiqReport::ImportExport
 
       db = db.gsub(/::/, '_')
 
-      current_role = current_user.try(:miq_user_role)
-      current_role = current_role.name.split("-").last if current_role.try(:read_only?)
+      role = role.name.split("-").last if role.try(:read_only?)
 
       # Build the view file name
       if suffix
         viewfile = "#{VIEWS_FOLDER}/#{db}-#{suffix}.yaml"
-        viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{suffix}-#{current_role}.yaml"
+        viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{suffix}-#{role}.yaml"
       else
         viewfile = "#{VIEWS_FOLDER}/#{db}.yaml"
-        viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{current_role}.yaml"
+        viewfilebyrole = "#{VIEWS_FOLDER}/#{db}-#{role}.yaml"
       end
 
       if viewfilerestricted && File.exist?(viewfilerestricted)

--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -57,15 +57,12 @@ module MiqReport::ImportExport
     # @option options :view_suffix [String] used for a view suffix
     # @param cache [Hash] cache that holds yaml for the views
     def load_from_view_options(db, current_user = nil, options = {}, cache = {})
-      view_yaml = MiqReport.view_yaml_filename(db, current_user, options)
-      view      = MiqReport.new(get_db_view_yaml(view_yaml, cache))
-      view.db   = db if view_yaml.ends_with?("Vm__restricted.yaml")
+      filename = MiqReport.view_yaml_filename(db, current_user, options)
+      yaml     = cache[filename] ||= YAML.load_file(filename)
+      view     = MiqReport.new(yaml)
+      view.db  = db if filename.ends_with?("Vm__restricted.yaml")
       view.extras ||= {}                        # Always add in the extras hash
       view
-    end
-
-    def get_db_view_yaml(filename, db_view_yaml_cache)
-      db_view_yaml_cache[filename] ||= YAML.load_file(filename)
     end
 
     def view_yaml_filename(db, current_user, options)

--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -50,6 +50,24 @@ module MiqReport::ImportExport
       return rep, result
     end
 
+    # @param db [Class] name of report (typically class name)
+    # @param current_user [User] User for restricted access to reports
+    # @param options [Hash]
+    # @option options :association [String] used for a view suffix
+    # @option options :view_suffix [String] used for a view suffix
+    # @param cache [Hash] cache that holds yaml for the views
+    def load_from_view_options(db, current_user = nil, options = {}, cache = {})
+      view_yaml = MiqReport.view_yaml_filename(db, current_user, options)
+      view      = MiqReport.new(get_db_view_yaml(view_yaml, cache))
+      view.db   = db if view_yaml.ends_with?("Vm__restricted.yaml")
+      view.extras ||= {}                        # Always add in the extras hash
+      view
+    end
+
+    def get_db_view_yaml(filename, db_view_yaml_cache)
+      db_view_yaml_cache[filename] ||= YAML.load_file(filename)
+    end
+
     def view_yaml_filename(db, current_user, options)
       suffix = options[:association] || options[:view_suffix]
       db = db.to_s

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -74,26 +74,6 @@ describe ApplicationController do
     end
   end
 
-  context "#view_yaml_filename" do
-    let(:feature) { MiqProductFeature.find_all_by_identifier("vm_infra_explorer") }
-    let(:user)    { FactoryGirl.create(:user, :features => feature) }
-
-    before do
-      EvmSpecHelper.seed_specific_product_features("vm_infra_explorer", "host_edit")
-      login_as user
-    end
-
-    it "should return restricted view yaml for restricted user" do
-      user.current_group.miq_user_role.update_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
-      expect(controller.send(:view_yaml_filename, VmCloud.name, {})).to include("Vm__restricted.yaml")
-    end
-
-    it "should return VmCloud view yaml for non-restricted user" do
-      user.current_group.miq_user_role.update_attributes(:settings => {})
-      expect(controller.send(:view_yaml_filename, VmCloud.name, {})).to include("ManageIQ_Providers_CloudManager_Vm.yaml")
-    end
-  end
-
   context "#previous_breadcrumb_url" do
     it "should return url when 2 entries" do
       controller.instance_variable_set(:@breadcrumbs, [{:url => "test_url"}, 'placeholder'])

--- a/spec/models/miq_report/import_export_spec.rb
+++ b/spec/models/miq_report/import_export_spec.rb
@@ -85,4 +85,23 @@ describe MiqReport::ImportExport do
       end
     end
   end
+
+  context ".view_yaml_filename" do
+    let(:feature) { MiqProductFeature.find_all_by_identifier("vm_infra_explorer") }
+    let(:user)    { FactoryGirl.create(:user, :features => feature) }
+
+    before do
+      EvmSpecHelper.seed_specific_product_features("vm_infra_explorer", "host_edit")
+    end
+
+    it "should return restricted view yaml for restricted user" do
+      user.current_group.miq_user_role.update_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
+      expect(MiqReport.view_yaml_filename(VmCloud.name, user, {})).to include("Vm__restricted.yaml")
+    end
+
+    it "should return VmCloud view yaml for non-restricted user" do
+      user.current_group.miq_user_role.update_attributes(:settings => {})
+      expect(MiqReport.view_yaml_filename(VmCloud.name, user, {})).to include("ManageIQ_Providers_CloudManager_Vm.yaml")
+    end
+  end
 end


### PR DESCRIPTION
**before:**

We've been breaking a number of reports. They just aren't well understood. Between `ApplicationController`, `MiqExpression`, `MiqFilter`, `Rbac` and the 19 extra files in `miq_report/**.rb`.

**after:**

Baby steps... introduce `MiqReport.load_from_view_options` to give mere mortals the ability to load a report from a yaml file.

Since the table name is stored in the model, `VIEW_DIRECTORY` seemed similar enough.

**future:**

- move special report manipulation logic from application controller logic into the model
- testing harness around reports
- performance harness around reports