### PR TITLE
Queue miq-observe requests and wait for queue to empty in miqJqueryRequest

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require miq_global
+//= require es6-shim
 //= require jquery
 //= require jquery_overrides
 //= require i18n

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1262,7 +1262,7 @@ function miqObserveRequest(url, options) {
 }
 
 function miqJqueryRequest(url, options) {
-  if ((ManageIQ.observe.processing || ManageIQ.observe.queue.length) && ! options.observe) {
+  if ((ManageIQ.observe.processing || ManageIQ.observe.queue.length) && (!options || !options.observe)) {
     console.debug('Postponing miqJqueryRequest - waiting for the observe queue to empty first');
 
     return new Promise(function(resolve, reject) {

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -68,5 +68,9 @@ if (typeof(ManageIQ) === 'undefined') {
       expandAll: true,
     },
     gridChecks: [], // list of checked checkboxes in current list grid
+    observe: { // keeping track of data-miq_observe requests
+      processing: false, // is a request currently being processed?
+      queue: [], // a queue of pending requests
+    },
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -39,6 +39,7 @@
     "sprintf": "^1.0.3",
     "tota11y": "^0.1.3",
     "xml_display": "^0.1.1",
-    "spice-html5-bower": "himdel/spice-html5-bower#^0.1.5"
+    "spice-html5-bower": "himdel/spice-html5-bower#^0.1.5",
+    "es6-shim": "^0.35.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -40,6 +40,7 @@
     "tota11y": "^0.1.3",
     "xml_display": "^0.1.1",
     "spice-html5-bower": "himdel/spice-html5-bower#^0.1.5",
-    "es6-shim": "^0.35.0"
+    "es6-shim": "^0.35.0",
+    "phantomjs-polyfill": "^0.0.2"
   }
 }

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -197,16 +197,19 @@ describe('miq_application.js', function() {
     });
 
     it("doesn't die on null callback", function() {
-      spyOn(window, 'miqJqueryRequest').and.returnValue({
-        done: function(fn) { fn(); },
+      spyOn(window, 'miqObserveRequest');
+      spyOn(_, 'debounce').and.callFake(function(fn, opts) {
+        return fn;
       });
 
       miqSelectPickerEvent('miq-select-picker-1', '/foo/');
 
       $('#miq-select-picker-1').val('quux').trigger('change');
 
-      expect(miqJqueryRequest).toHaveBeenCalledWith('/foo/?miq-select-picker-1=quux', {
+      expect(miqObserveRequest).toHaveBeenCalledWith('/foo/?miq-select-picker-1=quux', {
         no_encoding: true,
+        beforeSend: undefined,
+        complete: undefined,
       });
     });
   });

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -208,8 +208,8 @@ describe('miq_application.js', function() {
 
       expect(miqObserveRequest).toHaveBeenCalledWith('/foo/?miq-select-picker-1=quux', {
         no_encoding: true,
-        beforeSend: undefined,
-        complete: undefined,
+        beforeSend: false,
+        complete: false,
       });
     });
   });

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -333,6 +333,48 @@ describe('miq_application.js', function() {
     });
   });
 
+  describe('miqJqueryRequest', function() {
+    beforeEach(function() {
+      spyOn($, 'ajax').and.callFake(function() {
+        return { then: function(ok, err) { /* nope */ } };
+      });
+    });
+
+    it('queues itself when processing observe queue', function() {
+      ManageIQ.observe.processing = true;
+      ManageIQ.observe.queue = [];
+
+      spyOn(window, 'setTimeout');
+      miqJqueryRequest('/foo');
+
+      expect(setTimeout).toHaveBeenCalled();
+    });
+
+    it('queues itself when observe queue nonempty', function() {
+      ManageIQ.observe.processing = false;
+      ManageIQ.observe.queue = [{}];
+
+      spyOn(window, 'setTimeout');
+      miqJqueryRequest('/foo');
+
+      expect(setTimeout).toHaveBeenCalled();
+    });
+
+    it('doesn\'t try to queue when passed options.observe', function() {
+      ManageIQ.observe.processing = true;
+      ManageIQ.observe.queue = [{}];
+
+      spyOn(window, 'setTimeout');
+      miqJqueryRequest('/foo', { observe: true });
+
+      expect(setTimeout).not.toHaveBeenCalled();
+    });
+
+    it('returns a Promise', function() {
+      expect(miqJqueryRequest('/foo')).toEqual(jasmine.any(Promise));
+    });
+  });
+
   describe('miqSelectPickerEvent', function () {
     beforeEach(function () {
       var html = '<input id="miq-select-picker-1" value="bar">';

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -300,6 +300,39 @@ describe('miq_application.js', function() {
     });
   });
 
+  describe('miqObserveRequest', function() {
+    beforeEach(function() {
+      spyOn(window, 'miqProcessObserveQueue');
+
+      ManageIQ.observe.processing = false;
+      ManageIQ.observe.queue = [];
+    });
+
+    it('sets observe: true on options', function() {
+      miqObserveRequest('/foo', {});
+      expect(ManageIQ.observe.queue[0].options.observe).toBe(true);
+    });
+
+    it('sets observe: true on options even without options', function() {
+      miqObserveRequest('/foo');
+      expect(ManageIQ.observe.queue[0].options.observe).toBe(true);
+    });
+
+    it('adds to queue', function() {
+      miqObserveRequest('/foo');
+      expect(ManageIQ.observe.queue[0].url).toBe('/foo');
+    });
+
+    it('calls miqProcessObserveQueue', function() {
+      miqObserveRequest('/foo');
+      expect(miqProcessObserveQueue).toHaveBeenCalled();
+    });
+
+    it('returns a Promise', function() {
+      expect(miqObserveRequest('/foo')).toEqual(jasmine.any(Promise));
+    });
+  });
+
   describe('miqSelectPickerEvent', function () {
     beforeEach(function () {
       var html = '<input id="miq-select-picker-1" value="bar">';

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -190,6 +190,28 @@ describe('miq_application.js', function() {
     });
   });
 
+  describe('miqSendOneTrans', function () {
+    beforeEach(function() {
+      ManageIQ.oneTransition.oneTrans = undefined;
+      ManageIQ.oneTransition.IEButtonPressed = undefined;
+
+      spyOn(window, 'miqObserveRequest');
+      spyOn(window, 'miqJqueryRequest');
+    });
+
+    it('calls miqJqueryRequest when given only url', function() {
+      miqSendOneTrans('/foo');
+      expect(miqJqueryRequest).toHaveBeenCalled();
+      expect(miqObserveRequest).not.toHaveBeenCalled();
+    });
+
+    it('calls miqObserveRequest when given observe: true', function() {
+      miqSendOneTrans('/foo', { observe: true });
+      expect(miqJqueryRequest).not.toHaveBeenCalled();
+      expect(miqObserveRequest).toHaveBeenCalled();
+    });
+  });
+
   describe('miqSelectPickerEvent', function () {
     beforeEach(function () {
       var html = '<input id="miq-select-picker-1" value="bar">';

--- a/spec/javascripts/resizable_sidebar_spec.js
+++ b/spec/javascripts/resizable_sidebar_spec.js
@@ -24,7 +24,11 @@ describe('resizable-sidebar.js', function () {
 
     setFixtures(html);
     $('div.container-fluid.resizable-sidebar').resizableSidebar();
-    spyOn($, 'ajax'); // we're not testing the backend
+
+    // we're not testing the backend
+    spyOn($, 'ajax').and.callFake(function() {
+      return Promise.resolve({});
+    });
   });
 
   it('hide sidebar', function () {

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -12,6 +12,7 @@
 #
 src_files:
   - __spec__/helpers/i18n-test.js
+  - assets/phantomjs-polyfill/bind-polyfill
   - assets/application
   - assets/jasmine-jquery
   - assets/angular-mocks


### PR DESCRIPTION
@h-kataria this is for you.. :)

The main changes are these:

   * add miqObserveRequest with the same signature as miqJqueryRequest, but queueing the actions, waiting for each to complete before trying the next..
   * add a _.debounce around the on change handlers - so that we do the request at most every 700ms
   * use miqObserveRequest in all the observe-related functions (hoping it's all of them at least...)
   * make miqJqueryRequest wait for the queue to empty

+ various tiny changes like we can't call `.done` on miqObserveRequest results because it doesn't return the right promise (can be fixed if we add kriskowal/q or rely on native Promise, but I just added .done as an option there), miqSendOneTrans being used for 2 different things.. etc.

https://bugzilla.redhat.com/show_bug.cgi?id=1328828