### PR TITLE
SmartState: Make docker registry & repo configurable for 'image-inspector'.

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -3,7 +3,7 @@ require 'kubeclient'
 
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager
-  INSPECTOR_NAMESPACE_FALLBACK = 'management-infra'
+  INSPECTOR_IMAGE_TAG = '2.1'.freeze
   INSPECTOR_PORT = 8080
   DOCKER_SOCKET = '/var/run/docker.sock'
   SCAN_CATEGORIES = %w(system software)
@@ -48,7 +48,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     return queue_signal(:abort_job, "cannot analyze non docker images", "error") unless image.docker_id
 
     namespace = ::Settings.ems.ems_kubernetes.miq_namespace
-    namespace = INSPECTOR_NAMESPACE_FALLBACK if namespace.blank?
 
     update!(:options => options.merge(
       :docker_image_id => image.docker_id,
@@ -419,7 +418,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def inspector_image
-    'docker.io/openshift/image-inspector:2.1'
+    registry = ::Settings.ems.ems_kubernetes.image_inspector_registry
+    repo = ::Settings.ems.ems_kubernetes.image_inspector_repository
+    "#{registry}/#{repo}:#{INSPECTOR_IMAGE_TAG}"
   end
 
   def inspector_proxy_env_variables

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,6 +102,8 @@
       :read_timeout: 1.hour
   :ems_kubernetes:
     :miq_namespace: management-infra
+    :image_inspector_registry: docker.io
+    :image_inspector_repository: openshift/image-inspector
   :ems_azure:
     :disabled_regions: []
     :additional_regions: {}


### PR DESCRIPTION
RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1378007

Based on #7036 by @dtrieu80 (preserving Author), believe I addressed comments there.

> Currently, job.rb has a hardcoded reference to the image-inspector. It assumes that it can be retrievable from docker.io.
> In some instances, the docker.io registry is inaccessible, so we need to be able to configure a different registry (local or other reachable registry).

@dtrieu80 Note that this will probably not suffice to do image scanning in a disconnected installation — the image inspector needs internet access to download OpenSCAP definitions.
That part is tracked in https://bugzilla.redhat.com/show_bug.cgi?id=1378007 / https://github.com/openshift/image-inspector/issues/18.
- Rebased on master, use Settings instead of deprecated Config.
- Tag left as constant in code as @simon3z said our code strictly depends on a specific version.
- @moolitayer suggested assuming the new setting is always there ("can crash and burn").
  But the actual failure mode if user will delete these settings is bad: nil silently becomes empty string => we do create a pod with malformed image name e.g. `docker.io/:v1.0.z` => the pod never runs (RunContainerError or ImagePullBackOff state) => wait_pod goes into infinite loop.
  I didn't want to add exception catching and reporting for a scenario which "shouldn't happen", so made the setting optional with a default value in the code, as already done with `miq_namespace`.  Easy but non-DRY...
- What's worse, if the configuration exists but is bad — including the original motivation here of docker.io being inaccessible on some networks — the pod never runs and ~~we go into infinite loop~~.  The user gets no diagnostic :-(

[@moolitayer has some PRs for better error handling, anyway out of scope here.]

P.S. I haven't tested the full scenario of running my own registry.
But I see a pod with customized image name being created:

```
[----] I, [2016-05-...]  INFO -- : ... MIQ(ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job#start) creating pod ...: {"apiVersion":"v1","kind":"Pod","metadata":...,"spec":{"restartPolicy":"Never","containers":[{"name":"image-inspector","image":"myregistry.example.com/openshift-fork/image-inspector-spoon:v1.0.z", ...}],"volumes":...}}

$ oc describe pod -n management-infra manageiq-img-scan-2b05b
Name:       manageiq-img-scan-2b05b
Namespace:  management-infra
Image(s):   myregistry.example.com/openshift-fork/image-inspector-spoon:2.0
...
```
