### PR TITLE
Don't use git based 3.0.1, bump the version since our fork has changes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 gem "color",                          "~>1.8"
-gem "default_value_for",              "~>3.0.1", :git => "git://github.com/matthewd/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
+gem "default_value_for",              "~>3.0.2.alpha-miq.1", :git => "git://github.com/jrafanie/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
 gem "draper",                         "~>2.1.0", :git => "git://github.com/janraasch/draper.git", :branch => "feature/rails5-compatibility" # https://github.com/drapergem/draper/pull/712
 gem "hamlit-rails",                   "~>0.1.0"
 gem "high_voltage",                   "~>2.4.0"


### PR DESCRIPTION
It's confusing to re-use a gem version with changes on top.  We can bump our
version using a prerelease 3.0.2 version and not worry about colliding with
upstream since we won't be moving to theirs until 3.0.2 is released.

```ruby
irb(main):031:0> Gem::Requirement.new("~> 3.0.2.alpha-miq.1").satisfied_by?(Gem::Version.new("3.0.2.alpha-miq.1"))
=> true
irb(main):032:0> Gem::Requirement.new("~> 3.0.2.alpha-miq.1").satisfied_by?(Gem::Version.new("3.0.2.alpha-miq.2"))
=> true
irb(main):033:0> Gem::Requirement.new("~> 3.0.2.alpha-miq.1").satisfied_by?(Gem::Version.new("3.0.2"))
=> true
```

Note, the a-z character version component is used for prereleased versions.
You therefore cannot try to use a released gem version, 3.0.1 and add a .miq or
something like "~> 3.0.1.miq-1` because the EXISTING 3.0.1 satisfies that
prerelease constraint:

```ruby
irb(main):029:0> Gem::Requirement.new("~> 3.0.1.alpha-miq.1").satisfied_by?(Gem::Version.new("3.0.1"))
=> true
```

All that for rails 5 support from FooBarWidget default_value_for PR 57