### PR TITLE
Upgrade fog-openstack to 0.1.5

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -21,7 +21,7 @@ gem "excon",                   "~>0.40",            :require => false
 gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
-gem "fog-openstack",           "~>0.1.2",           :require => false
+gem "fog-openstack",           "~>0.1.5",           :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.2",           :require => false
 gem "kubeclient",              "=1.1.3",            :require => false


### PR DESCRIPTION
The evacuate API call is broken with the prior version. The managiq evacuate UI fails with fog errors with prior versions. These two fog-openstack PRs fix the problem (and are included in 0.1.5): fog/fog-openstack#92 and fog/fog-openstack#89