### PR TITLE
[WIP] Use ERB::Util.url_encode instead of URI.encode in miq-file.rb

### DIFF
--- a/gems/pending/spec/util/miq-file_spec.rb
+++ b/gems/pending/spec/util/miq-file_spec.rb
@@ -1,0 +1,31 @@
+require 'util/extensions/miq-file'
+
+describe 'MIQFile' do
+  context 'path_to_uri' do
+    let(:hostname) { MiqSockUtil.getFullyQualifiedDomainName }
+
+    it 'is defined and returns a string' do
+      expect(File).to respond_to(:path_to_uri)
+      expect(File.path_to_uri('foo')).to be_kind_of(String)
+    end
+
+    it 'returns the expected result' do
+      expect(File.path_to_uri('foo')).to eql("file://#{hostname}/foo")
+      expect(File.path_to_uri('foo/bar')).to eql("file://#{hostname}/foo/bar")
+      expect(File.path_to_uri('foo/C:/bar')).to eql("file://#{hostname}/foo/C:/bar")
+      expect(File.path_to_uri('foo/[bar]')).to eql("file://#{hostname}/foo/%5Bbar%5D")
+    end
+
+    it 'accepts an optional hostname and returns the expected result' do
+      hostname = 'test-host'
+      expect(File.path_to_uri('foo', hostname)).to eql("file://#{hostname}/foo")
+      expect(File.path_to_uri('foo/bar', hostname)).to eql("file://#{hostname}/foo/bar")
+      expect(File.path_to_uri('foo/C:/bar', hostname)).to eql("file://#{hostname}/foo/C:/bar")
+      expect(File.path_to_uri('foo/[bar]', hostname)).to eql("file://#{hostname}/foo/%5Bbar%5D")
+    end
+
+    it 'requires at least one argument' do
+      expect { File.path_to_uri }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/gems/pending/util/extensions/miq-file.rb
+++ b/gems/pending/util/extensions/miq-file.rb
@@ -52,7 +52,7 @@ class File
 
   def self.path_to_uri(file, hostname = nil)
     hostname ||= MiqSockUtil.getFullyQualifiedDomainName
-    URI.join("file://#{hostname}", "/#{URI.encode(file.tr('\\', '/'))}").to_s
+    URI.join("file://#{hostname}", URI.encode(file.tr('\\', '/'), '[ ]-')).to_s
   end
 
   def self.uri_to_local_path(uri_path)


### PR DESCRIPTION
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1287866.

The problem is that some of the SCVMM datastores have brackets in their name, and this method is called in the Microsoft refresh_parser.rb file. This causes URI.join to choke because URI.encode won't encode illegal characters in a URI by default. To wit:
```
irb(main):055:0> URI.join("foo://bar", URI.encode("[baz]"))
URI::InvalidURIError: bad URI(is not URI?): [baz]
	from /Users/dberger/.rbenv/versions/2.2.3/lib/ruby/2.2.0/uri/generic.rb:1100:in `rescue in merge'
	from /Users/dberger/.rbenv/versions/2.2.3/lib/ruby/2.2.0/uri/generic.rb:1097:in `merge'
	from /Users/dberger/.rbenv/versions/2.2.3/lib/ruby/2.2.0/uri/rfc3986_parser.rb:88:in `each'
	from /Users/dberger/.rbenv/versions/2.2.3/lib/ruby/2.2.0/uri/rfc3986_parser.rb:88:in `inject'
	from /Users/dberger/.rbenv/versions/2.2.3/lib/ruby/2.2.0/uri/rfc3986_parser.rb:88:in `join'
	from /Users/dberger/.rbenv/versions/2.2.3/lib/ruby/2.2.0/uri/common.rb:264:in `join'
	from (irb):55
	from /Users/dberger/.rbenv/versions/2.2.3/bin/irb:11:in `<main>'

irb(main):056:0> URI.join("foo://bar", ERB::Util.url_encode("[baz]"))
=> #<URI::Generic foo://bar/%5Bbaz%5D>
```

The general consensus on the intertubes is that URI.encode is kind of crappy and that you should use either CGI.encode or ERB::Util.url_encode. Since ERB is already loaded (as the templating system for Rails in general), I chose the latter.

There's also no need for the leading "/" since the .join call takes care of that already.

Work in Progress because there's apparently no specs for miq-file.rb yet...

