### PR TITLE
Add previously_migrated_as? check to renamed migrations

### DIFF
--- a/db/migrate/20160428215808_add_filters_to_entitlements.rb
+++ b/db/migrate/20160428215808_add_filters_to_entitlements.rb
@@ -1,7 +1,11 @@
 class AddFiltersToEntitlements < ActiveRecord::Migration[5.0]
+  include MigrationHelper
+
   class Entitlement < ActiveRecord::Base; end
 
   def change
+    return if previously_migrated_as?("20160414123914")
+
     add_column :entitlements, :filters, :text
 
     # HACK, this shouldn't be required, figure out why. :cry:

--- a/db/migrate/20160428215825_move_filters_to_entitlements.rb
+++ b/db/migrate/20160428215825_move_filters_to_entitlements.rb
@@ -1,4 +1,6 @@
 class MoveFiltersToEntitlements < ActiveRecord::Migration[5.0]
+  include MigrationHelper
+
   class MiqGroup < ActiveRecord::Base
     has_one :entitlement, :class_name => 'MoveFiltersToEntitlements::Entitlement'
     serialize :filters
@@ -10,6 +12,7 @@ class MoveFiltersToEntitlements < ActiveRecord::Migration[5.0]
   end
 
   def up
+    return if previously_migrated_as?("20160414124134")
     say_with_time 'Moving MiqGroup filters to Entitlements' do
       MiqGroup.find_each do |group|
         if group.filters && group.entitlement

--- a/db/migrate/20160428215838_remove_filters_from_miq_groups.rb
+++ b/db/migrate/20160428215838_remove_filters_from_miq_groups.rb
@@ -1,5 +1,8 @@
 class RemoveFiltersFromMiqGroups < ActiveRecord::Migration[5.0]
+  include MigrationHelper
+
   def change
+    return if previously_migrated_as?("20160414132130")
     remove_column :miq_groups, :filters, :text
   end
 end


### PR DESCRIPTION
Commit bb822f93284347c049e00971118412a6ff83a329 renamed some migrations that were failing a new spec test.  Some databases may have already run those migrations, causing failures with the new names.

This change will allow those databases to be migrated successfully.

@jrafanie please review
Thanks @kbrock for showing me this helper method.

Fixes #8385