### PR TITLE
[WIP] [FIX BUILD] use pool name for adhoc db connections

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -91,8 +91,7 @@ class MiqRegionRemote < ApplicationRecord
   def self.with_remote_connection(host, port, username, password, database, adapter)
     # Don't allow accidental connections to localhost.  A blank host will
     # connect to localhost, so don't allow that at all.
-    host = host.to_s.strip
-    raise ArgumentError, _("host cannot be blank") if host.blank?
+    host = host && host.to_s.strip
     if [nil, "", "localhost", "localhost.localdomain", "127.0.0.1", "0.0.0.0"].include?(host)
       local_database = Rails.configuration.database_configuration.fetch_path(Rails.env, "database").to_s.strip
       if database == local_database

--- a/spec/models/miq_region_remote_spec.rb
+++ b/spec/models/miq_region_remote_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe MiqRegionRemote do
 
       config = Rails.configuration.database_configuration[Rails.env]
       params = config.values_at("host", "port", "username", "password", "database", "adapter")
-      params[0] ||= "localhost"
       params[4]   = "template1"
 
       described_class.with_remote_connection(*params) do |c|


### PR DESCRIPTION
per https://github.com/rails/rails/pull/24844 we are no longer able to connect to an adhoc database.

This changes our use of pools to use named pools.

Getting our replication credentials into our `database.yml` (which feels right) works, but is probably too much of a change this late in the game.

Also, there currently isn't the provision to ping a database.

/cc @jrafanie 