### PR TITLE
Alignment of Hash rockets causes Rubocop errors in Haml

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -66,6 +66,7 @@ linters:
       - Style/TrailingBlankLines
       - Style/TrailingWhitespace
       - Style/WhileUntilModifier
+      - Style/SpaceAroundOperators
 
   RubyComments:
     enabled: true


### PR DESCRIPTION
As alignment of hash rockets is more important in Haml files than
not having spaces around hash rockets, ignoring this style for
haml-lint

/cc @Fryguy