### PR TITLE
Expose private network and public network to automate service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_cloud_network.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_cloud_network.rb
@@ -8,7 +8,5 @@ module MiqAeMethodService
     expose :floating_ips,          :association => true
     expose :network_ports,         :association => true
     expose :network_routers,       :association => true
-    expose :public_networks,       :association => true
-    expose :private_networks,      :association => true
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-cloud_network-private.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-cloud_network-private.rb
@@ -1,4 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Openstack_NetworkManager_CloudNetwork_Private < MiqAeServiceManageIQ_Providers_Openstack_NetworkManager_CloudNetwork
+    expose :public_networks, :association => true
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-cloud_network-public.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-cloud_network-public.rb
@@ -1,4 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Openstack_NetworkManager_CloudNetwork_Public < MiqAeServiceManageIQ_Providers_Openstack_NetworkManager_CloudNetwork
+    expose :private_networks, :association => true
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_network_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_network_spec.rb
@@ -31,13 +31,5 @@ module MiqAeServiceCloudNetworkSpec
     it "#network_routers" do
       expect(described_class.instance_methods).to include(:network_routers)
     end
-
-    it "#public_networks" do
-      expect(described_class.instance_methods).to include(:public_networks)
-    end
-
-    it "#private_networks" do
-      expect(described_class.instance_methods).to include(:private_networks)
-    end
   end
 end


### PR DESCRIPTION
There should be only private network and public network for Openstack cloud.
Public network is connected to private_networks via routers and private network is connected to public_networks via subnets and routers.

https://bugzilla.redhat.com/show_bug.cgi?id=1332043