### PR TITLE
ui_1 - fix form_field_changed url to actually be the whole path, not just method name

### DIFF
--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -1,4 +1,4 @@
-- url = "form_field_changed"
+- url = url_for(:action => "form_field_changed")
 - url_json = {:url => url_for(:action => "form_field_changed")}.to_json
 = render :partial => "layouts/flash_msg"
 


### PR DESCRIPTION
If you acccess My settings via the menu, you end up at `/configuration/index`, so, POSTing observe events to `form_field_changed` actually works just fine.

But you can also end up at `/configuration`, which results in `/form_field_changed` for the POST.

Fixing to call `url_for` to get the full path :).

@h-kataria could you, please? (Mostly because you may have had a reason.. :))