### PR TITLE
Fix Foreman & Ansible Tower reports

### DIFF
--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
@@ -47,6 +47,7 @@ include_for_find:
 col_order:
 - name
 - provider.url
+- type
 - zone.name
 - last_refresh_date
 - region_description
@@ -57,6 +58,7 @@ col_order:
 headers:
 - Provider Name
 - URL
+- Type
 - Zone
 - Last Refresh Date
 - Region Description
@@ -66,7 +68,7 @@ headers:
 col_formats:
 -
 -
--
+- :model_name
 -
 -
 

--- a/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
@@ -60,8 +60,8 @@ col_order:
 headers:
 - Provider Name
 - URL
-- Zone
 - Type
+- Zone
 - Last Refresh Date
 - Region Description
 - Status
@@ -71,7 +71,7 @@ headers:
 col_formats:
 -
 -
--
+- :model_name
 -
 -
 -


### PR DESCRIPTION
Fixes:
* Correct headers of displayed columns in foreman report
* Added provider type column to ansible tower report
* type in both reports will display nice provider type string (rather than model name)

Ansible before:
![ansible-before](https://cloud.githubusercontent.com/assets/6648365/15012857/3dbea9e6-11fc-11e6-920b-16446a827111.jpg)

Ansible after:
![ansible-after](https://cloud.githubusercontent.com/assets/6648365/15012858/3dc09332-11fc-11e6-8a55-f7e3df86bb7c.jpg)

Foreman before:
![foreman-before](https://cloud.githubusercontent.com/assets/6648365/15012866/4a3557e2-11fc-11e6-9d47-af8c929862a0.jpg)

Foreman after:
![foreman-after](https://cloud.githubusercontent.com/assets/6648365/15012867/4a38e98e-11fc-11e6-90e3-516fc5e83949.jpg)

