### PR TITLE
Allow for service templates to have multiple VM's

### DIFF
--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -53,16 +53,20 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
 
   def number_of_vms(service_task, parent_svc, template_service_resource)
     parent_task = MiqRequestTask.find_by_id(service_task.options[:parent_task_id])
-    resource = template_service_resource.resource
-    root_svc = parent_svc
-    root_svc = parent_svc.parent if parent_svc && parent_svc.parent
     vm_count = nil
     if template_service_resource
+      root_svc = get_root_svc(parent_svc)
       value = number_of_vms_from_dialog(root_svc, parent_task) if root_svc && parent_task
       vm_count = value.to_i unless value.blank?
+      resource = template_service_resource.resource
       vm_count ||= resource.get_option(:number_of_vms) if resource.respond_to?(:get_option)
     end
     vm_count
+  end
+
+  def get_root_svc(parent_svc)
+    return nil unless parent_svc
+    parent_svc.parent ? parent_svc.parent : parent_svc
   end
 
   def number_of_vms_from_dialog(root_svc, parent_task)

--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -73,7 +73,7 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
     value = root_svc.options[:dialog]["dialog_option_0_number_of_vms"]
     if parent_task.service_resource
       index = parent_task.service_resource.provision_index
-      value ||= root_svc.options[:dialog]["dialog_option_#{index+1}_number_of_vms"]
+      value ||= root_svc.options[:dialog]["dialog_option_#{index + 1}_number_of_vms"]
     end
     value ||= root_svc.options[:dialog]["dialog_option_number_of_vms"]
     value ||= root_svc.options[:dialog]["dialog_number_of_vms"]

--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -56,7 +56,7 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
     resource = template_service_resource.resource
     root_svc = parent_svc
     root_svc = parent_svc.parent if parent_svc && parent_svc.parent
-
+    vm_count = nil
     if template_service_resource
       value = number_of_vms_from_dialog(root_svc, parent_task) if root_svc && parent_task
       vm_count = value.to_i unless value.blank?

--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -52,9 +52,9 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
   end
 
   def number_of_vms(service_task, parent_svc, template_service_resource)
-    parent_task = MiqRequestTask.find_by_id(service_task.options[:parent_task_id])
     vm_count = nil
     if template_service_resource
+      parent_task = get_parent_task(service_task)
       root_svc = get_root_svc(parent_svc)
       value = number_of_vms_from_dialog(root_svc, parent_task) if root_svc && parent_task
       vm_count = value.to_i unless value.blank?
@@ -67,6 +67,10 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
   def get_root_svc(parent_svc)
     return nil unless parent_svc
     parent_svc.parent ? parent_svc.parent : parent_svc
+  end
+
+  def get_parent_task(service_task)
+    MiqRequestTask.find_by_id(service_task.options[:parent_task_id])
   end
 
   def number_of_vms_from_dialog(root_svc, parent_task)

--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -1,8 +1,10 @@
 class MiqProvisionRequestTemplate < MiqProvisionRequest
   def create_tasks_for_service(service_task, parent_svc)
     template_service_resource = ServiceResource.find_by_id(service_task.options[:service_resource_id])
-    scaling_min = template_service_resource.try(:scaling_min) || 1
+    scaling_min = number_of_vms(service_task, parent_svc, template_service_resource)
+    scaling_min ||= template_service_resource.try(:scaling_min) || 1
 
+    _log.info("create_tasks_for_service ID #{service_task.id} SCALING : #{scaling_min}")
     scaling_min.times.collect do |idx|
       create_request_task(idx) do |req_task|
         req_task.miq_request_id = service_task.miq_request.id
@@ -47,5 +49,30 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
       :owner_first_name => user.first_name,
       :owner_last_name  => user.last_name
     }
+  end
+
+  def number_of_vms(service_task, parent_svc, template_service_resource)
+    parent_task = MiqRequestTask.find_by_id(service_task.options[:parent_task_id])
+    resource = template_service_resource.resource
+    root_svc = parent_svc
+    root_svc = parent_svc.parent if parent_svc && parent_svc.parent
+
+    if template_service_resource
+      value = number_of_vms_from_dialog(root_svc, parent_task) if root_svc && parent_task
+      vm_count = value.to_i unless value.blank?
+      vm_count ||= resource.get_option(:number_of_vms) if resource.respond_to?(:get_option)
+    end
+    vm_count
+  end
+
+  def number_of_vms_from_dialog(root_svc, parent_task)
+    value = root_svc.options[:dialog]["dialog_option_0_number_of_vms"]
+    if parent_task.service_resource
+      index = parent_task.service_resource.provision_index
+      value ||= root_svc.options[:dialog]["dialog_option_#{index+1}_number_of_vms"]
+    end
+    value ||= root_svc.options[:dialog]["dialog_option_number_of_vms"]
+    value ||= root_svc.options[:dialog]["dialog_number_of_vms"]
+    value
   end
 end

--- a/app/services/service_template_fields_visibility_service.rb
+++ b/app/services/service_template_fields_visibility_service.rb
@@ -2,7 +2,7 @@ class ServiceTemplateFieldsVisibilityService
   def determine_visibility(service_template_request)
     field_names_to_hide = []
     if service_template_request
-      field_names_to_hide += [:number_of_vms, :vm_description, :schedule_type, :schedule_time]
+      field_names_to_hide += [:vm_description, :schedule_type, :schedule_time]
     end
 
     {:hide => field_names_to_hide}

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -95,10 +95,10 @@ def set_vm_name(dialog_options_hash, prov)
 end
 
 def set_all_vm_name_attrs(prov, new_vm_name)
-    prov.set_option(:vm_target_name, new_vm_name)
-    prov.set_option(:vm_target_hostname, new_vm_name)
-    prov.set_option(:vm_name, new_vm_name)
-    prov.set_option(:linux_host_name, new_vm_name)
+  prov.set_option(:vm_target_name, new_vm_name)
+  prov.set_option(:vm_target_hostname, new_vm_name)
+  prov.set_option(:vm_name, new_vm_name)
+  prov.set_option(:linux_host_name, new_vm_name)
 end
 
 def service_item_dialog_values(dialogs_options_hash)

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -81,17 +81,19 @@ def assign_service_tag(tag_category, tag_value)
   @service.tag_assign("#{tag_category}/#{tag_value}")
 end
 
-def get_vm_name(dialog_options_hash, prov)
-  log_and_update_message(:info, "Processing get_vm_name", true)
+def set_vm_name(dialog_options_hash, prov)
+  log_and_update_message(:info, "Processing set_vm_name", true)
   new_vm_name = dialog_options_hash.fetch(:vm_name, nil) || dialog_options_hash.fetch(:vm_target_name, nil)
-
-  new_vm_name = prov.get_option(:vm_target_name) if new_vm_name.blank?
-
-  dialog_options_hash[:vm_target_name] = new_vm_name
-  dialog_options_hash[:vm_target_hostname] = new_vm_name
-  dialog_options_hash[:vm_name] = new_vm_name
-  dialog_options_hash[:linux_host_name] = new_vm_name
-  log_and_update_message(:info, "Processing get_vm_name...Complete", true)
+  if new_vm_name.blank?
+    log_and_update_message(:info, "Using default vm name: #{prov.get_option(:vm_target_name)}", true)
+  else
+    prov.set_option(:vm_target_name, new_vm_name)
+    prov.set_option(:vm_target_hostname, new_vm_name)
+    prov.set_option(:vm_name, new_vm_name)
+    prov.set_option(:linux_host_name, new_vm_name)
+    log_and_update_message(:info, "Setting vm name to: #{prov.get_option(:vm_target_name)}", true)
+  end
+  log_and_update_message(:info, "Processing set_vm_name...Complete", true)
 end
 
 def service_item_dialog_values(dialogs_options_hash)
@@ -172,7 +174,7 @@ end
 def pass_dialog_values_to_provision_task(provision_task, dialog_options_hash, dialog_tags_hash)
   provision_task.miq_request_tasks.each do |prov|
     log_and_update_message(:info, "Grandchild Task: #{prov.id} Desc: #{prov.description} type: #{prov.source_type}")
-    get_vm_name(dialog_options_hash, prov)
+    set_vm_name(dialog_options_hash, prov)
     tag_provision_task(dialog_tags_hash, prov)
     set_option_on_provision_task(dialog_options_hash, prov)
   end

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -85,15 +85,20 @@ def set_vm_name(dialog_options_hash, prov)
   log_and_update_message(:info, "Processing set_vm_name", true)
   new_vm_name = dialog_options_hash.fetch(:vm_name, nil) || dialog_options_hash.fetch(:vm_target_name, nil)
   if new_vm_name.blank?
+    set_all_vm_name_attrs(prov, prov.get_option(:vm_target_name))
     log_and_update_message(:info, "Using default vm name: #{prov.get_option(:vm_target_name)}", true)
   else
+    set_all_vm_name_attrs(prov, new_vm_name)
+    log_and_update_message(:info, "Setting vm name to: #{prov.get_option(:vm_target_name)}", true)
+  end
+  log_and_update_message(:info, "Processing set_vm_name...Complete", true)
+end
+
+def set_all_vm_name_attrs(prov, new_vm_name)
     prov.set_option(:vm_target_name, new_vm_name)
     prov.set_option(:vm_target_hostname, new_vm_name)
     prov.set_option(:vm_name, new_vm_name)
     prov.set_option(:linux_host_name, new_vm_name)
-    log_and_update_message(:info, "Setting vm name to: #{prov.get_option(:vm_target_name)}", true)
-  end
-  log_and_update_message(:info, "Processing set_vm_name...Complete", true)
 end
 
 def service_item_dialog_values(dialogs_options_hash)

--- a/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -8,7 +8,7 @@ describe "CatalogItemInitialization Automate Method" do
     build_model
   end
 
-  def create_request_and_tasks(dialog_options = {})
+  def create_request_and_tasks(dialog_options = {:dialog => {}})
     @request = build_service_template_request("top", @user, dialog_options)
     service_template_stubs
     request_stubs

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -4,7 +4,7 @@ describe MiqProvisionRequestTemplate do
     FactoryGirl.create(:template_vmware,
                        :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication))
   end
-  let(:parent_svc)       { FactoryGirl.create(:service, :guid => MiqUUID.new_guid, :options => {:dialog => {}}) }
+  let(:parent_svc) { FactoryGirl.create(:service, :guid => MiqUUID.new_guid, :options => {:dialog => {}}) }
   let(:bundle_parent_svc) do
     FactoryGirl.create(:service, :guid => MiqUUID.new_guid, :options => {:dialog => {}})
   end

--- a/spec/services/service_template_fields_visibility_service_spec.rb
+++ b/spec/services/service_template_fields_visibility_service_spec.rb
@@ -7,7 +7,7 @@ describe ServiceTemplateFieldsVisibilityService do
 
       it "adds values to field names to hide" do
         expect(subject.determine_visibility(service_template_request)).to eq(
-          :hide => [:number_of_vms, :vm_description, :schedule_type, :schedule_time]
+          :hide => [:vm_description, :schedule_type, :schedule_time]
         )
       end
     end

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -7,11 +7,13 @@ module ServiceTemplateHelper
   def build_all_atomics(hash)
     hash.each do |name, value|
       next unless value[:type] == "atomic"
-      item = FactoryGirl.create(:service_template, :name         => name,
-                                                   :service_type => 'atomic')
+      item  = FactoryGirl.create(:service_template, :name         => name,
+                                                    :options      => {:dialog => {}},
+                                                    :service_type => 'atomic')
       item.update_attributes(:prov_type => value[:prov_type]) if value[:prov_type].present?
-
       options = value[:request]
+      options ||= {}
+      options[:dialog] = {}
       mprt = FactoryGirl.create(:miq_provision_request_template,
                                 :requester => options[:requester],
                                 :src_vm_id => options[:src_vm_id],
@@ -30,6 +32,7 @@ module ServiceTemplateHelper
 
   def build_a_composite(name, hash)
     item = FactoryGirl.create(:service_template, :name         => name,
+                                                 :options      => {:dialog => {}},
                                                  :service_type => 'composite')
     properties = hash[name]
     link_all_children(item, properties, hash) unless properties[:children].empty?

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -7,9 +7,9 @@ module ServiceTemplateHelper
   def build_all_atomics(hash)
     hash.each do |name, value|
       next unless value[:type] == "atomic"
-      item  = FactoryGirl.create(:service_template, :name         => name,
-                                                    :options      => {:dialog => {}},
-                                                    :service_type => 'atomic')
+      item = FactoryGirl.create(:service_template, :name         => name,
+                                                   :options      => {:dialog => {}},
+                                                   :service_type => 'atomic')
       item.update_attributes(:prov_type => value[:prov_type]) if value[:prov_type].present?
       options = value[:request]
       options ||= {}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1331867

Expose the number_of_vms when building the provision request for
a service.
The number_of_vms can be set it multiple places

(1) In the Provision Request
(2) In the Single Service Item Dialog
(3) In the Service Bundle Dialog
(4) Default, allow a single vm under a service