### PR TITLE
Hawkular Event Catcher - Tagged Events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -108,10 +108,8 @@ class EmsEvent < EventStream
 
     # Write the event
     new_event = create_event(event_hash)
-
     # Create a 'completed task' event if this is the last in a series of events
     create_completed_event(event_hash) if task_final_events.key?(event_type.to_sym)
-
     new_event
   end
 
@@ -168,8 +166,8 @@ class EmsEvent < EventStream
       unless klass.nil?
         process_object_in_event!(klass, event, :ems_ref_key => :middleware_ref)
       end
-      event.except!(:middleware_ref, :middleware_type)
     end
+    event.except!(:middleware_ref, :middleware_type)
   end
 
   def self.process_availability_zone_in_event!(event, options = {})

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
     @start_time ||= (Time.current - 1.minute).to_i * 1000
     $mw_log.debug "Catching Events since [#{@start_time}]"
 
-    new_events = @alerts_client.list_events("startTime" => @start_time)
+    new_events = @alerts_client.list_events("startTime" => @start_time, "tags" => "miq.event_type|*", "thin" => true)
     @start_time = new_events.max_by(&:ctime).ctime + 1 unless new_events.empty? # add 1 ms to avoid dups with GTE filter
     new_events
   rescue => err

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -210,8 +210,10 @@
     :application:
       :critical:
       - hawkular_deployment.error
+      - hawkular_event.critical
       :detail:
-      - hawkular_deployment.success
+      - hawkular_deployment.ok
+      - hawkular_event
       :name: Application
     :configuration:
       :critical:

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/deployment_ok.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/HAWKULAR.class/deployment_ok.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: Deployment Success
-    name: hawkular_deployment.success 
+    name: hawkular_deployment.ok
     inherits: 
     description: 
   fields:

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner_spec.rb
@@ -1,0 +1,83 @@
+describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner do
+  subject do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    auth                 = AuthToken.new(:name     => "test",
+                                         :auth_key => "valid-token",
+                                         :userid   => "jdoe",
+                                         :password => "password")
+    ems                  = FactoryGirl.create(:ems_hawkular,
+                                              :hostname        => 'localhost',
+                                              :port            => 8080,
+                                              :authentications => [auth],
+                                              :zone            => zone)
+    described_class.new(:ems_id => ems.id)
+  end
+
+  before do
+    allow_any_instance_of(ManageIQ::Providers::Hawkular::MiddlewareManager)
+      .to receive_messages(:authentication_check => [true, ""])
+    allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
+  end
+
+  context "#whitelist" do
+    require 'hawkular_all'
+
+    it "accepts event tagged with known event_type" do
+      event      = ::Hawkular::Alerts::Event.new({})
+      event.tags = {'miq.event_type' => 'hawkular_event.critical'}
+      expect(subject.send(:whitelist?, event)).to be true
+    end
+
+    it "rejects event tagged with unknown event_type" do
+      event      = ::Hawkular::Alerts::Event.new({})
+      event.tags = {'miq.event_type' => 'hawkular_event.unknown'}
+      expect(subject.send(:whitelist?, event)).to be false
+    end
+
+    it "rejects event without event_type tag" do
+      event = ::Hawkular::Alerts::Event.new({})
+      expect(subject.send(:whitelist?, event)).to be false
+    end
+  end
+
+  context "#event_hash" do
+    require 'hawkular_all'
+
+    it "properly converts event supplying only required fields" do
+      event = ::Hawkular::Alerts::Event.new({})
+      event.ctime = Time.now.to_i
+      event.text = 'text message'
+      event.tags = {'miq.event_type' => 'hawkular_event.critical'}
+
+      hash = subject.send(:event_to_hash, event, 1)
+      expect(hash).to be_an Hash
+      expect(hash[:ems_id]).to eq 1
+      expect(hash[:source]).to eq 'HAWKULAR'
+      expect(hash[:timestamp]).to be_an Time
+      expect(hash[:event_type]).to eq 'hawkular_event.critical'
+      expect(hash[:message]).to eq 'text message'
+      expect(hash[:middleware_ref]).to be_nil
+      expect(hash[:middleware_type]).to be_nil
+      expect(hash[:full_data]).to be_an String
+    end
+
+    it "properly converts event supplying optional fields" do
+      event = ::Hawkular::Alerts::Event.new({})
+      event.ctime = Time.now.to_i
+      event.text    = 'text message'
+      event.context = {'resource_path' => 'canonical_path', 'message' => 'context message'}
+      event.tags    = {'miq.event_type' => 'hawkular_event.critical', 'miq.resource_type' => 'MiddlewareServer'}
+
+      hash = subject.send(:event_to_hash, event, 1)
+      expect(hash).to be_an Hash
+      expect(hash[:ems_id]).to eq 1
+      expect(hash[:source]).to eq 'HAWKULAR'
+      expect(hash[:timestamp]).to be_an Time
+      expect(hash[:event_type]).to eq 'hawkular_event.critical'
+      expect(hash[:message]).to eq 'context message'
+      expect(hash[:middleware_ref]).to eq 'canonical_path'
+      expect(hash[:middleware_type]).to eq 'MiddlewareServer'
+      expect(hash[:full_data]).to be_an String
+    end
+  end
+end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
@@ -33,7 +33,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream 
           subject.stop
         end
         expect(result.count).to be == 1
-        expect(result[0].category).to eq 'Hawkular Deployment'
+        expect(result[0].tags['miq.event_type']).to eq 'hawkular_event.critical'
       end
     end
   end

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?startTime=1460395364000
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?startTime=1462564369000&tags=miq.event_type%7C*&thin=true
     body:
       encoding: US-ASCII
       string: ''
@@ -33,7 +33,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 17:23:44 GMT
+      - Fri, 06 May 2016 19:53:49 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -41,27 +41,22 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '558'
+      - '339'
       Link:
-      - <http://localhost:8080/hawkular/alerts/events?startTime=1460395364000>; rel="current",
-        <http://localhost:8080/hawkular/alerts/events?startTime=1460395364000&page=0>;
+      - <http://localhost:8080/hawkular/alerts/events?startTime=1462564369000&tags=miq.event_type%7c*&thin=true>;
+        rel="current", <http://localhost:8080/hawkular/alerts/events?startTime=1462564369000&tags=miq.event_type%7c*&thin=true&page=0>;
         rel="last"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAALVTXWvbMBT9K0J7rRx/xZFTNihpQgvd1iVhY7ONke3rVJ0j
-        uZacNJT2t+862WAPeyiUyU+6X+fco+PkicIOlF0fWqBTOv86/7SmZ9SCEspe
-        VxjyuetHRRAxXkPIwiDwGQ9LzsZ+CN4kEBEvauyQQy3EfDKOfc5CEBULx3XB
-        hHBd5nluGdVVBDz2sLa0cotoXhi5QTwO4jDwwjNaCStWuu/KgUiutIKcnqJH
-        HhMRRKEXe0gBYhZW45gVwH0Wcz7mHGrEDkY3uhRNfgltow8XbdvIUlip1RJM
-        q5WBAVtY2OjugBOvxP5n34iOnOq3KMNx9Uc7KLFcfl4O9VqdIk/0IxgjNgO7
-        me6biihtSQtdrbstSU4zMqIVEST5CzsjG4kKk+JApBqkRnDSCntHkpE9f426
-        o/r8Vct358f1X14y0sFDD8ZCNfBJfNeLmBviM6y9ydQPfmRTshCywbTVpDoy
-        J4nFBmbktm2ABY6L3150Waq8KbkXO+E0Qm2c+WMJ7bDWlDyl9Nvi5vtsfeN6
-        3J2SFXQ7WYIhe4nLbaUxUm1GvcJe2YiigQEJVAWqlGBSSt5/IEmqCJ6U3hfa
-        GAfVNBJpqxJ6Ja2Tpin9J6133d1D2w9pIs0fLJKcpiixxZvz++WcI/lTZjCT
-        OVrMOMurL5erLKVnb6bg5Pnierla57dXF6t5nr+ZUqqyZ7TeTOBPgC5qbtEt
-        6Lr/ZRf6/Jz9AkJCADQIBAAA
+        H4sIAAAAAAAAAI1RXU/CMBT9K7MJbxRG99Ehr0Bior5IfDFmuWsvo7p12BVh
+        IfjbbYcuPvrQpDk9595zTl/OBD9R2023R3JLVs+rxw0ZE4satL2TDmJZyNIi
+        Smm2xZjGUcRoFouMJizGGY8gzYqtUyjPxbqlOzi+HyowtJ9Lk8Q9CqtqN34W
+        pyxJOU/TMAzHRIKFp+ZghN+c60Zj7rlgsWxM592cLBoNVW/oZB2ywdYGa1DV
+        jWc2+gqfSY1tCyX+0VRdoPQbCosyWHknQZJ4kcG2X5nvwe4cf2oX/0k43S44
+        FKzgICmbFwWN43lCIcuAcpSCFzyUgDg1i/tGQPX1NdxGbC1xXzVd7UyMouXQ
+        j2jqGrSkpQt8hI4ewUzcIReXFsq2j6U+Jn2Nub3+z68479GJMMoq0RfkqUO2
+        H/aDkrJysw0uBwfkcnn9BpoXKT31AQAA
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 17:23:44 GMT
+  recorded_at: Fri, 06 May 2016 19:53:49 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Alter and simplify approach
- pull only tagged [hawkular] events
- Let the hawkular event now provide the desired event_type
- Let the hawkular event optionally provide info to link to a resource
- Whitelist defined event_types
- Add new general, summary level event_type: hawkular_event.critical
- Fix issue with event_type hawkular_deployment.success