### PR TITLE
Fix Volumes UI - show capacity value

### DIFF
--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module PersistentVolumeHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name creation_timestamp resource_version capacity access_modes reclaim_policy status_phase
+    %i(name creation_timestamp resource_version access_modes reclaim_policy status_phase
        storage_medium_type gce_pd_resource git_repository git_revision nfs_server
        iscsi_target_portal iscsi_target_qualified_name iscsi_target_lun_number glusterfs_endpoint_name
        rados_ceph_monitors rados_image_name rados_pool_name rados_user_name rados_keyring
@@ -25,6 +25,11 @@ module PersistentVolumeHelper::TextualSummary
     items.collect { |m| send("textual_#{m}") }.flatten.compact
   end
 
+  def textual_group_capacity
+    labels = [_("Resource"), _("Quantity")]
+    {:labels => labels, :values => @record.capacity}
+  end
+
   #
   # Items
   #
@@ -35,10 +40,6 @@ module PersistentVolumeHelper::TextualSummary
 
   def textual_resource_version
     @record.resource_version
-  end
-
-  def textual_capacity
-    @record.capacity
   end
 
   def textual_access_modes

--- a/app/views/persistent_volume/_main.html.haml
+++ b/app/views/persistent_volume/_main.html.haml
@@ -10,3 +10,5 @@
                                                                :items => textual_group_relationships}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
                                                                     :items => textual_group_smart_management}
+    = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Capacity"),
+                                                                    :items => textual_group_capacity}


### PR DESCRIPTION
 #7955 changed capacity field from string to hash, so currently the capacity value does not show up. This fix adds a capacity table to support multiple resources.
cc @alongoldboim @simon3z 

![cap1](https://cloud.githubusercontent.com/assets/11769555/15097663/45d86c98-152b-11e6-83fb-59edd0c615b3.png)

![cap9](https://cloud.githubusercontent.com/assets/11769555/15187786/3638686a-17ab-11e6-9b1c-e83202b35ea1.png)

