### PR TITLE
Removes duplicated block of code - creds angular

### DIFF
--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -58,18 +58,6 @@
           = change_stored_password
         %a{:href => "", "ng-show" => "bChangeStoredPassword", "ng-click" => "cancelPasswordChange()"}
           = cancel_password_change
-    %div{"ng-show" => "!showVerify('#{prefix}_userid')"}
-      .form-group
-        %label.col-md-2
-        .col-md-4
-          = render :partial => "layouts/angular/form_buttons_verify_angular",
-                                       :locals  => {:ng_show          => "#{ng_show}",
-                                                    :validate_url     => validate_url,
-                                                    :id               => id,
-                                                    :valtype          => "#{prefix}",
-                                                    :verify_title_off => verify_title_off,
-                                                    :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}
-
     %div{"ng-show" => "#{ng_show}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_verify.$error.required || (#{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd)}"}
       %label.col-md-2.control-label{"ng-show" => "showVerify('#{prefix}_userid')", "for" => "textInput-markup"}
@@ -91,7 +79,7 @@
             = _("Required")
           %span.help-block{"ng-show" => "!angularForm.#{prefix}_verify.$error.required && #{prefix}_VerifyCtrl != undefined && #{prefix}_VerifyCtrl.$error.verifypasswd"}
             = passwd_mismatch
-    %div{"ng-show" => "showVerify('#{prefix}_userid')"}
+    %div{"ng-show" => ng_show}
       .form-group
         %label.col-md-2
         .col-md-4


### PR DESCRIPTION
There was a block of code duplicated rendering partial
for "Validate" button in auth credentials angular partial
once with condition set to return value of showVerify call
and the other was the same call with the same args but negated.

This patch removes that duplication.