### PR TITLE
Bug fix: Use local variable rather than redefine a constant

### DIFF
--- a/spec/models/service_ansible_tower_spec.rb
+++ b/spec/models/service_ansible_tower_spec.rb
@@ -71,11 +71,11 @@ describe ServiceAnsibleTower do
     end
 
     it 'always saves options even when the manager fails to create a stack' do
-      ProvisionError = MiqException::MiqOrchestrationProvisionError
-      allow_any_instance_of(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job).to receive(:stack_create).and_raise(ProvisionError, 'test failure')
+      provision_error = MiqException::MiqOrchestrationProvisionError
+      allow_any_instance_of(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job).to receive(:stack_create).and_raise(provision_error, 'test failure')
 
       expect(service_mix_dialog_setter).to receive(:save_launch_options)
-      expect { service_mix_dialog_setter.launch_job }.to raise_error(ProvisionError)
+      expect { service_mix_dialog_setter.launch_job }.to raise_error(provision_error)
     end
   end
 end

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -99,11 +99,11 @@ describe ServiceOrchestration do
     end
 
     it 'always saves options even when the manager fails to create a stack' do
-      ProvisionError = MiqException::MiqOrchestrationProvisionError
-      allow_any_instance_of(ManageIQ::Providers::Amazon::CloudManager).to receive(:stack_create).and_raise(ProvisionError, 'test failure')
+      provision_error = MiqException::MiqOrchestrationProvisionError
+      allow_any_instance_of(ManageIQ::Providers::Amazon::CloudManager).to receive(:stack_create).and_raise(provision_error, 'test failure')
 
       expect(service_mix_dialog_setter).to receive(:save_create_options)
-      expect { service_mix_dialog_setter.deploy_orchestration_stack }.to raise_error(ProvisionError)
+      expect { service_mix_dialog_setter.deploy_orchestration_stack }.to raise_error(provision_error)
     end
   end
 


### PR DESCRIPTION
Fixes Travis warnings
```
/home/travis/build/ManageIQ/manageiq/spec/models/service_ansible_tower_spec.rb:74: warning: already initialized constant ProvisionError 
/home/travis/build/ManageIQ/manageiq/spec/models/service_orchestration_spec.rb:102: warning: previous definition of ProvisionError was here
```