### PR TITLE
li_link(): restore tag_attrs when doing polymorphic links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -927,7 +927,7 @@ module ApplicationHelper
       tag_attrs[:onclick] = 'return miqCheckForChanges()' if check_changes
       content_tag(:li) do
         if args[:record] && restful_routed?(args[:record])
-          link_to(link_text, polymorphic_path(args[:record], :display => args[:display]))
+          link_to(link_text, polymorphic_path(args[:record], :display => args[:display]), tag_attrs)
         else
           link_to(link_text, link_params, tag_attrs)
         end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1591,7 +1591,8 @@ describe ApplicationHelper do
          :controller => 'availability_zone',
          :record     => FactoryGirl.create(:availability_zone),
          :action     => 'show_list',
-         :display    => 'something'}
+         :display    => 'something',
+         :title      => 'sometitle'}
       end
 
       subject { li_link(args) }
@@ -1602,6 +1603,10 @@ describe ApplicationHelper do
 
       it 'renders onclick correctly' do
         expect(subject).to have_xpath("//a[@onclick = 'return miqCheckForChanges()']")
+      end
+
+      it 'renders title correctly' do
+        expect(subject).to have_xpath("//a[@title = 'sometitle']")
       end
     end
 
@@ -1611,7 +1616,8 @@ describe ApplicationHelper do
          :controller => 'availability_zone',
          :record_id  => FactoryGirl.create(:availability_zone).id,
          :action     => 'show_list',
-         :display    => 'something'}
+         :display    => 'something',
+         :title      => 'sometitle'}
       end
 
       subject { li_link(args) }
@@ -1622,6 +1628,10 @@ describe ApplicationHelper do
 
       it 'renders onclick correctly' do
         expect(subject).to have_xpath("//a[@onclick = 'return miqCheckForChanges()']")
+      end
+
+      it 'renders title correctly' do
+        expect(subject).to have_xpath("//a[@title = 'sometitle']")
       end
     end
   end


### PR DESCRIPTION
The tag_attrs need to be part of `link_to()` invocation to be able to put title (tooltip)
into the rendered link correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1333955