### PR TITLE
Filter networks and floating_ips for OpenStack provisioning

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -4,4 +4,7 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
                           :join_table              => "cloud_tenants_vms",
                           :association_foreign_key => "vm_id",
                           :class_name              => "ManageIQ::Providers::Openstack::CloudManager::Template"
+
+  has_many :private_networks, :foreign_key => :cloud_tenant_id, :dependent => :destroy,
+           :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private"
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -5,6 +5,6 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
                           :association_foreign_key => "vm_id",
                           :class_name              => "ManageIQ::Providers::Openstack::CloudManager::Template"
 
-  has_many :private_networks, :foreign_key => :cloud_tenant_id, :dependent => :destroy,
+  has_many :private_networks,
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private"
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -329,20 +329,20 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           end
 
           it "#allowed_floating_ip_addresses with tenant selected" do
-            workflow.values.merge!(:cloud_tenant  => @ct2.id)
-            workflow.values.merge!(:cloud_network => @cloud_network.id)
+            workflow.values[:cloud_tenant]  = @ct2.id
+            workflow.values[:cloud_network] = @cloud_network.id
             ips = workflow.allowed_floating_ip_addresses
             expect(ips.keys).to match_array [@ip2.id]
           end
 
           it "#allowed_floating_ip_addresses with tenant not selected" do
-            workflow.values.merge!(:cloud_network => @cloud_network.id)
+            workflow.values[:cloud_network] = @cloud_network.id
             ips = workflow.allowed_floating_ip_addresses
             expect(ips.keys).to match_array [@ip2.id, @ip1.id]
           end
 
           it "#allowed_floating_ip_addresses with network not connected to the router" do
-            workflow.values.merge!(:cloud_network => @cloud_network_2.id)
+            workflow.values[:cloud_network] = @cloud_network_2.id
             ips = workflow.allowed_floating_ip_addresses
             expect(ips.keys).to match_array []
           end


### PR DESCRIPTION
Filter networks and floating_ips for OpenStack provisioning. Only
non-external networks should be connectable to the VM. And only
floating IPs, that are connected through the router to the
chosen non external network should be available. The connection
is now shown in the topology graph.