### PR TITLE
 Change C&U chart to timeseries charts 

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1645,9 +1645,11 @@ function add_expanding_icon(element){
 }
 
 function chartData(type, data, data2) {
-  if(_.isObject(data.axis) && _.isObject(data.axis.x) && data.axis.x.categories.length > 10 ){
-    data.axis.x.tick = {centered: true, count: 10};
+  if(_.isObject(data.miq) && data.miq.performance){
+    data.axis.x.tick.centered = true;
+    data.axis.x.tick.culling = {max: 5}
   }
+
   if (_.isObject(data.axis) && _.isObject(data.axis.y) && _.isObject(data.axis.y.tick) && _.isObject(data.axis.y.tick.format)) {
     var o = data.axis.y.tick.format;
     data.axis.y.tick.format = ManageIQ.charts.formatters[o.function].c3(o.options);
@@ -1657,12 +1659,12 @@ function chartData(type, data, data2) {
     }
   }
   var config = _.cloneDeep(ManageIQ.charts.c3config[type]);
+
   // some PatternFly default configs define contents function, but it breaks formatting
   if(_.isObject(config.tooltip)) {
     config.tooltip.contents = undefined;
   }
   return _.defaultsDeep({}, data, config, data2);
-
 }
 
 $(function () {

--- a/app/assets/javascripts/miq_c3_config.js
+++ b/app/assets/javascripts/miq_c3_config.js
@@ -165,7 +165,7 @@
 
     Line: _.defaultsDeep(
       {
-        axis : {x:{type: 'category', tick: {centered: true}}},
+        axis : {x:{type: 'category'}},
         data : {type: 'line'},
       },c3mixins.pfColorPattern,
       $().c3ChartDefaults().getDefaultLineConfig()


### PR DESCRIPTION
Parent issue #6627
Change the way we generate C&U charts for C3. Now we use timeseries charts in C&U and will be easier fix some issues in report charts without affecting C&U charts.
![firefox_screenshot_2016-05-06t08-40-23 307z](https://cloud.githubusercontent.com/assets/9535558/15068362/fe947d0a-1376-11e6-8818-4b25c0bf76e0.png)

@martinpovolny please review