### PR TITLE
Rbac ids

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -111,7 +111,7 @@ class MiqSchedule < ApplicationRecord
     # Let RBAC evaluate the filter's MiqExpression, and return the first value (the target ids)
     my_filter = get_filter
     return [] if my_filter.nil?
-    Rbac.filtered(towhat, :filter => my_filter)
+    Rbac.filtered(towhat, :filter => my_filter, :results_format => :ids)
   end
 
   def get_targets

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -316,7 +316,7 @@ module Rbac
   end
 
   def self.filtered(objects, options = {})
-    Rbac.search(options.merge(:targets => objects, :results_format => :objects)).first
+    Rbac.search(options.reverse_merge(:targets => objects, :results_format => :objects)).first
   end
 
   # @param klass [Class] base_class found in CLASSES_THAT_PARTICIPATE_IN_RBAC
@@ -355,7 +355,7 @@ module Rbac
   # @option options :sub_filter
   # @option options :include_for_find [Array<Symbol>]
   # @option options :filter
-  # @option options :results_format [:id, :objects] (default: for object targets, :object, otherwise :id)
+  # @option options :results_format [:ids, :objects] (default: for object targets, :object, otherwise :ids)
 
   # @option options :user         [User]     (default: current_user)
   # @option options :userid       [String]   User#userid (not user_id)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -316,11 +316,6 @@ module Rbac
   end
 
   def self.filtered(objects, options = {})
-    if objects.nil?
-      Vmdb::Deprecation.deprecation_warning("objects = nil",
-                                            "use [] to get an empty result back. nil will return all records",
-                                            caller(0)) unless Rails.env.production?
-    end
     Rbac.search(options.merge(:targets => objects, :results_format => :objects)).first
   end
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -321,7 +321,7 @@ module Rbac
                                             "use [] to get an empty result back. nil will return all records",
                                             caller(0)) unless Rails.env.production?
     end
-    Rbac.search(options.merge(:targets => objects, :results_format => :objects, :empty_means_empty => true)).first
+    Rbac.search(options.merge(:targets => objects, :results_format => :objects)).first
   end
 
   # @param klass [Class] base_class found in CLASSES_THAT_PARTICIPATE_IN_RBAC
@@ -381,15 +381,8 @@ module Rbac
   # @option attrs target_ids_for_paging
 
   def self.search(options = {})
-    # now:   search(:targets => [],  :class => Vm) searches Vms
-    # later: search(:targets => [],  :class => Vm) returns []
-    #        search(:targets => nil, :class => Vm) will always search Vms
     if options.key?(:targets) && options[:targets].kind_of?(Array) && options[:targets].empty?
-      return [], {:total_count => 0} if options[:empty_means_empty]
-
-      Vmdb::Deprecation.deprecation_warning(":targets => []", "use :targets => nil to search all records",
-                                            caller(0)) unless Rails.env.production?
-      options[:targets] = nil
+      return [], {:total_count => 0}
     end
     # => empty inputs - normal find with optional where_clause
     # => list if ids - :class is required for this format.


### PR DESCRIPTION
- `MiqSchedule#target_ids` needs to return ids not objects. Change `Rbac.filtered` to `reverse_merge` the options to let the caller override.

The line was too long and rubocop was complaining
So I removed useless deprecation:

- Rbac.filtered(`nil`) is not called in any of our code, remove the deprecation. 
- Rbac.search(:targets => []) - the 1 caller of interest was removed.

/cc @gtanzillo 