### PR TITLE
fix bug perf_capture_timer throwing exception for orphans on amazon.

### DIFF
--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -27,26 +27,19 @@ module Metric::Targets
     targets
   end
 
+  # @return vms under all availability zones
+  #         and vms under no availability zone
+  # NOTE: some stacks (e.g. nova) default to no availability zone
   def self.capture_cloud_targets(zone, options = {})
-    # things to worry about
-    # 1) need to find all the VMs under all the availability zones
-    # 2) need to find all the VMs that may not be in an availability zone
-    # 3) cloudy clusters?
-    targets = []
     return [] if options[:exclude_vms]
 
     includes = {:availability_zones => :tags}
     MiqPreloader.preload(zone.ems_clouds, includes)
 
-    targets += capture_vm_targets(zone.availability_zones, AvailabilityZone, options)
+    vms_with_availability_zone = capture_vm_targets(zone.availability_zones, AvailabilityZone, options)
+    vms_without_availability_zone = zone.vms_without_availability_zone
 
-    # Unlike in the infra world--where every VM must be on a Host--in the cloud
-    #   world (at least in OpenStack) some VMs might not be in an availability
-    #   zone ... in fact, the out-of-the-box setting in nova for the default
-    #   availability zone applied to new VMs is <NONE>.
-    # Track down those cloudy VMs that have no availability zone
-    targets += zone.vms_without_availability_zone unless options[:exclude_vms]
-    targets
+    vms_with_availability_zone + vms_without_availability_zone
   end
 
   def self.capture_container_targets(zone, _options)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -36,9 +36,9 @@ module Metric::Targets
     includes = {:availability_zones => [:tags, {:vms => :ext_management_system}], :vms => :availability_zone }
     MiqPreloader.preload(zone.ems_clouds, includes)
 
-    availability_zones = zone.ems_clouds.flat_map(&:availability_zones)
-    enabled_parents = availability_zones.select { |t| t.perf_capture_enabled? }
-    vms_with_availability_zone = enabled_parents.flat_map { |t| t.vms.select { |v| v.state == 'on' } }
+    vms_with_availability_zone = zone.ems_clouds.flat_map(&:availability_zones)
+                                     .select { |t| t.perf_capture_enabled? }
+                                     .flat_map { |t| t.vms.select { |v| v.state == 'on' } }
 
     vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
 

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -37,14 +37,9 @@ module Metric::Targets
     MiqPreloader.preload(zone.ems_clouds, includes)
 
     availability_zones = zone.ems_clouds.flat_map(&:availability_zones)
-    # vms_with_availability_zone = capture_vm_targets(availability_zones, AvailabilityZone, options)
-    targets = availability_zones
-      enabled_parents = targets.select do |t|
-        t.perf_capture_enabled?
-      end
+    enabled_parents = availability_zones.select { |t| t.perf_capture_enabled? }
       MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
-      vms = enabled_parents.flat_map { |t| t.vms.select { |v| v.state == 'on' } }
-    vms_with_availability_zone = vms
+    vms_with_availability_zone = enabled_parents.flat_map { |t| t.vms.select { |v| v.state == 'on' } }
 
     vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
 

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -33,11 +33,12 @@ module Metric::Targets
   def self.capture_cloud_targets(zone, options = {})
     return [] if options[:exclude_vms]
 
-    includes = {:availability_zones => :tags}
+    includes = {:availability_zones => :tags, :vms => :availability_zone }
     MiqPreloader.preload(zone.ems_clouds, includes)
 
-    vms_with_availability_zone = capture_vm_targets(zone.availability_zones, AvailabilityZone, options)
-    vms_without_availability_zone = zone.vms_without_availability_zone
+    availability_zones = zone.ems_clouds.flat_map(&:availability_zones)
+    vms_with_availability_zone = capture_vm_targets(availability_zones, AvailabilityZone, options)
+    vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
 
     vms_with_availability_zone + vms_without_availability_zone
   end

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -37,7 +37,21 @@ module Metric::Targets
     MiqPreloader.preload(zone.ems_clouds, includes)
 
     availability_zones = zone.ems_clouds.flat_map(&:availability_zones)
-    vms_with_availability_zone = capture_vm_targets(availability_zones, AvailabilityZone, options)
+    # vms_with_availability_zone = capture_vm_targets(availability_zones, AvailabilityZone, options)
+    targets, parent_class = availability_zones, AvailabilityZone
+    vms = []
+    unless options[:exclude_vms]
+      enabled_parents = targets.select do |t|
+        t.kind_of?(parent_class) &&
+        t.kind_of?(Metric::CiMixin) &&
+        t.perf_capture_enabled? &&
+        t.respond_to?(:vms)
+      end
+      MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
+      vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
+    end
+    vms_with_availability_zone = vms
+
     vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
 
     vms_with_availability_zone + vms_without_availability_zone

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -36,8 +36,7 @@ module Metric::Targets
     MiqPreloader.preload(zone.ems_clouds, :vms => [{:availability_zone => :tags}, :ext_management_system])
 
     zone.ems_clouds.flat_map(&:vms).select do |vm|
-      (vm.availability_zone.nil? || vm.availability_zone.perf_capture_enabled?) &&
-        vm.ext_management_system && vm.state == 'on'
+      vm.state == 'on' && (vm.availability_zone.nil? || vm.availability_zone.perf_capture_enabled?)
     end
   end
 

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -43,7 +43,7 @@ module Metric::Targets
         t.perf_capture_enabled?
       end
       MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
-      vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
+      vms = enabled_parents.flat_map { |t| t.vms.select { |v| v.state == 'on' } }
     vms_with_availability_zone = vms
 
     vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -35,9 +35,10 @@ module Metric::Targets
 
     MiqPreloader.preload(zone.ems_clouds, :vms => [{:availability_zone => :tags}, :ext_management_system])
 
-    zone.ems_clouds.flat_map(&:vms)
-        .select { |vm| vm.availability_zone.nil? || vm.availability_zone && vm.availability_zone.perf_capture_enabled? }
-      .select { |vm| vm.ext_management_system && vm.state == 'on' }
+    zone.ems_clouds.flat_map(&:vms).select do |vm|
+      (vm.availability_zone.nil? || vm.availability_zone.perf_capture_enabled?) &&
+        vm.ext_management_system && vm.state == 'on'
+    end
   end
 
   def self.capture_container_targets(zone, _options)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -37,11 +37,11 @@ module Metric::Targets
 
     vms_with_availability_zone = zone.ems_clouds.flat_map(&:vms)
                                      .select { |vm| vm.availability_zone && vm.availability_zone.perf_capture_enabled? }
-                                     .select { |v| v.state == 'on' }
 
     vms_without_availability_zone = zone.ems_clouds.flat_map(&:vms).select { |vm| vm.availability_zone.nil? }
 
-    vms_with_availability_zone + vms_without_availability_zone
+    (vms_with_availability_zone + vms_without_availability_zone)
+      .select { |vm| vm.ext_management_system && vm.state == 'on' }
   end
 
   def self.capture_container_targets(zone, _options)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -38,9 +38,9 @@ module Metric::Targets
 
     vms_with_availability_zone = zone.ems_clouds.flat_map(&:availability_zones)
                                      .select { |t| t.perf_capture_enabled? }
-                                     .flat_map { |t| t.vms.select { |v| v.state == 'on' } }
+                                     .flat_map(&:vms).select { |v| v.state == 'on' }
 
-    vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
+    vms_without_availability_zone = zone.ems_clouds.flat_map(&:vms).select { |vm| vm.availability_zone.nil? }
 
     vms_with_availability_zone + vms_without_availability_zone
   end

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -33,12 +33,11 @@ module Metric::Targets
   def self.capture_cloud_targets(zone, options = {})
     return [] if options[:exclude_vms]
 
-    includes = {:availability_zones => [:tags, {:vms => :ext_management_system}], :vms => :availability_zone }
-    MiqPreloader.preload(zone.ems_clouds, includes)
+    MiqPreloader.preload(zone.ems_clouds, :vms => [{:availability_zone => :tags}, :ext_management_system])
 
-    vms_with_availability_zone = zone.ems_clouds.flat_map(&:availability_zones)
-                                     .select { |t| t.perf_capture_enabled? }
-                                     .flat_map(&:vms).select { |v| v.state == 'on' }
+    vms_with_availability_zone = zone.ems_clouds.flat_map(&:vms)
+                                     .select { |vm| vm.availability_zone && vm.availability_zone.perf_capture_enabled? }
+                                     .select { |v| v.state == 'on' }
 
     vms_without_availability_zone = zone.ems_clouds.flat_map(&:vms).select { |vm| vm.availability_zone.nil? }
 

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -33,12 +33,11 @@ module Metric::Targets
   def self.capture_cloud_targets(zone, options = {})
     return [] if options[:exclude_vms]
 
-    includes = {:availability_zones => :tags, :vms => :availability_zone }
+    includes = {:availability_zones => [:tags, {:vms => :ext_management_system}], :vms => :availability_zone }
     MiqPreloader.preload(zone.ems_clouds, includes)
 
     availability_zones = zone.ems_clouds.flat_map(&:availability_zones)
     enabled_parents = availability_zones.select { |t| t.perf_capture_enabled? }
-      MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
     vms_with_availability_zone = enabled_parents.flat_map { |t| t.vms.select { |v| v.state == 'on' } }
 
     vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -33,6 +33,7 @@ module Metric::Targets
     # 2) need to find all the VMs that may not be in an availability zone
     # 3) cloudy clusters?
     targets = []
+    return [] if options[:exclude_vms]
 
     includes = {:availability_zones => :tags}
     MiqPreloader.preload(zone.ems_clouds, includes)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -38,18 +38,12 @@ module Metric::Targets
 
     availability_zones = zone.ems_clouds.flat_map(&:availability_zones)
     # vms_with_availability_zone = capture_vm_targets(availability_zones, AvailabilityZone, options)
-    targets, parent_class = availability_zones, AvailabilityZone
-    vms = []
-    unless options[:exclude_vms]
+    targets = availability_zones
       enabled_parents = targets.select do |t|
-        t.kind_of?(parent_class) &&
-        t.kind_of?(Metric::CiMixin) &&
-        t.perf_capture_enabled? &&
-        t.respond_to?(:vms)
+        t.perf_capture_enabled?
       end
       MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
       vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
-    end
     vms_with_availability_zone = vms
 
     vms_without_availability_zone = zone.ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -35,12 +35,8 @@ module Metric::Targets
 
     MiqPreloader.preload(zone.ems_clouds, :vms => [{:availability_zone => :tags}, :ext_management_system])
 
-    vms_with_availability_zone = zone.ems_clouds.flat_map(&:vms)
-                                     .select { |vm| vm.availability_zone && vm.availability_zone.perf_capture_enabled? }
-
-    vms_without_availability_zone = zone.ems_clouds.flat_map(&:vms).select { |vm| vm.availability_zone.nil? }
-
-    (vms_with_availability_zone + vms_without_availability_zone)
+    zone.ems_clouds.flat_map(&:vms)
+        .select { |vm| vm.availability_zone.nil? || vm.availability_zone && vm.availability_zone.perf_capture_enabled? }
       .select { |vm| vm.ext_management_system && vm.state == 'on' }
   end
 

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -168,9 +168,8 @@ class Zone < ApplicationRecord
   end
 
   def vms_without_availability_zone
-    clouds = ext_management_systems.select { |e| e.kind_of?(EmsCloud) }
-    MiqPreloader.preload(clouds, :vms => :availability_zone)
-    clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
+    MiqPreloader.preload(ems_clouds, :vms => :availability_zone)
+    ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
   end
 
   def vms_and_templates

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -167,11 +167,6 @@ class Zone < ApplicationRecord
     ems_clouds.flat_map(&:availability_zones)
   end
 
-  def vms_without_availability_zone
-    MiqPreloader.preload(ems_clouds, :vms => :availability_zone)
-    ems_clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
-  end
-
   def vms_and_templates
     MiqPreloader.preload(self, :ext_management_systems => :vms_and_templates)
     ext_management_systems.flat_map(&:vms_and_templates)

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1107,6 +1107,7 @@ describe Metric do
         @vms_in_az = []
         2.times { @vms_in_az << FactoryGirl.create(:vm_openstack, :ems_id => @ems_openstack.id) }
         @availability_zone.vms = @vms_in_az
+        @availability_zone.vms.push(FactoryGirl.create(:vm_openstack, :ems_id => nil))
 
         @vms_not_in_az = []
         3.times { @vms_not_in_az << FactoryGirl.create(:vm_openstack, :ems_id => @ems_openstack.id) }

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -60,29 +60,6 @@ describe Zone do
 
       expect(@zone.availability_zones).to match_array(azs)
     end
-
-    it "returns the set of vms_without_availability_zones" do
-      openstacks = [FactoryGirl.create(:ems_openstack, :zone => @zone),
-                    FactoryGirl.create(:ems_openstack, :zone => @zone)]
-      azs        = [FactoryGirl.create(:availability_zone, :ems_id => openstacks[0].id),
-                    FactoryGirl.create(:availability_zone, :ems_id => openstacks[1].id)]
-      vms_in_az = []
-      vms_not_in_az = []
-      2.times do
-        vm = FactoryGirl.create(:vm_openstack)
-        azs[0].vms << vm
-        vms_in_az << vm
-      end
-      2.times do
-        vm = FactoryGirl.create(:vm_openstack)
-        azs[1].vms << vm
-        vms_in_az << vm
-      end
-      3.times { vms_not_in_az << FactoryGirl.create(:vm_openstack, :ems_id => openstacks[0].id) }
-      3.times { vms_not_in_az << FactoryGirl.create(:vm_openstack, :ems_id => openstacks[1].id) }
-
-      expect(@zone.vms_without_availability_zone).to match_array(vms_not_in_az)
-    end
   end
 
   context ".determine_queue_zone" do


### PR DESCRIPTION
```
[----] E, [2016-05-03T09:36:32.318121 #18752:df5994] ERROR -- : MIQ(MiqQueue#deliver) Message id: [1000005808463], Error: [undefined method `metrics_collector_queue_name' for nil:NilClass]
[----] E, [2016-05-03T09:36:32.318339 #18752:df5994] ERROR -- : [NoMethodError]: undefined method `metrics_collector_queue_name' for nil:NilClass  Method:[rescue in deliver]
[----] E, [2016-05-03T09:36:32.318634 #18752:df5994] ERROR -- : /var/www/miq/vmdb/app/models/metric/ci_mixin/capture.rb:19:in `queue_name_for_metrics_collection'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1332579
https://bugzilla.redhat.com/show_bug.cgi?id=1331803


**before:**

The code that lists machines that need to run performance capture is returning machines with no ems. This is blowing up when looking up the queue_name to submit the job.

For vms that are in an availability zone, it captures performance from vms that have a `state == "on"`. For vms that are not in an availability zone, it captures vms that are in any state.

Vms are looked up in multiple ways. Vms can be brought back 2-3 times.

**after:**

Capture is only performed on vms that are "on" and have an ems. They are brought back in 1 query.