### PR TITLE
Fixes for Live Migrate UI

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -96,7 +96,7 @@ class VmCloudController < ApplicationController
   def live_migrate
     assert_privileges("instance_live_migrate")
     @record = find_by_id_filtered(VmOrTemplate, params[:id]) # Set the VM object
-    if @record.is_available(:live_migrate)
+    if @record.is_available?(:live_migrate)
       drop_breadcrumb(
         :name => _("Live Migrate Instance '%{name}'") % {:name => @record.name},
         :url  => "/vm_cloud/live_migrate"

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -96,16 +96,11 @@ class VmCloudController < ApplicationController
   def live_migrate
     assert_privileges("instance_live_migrate")
     @record = find_by_id_filtered(VmOrTemplate, params[:id]) # Set the VM object
-    if @record.is_available?(:live_migrate)
+    if @record.is_available?(:live_migrate) && !@record.ext_management_system.nil?
       drop_breadcrumb(
         :name => _("Live Migrate Instance '%{name}'") % {:name => @record.name},
         :url  => "/vm_cloud/live_migrate"
       ) unless @explorer
-      @edit = {}
-      @edit[:key] = "vm_migrate__#{@record.id}"
-      @edit[:vm_id] = @record.id
-      @edit[:explorer] = true if params[:action] == "x_button" || session.fetch_path(:edit, :explorer)
-      session[:edit] = @edit
       @in_a_form = true
       @refresh_partial = "vm_common/live_migrate"
     else
@@ -120,15 +115,20 @@ class VmCloudController < ApplicationController
   def live_migrate_form_fields
     assert_privileges("instance_live_migrate")
     @record = find_by_id_filtered(VmOrTemplate, params[:id])
-    clusters = @record.ext_management_system.ems_clusters.map do |c|
-      {:id => c.id, :name => c.name}
-    end
-    hosts = @record.ext_management_system.hosts.map do |h|
-      {:id => h.id, :name => h.name, :cluster_id => h.emd_cluster.id}
+    hosts = []
+    unless @record.ext_management_system.nil?
+      connection = @record.ext_management_system.connect
+      current_hostname = connection.handled_list(:servers).find do |s|
+        s.name == @record.name
+      end.os_ext_srv_attr_hypervisor_hostname
+      # OS requires its own name for the host be used in the migrate API, so get the
+      # provider hostname from fog.
+      hosts = connection.hosts.select { |h| h.service_name == "compute" && h.host_name != current_hostname }.map do |h|
+        {:name => h.host_name, :id => h.host_name}
+      end
     end
     render :json => {
-      :clusters => clusters,
-      :hosts    => hosts
+      :hosts => hosts
     }
   end
 
@@ -138,26 +138,24 @@ class VmCloudController < ApplicationController
 
     case params[:button]
     when "cancel"
-      add_flash(_("Live Migration of %{model} \"%{name}\" was cancelled by the user") % {
-        :model => ui_lookup(:table => "vm_cloud"), :name => @record.name})
-      session[:flash_msgs] = @flash_array.dup
-      render :update do |page|
-        page.redirect_to(previous_breadcrumb_url)
-      end
+      cancel_action(_("Live Migration of %{model} \"%{name}\" was cancelled by the user") % {
+        :model => ui_lookup(:table => 'vm_cloud'),
+        :name  => @record.name
+      })
     when "submit"
       if @record.is_available?(:live_migrate)
-        if params['auto_select_host'] == '1'
+        if params['auto_select_host'] == 'on'
           hostname = nil
         else
-          hostname = find_by_id_filtered(Host, params[:destination_host_id]).hostname
-          block_migration = @params[:block_migration]
-          disk_over_commit = @params[:disk_over_commit]
+          hostname = params[:destination_host]
         end
+        block_migration = params[:block_migration]
+        disk_over_commit = params[:disk_over_commit]
         begin
           @record.live_migrate(
             :hostname         => hostname,
-            :block_migration  => block_migration == '1',
-            :disk_over_commit => disk_over_commit == '1'
+            :block_migration  => block_migration == 'on',
+            :disk_over_commit => disk_over_commit == 'on'
           )
           add_flash(_("Live Migrating %{instance} \"%{name}\"") % {
             :instance => ui_lookup(:table => 'vm_cloud'),

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -164,7 +164,7 @@ class VmCloudController < ApplicationController
           add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
             :instance => ui_lookup(:table => 'vm_cloud'),
             :name     => @record.name,
-            :details  => ex}, :error)
+            :details  => get_error_message_from_fog(ex.to_s)}, :error)
         end
       else
         add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
@@ -382,5 +382,10 @@ class VmCloudController < ApplicationController
 
   def skip_breadcrumb?
     breadcrumb_prohibited_for_action?
+  end
+
+  def get_error_message_from_fog(ex)
+    matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
+    matched_message ? matched_message[1] : ex
   end
 end

--- a/app/helpers/application_helper/button/instance_migrate.rb
+++ b/app/helpers/application_helper/button/instance_migrate.rb
@@ -1,5 +1,10 @@
 class ApplicationHelper::Button::InstanceMigrate < ApplicationHelper::Button::Basic
-  def skip?
+  def calculate_properties
+    super
+    self[:title] = @record.is_available_now_error_message(:live_migrate) if disabled?
+  end
+
+  def disabled?
     !@record.is_available?(:live_migrate)
   end
 end

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -104,7 +104,14 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           'fa fa-clock-o fa-lg',
           t = N_('Retire this Instance'),
           t,
-          :confirm => N_("Retire this Instance?"))
+          :confirm => N_("Retire this Instance?")),
+        button(
+          :instance_live_migrate,
+          'product product-migrate fa-lg',
+          t = N_('Migrate Instance'),
+          t,
+          :klass     => ApplicationHelper::Button::InstanceMigrate,
+          :url_parms => 'main_div')
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -112,13 +112,6 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           t = N_('Retire this Instance'),
           t,
           :confirm => N_("Retire this Instance?")),
-        button(
-          :instance_live_migrate,
-          'product product-migrate fa-lg',
-          t = N_('Migrate Instance'),
-          t,
-          :klass     => ApplicationHelper::Button::InstanceMigrate,
-          :url_parms => 'main_div')
       ]
     ),
   ])

--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -7,52 +7,46 @@
       %label.col-md-2.control-label
         = _('Auto-select Host?')
       .col-md-8
-        = check_box_tag("auto_select_host",
-                        '1',
-                        @edit[:auto_select_host],
-                        'ng-model'     => "vmCloudModel.auto_select_host",
-                        :miqrequired   => true,
-                        :checkchange   => true,
-                        'ng-disabled'  => "hosts.length == 0")
-        = hidden_field_tag("auto_select_host",
-                           '1',
-                           'ng-disabled'  => "hosts.length > 0")
+        %input{:type         => "checkbox",
+               :name         => "auto_select_host",
+               'ng-model'    => "vmCloudModel.auto_select_host",
+               :miqrequired  => true,
+               :checkchange  => true,
+               'ng-disabled' => "hosts.length == 0"}
+
+        %input{:type         => "hidden",
+               :name         => "auto_select_host",
+               :value        => "on",
+               'ng-if'       => "hosts.length == 0"}
     .form-group
       %label.col-md-2.control-label
         = _('Block Migration')
       .col-md-8
-        = check_box_tag("block_migration",
-                        '1',
-                        @edit[:block_migration],
-                        'ng-model'     => "vmCloudModel.block_migration",
-                        :miqrequired   => true,
-                        :checkchange   => true)
+        %input{:type        => "checkbox",
+               :name        => "block_migration",
+               'ng-model'   => "vmCloudModel.block_migration",
+               :miqrequired => true,
+               :checkchange => true}
     .form-group
       %label.col-md-2.control-label
         = _('Disk Over Commit')
       .col-md-8
-        = check_box_tag("disk_over_commit",
-                        '1',
-                        @edit[:disk_over_commit],
-                        'ng-model'     => "vmCloudModel.disk_over_commit",
-                        :miqrequired   => true,
-                        :checkchange   => true)
+        %input{:type        => "checkbox",
+               :name        => "disk_over_commit",
+               'ng-model'   => "vmCloudModel.disk_over_commit",
+               :miqrequired => true,
+               :checkchange => true}
   #live-migrate-select-destination-host{'ng-hide' => 'vmCloudModel.auto_select_host'}
     %h3
       = _('Select Destination Host')
     .form-horizontal
       .form-group
         %label.col-md-2.control-label
-          = _('Cluster')
-        .col-md-8
-          %select{:name => 'cluster_id', 'ng-model' => 'vmCloudModel.cluster', 'ng-options' => 'cluster as cluster.name for cluster in clusters'}
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label
           = _('Destination Host')
         .col-md-8
-          %select{:name => 'destination_host_id', 'ng-model' => 'vmCloudModel.host', 'ng-options' => 'host.id as host.name for host in hosts | filter : {cluster_id: vmCloudModel.cluster.id}'}
-
+          %select{:name      => 'destination_host_id',
+                  'ng-model' => 'vmCloudModel.host',
+                  'ng-options' => 'host.name as host.name for host in hosts track by host.id'}
 
   %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
                   'paging_div_buttons_state_enabled' => true,

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -102,4 +102,18 @@ describe VmCloudController do
       end
     end
   end
+
+  context "#parse error messages" do
+    it "simplifies fog error message" do
+      raw_msg = "Expected(200) <=> Actual(400 Bad Request)\nexcon.error.response\n  :body          => "\
+                "\"{\\\"badRequest\\\": {\\\"message\\\": \\\"Keypair data is invalid: failed to generate "\
+                "fingerprint\\\", \\\"code\\\": 400}}\"\n  :cookies       => [\n  ]\n  :headers       => {\n "\
+                "\"Content-Length\"       => \"99\"\n    \"Content-Type\"         => \"application/json; "\
+                "charset=UTF-8\"\n    \"Date\"                 => \"Mon, 02 May 2016 08:15:51 GMT\"\n ..."\
+                ":reason_phrase => \"Bad Request\"\n  :remote_ip     => \"10....\"\n  :status        => 400\n  "\
+                ":status_line   => \"HTTP/1.1 400 Bad Request\\r\\n\"\n"
+      expect(subject.send(:get_error_message_from_fog, raw_msg)).to eq "Keypair data is invalid: failed to generate "\
+                                                                       "fingerprint"
+    end
+  end
 end

--- a/spec/helpers/application_helper/buttons/instance_migrate.rb
+++ b/spec/helpers/application_helper/buttons/instance_migrate.rb
@@ -1,0 +1,40 @@
+describe ApplicationHelper::Button::InstanceMigrate do
+  describe '#disabled?' do
+    it "when the live migrate action is available then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true)}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the live migrate action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the live migrate action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :is_available? => false, :is_available_now_error_message => "unavailable")}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("unavailable")
+    end
+
+    it "when the live migrate is avaiable, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true)}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
Update: Working on the Evacuate pull request with @sseago revealed a number of problems that applied to Live Migrate that this pull request is intended to resolve.

* Move Live Migrate button to the openstack-specific single vm toolbar
* Gracefully flash an error if Live Migrate is selected from the
  list view for an instance that doesn't support it.
* Disable and show a title message on the Live Migrate button rather than skipping it if the action is unsupported for a given instance.
* Show the human readable error message rather than the entire Fog exception when Migrate fails
* Fix incorrect handling of parameters from the front end
* Improve angular style of the live_migrate form partial.