### PR TITLE
Add selected group to group select box in ownership screen

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -79,7 +79,7 @@ module ApplicationController::CiProcessing
   # Build the ownership assignment screen
   def ownership_build_screen
     @users = {}   # Users array for first chooser
-    User.with_current_user_groups.each { |u| @users[u.name] = u.id.to_s }
+    rbac_filtered_objects(User).each { |u| @users[u.name] = u.id.to_s }
     record = @edit[:klass].find(@edit[:ownership_items][0])
     user = record.evm_owner if @edit[:ownership_items].length == 1
     @edit[:new][:user] = user ? user.id.to_s : nil            # Set to first category, if not already set
@@ -88,7 +88,7 @@ module ApplicationController::CiProcessing
     # need to do this only if 1 vm is selected and miq_group has been set for it
     group = record.miq_group if @edit[:ownership_items].length == 1
     @edit[:new][:group] = group ? group.id.to_s : nil
-    MiqGroup.with_current_user_groups.each { |g| @groups[g.description] = g.id.to_s }
+    rbac_filtered_objects(MiqGroup).each { |g| @groups[g.description] = g.id.to_s }
 
     @edit[:new][:user] = @edit[:new][:group] = DONT_CHANGE_OWNER if @edit[:ownership_items].length > 1
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -65,6 +65,7 @@ module Rbac
   TENANT_ACCESS_STRATEGY = {
     'ExtManagementSystem'    => :ancestor_ids,
     'MiqAeNamespace'         => :ancestor_ids,
+    'MiqGroup'               => :descendant_ids,
     'MiqRequest'             => :descendant_ids,
     'MiqRequestTask'         => nil, # tenant only
     'MiqTemplate'            => :ancestor_ids,
@@ -73,6 +74,7 @@ module Rbac
     'ServiceTemplate'        => :ancestor_ids,
     'Service'                => :descendant_ids,
     'Tenant'                 => :descendant_ids,
+    'User'                   => :descendant_ids,
     'Vm'                     => :descendant_ids
   }
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -237,8 +237,8 @@ describe Rbac do
   end
 
   context "common setup" do
-    let(:group) { FactoryGirl.create(:miq_group) }
-    let(:user) { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let(:group) { FactoryGirl.create(:miq_group, :tenant => default_tenant) }
+    let(:user)  { FactoryGirl.create(:user, :miq_groups => [group]) }
 
     before(:each) do
       @tags = {
@@ -1145,7 +1145,7 @@ describe Rbac do
                                                 :miq_group      => group,
                                                 :results_format => :objects)
         expect(results.length).to eq(2)
-        expect(attrs[:total_count]).to eq(2)
+        expect(attrs[:total_count]).to eq(3)
       end
     end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1330022

We are listing user's groups in group select box in ownership screen for non-admin users, but
when administrator will select group or tenant which is not included in this list then this group is not displayed.

so I am adding this extra group to this group list also. 
This not done for user select box because there is <no user> option.

example, let's assume: 
Non-user has only group G1.
Admin will select some tenant for the VM. 
The non-user can see the VM because of related tenant strategy and he see in set owner ship screen:

before
<img width="870" alt="screen shot 2016-05-06 at 14 39 06" src="https://cloud.githubusercontent.com/assets/14937244/15073185/70efe6ac-1398-11e6-8e72-2a4283912c50.png">

after
<img width="892" alt="screen shot 2016-05-06 at 14 41 04" src="https://cloud.githubusercontent.com/assets/14937244/15073222/a56005a2-1398-11e6-9d14-2293d8b33c2f.png">

cc @gtanzillo 



