### PR TITLE
Add the master branch buildstats history to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Translate](https://img.shields.io/badge/translate-zanata-blue.svg)](https://translate.zanata.org/zanata/project/view/manageiq)
 
+[![Build history for master branch](https://buildstats.info/travisci/chart/ManageIQ/manageiq?branch=master&buildCount=50)](https://travis-ci.org/ManageIQ/manageiq/branches)
+
 ManageIQ is a Cloud Management Platform that delivers the insight, control, and
 automation that enterprises need to address the challenges of managing hybrid
 cloud environments.  It has the following feature sets:


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/19339/15114920/4c5e630c-15ca-11e6-8fe8-25523212b422.png)

Note, it looks like they have a bug showing our  history right now.  We're not red for the last 50 builds.

It should look more like this (and did on Friday before the connection_pool refactor hit rails master)... (this is rails master currently):

![image](https://cloud.githubusercontent.com/assets/19339/15115290/4b40a744-15cc-11e6-9969-855404e8ce78.png)


Note: Currently, darga history doesn't currently appear to work properly, but it
would look something like this:

`[![Build history for darga branch](https://buildstats.info/travisci/chart/ManageIQ/manageiq?branch=darga)](https://travis-ci.org/ManageIQ/manageiq/branches)`

[ci skip]

@chessbyte @Fryguy I like how this makes it obvious when we have multiple failures in a row.  Oleg, I figured you'd like this since you will try any new metric to test drive it's usefulness.