### PR TITLE
Use ruby 2.3.1 on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- '2.2.5'
+- '2.3.1'
 sudo: false
 cache: bundler
 env:


### PR DESCRIPTION
Purpose or Intent
-----------------

Use ruby 2.3.1 on travis.

Ruby 2.3.1 is the latest stable release of ruby and is mostly compatible with 2.2.5 but offers some new features such:

* frozen string literals
* lonely `&.` operator (safe navigation operator, similar to Hash#fetch_path)
* did_you_mean gem for useful errors
* indented heredoc
* Clearer ArgumentError message:
```
2.2.5: wrong number of arguments (0 for 1..3)
2.3.1: wrong number of arguments (given 0, expected 1..3)
```
* more, see below

Links
-----
 * [summary of ruby 2.3.1 changes](https://github.com/ruby/spec/issues/175)

Related: 
https://github.com/ManageIQ/manageiq-appliance-build/issues/141
https://github.com/ManageIQ/manageiq/issues/9829
