### PR TITLE
Fixes Migrate UI bug with auto_select_host field

### DIFF
--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -14,6 +14,9 @@
                         :miqrequired   => true,
                         :checkchange   => true,
                         'ng-disabled'  => "hosts.length == 0")
+        = hidden_field_tag("auto_select_host",
+                           '1',
+                           'ng-disabled'  => "hosts.length > 0")
     .form-group
       %label.col-md-2.control-label
         = _('Block Migration')


### PR DESCRIPTION
When the auto_select_host field is disabled, we need a hidden
field that passes the value. Disabling a field keeps it from
being submitted, but in the case where auto_select_host is
disabled, it needs to be set to '1' to enable auto select.
This is similar to the way we handle this same field value
with host evacuation