### PR TITLE
Use N_() instead of _() in button classes

### DIFF
--- a/app/helpers/application_helper/button/chargeback_download_choice.rb
+++ b/app/helpers/application_helper/button/chargeback_download_choice.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Button::ChargebackDownloadChoice < ApplicationHelper::B
     if @view_context.x_active_tree == :cb_reports_tree &&
        @report && !@report.contains_records?
       self[:enabled] = false
-      self[:title] = _("No records found for this report")
+      self[:title] = N_("No records found for this report")
     end
   end
 end

--- a/app/helpers/application_helper/button/chargeback_rate_edit.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_edit.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Button::ChargebackRateEdit < ApplicationHelper::Button:
     super
     if @record.default?
       self[:enabled] = false
-      self[:title] = _("Default Chargeback Rate cannot be edited.")
+      self[:title] = N_("Default Chargeback Rate cannot be edited.")
     end
   end
 end

--- a/app/helpers/application_helper/button/chargeback_rate_remove.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_remove.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Button::ChargebackRateRemove < ApplicationHelper::Butto
     super
     if @record.default?
       self[:enabled] = false
-      self[:title] = _("Default Chargeback Rate cannot be removed.")
+      self[:title] = N_("Default Chargeback Rate cannot be removed.")
     end
   end
 end

--- a/app/helpers/application_helper/button/chargeback_report_only.rb
+++ b/app/helpers/application_helper/button/chargeback_report_only.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Button::ChargebackReportOnly < ApplicationHelper::Butto
     if @view_context.x_active_tree == :cb_reports_tree &&
        @report && !@report.contains_records?
       self[:enabled] = false
-      self[:title] = _("No records found for this report")
+      self[:title] = N_("No records found for this report")
     end
   end
 end

--- a/app/helpers/application_helper/button/old_dialogs_edit_delete.rb
+++ b/app/helpers/application_helper/button/old_dialogs_edit_delete.rb
@@ -4,9 +4,9 @@ class ApplicationHelper::Button::OldDialogsEditDelete < ApplicationHelper::Butto
     if @view_context.x_active_tree == :old_dialogs_tree && @record && @record[:default]
       self[:enabled] = false
       self[:title] = if self[:id] =~ /_edit/
-                       _('Default dialogs cannot be edited')
+                       N_('Default dialogs cannot be edited')
                      else
-                       _('Default dialogs cannot be removed from the VMDB')
+                       N_('Default dialogs cannot be removed from the VMDB')
                      end
     end
   end

--- a/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
+++ b/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
@@ -5,9 +5,9 @@ class ApplicationHelper::Button::OrchestrationTemplateEditRemove < ApplicationHe
       if @record.in_use?
         self[:enabled] = false
         self[:title] = if self[:id] =~ /_edit$/
-                         _('Orchestration Templates that are in use cannot be edited')
+                         N_('Orchestration Templates that are in use cannot be edited')
                        else
-                         _('Orchestration Templates that are in use cannot be removed')
+                         N_('Orchestration Templates that are in use cannot be removed')
                        end
       end
     end


### PR DESCRIPTION
We don't need to use `_()` in button clases, since the strings will go through the `_()`
routine once more in toolbar builder, so the gettext lookup would have to be done twice.

Using `N_()` here is sufficient.

@martinpovolny 