### PR TITLE
Azure: Upgrade to latest azure-armrest gem

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -15,7 +15,7 @@ gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails
 # Not locally modified and not required
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.3",            :require => false
-gem "azure-armrest",           "~> 0.2.4"
+gem "azure-armrest",           "~> 0.2.6"
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false


### PR DESCRIPTION
Version 0.2.6 of the azure-armrest gem contains a code change that selects a default subscription ID that   has been tested and proven to match the tenant ID supplied by the user when adding an Azure provider. For a more detailed description of the problem and solution refer to:
https://github.com/ManageIQ/azure-armrest/pull/164

https://bugzilla.redhat.com/show_bug.cgi?id=1331843