### PR TITLE
Fix ascending ordering exception

### DIFF
--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -49,6 +49,8 @@ module MiqReport::Search
 
     if (self.order && self.order.downcase == "descending")
       order = order.map { |col| Arel::Nodes::Descending.new col }
+    elsif (self.order && self.order.downcase == "ascending")
+      order = order.map { |col| Arel::Nodes::Ascending.new col }
     end
 
     order


### PR DESCRIPTION
For distinct and order together in active record, for acending,
we can either send Arel::Nodes::NamedFunction, which will
just do ORDER BY without direction, which will default to ASC.
Or we can send Arel::Nodes::Ascending, which will do ORDER BY
ASC.

Right now, for columns other than :string, :text, we were sending
only Arel::Attributes::Attribute, which will blow up in
active_record, when it tries to call to_sql on itself.

Best solution seems to be to always send Arel::Nodes::Ascending,
when we order in that direction.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1333137