### PR TITLE
dialog_field_refresh.js#initializeDialogSelectPicker - fix 2 ignored and broken specs

### DIFF
--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -80,7 +80,9 @@ describe('dialogFieldRefresh', function() {
     beforeEach(function() {
       spyOn(dialogFieldRefresh, 'triggerAutoRefresh');
       spyOn(window, 'miqInitSelectPicker');
-      spyOn(window, 'miqSelectPickerEvent');
+      spyOn(window, 'miqSelectPickerEvent').and.callFake(function(fieldName, url, options) {
+        options.callback();
+      });
       spyOn($.fn, 'selectpicker');
       fieldName = 'fieldName';
       fieldId = 'fieldId';

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -116,15 +116,13 @@ describe('dialogFieldRefresh', function() {
       expect(window.miqSelectPickerEvent).toHaveBeenCalledWith('fieldName', 'url', {callback: jasmine.any(Function)});
     });
 
-    it('triggers the auto refresh when the drop down changes', function(done) {
+    it('triggers the auto refresh when the drop down changes', function() {
       dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
-      done();
       expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith(fieldId, 'true');
     });
 
-    it('triggers autorefresh with "false" when triggerAutoRefresh arg is false', function(done) {
+    it('triggers autorefresh with "false" when triggerAutoRefresh arg is false', function() {
       dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url, 'false');
-      done();
       expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith(fieldId, 'false');
     });
   });


### PR DESCRIPTION
Because a stray `done()` was called before any `expect` calls, the test would "succeed" but not actually test anything. With a warning in browser console..

```
Spec 'dialogFieldRefresh #initializeDialogSelectPicker triggers the auto refresh when the drop down changes' has no expectations.
Spec 'dialogFieldRefresh #initializeDialogSelectPicker triggers autorefresh with "false" when triggerAutoRefresh arg is false' has no expectations.
```

Fixing that made both specs fail - the failing test mocks `miqSelectPickerEvent` in `beforeEach`, but calls a function that passes that `triggerAutoRefresh` as a callback to `miqSelectPickerEvent` .. and expects `triggerAutoRefresh` to be called.

```
dialogFieldRefresh #initializeDialogSelectPicker triggers the auto refresh when the drop down changes
Expected spy triggerAutoRefresh to have been called with [ 'fieldId', 'true' ] but it was never called.

dialogFieldRefresh #initializeDialogSelectPicker triggers autorefresh with "false" when triggerAutoRefresh arg is false
Expected spy triggerAutoRefresh to have been called with [ 'fieldId', 'false' ] but it was never called.
```

Making the mock actually call the callback fixes the tests :).

The failure is the same as in https://github.com/ManageIQ/manageiq/pull/8514#issuecomment-217492071, and indeed this PR fixes it. => Cc: @petrblaho 