### PR TITLE
Remove static method MiqExpression.evaluate

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1016,8 +1016,8 @@ class MiqExpression
     Metric::Rollup.excluded_col_for_expression?(col.to_sym)
   end
 
-  def self.evaluate(expression, obj, tz = nil)
-    ruby_exp = expression.kind_of?(Hash) ? new(expression).to_ruby(tz) : expression.to_ruby(tz)
+  def evaluate(obj, tz = nil)
+    ruby_exp = to_ruby(tz)
     _log.debug("Expression before substitution: #{ruby_exp}")
     subst_expr = Condition.subst(ruby_exp, obj)
     _log.debug("Expression after substitution: #{subst_expr}")
@@ -1026,13 +1026,9 @@ class MiqExpression
     result
   end
 
-  def evaluate(obj, tz = nil)
-    self.class.evaluate(self, obj, tz)
-  end
-
   def self.evaluate_atoms(exp, obj)
     exp = exp.kind_of?(self) ? copy_hash(exp.exp) : exp
-    exp["result"] = evaluate(exp, obj)
+    exp["result"] = new(exp).evaluate(obj)
 
     operators = exp.keys
     operators.each do|k|

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -2094,4 +2094,16 @@ describe MiqExpression do
       expect(obj.evaluate(@data_hash)).to eq(false)
     end
   end
+
+  describe ".evaluate_atoms" do
+    it "adds mapping 'result'=>false to expression if expression evaluates to false on supplied object" do
+      expression = {">=" => {"field" => "Vm-num_cpu",
+                             "value" => "2"}}
+      result = described_class.evaluate_atoms(expression, FactoryGirl.build(:vm))
+      expect(result).to include(
+        ">="     => {"field" => "Vm-num_cpu",
+                     "value" => "2"},
+        "result" => false)
+    end
+  end
 end


### PR DESCRIPTION
Refactoring MiqExpression - #7751

1. Removed class method .evaluate - it is used only localy, and implementation moved to instance method. 
2. Added test coverage for .evaluate_atoms

/cc @imtayadeway 
@miq-bot add-label core, refactoring