### PR TITLE
Lazy load message catalogs (po) on first use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem "secure_headers",                 "~>3.0.0"
 # Needed by the REST API
 gem "gettext_i18n_rails",             "~>1.4.0"
 gem "gettext_i18n_rails_js",          "~>1.0.3"
+gem "fast_gettext",                   "~>1.1.0"
 gem "jbuilder",                       "~>2.3.1"
 gem "paperclip",                      "~>4.3.0"
 gem "rails-i18n",                     "~>5.x"

--- a/config/human_locale_names.yaml
+++ b/config/human_locale_names.yaml
@@ -1,0 +1,6 @@
+---
+human_locale_names:
+  en: English
+  ja: 日本語
+  nl: Nederlands
+  zh_CN: 简体中文

--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -5,6 +5,7 @@ begin
   # trying to debug something other than their parser, we need to
   # temporarily force it off while we load stuff.
   Vmdb::FastGettextHelper.register_locales
+  Vmdb::FastGettextHelper.register_human_localenames
   gettext_options = %w(--sort-by-msgid --location --no-wrap)
   Rails.application.config.gettext_i18n_rails.msgmerge = gettext_options + ["--no-fuzzy-matching"]
   Rails.application.config.gettext_i18n_rails.xgettext = gettext_options + ["--add-comments=TRANSLATORS"]

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -90,4 +90,26 @@ namespace :gettext do
       end
     end
   end
+
+  desc "Extract human locale names from translation catalogs and store them in a yaml file"
+  task :extract_locale_names do
+    require 'yaml/store'
+    require Rails.root.join("lib/vmdb/fast_gettext_helper")
+
+    Vmdb::FastGettextHelper.register_locales
+
+    locale_hash = {}
+    FastGettext.available_locales.each do |locale|
+      FastGettext.locale = locale
+      # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
+      human_locale = _("locale_name")
+      human_locale = locale if human_locale == "locale_name"
+      locale_hash[locale] = human_locale
+    end
+
+    store = YAML::Store.new("config/human_locale_names.yaml")
+    store.transaction do
+      store['human_locale_names'] = locale_hash
+    end
+  end
 end

--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -1,28 +1,14 @@
 module Vmdb
   module FastGettextHelper
-    def self.human_locale(locale)
-      # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
-
-      # We lazy load the message catalogs on first use so we need to find another
-      # way to get a human friendly locale besides loading all of the catalogs
-      # to get this "human friendly locale" value.
-      return locale
-      human_locale = _("locale_name")
-      human_locale = locale if human_locale == "locale_name"
-      human_locale
-    end
-
     def self.register_human_localenames
-      original_locale = FastGettext.locale
+      human_locale_names = YAML.load_file(Rails.root.join('config/human_locale_names.yaml'))['human_locale_names']
+
       FastGettext.class.class_eval { attr_accessor :human_available_locales }
       FastGettext.human_available_locales = []
       FastGettext.available_locales.each do |locale|
-        FastGettext.locale = locale
-        FastGettext.human_available_locales << [human_locale(locale), locale]
+        FastGettext.human_available_locales << [human_locale_names[locale], locale]
       end
       FastGettext.human_available_locales.sort! { |a, b| a[0] <=> b[0] }
-    ensure
-      FastGettext.locale = original_locale
     end
 
     def self.fix_i18n_available_locales
@@ -76,7 +62,6 @@ module Vmdb
       # temporary hack to fix a problem with locales including "_"
       fix_i18n_available_locales
       FastGettext.default_text_domain = 'manageiq'
-      register_human_localenames
     end
   end
 end

--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -2,6 +2,11 @@ module Vmdb
   module FastGettextHelper
     def self.human_locale(locale)
       # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
+
+      # We lazy load the message catalogs on first use so we need to find another
+      # way to get a human friendly locale besides loading all of the catalogs
+      # to get this "human friendly locale" value.
+      return locale
       human_locale = _("locale_name")
       human_locale = locale if human_locale == "locale_name"
       human_locale


### PR DESCRIPTION
UPDATED AGAIN:
Lazy loading message catalogs is now the default in fast_gettext as of 1.1.0, due to grosser/fast_gettext#79.

Create list of human locale names from a pre-prepared yaml file to avoid loading all of the catalogs for a human friendly locale name value.

https://bugzilla.redhat.com/show_bug.cgi?id=1341321

**Before**
```
# Rails console has 4 MO files loaded
irb(main):001:0> ObjectSpace.each_object(FastGettext::GetText::MOFile) {}
=> 4

# time bin/rails r 1
bin/rails r 1  6.95s user 1.51s system 99% cpu 8.492 total
bin/rails r 1  6.99s user 1.50s system 99% cpu 8.521 total
```

**After**
```
# Rails console has 1 MO file loaded
irb(main):001:0> ObjectSpace.each_object(FastGettext::GetText::MOFile) {}
=> 1

# time bin/rails r 1
bin/rails r 1  5.05s user 1.55s system 99% cpu 6.644 total
bin/rails r 1  5.08s user 1.64s system 98% cpu 6.789 total
```

**Rails runner memory usage**

```
RAILS_ENV=production bin/rails r 'top = `/usr/bin/top -l 1 -pid #{Process.pid} | grep -E "ruby.+M"`; memory = top.split[7].to_i; puts memory'
```

memory before | memory after
--- | ---
176 | 149
176 | 146
172 | 144
