### PR TITLE
Null coalescing operator for Automate Attributes

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -472,9 +472,15 @@ module MiqAeEngine
 
     def get_null_coalesced_value(f, type = nil)
       result = nil
+      current_value = nil
       f['value'].split(NULL_COALESCING_OPERATOR).each do |value|
         next unless result.blank?
-        result = substitute_value(value.strip, type)
+        begin
+          current_value = value.strip
+          result = substitute_value(current_value, type)
+        rescue => err
+          $miq_ae_logger.warn("#{err.message}, while evaluating :#{current_value} null coalecing attribute")
+        end
       end
       result = f['default_value'] if result.blank?
       result

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -38,7 +38,7 @@ module MiqAeEngine
       'request'                => 'MiqRequest',
       'server'                 => 'MiqServer'
     )
-    NULL_COALESCING_OPERATOR = '||'
+    NULL_COALESCING_OPERATOR = '||'.freeze
     attr_accessor :attributes, :namespace, :klass, :instance, :object_name, :instance_methods, :workspace, :current_field, :current_message
     attr_accessor :node_parent
     attr_reader :node_children

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -471,19 +471,23 @@ module MiqAeEngine
     end
 
     def get_null_coalesced_value(f, type = nil)
+      initial_value = f['value'] || f['default_value']
+      return nil unless initial_value
+
       result = nil
-      current_value = nil
-      f['value'].split(NULL_COALESCING_OPERATOR).each do |value|
-        next unless result.blank?
-        begin
-          current_value = value.strip
-          result = substitute_value(current_value, type)
-        rescue => err
-          $miq_ae_logger.warn("#{err.message}, while evaluating :#{current_value} null coalecing attribute")
-        end
+      initial_value.split(NULL_COALESCING_OPERATOR).each do |value|
+        result = resolve_value(value, type)
+        break unless result.blank?
       end
-      result = f['default_value'] if result.blank?
       result
+    end
+
+    def resolve_value(value, type)
+      current_value = value.strip
+      substitute_value(current_value, type)
+    rescue => err
+      $miq_ae_logger.warn("#{err.message}, while evaluating :#{current_value} null coalecing attribute")
+      nil
     end
 
     def self.convert_boolean_value(value)

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -11,11 +11,13 @@ class MiqAeField < ApplicationRecord
   validates_format_of     :name, :with => /\A[A-Za-z0-9_]+\z/i
 
   validates_inclusion_of  :substitute, :in => [true, false]
+
+  NULL_COALESCING_DATATYPE = "null coalescing"
   AVAILABLE_SCOPES    = ["class", "instance", "local"]
   validates_inclusion_of  :scope,      :in => AVAILABLE_SCOPES,    :allow_nil => true  # nil => instance
   AVAILABLE_AETYPES   = ["assertion", "attribute", "method", "relationship", "state"]
   validates_inclusion_of  :aetype,     :in => AVAILABLE_AETYPES,   :allow_nil => true  # nil => attribute
-  AVAILABLE_DATATYPES_FOR_UI = ["string", "symbol", "integer", "float", "boolean", "time", "array", "password"]
+  AVAILABLE_DATATYPES_FOR_UI = ["string", "symbol", "integer", "float", "boolean", "time", "array", "password", NULL_COALESCING_DATATYPE]
   AVAILABLE_DATATYPES        = AVAILABLE_DATATYPES_FOR_UI + ["host", "vm", "storage", "ems", "policy", "server", "request", "provision"]
   validates_inclusion_of  :datatype,   :in => AVAILABLE_DATATYPES, :allow_nil => true  # nil => string
 

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -12,12 +12,13 @@ class MiqAeField < ApplicationRecord
 
   validates_inclusion_of  :substitute, :in => [true, false]
 
-  NULL_COALESCING_DATATYPE = "null coalescing"
+  NULL_COALESCING_DATATYPE = "null coalescing".freeze
   AVAILABLE_SCOPES    = ["class", "instance", "local"]
   validates_inclusion_of  :scope,      :in => AVAILABLE_SCOPES,    :allow_nil => true  # nil => instance
   AVAILABLE_AETYPES   = ["assertion", "attribute", "method", "relationship", "state"]
   validates_inclusion_of  :aetype,     :in => AVAILABLE_AETYPES,   :allow_nil => true  # nil => attribute
-  AVAILABLE_DATATYPES_FOR_UI = ["string", "symbol", "integer", "float", "boolean", "time", "array", "password", NULL_COALESCING_DATATYPE]
+  AVAILABLE_DATATYPES_FOR_UI = ["string", "symbol", "integer", "float", "boolean", "time",
+                                "array", "password", NULL_COALESCING_DATATYPE].freeze
   AVAILABLE_DATATYPES        = AVAILABLE_DATATYPES_FOR_UI + ["host", "vm", "storage", "ems", "policy", "server", "request", "provision"]
   validates_inclusion_of  :datatype,   :in => AVAILABLE_DATATYPES, :allow_nil => true  # nil => string
 

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -797,12 +797,18 @@ module MiqAeEngineSpec
     before do
       @user = FactoryGirl.create(:user_with_group)
       nco_value = '${/#var1} || ${XY/ABC#var2} || Pebbles'
+      default_value = '${/#var2} || ${XY/ABC#var2} || Bamm Bamm Rubble'
       instance_name = 'FRED'
       ae_instances = {instance_name => {'field1' => {:value => nco_value},
-                                        'field2' => {:value => 'Bamm Bamm Rubble'}}}
+                                        'field2' => {:value => nil},
+                                        'field3' => {:value => nil}}}
 
-      ae_fields = {'field1' => {:aetype => 'attribute', :datatype => MiqAeField::NULL_COALESCING_DATATYPE},
-                   'field2' => {:aetype => 'attribute', :datatype => MiqAeField::NULL_COALESCING_DATATYPE}}
+      ae_fields = {'field1' => {:aetype => 'attribute', :default_value => default_value,
+                                :datatype => MiqAeField::NULL_COALESCING_DATATYPE},
+                   'field2' => {:aetype => 'attribute', :default_value => default_value,
+                                :datatype => MiqAeField::NULL_COALESCING_DATATYPE},
+                   'field3' => {:aetype => 'attribute',
+                                :datatype => MiqAeField::NULL_COALESCING_DATATYPE}}
       create_ae_model(:name => 'LUIGI', :ae_class => 'BARNEY',
                       :ae_namespace => 'A/C',
                       :ae_fields => ae_fields, :ae_instances => ae_instances)
@@ -821,6 +827,12 @@ module MiqAeEngineSpec
 
         expect(workspace.root['field1']).to eq('wilma')
         expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')
+      end
+
+      it "undefined variable" do
+        workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED", @user)
+        expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')
+        expect(workspace.root.attributes.keys.exclude?('field3')).to be_truthy
       end
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -1,3 +1,4 @@
+include AutomationSpecHelper
 module MiqAeEngineSpec
   include MiqAeEngine
   describe MiqAeEngine do
@@ -788,6 +789,38 @@ module MiqAeEngineSpec
         allow(MiqAeEngine).to receive(:create_automation_attribute_key).with(any_args).and_return("abc")
         expect(test_class).to receive(:before_ae_starts).once.with(options)
         MiqAeEngine.deliver(options)
+      end
+    end
+  end
+
+  describe MiqAeEngine do
+    before do
+      @user = FactoryGirl.create(:user_with_group)
+      nco_value = '${/#var1} || ${/#var2} || Pebbles'
+      instance_name = 'FRED'
+      ae_instances = {instance_name => {'field1' => {:value => nco_value},
+                                        'field2' => {:value => 'Bamm Bamm Rubble'}}}
+
+      ae_fields = {'field1' => {:aetype => 'attribute', :datatype => MiqAeField::NULL_COALESCING_DATATYPE},
+                   'field2' => {:aetype => 'attribute', :datatype => MiqAeField::NULL_COALESCING_DATATYPE}}
+      create_ae_model(:name => 'LUIGI', :ae_class => 'BARNEY',
+                      :ae_namespace => 'A/C',
+                      :ae_fields => ae_fields, :ae_instances => ae_instances)
+    end
+
+    context "null colaescing" do
+      it "uses default when variable missing" do
+        workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED", @user)
+
+        expect(workspace.root['field1']).to eq('Pebbles')
+        expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')
+      end
+
+      it "first non nil value" do
+        workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED?var2=wilma", @user)
+
+        expect(workspace.root['field1']).to eq('wilma')
+        expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')
       end
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -807,7 +807,7 @@ module MiqAeEngineSpec
                                 :datatype => MiqAeField::NULL_COALESCING_DATATYPE},
                    'field2' => {:aetype => 'attribute', :default_value => default_value,
                                 :datatype => MiqAeField::NULL_COALESCING_DATATYPE},
-                   'field3' => {:aetype => 'attribute',
+                   'field3' => {:aetype   => 'attribute',
                                 :datatype => MiqAeField::NULL_COALESCING_DATATYPE}}
       create_ae_model(:name => 'LUIGI', :ae_class => 'BARNEY',
                       :ae_namespace => 'A/C',

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -796,7 +796,7 @@ module MiqAeEngineSpec
   describe MiqAeEngine do
     before do
       @user = FactoryGirl.create(:user_with_group)
-      nco_value = '${/#var1} || ${/#var2} || Pebbles'
+      nco_value = '${/#var1} || ${XY/ABC#var2} || Pebbles'
       instance_name = 'FRED'
       ae_instances = {instance_name => {'field1' => {:value => nco_value},
                                         'field2' => {:value => 'Bamm Bamm Rubble'}}}
@@ -817,7 +817,7 @@ module MiqAeEngineSpec
       end
 
       it "first non nil value" do
-        workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED?var2=wilma", @user)
+        workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED?var1=wilma", @user)
 
         expect(workspace.root['field1']).to eq('wilma')
         expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')

--- a/spec/lib/miq_automation_engine/models/miq_ae_field_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_field_spec.rb
@@ -133,7 +133,8 @@ describe MiqAeField do
 
     it "should validate datatypes" do
       MiqAeField.available_datatypes.each do |datatype|
-        f = @c1.ae_fields.build(:name => "fname_#{datatype}", :aetype => "attribute", :datatype => datatype)
+        f = @c1.ae_fields.build(:name => "fname_#{datatype.gsub(/ /,'_')}",
+                                :aetype => "attribute", :datatype => datatype)
         expect(f).to be_valid
         expect(f.save!).to be_truthy
       end


### PR DESCRIPTION
Null coalescing automate attributes
    
    Allow for automate attributes to contain multiple values
    separated by || (two vertical bars). At runtime we use the first non nil value,
    the rest are ignored.
    
    e.g.
    
    '${/#var1} || ${/#var2} || Pebbles'
    
    When defining a field in the class schema you can set the datatype
    to null coalescing to get this feature.