### PR TITLE
Render user-friendly type of configured system in reports

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -725,7 +725,8 @@ en:
       ManageIQ::Providers::AnsibleTower::ConfigurationManager:              Configuration Manager (Ansible)
       ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
-      ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Foreman Configured System
+      ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem: Configured System (Ansible)
+      ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Configured System (Foreman)
       ManageIQ::Providers::CloudManager:                                    Cloud Provider
       ManageIQ::Providers::CloudManager::Vm:                                Instance
       ManageIQ::Providers::CloudManager::Template:                          Image

--- a/product/views/ConfiguredSystem.yaml
+++ b/product/views/ConfiguredSystem.yaml
@@ -49,7 +49,7 @@ headers:
 
 col_formats:
 -
--
+- :model_name
 -
 -
 

--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
@@ -50,7 +50,7 @@ headers:
 
 col_formats:
 -
--
+- :model_name
 -
 -
 

--- a/product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+++ b/product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
@@ -52,7 +52,7 @@ headers:
 
 col_formats:
 -
--
+- :model_name
 -
 -
 -


### PR DESCRIPTION
Before:

![configured-systems-before](https://cloud.githubusercontent.com/assets/6648365/15013468/078c1e2c-1200-11e6-8fd8-4c3e3f0ecd65.jpg)

After:
![configured-systems-after](https://cloud.githubusercontent.com/assets/6648365/15013469/079f8a34-1200-11e6-9d12-23c672c75b85.jpg)
