### PR TITLE
Remove inputs parameter from MiqExpression#evaluate and MiqExpression.evaluate

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1016,7 +1016,7 @@ class MiqExpression
     Metric::Rollup.excluded_col_for_expression?(col.to_sym)
   end
 
-  def self.evaluate(expression, obj, _inputs = {}, tz = nil)
+  def self.evaluate(expression, obj, tz = nil)
     ruby_exp = expression.kind_of?(Hash) ? new(expression).to_ruby(tz) : expression.to_ruby(tz)
     _log.debug("Expression before substitution: #{ruby_exp}")
     subst_expr = Condition.subst(ruby_exp, obj)
@@ -1026,22 +1026,22 @@ class MiqExpression
     result
   end
 
-  def evaluate(obj, inputs = {}, tz = nil)
-    self.class.evaluate(self, obj, inputs, tz)
+  def evaluate(obj, tz = nil)
+    self.class.evaluate(self, obj, tz)
   end
 
-  def self.evaluate_atoms(exp, obj, inputs = {})
+  def self.evaluate_atoms(exp, obj)
     exp = exp.kind_of?(self) ? copy_hash(exp.exp) : exp
-    exp["result"] = evaluate(exp, obj, inputs)
+    exp["result"] = evaluate(exp, obj)
 
     operators = exp.keys
     operators.each do|k|
       if ["and", "or"].include?(k.to_s.downcase)      # and/or atom is an array of atoms
         exp[k].each do|atom|
-          evaluate_atoms(atom, obj, inputs)
+          evaluate_atoms(atom, obj)
         end
       elsif ["not", "!"].include?(k.to_s.downcase)    # not atom is a hash expression
-        evaluate_atoms(exp[k], obj, inputs)
+        evaluate_atoms(exp[k], obj)
       else
         next
       end

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -262,7 +262,7 @@ module MiqReport::Generator::Html
       return atom[:class] if atom[:operator].downcase == "default"
 
       exp = expression_for_style_class(field, atom)
-      return atom[:class] if exp.evaluate(nh, {}, tz)
+      return atom[:class] if exp.evaluate(nh, tz)
     end
     nil
   end

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -2059,4 +2059,39 @@ describe MiqExpression do
       expect(obj.field_in_sql?(field)).to eq(true)
     end
   end
+
+  describe "#evaluate" do
+    before do
+      @data_hash = {"guest_applications.name"   => "VMware Tools",
+                    "guest_applications.vendor" => "VMware, Inc."}
+    end
+
+    it "returns true if expression evaluated to value equal to value in supplied hash" do
+      expression = {"=" => {"field" => "Vm.guest_applications-name",
+                            "value" => "VMware Tools"}}
+      obj = described_class.new(expression, "hash")
+      expect(obj.evaluate(@data_hash)).to eq(true)
+    end
+
+    it "returns false if expression evaluated to value not equal to value in supplied hash" do
+      expression = {"=" => {"field" => "Vm.guest_applications-name",
+                            "value" => "Hello"}}
+      obj = described_class.new(expression, "hash")
+      expect(obj.evaluate(@data_hash)).to eq(false)
+    end
+
+    it "returns true if expression is regex and there is match in supplied hash" do
+      expression = {"REGULAR EXPRESSION MATCHES" => {"field" => "Vm.guest_applications-vendor",
+                                                     "value" => "/^[^.]*ware.*$/"}}
+      obj = described_class.new(expression, "hash")
+      expect(obj.evaluate(@data_hash)).to eq(true)
+    end
+
+    it "returns false if expression is regex and there is no match in supplied hash" do
+      expression = {"REGULAR EXPRESSION MATCHES" => {"field" => "Vm.guest_applications-vendor",
+                                                     "value" => "/^[^.]*hello.*$/"}}
+      obj = described_class.new(expression, "hash")
+      expect(obj.evaluate(@data_hash)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Refactoring MiqExpression - #7751

This PR is next step after #8232 
1. Remove not used parameter 'input' from #evaluate and .evaluate
2. Added test coverage for MiqExpression#evaluate

/cc @imtayadeway 
@miq-bot add-label core, refactoring 
