### PR TITLE
Log stdout of an ansible tower job when it fails

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
@@ -34,6 +34,9 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job < ::Orchestra
     ext_management_system.with_provider_connection do |connection|
       update_with_provider_object(connection.api.jobs.find(ems_ref))
     end
+  rescue Faraday::ResourceNotFound
+    msg = "AnsibleTower Job #{name} with id(#{id}) does not exist on #{ext_management_system.name}"
+    raise MiqException::MiqOrchestrationStackNotExistError, msg
   rescue => err
     _log.error "Refreshing job(#{name}, ems_ref=#{ems_ref}), error: #{err}"
     raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
@@ -60,6 +63,18 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job < ::Orchestra
     raise MiqException::MiqOrchestrationStackNotExistError, msg
   rescue => err
     _log.error "AnsibleTower Job #{name} with id(#{id}) status error: #{err}"
+    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+  end
+
+  def raw_stdout
+    ext_management_system.with_provider_connection do |connection|
+      connection.api.jobs.find(ems_ref).stdout
+    end
+  rescue Faraday::ResourceNotFound
+    msg = "AnsibleTower Job #{name} with id(#{id}) does not exist on #{ext_management_system.name}"
+    raise MiqException::MiqOrchestrationStackNotExistError, msg
+  rescue => err
+    _log.error "Reading AnsibleTower Job #{name} with id(#{id}) stdout failed with error: #{err}"
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/job/status.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/job/status.rb
@@ -10,4 +10,20 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job::Status < ::O
   def canceled?
     status.casecmp("canceled").zero?
   end
+
+  def normalized_status
+    return ['transient', reason || status] unless completed?
+
+    if succeeded?
+      ['create_complete', reason || 'OK']
+    elsif deleted?
+      ['delete_complete', reason || 'Job was deleted']
+    elsif canceled?
+      ['create_canceled', reason || 'Job launching was canceled']
+    elsif updated?
+      ['update_complete', reason || 'OK']
+    else
+      ['failed', reason || 'Job launching failed']
+    end
+  end
 end

--- a/app/models/service_ansible_tower.rb
+++ b/app/models/service_ansible_tower.rb
@@ -52,15 +52,12 @@ class ServiceAnsibleTower < Service
   PASSWORD_PREFIX_LEN = PASSWORD_PREFIX.size
 
   def extra_vars_from_dialog(dialog_options)
-    params = {}
-
-    dialog_options.each do |attr, val|
+    dialog_options.each_with_object({}) do |(attr, val), params|
       if attr.start_with?(PARAM_PREFIX)
         params[attr[PARAM_PREFIX_LEN..-1]] = val
       elsif attr.start_with?(PASSWORD_PREFIX)
         params[attr[PASSWORD_PREFIX_LEN..-1]] = MiqPassword.decrypt(val)
       end
     end
-    params
   end
 end

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
@@ -9,7 +9,7 @@ class AnsibleTowerCheckProvisioned
   end
 
   def main
-    @handle.log("info", "Starting Ansible Tower Provisioning")
+    @handle.log("info", "Checking status of Ansible Tower Provisioning")
     check_provisioned(task, service)
   end
 
@@ -43,6 +43,7 @@ class AnsibleTowerCheckProvisioned
     when /failed$/, /canceled$/
       @handle.root['ae_result'] = 'error'
       @handle.root['ae_reason'] = reason
+      @handle.log('error', "Ansible Tower Job #{job.name} standard output: #{job.raw_stdout}")
     else
       # job not done yet in provider
       @handle.root['ae_result']         = 'retry'

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
@@ -8,7 +8,8 @@ class AnsibleTowerPostProvision
 
   def main
     @handle.log("info", "Starting Ansible Tower Post-Provisioning")
-    # job = service.job
+    job = service.job
+    raise "Job was not created" unless job
 
     # You can add logic to process the job object in VMDB
     # For example, dump all outputs from the job
@@ -28,6 +29,11 @@ class AnsibleTowerPostProvision
     task.destination.tap do |service|
       raise "service is not of type AnsibleTower" unless service.respond_to?(:job_template)
     end
+  end
+
+  def dump_job_outputs(job)
+    log_type = job.status == 'failed' ? 'error' : 'info'
+    @handle.log(log_type, "Ansible Tower Job #{job.name} standard output: #{job.raw_stdout}")
   end
 end
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-job.rb
@@ -2,6 +2,7 @@ module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_Job < MiqAeServiceOrchestrationStack
     expose :job_template, :association => true
     expose :refresh_ems
+    expose :raw_stdout
 
     def self.create_job(template, args = {})
       template_object = ConfigurationScript.find_by(:id => template.id)

--- a/spec/automation/unit/method_validation/ansible_tower_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/ansible_tower_check_provisioned_spec.rb
@@ -37,6 +37,7 @@ describe AnsibleTowerCheckProvisioned do
       before { allow_any_instance_of(job_class).to receive(:normalized_live_status).and_return(['create_failed', 'bad']) }
       it "signals error" do
         expect(job).to receive(:refresh_ems)
+        expect(job).to receive(:raw_stdout)
         described_class.new(ae_service).main
         expect(ae_service.root['ae_result']).to eq('error')
         expect(ae_service.root['ae_reason']).to eq('bad')

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/job/status_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/job/status_spec.rb
@@ -16,7 +16,7 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job::Status do
     expect(status.failed?).to      be_truthy
     expect(status.deleted?).to     be_falsey
     expect(status.rolled_back?).to be_falsey
-    expect(status.normalized_status).to eq(['failed', 'Stack creation failed'])
+    expect(status.normalized_status).to eq(['failed', 'Job launching failed'])
   end
 
   it 'parses Canceled' do
@@ -26,7 +26,7 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job::Status do
     expect(status.canceled?).to    be_truthy
     expect(status.deleted?).to     be_falsey
     expect(status.rolled_back?).to be_falsey
-    expect(status.normalized_status).to eq(['create_canceled', 'Stack creation was canceled'])
+    expect(status.normalized_status).to eq(['create_canceled', 'Job launching was canceled'])
   end
 
   it 'parses transient status' do


### PR DESCRIPTION
The output from an AnsibleTower job can be very long. We decide not to store it in VMDB. But when an AnsibleTower provisioning job fails, how can we help the user to find the reason? This work is to save the output of failed jobs to evm log.

1. Add getting stdout method to AnsibleTower/Job class, and expose it to automate service model.
2. At check_provisioned step, log the output to evm log
3. As an example, user can choose to log output from succeeded jobs
4. Enhance Job/Status message so that it says job instead of stack.  