### PR TITLE
Output reports in different currency types instead only USD

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -95,6 +95,15 @@ module MiqReport::Formatting
     end
 
     options[:column] = col
+
+    # Chargeback Reports: Add the selected currency in the assigned rate to options
+    if db.to_s == "ChargebackVm" || db.to_s == "ChargebackContainerProject"
+      compute_selected_rate = ChargebackRate.get_assignments(:compute)[0]
+      storage_selected_rate = ChargebackRate.get_assignments(:storage)[0]
+      selected_rate = compute_selected_rate.nil? ? storage_selected_rate : compute_selected_rate
+      options[:unit] = selected_rate[:cb_rate].chargeback_rate_details[0].detail_currency.symbol unless selected_rate.nil?
+    end
+
     format.merge!(options) if format # Merge additional options that were passed in as overrides
     value = apply_format_function(value, format) if format && !format[:function].nil?
 
@@ -134,6 +143,7 @@ module MiqReport::Formatting
     helper_options = {}
     helper_options[:delimiter] = options[:delimiter] if options.key?(:delimiter)
     helper_options[:separator] = options[:separator] if options.key?(:separator)
+    helper_options[:unit] = options [:unit] if options.key?(:unit)
     val = apply_format_precision(val, options[:precision])
     val = ApplicationController.helpers.number_to_currency(val, helper_options)
     apply_prefix_and_suffix(val, options)

--- a/spec/models/miq_report/formatting_spec.rb
+++ b/spec/models/miq_report/formatting_spec.rb
@@ -6,6 +6,22 @@ describe MiqReport, "::Formatting" do
       expect(subject.format_currency_with_delimiter(1234567890.50, :prefix => "Front ", :suffix => " Back"))
         .to eq("Front $1,234,567,890.50 Back")
     end
+    it "puts Dollars as the unit to NumberHelper#number_to_currency" do
+      expect(subject.format_currency_with_delimiter(1234567890.50, :unit => "$"))
+        .to eq("$1,234,567,890.50")
+    end
+    it "puts Euro as the unit to NumberHelper#number_to_currency" do
+      expect(subject.format_currency_with_delimiter(1234567890.50, :unit => "€"))
+        .to eq("€1,234,567,890.50")
+    end
+    it "puts Pounds as the unit to NumberHelper#number_to_currency" do
+      expect(subject.format_currency_with_delimiter(1234567890.50, :unit => "£"))
+        .to eq("£1,234,567,890.50")
+    end
+    it "puts Yen as the unit to NumberHelper#number_to_currency" do
+      expect(subject.format_currency_with_delimiter(1234567890.50, :unit => "¥"))
+        .to eq("¥1,234,567,890.50")
+    end
   end
 
   describe "#format_number_with_delimiter" do


### PR DESCRIPTION
This PR fixes #7723. 

Currently, ManageIQ only supports reports for USD. With this PR, we can generate them in different types of currencies, such as EUR, GBP, etc.

As we can generate Chargeback reports for compute and storage independently, we have chosen to force out those reports to the currency assigned to compute, due lack of information about that. It should be defined in the future.

![captura del escritorio de 06-05-16 11-03-09](https://cloud.githubusercontent.com/assets/13876427/15069058/8709210a-137b-11e6-91d2-be388077773c.gif)


@amaurygonzalez @delaluzparra thanks!