### PR TITLE
clear out availability_zone for orphans

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -63,6 +63,11 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     validate_unsupported(_("Resize"))
   end
 
+  def disconnect_ems(e = nil)
+    self.availability_zone = nil if e.nil? || ext_management_system == e
+    super
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -186,4 +186,9 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
   def validate_unset_node_maintenance
     {:available => true,   :message => nil}
   end
+
+  def disconnect_ems(e = nil)
+    self.availability_zone = nil if e.nil? || ext_management_system == e
+    super
+  end
 end


### PR DESCRIPTION
**before:**

When a `vm` is marked as an orphan, the `ems` referenced is cleared.
But the `availability_zone` is not.

**after:**

clear out the `availibility_zone` so BZs: [1332579] and [1331803] will not have a chance to occur.

[1332579]: https://bugzilla.redhat.com/show_bug.cgi?id=1332579
[1331803]: https://bugzilla.redhat.com/show_bug.cgi?id=1331803

**aside:**

of note, #8450 will make the system more resilient to this error.

/cc @blomquisg 

Fixes #8490