### PR TITLE
Re-enable Settings/Analytics product feature

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2465,6 +2465,10 @@
           :feature_type: admin
           :hidden: false
           :identifier: rbac_tenant_tags_edit
+  - :name: Analytics
+    :description: Analytics Accordion
+    :feature_type: node
+    :identifier: ops_analytics
   - :name: Diagnostics
     :description: Diagnostics Accordion
     :feature_type: node


### PR DESCRIPTION
The ops_analytics role is needed by UI since 5d750a2b, however product
feature was missing.

@miq-bot add_label bug