### PR TITLE
Removed .off on change event from bootstrap selects

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1344,7 +1344,6 @@ function miqSelectPickerEvent(element, url, options) {
   options.no_encoding = true;
   var firstarg = ! _.contains(url, '?');
 
-  $('#' + element).off('change');
   $('#' + element).on('change', _.debounce(function() {
     var selected = $(this).val();
     var finalUrl = url + (firstarg ? '?' : '&') + element + '=' + escape(selected);


### PR DESCRIPTION
Don't need to turn off on change event on selects as there are no other observers on the selects. This was causing it to not display selected value as selected in selects after user made a selection on some of the selects.

Fixes #8537 

https://bugzilla.redhat.com/show_bug.cgi?id=1328828

@martinpovolny @himdel @dclarizio please review, i tested various parts of UI it seems to be working well. Some of the areas i noticed issue on is Chargeback assignments, OPS/Settings/Authentication tab