### PR TITLE
Display correct toolbar for saved report

### DIFF
--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -340,9 +340,11 @@ class ApplicationHelper::ToolbarChooser
         return "miq_widget_set_center_tb"
       end
     elsif x_active_tree == :savedreports_tree
-      node = x_node
-      return  node == "root" || node.split('-').first != "rr" ?
-          "saved_reports_center_tb" : "saved_report_center_tb"
+      if x_node == "root" || x_node.split('_').last.split('-').first != "rr"
+        return "saved_reports_center_tb"
+      else
+        return "saved_report_center_tb"
+      end
     elsif x_active_tree == :reports_tree
       nodes = x_node.split('-')
       if nodes.length == 5


### PR DESCRIPTION
Previously, a toolbar for all saved reports would be rendered when a particular saved report was
selected in the explorer tree. This meant we were not able to delete the selected saved report.

Before:
![saved-reports-before](https://cloud.githubusercontent.com/assets/6648365/15009684/40edc156-11e8-11e6-8e06-c080ef9cdb34.jpg)

After:
![saved-reports-after](https://cloud.githubusercontent.com/assets/6648365/15009699/48e9dde0-11e8-11e6-885e-f49a8b5ccc7c.jpg)

