### PR TITLE
Migration for setting report type from chargeback to ChargebackVm on MiqReports

### DIFF
--- a/db/migrate/20160504074011_set_report_type_from_chargeback_to_chargeback_vm_on_miq_reports.rb
+++ b/db/migrate/20160504074011_set_report_type_from_chargeback_to_chargeback_vm_on_miq_reports.rb
@@ -1,0 +1,27 @@
+class SetReportTypeFromChargebackToChargebackVmOnMiqReports < ActiveRecord::Migration[5.0]
+  CHARGEBACK_REPORT_DB_MODEL = "Chargeback".freeze # old
+  CHARGEBACK_VM_REPORT_DB_MODEL = "ChargebackVm".freeze # new
+
+  class MiqReport < ActiveRecord::Base
+    serialize :db_options
+  end
+
+  def up
+    say_with_time('Set Chargeback to ChargebackVm on MiqReports for db column rtp_type in db_options') do
+      MiqReport.where(:db => CHARGEBACK_REPORT_DB_MODEL).all.each do |miq_report|
+        miq_report.db_options[:rpt_type] = miq_report.db = CHARGEBACK_VM_REPORT_DB_MODEL
+        miq_report.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time('Set ChargebackVm back to Chargeback on MiqReports for db column in db_options') do
+      MiqReport.where(:db => CHARGEBACK_VM_REPORT_DB_MODEL).all.each do |miq_report|
+        miq_report.db_options[:rpt_type] = CHARGEBACK_REPORT_DB_MODEL.downcase
+        miq_report.db = CHARGEBACK_REPORT_DB_MODEL
+        miq_report.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20160504074011_set_report_type_from_chargeback_to_chargeback_vm_on_miq_reports_spec.rb
+++ b/spec/migrations/20160504074011_set_report_type_from_chargeback_to_chargeback_vm_on_miq_reports_spec.rb
@@ -1,0 +1,43 @@
+require_migration
+
+describe SetReportTypeFromChargebackToChargebackVmOnMiqReports do
+  let(:miq_report_stub) { migration_stub(:MiqReport) }
+
+  migration_context :up do
+    it "sets with db = ChargeBack to ChargebackVm for column db and db_option[:rpt_type]" do
+      db_options = {}
+      db_options[:rpt_type] = described_class::CHARGEBACK_REPORT_DB_MODEL
+
+      miq_reports = Array.new(2) do
+        miq_report_stub.create!(:db => described_class::CHARGEBACK_REPORT_DB_MODEL, :db_options => db_options)
+      end
+
+      migrate
+
+      miq_reports.each do |miq_report|
+        miq_report.reload
+        expect(miq_report.db).to eq(described_class::CHARGEBACK_VM_REPORT_DB_MODEL)
+        expect(miq_report.db_options[:rpt_type]).to eq(described_class::CHARGEBACK_VM_REPORT_DB_MODEL)
+      end
+    end
+  end
+
+  migration_context :down do
+    it "sets with db = ChargeBackVm to Chargeback for column db and db_option[:rpt_type]" do
+      db_options = {}
+      db_options[:rpt_type] = described_class::CHARGEBACK_VM_REPORT_DB_MODEL
+
+      miq_reports = Array.new(2) do
+        miq_report_stub.create!(:db => described_class::CHARGEBACK_VM_REPORT_DB_MODEL, :db_options => db_options)
+      end
+
+      migrate
+
+      miq_reports.each do |miq_report|
+        miq_report.reload
+        expect(miq_report.db).to eq(described_class::CHARGEBACK_REPORT_DB_MODEL)
+        expect(miq_report.db_options[:rpt_type]).to eq(described_class::CHARGEBACK_REPORT_DB_MODEL.downcase)
+      end
+    end
+  end
+end


### PR DESCRIPTION
after design introduced in https://github.com/ManageIQ/manageiq/pull/7081, we are not longer using Chargeback as base model of reports, we have ChargebackVm and ChargebackContainerProjects instead of and especially ChargebackVm is previous Chargeback - so need to convert for existing chargeback reports to use ChargebackVm as report type (otherwise it is failing when queeing existing chargeback report)

so this migration it affects columns:
MiqReport#db and MiqReport#db_options[:rpt_type] - is set to ChargebackVm

cc @gtanzillo @zeari 
