### PR TITLE
Fix gettext string: 'Choose>' -> 'Choose'

### DIFF
--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -24,7 +24,7 @@
         = _('Type')
       .col-md-8
         = select_tag('emstype',
-                     options_for_select([["<#{_('Choose>')}", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
+                     options_for_select([["<#{_('Choose')}>", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
                      "ng-if"                       => "newRecord",
                      "ng-model"                    => "emsCommonModel.emstype",
                      "ng-change"                   => "providerTypeChanged()",

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -40,14 +40,14 @@
       = _('Security Protocol')
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose>')}", nil]] + @openstack_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + @openstack_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => defined?(security_protocol_not_required) ? false : true,
                        "selectpicker-for-select-tag" => "")
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'scvmm'"}
       = select_tag("#{prefix}_security_protocol",
-                       options_for_select([["<#{_('Choose>')}", nil]] + @scvmm_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + @scvmm_security_protocols, disabled: ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => "",

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -27,7 +27,7 @@
         = _('Type')
       .col-md-8
         = select_tag('provtype',
-                     options_for_select([["<#{_('Choose>')}", nil]] + @provider_types, disabled: ["<#{_('Choose')}>", nil]),
+                     options_for_select([["<#{_('Choose')}>", nil]] + @provider_types, disabled: ["<#{_('Choose')}>", nil]),
                      "ng-if"                       => "newRecord",
                      "ng-model"                    => "providerForemanModel.provtype",
                      "ng-change"                   => "providerTypeChanged()",

--- a/app/views/shared/views/ems_common/_form.html.haml
+++ b/app/views/shared/views/ems_common/_form.html.haml
@@ -20,7 +20,7 @@
       .col-md-8
         - if @edit[:ems_id].nil?
           = select_tag("server_emstype",
-                        options_for_select([["<#{_('Choose>')}", nil]] + Array(@edit[:ems_types].invert).sort_by(&:first), @edit[:new][:emstype]),
+                        options_for_select([["<#{_('Choose')}>", nil]] + Array(@edit[:ems_types].invert).sort_by(&:first), @edit[:new][:emstype]),
                         "class"            => "selectpicker")
           :javascript
             miqInitSelectPicker();

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -24,7 +24,7 @@
         = _('Type')
       .col-md-8
         = select_tag('emstype',
-                     options_for_select([["<#{_('Choose>')}", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
+                     options_for_select([["<#{_('Choose')}>", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
                      "ng-if"                       => "newRecord",
                      "ng-model"                    => "emsCommonModel.emstype",
                      "ng-change"                   => "providerTypeChanged()",


### PR DESCRIPTION
This is to be consistent across our UI & to have nicer looking strings in gettext catalogs.