### PR TITLE
Add replication monitoring methods

### DIFF
--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -85,6 +85,14 @@ class MiqPglogical
     end
   end
 
+  def replication_lag
+    pglogical.lag_bytes
+  end
+
+  def replication_wal_retained
+    pglogical.wal_retained_bytes
+  end
+
   def self.local_node_name
     region_to_node_name(MiqRegion.my_region_number)
   end


### PR DESCRIPTION
Add methods for monitoring replication status to the pglogical extension and expose them through the `MiqPglogical` class.

These methods can be run on a remote region to determine how far ahead of the global region you are and how that lag is impacting disk space consumed by the PostgreSQL WAL files.

@gtanzillo 