### PR TITLE
Fix VimBroker Continuous Full Refresh

### DIFF
--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -192,6 +192,11 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
       return
     end
 
+    unless self.class.emses_and_hosts_to_monitor.include?(ems)
+      _log.info "#{log_prefix} Not reconnecting inactive connection to #{event[:server]}"
+      return
+    end
+
     reconnect_ems(ems)
   end
 


### PR DESCRIPTION
If a VimBroker connection is opened for an EMS that is not in the server's zone the VimBrokerWorker terminates the connection.

When the VimBroker terminates the connection it fires off a MiqVimRemoved event.  The VimBrokerWorker was responding to this event by automatically re-connecting to that EMS.  Instead it should check the list of EMSs it is supposed to be connected to before re-connecting.

https://bugzilla.redhat.com/show_bug.cgi?id=1332317