### PR TITLE
Metric::Target capture_vm_targets

### DIFF
--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -75,7 +75,7 @@ module Metric::Targets
         t.respond_to?(:vms)
     end
     MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
-    enabled_parents.flat_map { |t| t.vms.select { |v| v.state == 'on' } }
+    enabled_parents.flat_map { |t| t.vms.select { |v| v.ext_management_system && v.state == 'on' } }
   end
 
   # If a Cluster, standalone Host, or Storage is not enabled, skip it.

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -75,8 +75,7 @@ module Metric::Targets
         t.respond_to?(:vms)
     end
     MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
-    vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
-    vms
+    enabled_parents.flat_map { |t| t.vms.select { |v| v.state == 'on' } }
   end
 
   # If a Cluster, standalone Host, or Storage is not enabled, skip it.

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -67,17 +67,15 @@ module Metric::Targets
   end
 
   def self.capture_vm_targets(targets, parent_class, options)
-    vms = []
-    unless options[:exclude_vms]
-      enabled_parents = targets.select do |t|
-        t.kind_of?(parent_class) &&
+    return Vm.none if options[:exclude_vms]
+    enabled_parents = targets.select do |t|
+      t.kind_of?(parent_class) &&
         t.kind_of?(Metric::CiMixin) &&
         t.perf_capture_enabled? &&
         t.respond_to?(:vms)
-      end
-      MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
-      vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
     end
+    MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
+    vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
     vms
   end
 


### PR DESCRIPTION
simplify `capture_vm_targets`

Tangentially related to #8429 and

https://bugzilla.redhat.com/show_bug.cgi?id=1332579
https://bugzilla.redhat.com/show_bug.cgi?id=1331803

**Before:**

- traversed all vm parents instead of the ones that we said were relevant. [performance]
- returned vms even if they did not have an ems [bug]

**After:**

- loop over the parents we said were relevant
- ensure the vm has an ems before returning it. This is no longer called for cloud vms, and doesn't show up for infra vms. Put this in anyway to ensure it is part of the contract.

/cc @blomquisg minor. benefit is more from the simplification and the bug / performance fix.