### PR TITLE
Show IP adresses based on network ports

### DIFF
--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module NetworkPortHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name mac_address type fixed_ips)
+    %i(name mac_address type floating_ip_addresses fixed_ip_addresses)
   end
 
   def textual_group_relationships
@@ -30,8 +30,12 @@ module NetworkPortHelper::TextualSummary
     ui_lookup(:model => @record.type)
   end
 
-  def textual_fixed_ips
-    @record.cloud_subnet_network_ports.collect(&:address).join(", ") unless @record.cloud_subnet_network_ports.blank?
+  def textual_fixed_ip_addresses
+    @record.fixed_ip_addresses.join(", ") if @record.fixed_ip_addresses
+  end
+
+  def textual_floating_ip_addresses
+    @record.floating_ip_addresses.join(", ") if @record.floating_ip_addresses
   end
 
   def textual_parent_ems_cloud

--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -49,8 +49,9 @@ module NetworkPortHelper::TextualSummary
   def textual_instance
     label    = ui_lookup(:table => "vm_cloud")
     instance = @record.device
-    h        = {:label => label, :image => "vm"}
+    h        = nil
     if instance && role_allows(:feature => "vm_show")
+      h = {:label => label, :image => "vm"}
       h[:value] = instance.name
       h[:link]  = url_for(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
       h[:title] = _("Show %{label}") % {:label => label}

--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module NetworkPortHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name mac_address type floating_ip_addresses fixed_ip_addresses)
+    %i(name mac_address type device_owner floating_ip_addresses fixed_ip_addresses)
   end
 
   def textual_group_relationships
@@ -28,6 +28,10 @@ module NetworkPortHelper::TextualSummary
 
   def textual_type
     ui_lookup(:model => @record.type)
+  end
+
+  def textual_device_owner
+    @record.device_owner
   end
 
   def textual_fixed_ip_addresses

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -6,7 +6,7 @@ module VmCloudHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name region server description ipaddress custom_1 container tools_status osinfo architecture advanced_settings resources guid virtualization_type root_device_type)
+    %i(name region server description ipaddress mac_address custom_1 container tools_status osinfo architecture advanced_settings resources guid virtualization_type root_device_type)
   end
 
   def textual_group_vm_cloud_relationships
@@ -93,6 +93,12 @@ module VmCloudHelper::TextualSummary
     return nil if @record.template?
     ips = @record.ipaddresses
     {:label => n_("IP Address", "IP Addresses", ips.size), :value => ips.join(", ")}
+  end
+
+  def textual_mac_address
+    return nil if @record.template?
+    macs = @record.mac_addresses
+    {:label => n_("MAC Address", "MAC Addresses", macs.size), :value => macs.join(", ")}
   end
 
   def textual_custom_1

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -26,6 +26,17 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
 
   default_value_for :cloud, true
 
+  virtual_column :ipaddresses,   :type => :string_set, :uses => {:network_ports => :ipaddresses}
+  virtual_column :mac_addresses, :type => :string_set, :uses => :network_ports
+
+  def ipaddresses
+    @ipaddresses ||= network_ports.collect(&:ipaddresses).flatten.compact.uniq
+  end
+
+  def mac_addresses
+    @mac_addresses ||= network_ports.collect(&:mac_address).compact.uniq
+  end
+
   def perf_rollup_parents(interval_name = nil)
     [availability_zone].compact unless interval_name == 'realtime'
   end

--- a/app/models/manageiq/providers/google/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm.rb
@@ -3,6 +3,17 @@ class ManageIQ::Providers::Google::CloudManager::Vm < ManageIQ::Providers::Cloud
 
   has_and_belongs_to_many :security_groups, :join_table => :security_groups_vms, :foreign_key => :vm_id
 
+  # TODO(NetworkManager) ipaddresses and mac_addresses will go away when we will rewrite google to have NetworkManager
+  virtual_column :ipaddresses,   :type => :string_set, :uses => {:hardware => :ipaddresses}
+  virtual_column :mac_addresses, :type => :string_set, :uses => {:hardware => :mac_addresses}
+  def ipaddresses
+    hardware.nil? ? [] : hardware.ipaddresses
+  end
+
+  def mac_addresses
+    hardware.nil? ? [] : hardware.mac_addresses
+  end
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.servers.get(name, availability_zone.name)

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -30,6 +30,22 @@ class NetworkPort < ApplicationRecord
   virtual_column :allowed_address_pairs,             :type => :string # :array
   virtual_column :fixed_ips,                         :type => :string # :array
 
+  virtual_column :ipaddresses, :type => :string_set, :uses => [:cloud_subnet_network_ports, :floating_ips]
+  virtual_column :fixed_ip_addresses, :type => :string_set, :uses => :cloud_subnet_network_ports
+  virtual_column :floating_ip_addresses, :type => :string_set, :uses => :floating_ips
+
+  def floating_ip_addresses
+    @floating_ip_addresses ||= floating_ips.collect(&:address).compact.uniq
+  end
+
+  def fixed_ip_addresses
+    @fixed_ip_addresses ||= cloud_subnet_network_ports.collect(&:address).compact.uniq
+  end
+
+  def ipaddresses
+    @ipaddresses ||= (fixed_ip_addresses || []) + (floating_ip_addresses || [])
+  end
+
   # Define all getters and setters for extra_attributes related virtual columns
   %i(binding_virtual_interface_details binding_virtual_nic_type binding_profile extra_dhcp_opts
      allowed_address_pairs fixed_ips).each do |action|

--- a/product/views/NetworkPort.yaml
+++ b/product/views/NetworkPort.yaml
@@ -21,6 +21,7 @@ db: NetworkPort
 cols:
 - name
 - mac_address
+- ipaddresses
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -40,13 +41,15 @@ include_for_find:
 col_order:
 - name
 - mac_address
+- ipaddresses
 #- device.name
 - ext_management_system.name
 
 # Column titles, in order
 headers:
 - Name
-- Mac Adress
+- Mac Address
+- IP Addresses
 #- Instance name
 - Network Provider
 


### PR DESCRIPTION
For Cloud VMs show IPs and MACs based on network_ports
    
For Cloud VMs show IPs and MACs based on network_ports. Which is
also fixing showing ip's when VM have multiple ports. And for
ipv6, showing all IPs, even when multiple IPs are associated to
one port.
    
For now, only Google Provider is not supporting this, until it will
be rewritten to use a NetworkManager.
    
Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1303997
https://bugzilla.redhat.com/show_bug.cgi?id=1316026

Also adding mac_addresses and ip_addresses to several summaries and lists