### PR TITLE
Fixed a typo.

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1552,7 +1552,7 @@ module VmCommon
   end
 
   # Replace the right cell of the explorer
-  def replace_right_cell(action = nil)
+  def replace_right_cell(action = nil, presenter = nil)
     @explorer = true
     @sb[:action] = action unless action.nil?
     if @sb[:action] || params[:display]
@@ -1597,7 +1597,7 @@ module VmCommon
     end
 
     # Build presenter to render the JS command for the tree update
-    presenter = ExplorerPresenter.new(
+    presenter ||= ExplorerPresenter.new(
       :active_tree => x_active_tree,
       :add_nodes   => add_nodes,         # Update the tree with any new nodes
       :delete_node => @delete_node,      # Remove a new node from the tree
@@ -1721,7 +1721,7 @@ module VmCommon
           ])
         # these subviews use angular, so they need to use a special partial
         # so the form buttons on the outer frame can be updated.
-        elsif %(attach detach live_migrate).include?(@sb[:action])
+        elsif %w(attach detach live_migrate).include?(@sb[:action])
           presenter.update(:form_buttons_div, r[:partial => "layouts/angular/paging_div_buttons"])
         elsif action != "retire" && action != "reconfigure_update"
           presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons', :locals => locals])

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -108,4 +108,28 @@ describe VmOrTemplateController do
       end
     end
   end
+
+  context '#replace_right_cell' do
+    it 'should display form button on Migrate request screen' do
+      vm = FactoryGirl.create(:vm_infra)
+      allow(controller).to receive(:params).and_return(:action => 'vm_migrate')
+      controller.instance_eval { @sb = {:active_tree => :vandt_tree, :action => "migrate"} }
+      controller.instance_eval { @record = vm }
+      controller.instance_eval { @in_a_form = true }
+      allow(controller).to receive(:render).and_return(nil)
+      presenter = ExplorerPresenter.new(:active_tree => :vandt_tree)
+      expect(controller).to receive(:render_to_string).with(:partial => "miq_request/prov_edit",
+                                                             :locals => {:controller => "vm"}).exactly(1).times
+      expect(controller).to receive(:render_to_string).with(:partial => "layouts/x_adv_searchbox",
+                                                             :locals => {:nameonly => true}).exactly(1).times
+      expect(controller).to receive(:render_to_string).with(:partial => "layouts/x_edit_buttons",
+                                                             :locals => {:action_url      => "prov_edit",
+                                                                         :record_id       => vm.id,
+                                                                         :no_reset        => true,
+                                                                         :submit_button   => true,
+                                                                         :continue_button => false}).exactly(1).times
+      controller.send(:replace_right_cell, 'migrate', presenter)
+      expect(presenter[:update_partials]).to have_key(:form_buttons_div)
+    end
+  end
 end


### PR DESCRIPTION
- Typo was making incorrect partial to be rendered on VM migrate request form, hence form buttons were missing from the screen.
- Added spec test to verify correct partials are being rendered. Changed replace_right_cell method to receive presenter as a parameter to get spec test to working & verify partial rendering.

https://bugzilla.redhat.com/show_bug.cgi?id=1333524

@mansam typo in https://github.com/ManageIQ/manageiq/pull/6176 caused form buttons to disappear on VM migrate request form in commit c4793d871dce3140f1bc48dbcdcf50d4e2fb9363

@dclarizio please review.

before:
![before](https://cloud.githubusercontent.com/assets/3450808/15075317/b9231722-1371-11e6-9880-80962e73470f.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/15075331/ca29cbf6-1371-11e6-8678-5c409bc31697.png)