### PR TITLE
Use Addressable instead of URI for File.path_to_uri.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -13,6 +13,7 @@ gem "activesupport",           "~> 5.0.x", :git => "git://github.com/rails/rails
 gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "master"
 
 # Not locally modified and not required
+gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.3",            :require => false
 gem "azure-armrest",           "~> 0.2.4"
 gem "bcrypt",                  "~> 3.1.10",         :require => false

--- a/gems/pending/spec/util/miq-file_spec.rb
+++ b/gems/pending/spec/util/miq-file_spec.rb
@@ -1,0 +1,33 @@
+require 'util/extensions/miq-file'
+
+describe 'MIQFile' do
+  context 'path_to_uri' do
+    let(:hostname) { MiqSockUtil.getFullyQualifiedDomainName }
+
+    it 'is defined and returns a string' do
+      expect(File).to respond_to(:path_to_uri)
+      expect(File.path_to_uri('foo')).to be_kind_of(String)
+    end
+
+    it 'returns the expected result' do
+      expect(File.path_to_uri('foo')).to eql("file://#{hostname}/foo")
+      expect(File.path_to_uri('foo/bar')).to eql("file://#{hostname}/foo/bar")
+      expect(File.path_to_uri('foo/bar-stuff')).to eql("file://#{hostname}/foo/bar-stuff")
+      expect(File.path_to_uri('foo/C:/bar')).to eql("file://#{hostname}/foo/C:/bar")
+      expect(File.path_to_uri('foo/[bar]')).to eql("file://#{hostname}/foo/%5Bbar%5D")
+    end
+
+    it 'accepts an optional hostname and returns the expected result' do
+      hostname = 'dell-r410-01.cloudformswin.lab.redhat.com'
+      expect(File.path_to_uri('foo', hostname)).to eql("file://#{hostname}/foo")
+      expect(File.path_to_uri('foo/bar', hostname)).to eql("file://#{hostname}/foo/bar")
+      expect(File.path_to_uri('foo/bar-stuff', hostname)).to eql("file://#{hostname}/foo/bar-stuff")
+      expect(File.path_to_uri('foo/C:/bar', hostname)).to eql("file://#{hostname}/foo/C:/bar")
+      expect(File.path_to_uri('foo/[bar]', hostname)).to eql("file://#{hostname}/foo/%5Bbar%5D")
+    end
+
+    it 'requires at least one argument' do
+      expect { File.path_to_uri }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/gems/pending/spec/util/miq-file_spec.rb
+++ b/gems/pending/spec/util/miq-file_spec.rb
@@ -18,12 +18,17 @@ describe 'MIQFile' do
     end
 
     it 'accepts an optional hostname and returns the expected result' do
-      hostname = 'dell-r410-01.cloudformswin.lab.redhat.com'
+      hostname = 'dell-r410-01.manageiqwin.lab.example.com'
       expect(File.path_to_uri('foo', hostname)).to eql("file://#{hostname}/foo")
       expect(File.path_to_uri('foo/bar', hostname)).to eql("file://#{hostname}/foo/bar")
       expect(File.path_to_uri('foo/bar-stuff', hostname)).to eql("file://#{hostname}/foo/bar-stuff")
       expect(File.path_to_uri('foo/C:/bar', hostname)).to eql("file://#{hostname}/foo/C:/bar")
       expect(File.path_to_uri('foo/[bar]', hostname)).to eql("file://#{hostname}/foo/%5Bbar%5D")
+    end
+
+    it 'handles an IPv6 hostname as expected' do
+      hostname = '::1'
+      expect(File.path_to_uri('foo', hostname)).to eql("file://[#{hostname}]/foo")
     end
 
     it 'requires at least one argument' do

--- a/gems/pending/util/extensions/miq-file.rb
+++ b/gems/pending/util/extensions/miq-file.rb
@@ -53,7 +53,12 @@ class File
 
   def self.path_to_uri(file, hostname = nil)
     hostname ||= MiqSockUtil.getFullyQualifiedDomainName
-    URI.join("file://#{hostname}", "/#{Addressable::URI.encode(file.tr('\\', '/'))}").to_s
+
+    URI::Generic.build(
+      :scheme => 'file',
+      :host   => hostname,
+      :path   => "/#{Addressable::URI.encode(file.tr('\\', '/'))}"
+    ).to_s
   end
 
   def self.uri_to_local_path(uri_path)

--- a/gems/pending/util/extensions/miq-file.rb
+++ b/gems/pending/util/extensions/miq-file.rb
@@ -4,6 +4,7 @@ require 'disk/modules/MiqLargeFile'
 require 'util/runcmd'
 require 'uri'
 require 'util/MiqSockUtil'
+require 'addressable'
 
 class File
   def self.paths_equal?(f1, f2)
@@ -52,7 +53,7 @@ class File
 
   def self.path_to_uri(file, hostname = nil)
     hostname ||= MiqSockUtil.getFullyQualifiedDomainName
-    URI.join("file://#{hostname}", "/#{URI.encode(file.tr('\\', '/'))}").to_s
+    URI.join("file://#{hostname}", "/#{Addressable::URI.encode(file.tr('\\', '/'))}").to_s
   end
 
   def self.uri_to_local_path(uri_path)


### PR DESCRIPTION
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1153706 and https://bugzilla.redhat.com/show_bug.cgi?id=1287866.

In short, the SCVMM datastore name has brackets surrounding the name, e.g. "[foo]" and this causes URI.join to choke.

The problem with `URI.encode`, `CGI.encode` and `ERB::Util.encode` is that they either don't encode illegal characters, or encode legal characters that we don't want encoded. Meanwhile, the addressable gem works as intended and, based on what I'm reading on the intertubes, is generally considered superior to URI in the stdlib.

This fixes it by use `Addressable::URI.encode`, which does require the addition of the addressable gem. I've also added some specs for miq-file.rb.