### PR TITLE
move disk sizes from vms to hardware

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -111,6 +111,23 @@ class Hardware < ApplicationRecord
       t[:disk_capacity]) * -100 + 100)
   end)
 
+  def disk_storage(col)
+    return nil if disks.blank?
+    disks.inject(0) do |t, d|
+      val = d.send(col)
+      t + (val.nil? ? d.size.to_i : val.to_i)
+    end
+  end
+  protected :disk_storage
+
+  def allocated_disk_storage
+    disk_storage(:size)
+  end
+
+  def used_disk_storage
+    disk_storage(:size_on_disk)
+  end
+
   def m_controller(_parent, xmlNode, deletes)
     # $log.info("Adding controller XML elements for [#{xmlNode.attributes["type"]}]")
     xmlNode.each_element do |e|

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1576,22 +1576,7 @@ class VmOrTemplate < ApplicationRecord
   # Hardware Disks/Memory storage methods
   #
 
-  def disk_storage(col)
-    return nil if hardware.nil? || hardware.disks.blank?
-    hardware.disks.inject(0) do |t, d|
-      val = d.send(col)
-      t + (val.nil? ? d.size.to_i : val.to_i)
-    end
-  end
-  protected :disk_storage
-
-  def allocated_disk_storage
-    disk_storage(:size)
-  end
-
-  def used_disk_storage
-    disk_storage(:size_on_disk)
-  end
+  delegate :allocated_disk_storage, :used_disk_storage, :to => :hardware, :allow_nil => true
 
   def provisioned_storage
     allocated_disk_storage.to_i + ram_size_in_bytes


### PR DESCRIPTION
The disk space calculations does not belong on vms.

Also, there is no reason to load all the disk values into memory just to get a sum from the database.

These should probably be declared as a `virtual_delegate` and `virtual_attributes` with `arel`. but that can be for another day.

Sorry, had intended on just putting this onto a future punch list, but it was quicker to just do it