### PR TITLE
Updated Azure refresher specs and cassette

### DIFF
--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Length:
       - '186'
       Content-Type:
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 2fb6b441-0e15-4965-ad49-392d61025d6a
+      - 036c0728-b757-4974-991a-a86e5934a2c6
       Client-Request-Id:
-      - c9220da6-2216-48b6-8387-c16963149cb1
+      - 86c946c7-9f55-4f3e-a407-4dc314cda595
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_226
+      - ESTSFE_IN_357
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -45,20 +45,22 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
+      - esctx=AAABAAAAiL9Kn2Z27UubvWFPbm0gLT7GTSDTJG-2B1JrAOKllQvOWeSI2DpRzSjIdi6nwXI4-8HYTdcMqyq3CCof5bYKKYb-Z6-Gm3lWVQ0lBWnKdxpRLLe-JxbBjZSgP0MldrHQzOoqomxSBMoVzIf-4KvSXv3HcnrnMCmZ55Y2lyYnnWRGJCAynB9tCeAuJiXPA-03IAA;
+        domain=.login.windows.net; path=/; secure; HttpOnly
       - flight-uxoptin=true; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 08 Apr 2016 15:24:39 GMT
+      - Mon, 09 May 2016 17:15:58 GMT
       Content-Length:
       - '1247'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1460132679","not_before":"1460128779","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg"}'
+      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1462817758","not_before":"1462813858","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ"}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:39 GMT
+  recorded_at: Mon, 09 May 2016 17:15:59 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -71,11 +73,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -94,23 +96,74 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - 88c0cf95-f34b-4185-8d86-6e0875ab2e83
+      - bb17f499-bea4-45ad-9a58-084002bfc0ad
       X-Ms-Correlation-Request-Id:
-      - 88c0cf95-f34b-4185-8d86-6e0875ab2e83
+      - bb17f499-bea4-45ad-9a58-084002bfc0ad
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152440Z:88c0cf95-f34b-4185-8d86-6e0875ab2e83
+      - NORTHCENTRALUS:20160509T171559Z:bb17f499-bea4-45ad-9a58-084002bfc0ad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:39 GMT
+      - Mon, 09 May 2016 17:15:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01"}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:40 GMT
+  recorded_at: Mon, 09 May 2016 17:15:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14851'
+      X-Ms-Request-Id:
+      - a2aab27c-17ed-4ae7-80b5-f02385f11162
+      X-Ms-Correlation-Request-Id:
+      - a2aab27c-17ed-4ae7-80b5-f02385f11162
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160509T171559Z:a2aab27c-17ed-4ae7-80b5-f02385f11162
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 09 May 2016 17:15:59 GMT
+      Content-Length:
+      - '2903'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName","tagName":"displayName","count":{"type":"Total","value":19},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterVirtualMachine","tagValue":"OpenShiftMasterVirtualMachine","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/DeployOpenShift","tagValue":"DeployOpenShift","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodes","tagValue":"OpenShiftNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/PrepNodes","tagValue":"PrepNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/KeyVault","tagValue":"KeyVault","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLB","tagValue":"OpenShiftNodeLB","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterNetworkInterface","tagValue":"OpenShiftMasterNetworkInterface","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeNetworkInterfaces","tagValue":"OpenShiftNodeNetworkInterfaces","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLBPublicIP","tagValue":"OpenShiftNodeLBPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterPublicIP","tagValue":"OpenShiftMasterPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualNetwork","tagValue":"VirtualNetwork","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/StorageAccounts","tagValue":"StorageAccounts","count":{"type":"Total","value":2}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand","tagName":"on-demand","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand/tagValues/true","tagValue":"true","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test","tagName":"rlt_test","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test/tagValues/b","tagValue":"b","count":{"type":"Total","value":1}}]}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 17:16:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -123,11 +176,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -146,20 +199,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - ed052027-653f-4ebb-8ec5-e26bc066f034
+      - 7b5fe41c-7e26-4967-bb37-58027269cdd7
       X-Ms-Correlation-Request-Id:
-      - ed052027-653f-4ebb-8ec5-e26bc066f034
+      - 7b5fe41c-7e26-4967-bb37-58027269cdd7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152440Z:ed052027-653f-4ebb-8ec5-e26bc066f034
+      - NORTHCENTRALUS:20160509T171601Z:7b5fe41c-7e26-4967-bb37-58027269cdd7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:39 GMT
+      - Mon, 09 May 2016 17:16:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+      string: '{"value":[{"namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West US (Partner)"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-03-25"]}]},{"namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]},{"namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -185,37 +242,39 @@ http_interactions:
         US","West US","South Central US","North Europe","East Asia","Japan East","West
         Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
         South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2015-07-01-preview","2015-07-01"]}]},{"namespace":"Microsoft.Automation","resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-04-01","2015-10-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2015-07-01-preview","2015-07-01"]}]},{"namespace":"Microsoft.Automation","resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
         Central US","Australia Southeast","Central India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
         Central US","Australia Southeast","Central India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Central India","Australia Southeast"],"apiVersions":["2015-10-31"]},{"resourceType":"operations","locations":["South
+        Central US","Central India","Australia Southeast"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Australia Southeast","Central India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
         Central US"],"apiVersions":["2015-10-31","2015-01-01-preview"]}]},{"namespace":"Microsoft.Batch","resourceTypes":[{"resourceType":"batchAccounts","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Southeast Asia","South Central US","Australia East","South India","Central
-        India","West India"],"apiVersions":["2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        India","West India","Canada Central","Canada East","UK South 2","UK North"],"apiVersions":["2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Southeast Asia","South Central US","Australia East","South India","Central
-        India","West India"],"apiVersions":["2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        India","West India","Canada Central","Canada East","UK South 2","UK North"],"apiVersions":["2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Southeast Asia","South Central US","Australia East","South India","Central
-        India","West India"],"apiVersions":["2015-12-01","2015-09-01"]}]},{"namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        India","West India","Canada Central","Canada East","UK South 2","UK North"],"apiVersions":["2015-12-01","2015-09-01"]}]},{"namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US (Partner)","West US"],"apiVersions":["2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-07-02"]}]},{"namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}]},{"namespace":"Microsoft.Cache","resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","Canada Central","Canada East","South India"],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        India","Canada Central","Canada East","South India"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","South India","Canada Central","Canada East"],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        India","South India","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -226,164 +285,179 @@ http_interactions:
         India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"operationresults","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operations","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]},{"resourceType":"edgenodes","locations":["Central
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2015-06-01"]}]},{"namespace":"Microsoft.CertificateRegistration","resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}]},{"namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]}]},{"namespace":"Microsoft.CertificateRegistration","resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}]},{"namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
-        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
-        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
-        Asia","Australia East","Australia Southeast","South India","Central India","West
-        India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
-        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
-        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
-        Asia","Australia East","Australia Southeast","South India","Central India","West
-        India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
-        Central US","South Central US","East US","East US 2","West US","Central US","East
-        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast","South India","Central India","West
-        India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2015-12-01","2015-10-01"]}]},{"namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","UK
+        North","UK South 2","Canada Central","Canada East","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","South India","Central India","West India","East
+        US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","UK
+        North","UK South 2","Canada Central","Canada East","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","South India","Central India","West India","East
+        US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","Central US","East Asia","Southeast Asia","North Europe","West
+        Europe","UK North","UK South 2","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","West India","East
+        US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]}]},{"namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"reservedIps","locations":["East
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}]},{"namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}]},{"namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
+        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","East US 2 (Stage)","North Central US (Stage)","East US","East US 2","North
-        Central US","North Europe","West Europe","Brazil South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        Central US","North Europe","West Europe","Brazil South","UK North","UK South
+        2","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","East US 2 (Stage)","North Central US (Stage)","East US","East US 2","North
-        Central US","North Europe","West Europe","Brazil South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}]},{"namespace":"Microsoft.ClassicInfrastructureMigrate","resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Central US","North Europe","West Europe","Brazil South","UK North","UK South
+        2","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}]},{"namespace":"Microsoft.ClassicInfrastructureMigrate","resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-06-15"]}]},{"namespace":"Microsoft.CognitiveServices","resourceTypes":[{"resourceType":"accounts","locations":["West
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}]},{"namespace":"Microsoft.CognitiveServices","resourceTypes":[{"resourceType":"accounts","locations":["West
         US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/publishers","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast","Brazil South"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"disks","locations":["Southeast
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"disks","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.ContainerService","resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.ContainerService","resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
-        Central US","West Europe","North Europe","East US"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        Central US","West Europe","North Europe","East US"],"apiVersions":["2016-03-30","2015-11-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
-        Central US","West Europe","North Europe","East US"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}]},{"namespace":"Microsoft.CortanaAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["West
+        Central US","West Europe","North Europe","East US"],"apiVersions":["2016-03-30","2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-30","2015-11-01-preview"]}]},{"namespace":"Microsoft.CortanaAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["West
         US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","Japan
         East","East Asia"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
@@ -395,32 +469,37 @@ http_interactions:
         US"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
         US"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
         US"],"apiVersions":["2015-08-01-preview"]}]},{"namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
-        US","North Europe"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
-        Europe","West US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
-        Europe","West US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}]},{"namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}]},{"namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.DataLakeStore","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.DataLakeStore","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":["East
+        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":["East
         US","North Europe","East Asia","West US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast"],"apiVersions":["2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":["East
         US","North Europe","East Asia","West US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast"],"apiVersions":["2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["East
         US","North Europe","East Asia","West US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast"],"apiVersions":["2016-02-03","2015-08-15-preview"]}]},{"namespace":"Microsoft.DevTestLab","resourceTypes":[{"resourceType":"labs","locations":["Southeast
-        Asia","East US","West US","West Europe","East Asia","East US 2","Japan East","Japan
-        West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"environments","locations":["Southeast
-        Asia","East US","West US","West Europe","East Asia","East US 2","Japan East","Japan
-        West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"labs/environments","locations":["Southeast
-        Asia","East US","West US","West Europe","East Asia","East US 2","Japan East","Japan
-        West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["Southeast
-        Asia","East US","West US","West Europe","East Asia","East US 2","Japan East","Japan
-        West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-05-21-preview","2015-05-01"]},{"resourceType":"locations/operations","locations":["East
-        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
-        East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-05-21-preview"]}]},{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["West
+        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
+        Central US","East US","West US","South Central US","West Europe","East Asia","East
+        US 2","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"environments","locations":["Southeast
+        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
+        Central US","East US","West US","West Europe","East Asia","East US 2","Japan
+        East","Japan West","Central US","South Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"labs/environments","locations":["Southeast
+        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
+        Central US","South Central US","East US","West US","West Europe","East Asia","East
+        US 2","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["Southeast
+        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
+        Central US","East US","West US","South Central US","West Europe","East Asia","East
+        US 2","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-05-21-preview","2015-05-01"]},{"resourceType":"locations/operations","locations":["Southeast
+        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
+        Central US","East US","East US 2","West US","South Central US","West Europe","East
+        Asia","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-05-21-preview"]}]},{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["West
         US","North Europe","West Europe","East US","East US 2","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","South India","South
         Central US","Central US","Japan East","Japan West"],"apiVersions":["2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["West
@@ -485,11 +564,11 @@ http_interactions:
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
-        India","West India"],"apiVersions":["2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
-        India","West India"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01","2014-12-19-preview"]}]},{"namespace":"Microsoft.Logic","resourceTypes":[{"resourceType":"workflows","locations":["North
+        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01","2014-12-19-preview"]}]},{"namespace":"Microsoft.Logic","resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
@@ -503,55 +582,59 @@ http_interactions:
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"expressRouteCircuits","locations":["West
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]}]},{"namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]}]},{"namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","East Asia","Southeast Asia","Brazil South","Japan
         East","Japan West","North Europe","West Europe"],"apiVersions":["2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
@@ -569,6 +652,7 @@ http_interactions:
         East","Japan West","North Europe","West Europe"],"apiVersions":["2014-09-01"]}]},{"namespace":"Microsoft.OperationalInsights","resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast"],"apiVersions":["2015-11-01-preview","2015-03-20"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20","2014-10-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]}]},{"namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US"],"apiVersions":["2016-01-29"]}]},{"namespace":"Microsoft.ProjectOxford","resourceTypes":[{"resourceType":"accounts","locations":["West
         US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.RemoteApp","resourceTypes":[{"resourceType":"collections","locations":["Australia
         East","Australia Southeast","Brazil South","Central US","East Asia","East
@@ -585,23 +669,23 @@ http_interactions:
         US","East Asia","Southeast Asia","East US","East US 2","West US","North Central
         US","South Central US","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","West India","South India","Central
-        India"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        India","UK North","UK South 2","Canada Central","Canada East"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","North Central
         US","South Central US","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","West India","South India","Central
-        India"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        India","UK North","UK South 2","Canada Central","Canada East"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
-        India","West India"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
-        India","West India"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
-        India","West India"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}]},{"namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
@@ -820,15 +904,18 @@ http_interactions:
         US","East US 2","East US 2 (Stage)","West US","West Europe","East Asia","Southeast
         Asia","Japan East","Japan West","North Central US","South Central US","Central
         US","North Europe","Brazil South","Australia East","Australia Southeast","South
-        India","Central India","West India"],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        India","Central India","West India","Canada East","Canada Central","UK North","UK
+        South 2"],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","East US 2 (Stage)","West Europe","North Europe","East Asia","Southeast
         Asia","Japan East","Japan West","North Central US","South Central US","East
         US 2","Central US","Australia East","Australia Southeast","Brazil South","South
-        India","Central India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        India","Central India","West India","Canada East","Canada Central","UK North","UK
+        South 2"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","East US 2 (Stage)","West Europe","North Europe","East Asia","Southeast
         Asia","Japan East","Japan West","North Central US","South Central US","East
         US 2","Central US","Australia East","Australia Southeast","Brazil South","South
-        India","Central India","West India"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        India","Central India","West India","Canada East","Canada Central","UK North","UK
+        South 2"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
         US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
         Asia","South Central US","East Asia","Japan West","North Central US","East
         US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
@@ -859,225 +946,225 @@ http_interactions:
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"managedHostingEnvironments","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"managedHostingEnvironments","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"apiManagementAccounts","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"apiManagementAccounts","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/powerAppsRegistrations","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/powerAppsRegistrations","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-08-01-preview","2015-08-01-beta","2015-08-01-alpha"]},{"resourceType":"apiManagementAccounts/connections","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-08-01-preview","2015-08-01-beta","2015-08-01-alpha"]},{"resourceType":"apiManagementAccounts/connections","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/connectionAcls","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/connectionAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections/connectionAcls","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections/connectionAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connectionAcls","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connectionAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apiAcls","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apiAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/apiAcls","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/apiAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections","locations":["South
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","MSFT West US","MSFT East US","MSFT East Asia","MSFT
-        North Europe","East US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North
-        Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"connections","locations":["North
+        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
+        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
+        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"connections","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
@@ -1100,7 +1187,7 @@ http_interactions:
         US","Australia Southeast","Australia East","South Central US"],"apiVersions":["2014-04-01"]}]},{"namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["West
         US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:40 GMT
+  recorded_at: Mon, 09 May 2016 17:16:01 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
@@ -1113,11 +1200,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -1134,22 +1221,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 738152bb-6195-4e44-8177-ac1b97ab5a62
+      - 93b81ec9-69cc-4e64-aa72-0139d306abd3
       X-Ms-Correlation-Request-Id:
-      - 738152bb-6195-4e44-8177-ac1b97ab5a62
+      - 93b81ec9-69cc-4e64-aa72-0139d306abd3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152441Z:738152bb-6195-4e44-8177-ac1b97ab5a62
+      - NORTHCENTRALUS:20160509T171602Z:93b81ec9-69cc-4e64-aa72-0139d306abd3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:41 GMT
+      - Mon, 09 May 2016 17:16:01 GMT
       Content-Length:
       - '566'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:41 GMT
+  recorded_at: Mon, 09 May 2016 17:16:02 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2016-03-30
@@ -1162,11 +1249,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -1187,20 +1274,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - 8154fe2d-6bc9-45fa-b5a0-9cb63be7d4a9
+      - dc999b4d-0603-4e62-a7d4-c122d9885d12
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14811'
       X-Ms-Correlation-Request-Id:
-      - 2bd7305e-ead0-43de-98a9-5d52adcf1b46
+      - d0ea5872-23c7-4ee4-867a-33561c57b84c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152442Z:2bd7305e-ead0-43de-98a9-5d52adcf1b46
+      - NORTHCENTRALUS:20160509T171602Z:d0ea5872-23c7-4ee4-867a-33561c57b84c
       Date:
-      - Fri, 08 Apr 2016 15:24:42 GMT
+      - Mon, 09 May 2016 17:16:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n
@@ -1295,19 +1382,19 @@ http_interactions:
         819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
         20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        1024000,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 40\r\n
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 40\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
         1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 2\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
         2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        28762,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 4\r\n
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 4\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
         4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        28762,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
         8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        57244,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
         2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
@@ -1320,6 +1407,36 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
         16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 40\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
         8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
@@ -1334,10 +1451,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 16\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:42 GMT
+  recorded_at: Mon, 09 May 2016 17:16:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1347,11 +1464,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -1368,28 +1485,35 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14799'
       X-Ms-Request-Id:
-      - 7efe237f-f101-4282-a54d-8059f92f21e6
+      - 5d6fc715-4efa-417c-9ba9-6c5a3bd295de
       X-Ms-Correlation-Request-Id:
-      - 7efe237f-f101-4282-a54d-8059f92f21e6
+      - 5d6fc715-4efa-417c-9ba9-6c5a3bd295de
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152444Z:7efe237f-f101-4282-a54d-8059f92f21e6
+      - NORTHCENTRALUS:20160509T171603Z:5d6fc715-4efa-417c-9ba9-6c5a3bd295de
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:43 GMT
+      - Mon, 09 May 2016 17:16:03 GMT
       Content-Length:
-      - '40155'
+      - '43127'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010","name":"Microsoft.WindowsServer2012R2Datacenter-20160222104010","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A1"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg241"},"networkSecurityGroupName":{"type":"String","value":"miqtestwinimg3696"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqtestwinimg6202"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.5830069Z","duration":"PT10M55.2480986S","correlationId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg241"},{"id":"Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},{"id":"Microsoft.Network/publicIpAddresses/miqtestwinimg6202"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646","name":"Microsoft.WindowsServer2012R2Datacenter-20160222101646","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg724"},"networkSecurityGroupName":{"type":"String","value":"miq-test-winimg"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miq-test-winimg"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.8666296Z","duration":"PT10M47.5658692S","correlationId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg724"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-winimg"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-winimg"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019","name":"Microsoft.WindowsServer2012R2Datacenter-20160218113019","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-win12"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miqazuretest19881"},"networkInterfaceName":{"type":"String","value":"miq-test-win12610"},"networkSecurityGroupName":{"type":"String","value":"miq-test-win12"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest14047"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.18.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.18.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-win12"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.8337856Z","duration":"PT11M9.8080785S","correlationId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-win12"},{"id":"Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-win12610"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-win12"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-win12"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest19881"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest14047"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651","name":"Canonical.UbuntuServer1510-20160218112651","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-ubuntu1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest16487"},"virtualNetworkName":{"type":"String","value":"miqazuretest18687"},"networkInterfaceName":{"type":"String","value":"miq-test-ubuntu1989"},"networkSecurityGroupName":{"type":"String","value":"miq-test-ubuntu1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest16487"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.17.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.17.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-ubuntu1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.2528115Z","duration":"PT4M10.3614981S","correlationId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-ubuntu1"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest18687"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest16487"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme","name":"failedme","properties":{"parameters":{"virtualMachineName":{"type":"String","value":"anym"},"adminUserName":{"type":"String","value":"admins"},"adminPassword":{"type":"SecureString"},"userImageName":{"type":"String","value":"https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd"},"operatingSystemType":{"type":"String","value":"windows"},"virtualMachineSize":{"type":"String","value":"Basic_A0"}},"mode":"Incremental","provisioningState":"Failed","timestamp":"2016-04-19T20:51:24.3745709Z","duration":"PT16.2313747S","correlationId":"39221b07-016e-4f80-948e-fb44b64ba108","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/myVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myVNET"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/anym","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"anym"}],"error":{"code":"DeploymentFailed","message":"At
+        least one resource deployment operation failed. Please list deployment operations
+        for details. Please see http://aka.ms/arm-debug for usage details.","details":[{"code":"BadRequest","message":"{\r\n  \"error\":
+        {\r\n    \"code\": \"InvalidParameter\",\r\n    \"target\": \"adminPassword\",\r\n    \"message\":
+        \"The supplied password must be between 8-123 characters long and must satisfy
+        at least 3 of password complexity requirements from the following: \\r\\n1)
+        Contains an uppercase character\\r\\n2) Contains a lowercase character\\r\\n3)
+        Contains a numeric digit\\r\\n4) Contains a special character.\"\r\n  }\r\n}"}]}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
+        output for test"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010","name":"Microsoft.WindowsServer2012R2Datacenter-20160222104010","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A1"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg241"},"networkSecurityGroupName":{"type":"String","value":"miqtestwinimg3696"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqtestwinimg6202"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.5830069Z","duration":"PT10M55.2480986S","correlationId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg241"},{"id":"Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},{"id":"Microsoft.Network/publicIpAddresses/miqtestwinimg6202"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646","name":"Microsoft.WindowsServer2012R2Datacenter-20160222101646","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg724"},"networkSecurityGroupName":{"type":"String","value":"miq-test-winimg"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miq-test-winimg"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.8666296Z","duration":"PT10M47.5658692S","correlationId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg724"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-winimg"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-winimg"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019","name":"Microsoft.WindowsServer2012R2Datacenter-20160218113019","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-win12"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miqazuretest19881"},"networkInterfaceName":{"type":"String","value":"miq-test-win12610"},"networkSecurityGroupName":{"type":"String","value":"miq-test-win12"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest14047"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.18.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.18.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-win12"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.8337856Z","duration":"PT11M9.8080785S","correlationId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-win12"},{"id":"Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-win12610"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-win12"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-win12"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest19881"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest14047"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651","name":"Canonical.UbuntuServer1510-20160218112651","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-ubuntu1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest16487"},"virtualNetworkName":{"type":"String","value":"miqazuretest18687"},"networkInterfaceName":{"type":"String","value":"miq-test-ubuntu1989"},"networkSecurityGroupName":{"type":"String","value":"miq-test-ubuntu1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest16487"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.17.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.17.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-ubuntu1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.2528115Z","duration":"PT4M10.3614981S","correlationId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-ubuntu1"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest18687"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest16487"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:44 GMT
+  recorded_at: Mon, 09 May 2016 17:16:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1399,11 +1523,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -1420,24 +1544,79 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14708'
       X-Ms-Request-Id:
-      - 2826ce6d-c3e1-486a-95ad-d189d297dd98
+      - 5d6dc89c-551a-4865-b05d-23b98ca31abe
       X-Ms-Correlation-Request-Id:
-      - 2826ce6d-c3e1-486a-95ad-d189d297dd98
+      - 5d6dc89c-551a-4865-b05d-23b98ca31abe
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152445Z:2826ce6d-c3e1-486a-95ad-d189d297dd98
+      - NORTHCENTRALUS:20160509T171604Z:5d6dc89c-551a-4865-b05d-23b98ca31abe
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:44 GMT
+      - Mon, 09 May 2016 17:16:03 GMT
       Content-Length:
-      - '5777'
+      - '2551'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/463322680080BF99","operationId":"463322680080BF99","properties":{"provisioningOperation":"Create","provisioningState":"Failed","timestamp":"2016-04-19T20:51:23.6186092Z","duration":"PT1.0769096S","trackingId":"03e11228-2231-4d5b-9803-5d16d4817a3a","serviceRequestId":"64f357e8-d1b4-4a02-a142-54effdfba772","statusCode":"BadRequest","statusMessage":{"error":{"code":"InvalidParameter","target":"adminPassword","message":"The
+        supplied password must be between 8-123 characters long and must satisfy at
+        least 3 of password complexity requirements from the following: \r\n1) Contains
+        an uppercase character\r\n2) Contains a lowercase character\r\n3) Contains
+        a numeric digit\r\n4) Contains a special character."}},"targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/anym","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"anym"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/F9F20A47A97EE080","operationId":"F9F20A47A97EE080","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:22.487592Z","duration":"PT0.9167668S","trackingId":"61348482-004f-46c0-88b3-65e3154b74ee","serviceRequestId":"170c3cfe-fffa-47ab-8e8b-815ece2e94e1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/3DCCD9CF9359AFF8","operationId":"3DCCD9CF9359AFF8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:21.4774538Z","duration":"PT12.4116622S","trackingId":"f38c5a77-b7dc-456d-811b-344f369b4484","serviceRequestId":"5205ab85-5f20-4302-bace-181cfd212c3e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/myVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myVNET"}}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:45 GMT
+  recorded_at: Mon, 09 May 2016 17:16:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2016-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14787'
+      X-Ms-Request-Id:
+      - 561e42eb-bf7f-4ee3-90de-26c360fec938
+      X-Ms-Correlation-Request-Id:
+      - 561e42eb-bf7f-4ee3-90de-26c360fec938
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160509T171605Z:561e42eb-bf7f-4ee3-90de-26c360fec938
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 09 May 2016 17:16:04 GMT
+      Content-Length:
+      - '6866'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
+    http_version: 
+  recorded_at: Mon, 09 May 2016 17:16:05 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json
@@ -1473,33 +1652,33 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2B22:2083:74D3BF6:5707CD3D
+      - 17EB2C22:644F:1848941:5730C4B8
       Content-Length:
       - '10366'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 08 Apr 2016 15:24:45 GMT
+      - Mon, 09 May 2016 17:16:05 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-ams4142-AMS
+      - cache-dfw1845-DFW
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 9d21d5db94ceca0160ede64c08fbeed03ff1b278
+      - 293a24c4b36ea2afaeca6f6420942130d2186850
       Expires:
-      - Fri, 08 Apr 2016 15:29:45 GMT
+      - Mon, 09 May 2016 17:21:05 GMT
       Source-Age:
-      - '0'
+      - '285'
     body:
       encoding: UTF-8
       string: |
@@ -1847,10 +2026,10 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:45 GMT
+  recorded_at: Mon, 09 May 2016 17:16:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1860,11 +2039,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -1881,24 +2060,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14772'
       X-Ms-Request-Id:
-      - f3bf4d8a-cdb4-4dd1-87fb-886aaf20935b
+      - cac9dd73-7e7c-48cf-a92d-33761596e462
       X-Ms-Correlation-Request-Id:
-      - f3bf4d8a-cdb4-4dd1-87fb-886aaf20935b
+      - cac9dd73-7e7c-48cf-a92d-33761596e462
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152447Z:f3bf4d8a-cdb4-4dd1-87fb-886aaf20935b
+      - NORTHCENTRALUS:20160509T171606Z:cac9dd73-7e7c-48cf-a92d-33761596e462
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:46 GMT
+      - Mon, 09 May 2016 17:16:06 GMT
       Content-Length:
-      - '680'
+      - '801'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:47 GMT
+  recorded_at: Mon, 09 May 2016 17:16:06 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json
@@ -1934,33 +2113,33 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2B1F:2081:44D526A:5707CD3E
+      - 17EB2C1F:644E:AB6F06:5730C4B9
       Content-Length:
       - '3830'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 08 Apr 2016 15:24:47 GMT
+      - Mon, 09 May 2016 17:16:06 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-ams4133-AMS
+      - cache-dfw1845-DFW
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 1306670877d6943dae7fbd8fb13a13a768f98823
+      - 8b77e34a78aa85dfec49139e85dd80373ae6d4a7
       Expires:
-      - Fri, 08 Apr 2016 15:29:47 GMT
+      - Mon, 09 May 2016 17:21:06 GMT
       Source-Age:
-      - '0'
+      - '285'
     body:
       encoding: UTF-8
       string: |
@@ -2099,10 +2278,10 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:47 GMT
+  recorded_at: Mon, 09 May 2016 17:16:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2112,11 +2291,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2133,27 +2312,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14831'
       X-Ms-Request-Id:
-      - c2490a22-ad62-4f4b-a2f2-9694e6c0234c
+      - cdc53616-0c69-4bb1-8745-9d5193ed0d06
       X-Ms-Correlation-Request-Id:
-      - c2490a22-ad62-4f4b-a2f2-9694e6c0234c
+      - cdc53616-0c69-4bb1-8745-9d5193ed0d06
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152449Z:c2490a22-ad62-4f4b-a2f2-9694e6c0234c
+      - NORTHCENTRALUS:20160509T171607Z:cdc53616-0c69-4bb1-8745-9d5193ed0d06
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:49 GMT
+      - Mon, 09 May 2016 17:16:06 GMT
       Content-Length:
-      - '5298'
+      - '6166'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:06.7915034Z","duration":"PT3M1.4329712S","trackingId":"b747ec27-f04a-4dc5-a097-03b78d06b4f3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:48:05.2174686Z","duration":"PT7M35.1627165S","trackingId":"dc765fff-be2e-485c-b812-26cbaf08492c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/3FD73BA3A618D357","operationId":"3FD73BA3A618D357","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:29.9601151Z","duration":"PT2.604551S","trackingId":"280b442e-2010-45a6-b9b2-ac761d5dee7d","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:18.3026417Z","duration":"PT4.8364985S","trackingId":"7d2f970a-57fc-40b4-9152-2c3c883d58c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/6CCA0B3A82197571","operationId":"6CCA0B3A82197571","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.0300385Z","duration":"PT13.4143548S","trackingId":"0830ff7f-fb77-44f0-a393-6003873380e8","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/291C0AC5D4F88BDB","operationId":"291C0AC5D4F88BDB","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.2645854Z","duration":"PT13.7950357S","trackingId":"bfd21915-f13e-4ece-a48c-19a5a9a58fcd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:14.3483638Z","duration":"PT0.8769498S","trackingId":"54ee2082-f487-4f98-b5da-08f4fb8450ac","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/08587429420731427531","operationId":"08587429420731427531","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.53375Z","duration":"PT0.5447355S","trackingId":"d4fae0de-498c-4177-8239-46a0f58e2ebf","statusCode":"OK","statusMessage":null}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:06.7915034Z","duration":"PT3M1.4329712S","trackingId":"b747ec27-f04a-4dc5-a097-03b78d06b4f3","serviceRequestId":"0b164261-eee1-422e-b558-7cb959e795eb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:48:05.2174686Z","duration":"PT7M35.1627165S","trackingId":"dc765fff-be2e-485c-b812-26cbaf08492c","serviceRequestId":"b4e8ecc8-2e94-4423-b928-2c29900ed123","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/3FD73BA3A618D357","operationId":"3FD73BA3A618D357","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:29.9601151Z","duration":"PT2.604551S","trackingId":"280b442e-2010-45a6-b9b2-ac761d5dee7d","serviceRequestId":"ebbe21b7-a988-4950-9675-0d063e84b60e","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:18.3026417Z","duration":"PT4.8364985S","trackingId":"7d2f970a-57fc-40b4-9152-2c3c883d58c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/6CCA0B3A82197571","operationId":"6CCA0B3A82197571","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.0300385Z","duration":"PT13.4143548S","trackingId":"0830ff7f-fb77-44f0-a393-6003873380e8","serviceRequestId":"ea9c728c-70ba-4de3-a55c-8cf6cd310ca0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/291C0AC5D4F88BDB","operationId":"291C0AC5D4F88BDB","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.2645854Z","duration":"PT13.7950357S","trackingId":"bfd21915-f13e-4ece-a48c-19a5a9a58fcd","serviceRequestId":"60371f22-c3c6-4256-b204-0efc36c51aae","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:14.3483638Z","duration":"PT0.8769498S","trackingId":"54ee2082-f487-4f98-b5da-08f4fb8450ac","serviceRequestId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/08587429420731427531","operationId":"08587429420731427531","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.53375Z","duration":"PT0.5447355S","trackingId":"d4fae0de-498c-4177-8239-46a0f58e2ebf","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:49 GMT
+  recorded_at: Mon, 09 May 2016 17:16:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2163,11 +2342,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2184,27 +2363,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14823'
       X-Ms-Request-Id:
-      - b4c5c944-a635-4cdb-8e70-b505f36d52b9
+      - 94902cfa-8e1e-4ad3-9801-aa2c6d45548c
       X-Ms-Correlation-Request-Id:
-      - b4c5c944-a635-4cdb-8e70-b505f36d52b9
+      - 94902cfa-8e1e-4ad3-9801-aa2c6d45548c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152451Z:b4c5c944-a635-4cdb-8e70-b505f36d52b9
+      - NORTHCENTRALUS:20160509T171607Z:94902cfa-8e1e-4ad3-9801-aa2c6d45548c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:50 GMT
+      - Mon, 09 May 2016 17:16:07 GMT
       Content-Length:
-      - '5293'
+      - '6161'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.1806556Z","duration":"PT3M14.7317782S","trackingId":"2e8bc5df-290e-4427-9d7e-b07dc8b56157","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:24:20.3730557Z","duration":"PT7M15.3472227S","trackingId":"b15735ed-1f9c-4235-8554-0359a94d8021","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/FAC43E00E60F40D6","operationId":"FAC43E00E60F40D6","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:04.9686575Z","duration":"PT1.7424043S","trackingId":"9cd93d46-01d3-4fcb-9d33-32d362efad6b","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/4A34D86BCACDE87A","operationId":"4A34D86BCACDE87A","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.172193Z","duration":"PT13.1694927S","trackingId":"f1189e74-dc7c-4a8e-9f87-f125c87fac6e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/857E6EBF700A64F8","operationId":"857E6EBF700A64F8","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.1483554Z","duration":"PT13.0919048S","trackingId":"ca1bda1a-fda1-4270-8442-a3145bfbe1f2","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:51.1217903Z","duration":"PT1.1217779S","trackingId":"76e77bc0-53a4-4df3-a941-4c5e007b6a66","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:50.9535836Z","duration":"PT0.9351894S","trackingId":"de79265b-c4a2-457b-807a-9e98060a82f6","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/08587429434771769170","operationId":"08587429434771769170","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.7888649Z","duration":"PT0.5055897S","trackingId":"d03c7b95-d9d8-48bb-a526-41e9651ad971","statusCode":"OK","statusMessage":null}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.1806556Z","duration":"PT3M14.7317782S","trackingId":"2e8bc5df-290e-4427-9d7e-b07dc8b56157","serviceRequestId":"e6051ebe-75e3-4280-ad61-5c4928614ad2","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:24:20.3730557Z","duration":"PT7M15.3472227S","trackingId":"b15735ed-1f9c-4235-8554-0359a94d8021","serviceRequestId":"b90d407e-ca03-4efe-ac8c-a40133c4521a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/FAC43E00E60F40D6","operationId":"FAC43E00E60F40D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:04.9686575Z","duration":"PT1.7424043S","trackingId":"9cd93d46-01d3-4fcb-9d33-32d362efad6b","serviceRequestId":"5b900931-b60d-4e18-8e0e-ea23472a6911","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/4A34D86BCACDE87A","operationId":"4A34D86BCACDE87A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.172193Z","duration":"PT13.1694927S","trackingId":"f1189e74-dc7c-4a8e-9f87-f125c87fac6e","serviceRequestId":"f4510097-ff5e-4476-9d16-ef1b3233a77d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/857E6EBF700A64F8","operationId":"857E6EBF700A64F8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.1483554Z","duration":"PT13.0919048S","trackingId":"ca1bda1a-fda1-4270-8442-a3145bfbe1f2","serviceRequestId":"7f2145f1-40af-4b08-addc-8356a4ddc063","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:51.1217903Z","duration":"PT1.1217779S","trackingId":"76e77bc0-53a4-4df3-a941-4c5e007b6a66","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:50.9535836Z","duration":"PT0.9351894S","trackingId":"de79265b-c4a2-457b-807a-9e98060a82f6","serviceRequestId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/08587429434771769170","operationId":"08587429434771769170","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.7888649Z","duration":"PT0.5055897S","trackingId":"d03c7b95-d9d8-48bb-a526-41e9651ad971","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:51 GMT
+  recorded_at: Mon, 09 May 2016 17:16:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2214,11 +2393,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2235,27 +2414,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14822'
       X-Ms-Request-Id:
-      - 37a80d78-7e2a-419b-bddc-da7d463b4026
+      - c3251e12-43e8-4e37-91bf-051201e7cdf6
       X-Ms-Correlation-Request-Id:
-      - 37a80d78-7e2a-419b-bddc-da7d463b4026
+      - c3251e12-43e8-4e37-91bf-051201e7cdf6
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152453Z:37a80d78-7e2a-419b-bddc-da7d463b4026
+      - NORTHCENTRALUS:20160509T171608Z:c3251e12-43e8-4e37-91bf-051201e7cdf6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:52 GMT
+      - Mon, 09 May 2016 17:16:07 GMT
       Content-Length:
-      - '5829'
+      - '6818'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","serviceRequestId":"57d6085f-2656-460f-9fdc-391f3813ba9b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","serviceRequestId":"9e20cfcf-cf82-4053-8a96-ba1a60126341","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","serviceRequestId":"fac0cc26-0839-4302-9536-69cff4273fb9","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","serviceRequestId":"82cddf5c-1792-4498-9ed5-ccdfaf52d93c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","serviceRequestId":"f082fd2f-3170-4f36-b9ff-a635e33f5fcf","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","serviceRequestId":"7df6e0cb-b78b-47ff-b479-90a1aee5a885","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","serviceRequestId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:53 GMT
+  recorded_at: Mon, 09 May 2016 17:16:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2265,11 +2444,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2286,27 +2465,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14662'
       X-Ms-Request-Id:
-      - e4391d12-9576-4bc0-9a3e-90237b7e326a
+      - 575bb77e-5116-4b03-bbd5-c4943829dddf
       X-Ms-Correlation-Request-Id:
-      - e4391d12-9576-4bc0-9a3e-90237b7e326a
+      - 575bb77e-5116-4b03-bbd5-c4943829dddf
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152455Z:e4391d12-9576-4bc0-9a3e-90237b7e326a
+      - NORTHCENTRALUS:20160509T171608Z:575bb77e-5116-4b03-bbd5-c4943829dddf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:55 GMT
+      - Mon, 09 May 2016 17:16:08 GMT
       Content-Length:
-      - '6608'
+      - '7718'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/15838BCFE46760A1","operationId":"15838BCFE46760A1","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:28.6222483Z","duration":"PT3M20.660116S","trackingId":"a6653508-59b3-4e4a-b796-f1cf431a9162","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/DDBEEC376EA09F7E","operationId":"DDBEEC376EA09F7E","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:38:07.8075094Z","duration":"PT7M9.35647S","trackingId":"943dac3c-a98b-465d-b759-06506e599546","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.5055633Z","duration":"PT0.6114738S","trackingId":"1b754371-18ec-4517-bd38-46c9d2ef975d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.3710882Z","duration":"PT0.4790524S","trackingId":"9dfcf1d7-6e4a-4a73-b17e-13b2afdf9d6b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/7F5153152761DD05","operationId":"7F5153152761DD05","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:38.3445066Z","duration":"PT1.6145978S","trackingId":"861a701b-3964-4754-954c-cb21d5e93db8","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/F97EC162743B5FF4","operationId":"F97EC162743B5FF4","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:57.7800754Z","duration":"PT34.9812759S","trackingId":"92865cda-40cb-41c9-9317-d864b2b3c309","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/EA21060B6C976C52","operationId":"EA21060B6C976C52","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.6308058Z","duration":"PT13.8442357S","trackingId":"e950697d-0ec6-40f5-8d14-7bfae0ecabf5","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/61B1466BCE99F9D3","operationId":"61B1466BCE99F9D3","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.4233646Z","duration":"PT13.6985797S","trackingId":"fd76215f-8c01-4e2a-8068-636237270be4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/58705CE1AC7417FE","operationId":"58705CE1AC7417FE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.5145163Z","duration":"PT13.7848628S","trackingId":"31027583-c7fb-4302-9bbe-9d1f79502a4c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/08587432846644519702","operationId":"08587432846644519702","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.7434262Z","duration":"PT2.0330234S","trackingId":"1bf25585-8cf8-4c99-9078-aa6f5c036128","statusCode":"OK","statusMessage":null}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/15838BCFE46760A1","operationId":"15838BCFE46760A1","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:28.6222483Z","duration":"PT3M20.660116S","trackingId":"a6653508-59b3-4e4a-b796-f1cf431a9162","serviceRequestId":"9df73a78-c24e-444a-82cb-ec8632cb8775","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/DDBEEC376EA09F7E","operationId":"DDBEEC376EA09F7E","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:38:07.8075094Z","duration":"PT7M9.35647S","trackingId":"943dac3c-a98b-465d-b759-06506e599546","serviceRequestId":"21e68a17-9e60-4b90-b988-c524ac8db616","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.5055633Z","duration":"PT0.6114738S","trackingId":"1b754371-18ec-4517-bd38-46c9d2ef975d","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.3710882Z","duration":"PT0.4790524S","trackingId":"9dfcf1d7-6e4a-4a73-b17e-13b2afdf9d6b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/7F5153152761DD05","operationId":"7F5153152761DD05","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:38.3445066Z","duration":"PT1.6145978S","trackingId":"861a701b-3964-4754-954c-cb21d5e93db8","serviceRequestId":"2d4bd016-1a2d-4e33-ac21-27105e650564","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/F97EC162743B5FF4","operationId":"F97EC162743B5FF4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:57.7800754Z","duration":"PT34.9812759S","trackingId":"92865cda-40cb-41c9-9317-d864b2b3c309","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/EA21060B6C976C52","operationId":"EA21060B6C976C52","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.6308058Z","duration":"PT13.8442357S","trackingId":"e950697d-0ec6-40f5-8d14-7bfae0ecabf5","serviceRequestId":"edf1e84f-f9ac-4254-85fa-93f2dd649032","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/61B1466BCE99F9D3","operationId":"61B1466BCE99F9D3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.4233646Z","duration":"PT13.6985797S","trackingId":"fd76215f-8c01-4e2a-8068-636237270be4","serviceRequestId":"5803f928-b459-4872-b035-ae900c9c3eee","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/58705CE1AC7417FE","operationId":"58705CE1AC7417FE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.5145163Z","duration":"PT13.7848628S","trackingId":"31027583-c7fb-4302-9bbe-9d1f79502a4c","serviceRequestId":"cd05b456-afab-41a8-8952-43c02b657253","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/08587432846644519702","operationId":"08587432846644519702","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.7434262Z","duration":"PT2.0330234S","trackingId":"1bf25585-8cf8-4c99-9078-aa6f5c036128","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:55 GMT
+  recorded_at: Mon, 09 May 2016 17:16:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2316,11 +2495,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2337,27 +2516,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14725'
       X-Ms-Request-Id:
-      - bcca93b9-c3d1-4e6b-9ba0-4658fa8bbfac
+      - 9dfbf847-ec84-4847-9348-a4b2fe88f12d
       X-Ms-Correlation-Request-Id:
-      - bcca93b9-c3d1-4e6b-9ba0-4658fa8bbfac
+      - 9dfbf847-ec84-4847-9348-a4b2fe88f12d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152456Z:bcca93b9-c3d1-4e6b-9ba0-4658fa8bbfac
+      - NORTHCENTRALUS:20160509T171609Z:9dfbf847-ec84-4847-9348-a4b2fe88f12d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:56 GMT
+      - Mon, 09 May 2016 17:16:09 GMT
       Content-Length:
-      - '6499'
+      - '7609'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/056F4B33F11A3099","operationId":"056F4B33F11A3099","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:01.4236054Z","duration":"PT1M23.6187466S","trackingId":"70c620a7-2c3c-4743-ae6f-e3836270f2f1","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/62E621EEEC5E62EE","operationId":"62E621EEEC5E62EE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:29:37.7414996Z","duration":"PT2M9.3834226S","trackingId":"48044c61-7a07-4aff-be71-aeacc2471e7b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.2125225Z","duration":"PT0.642269S","trackingId":"51ea1626-1a59-4e23-8590-445c4ca176d0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/34A4347ECF2A45BE","operationId":"34A4347ECF2A45BE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.1112967Z","duration":"PT0.5497549S","trackingId":"ce1e6b19-7951-4c73-9005-20fe16d36036","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8F3051FDE964A700","operationId":"8F3051FDE964A700","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:09.9030716Z","duration":"PT2.0210551S","trackingId":"ed583a8c-7b18-4b99-a285-f09a67c14a3b","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/9D251C6DB1BEEA3B","operationId":"9D251C6DB1BEEA3B","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:27.4794736Z","duration":"PT33.3813549S","trackingId":"f9366eee-29f7-42e3-b0fe-1f577c8ae55c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/7CE1E6C413F108AC","operationId":"7CE1E6C413F108AC","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.7755462Z","duration":"PT13.6793163S","trackingId":"ca83e042-a8c6-4ffb-9f2c-2e4a9f1bbd7c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/76F60549C9B601F7","operationId":"76F60549C9B601F7","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.0295771Z","duration":"PT12.9355177S","trackingId":"7fb0a493-ee8a-4d59-86f3-f435a2e1deba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/E142660DAD24486A","operationId":"E142660DAD24486A","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.101236Z","duration":"PT12.9593617S","trackingId":"68e1b6fa-040c-450f-bd16-0426d5af0f9f","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/Canonical.UbuntuServer1510-20160218112651/operations/08587432848725863745","operationId":"08587432848725863745","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.1079152Z","duration":"PT1.6252469S","trackingId":"229c4e55-24ce-4126-b6ff-de2aba268ff3","statusCode":"OK","statusMessage":null}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/056F4B33F11A3099","operationId":"056F4B33F11A3099","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:01.4236054Z","duration":"PT1M23.6187466S","trackingId":"70c620a7-2c3c-4743-ae6f-e3836270f2f1","serviceRequestId":"b592f413-95b5-42cb-84a1-817ab3f09275","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/62E621EEEC5E62EE","operationId":"62E621EEEC5E62EE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:29:37.7414996Z","duration":"PT2M9.3834226S","trackingId":"48044c61-7a07-4aff-be71-aeacc2471e7b","serviceRequestId":"e29ef1dc-4e0b-4a92-84f2-a3a746643bcd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.2125225Z","duration":"PT0.642269S","trackingId":"51ea1626-1a59-4e23-8590-445c4ca176d0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/34A4347ECF2A45BE","operationId":"34A4347ECF2A45BE","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.1112967Z","duration":"PT0.5497549S","trackingId":"ce1e6b19-7951-4c73-9005-20fe16d36036","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8F3051FDE964A700","operationId":"8F3051FDE964A700","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:09.9030716Z","duration":"PT2.0210551S","trackingId":"ed583a8c-7b18-4b99-a285-f09a67c14a3b","serviceRequestId":"c065af43-94f0-421b-a773-737f6584f645","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/9D251C6DB1BEEA3B","operationId":"9D251C6DB1BEEA3B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:27.4794736Z","duration":"PT33.3813549S","trackingId":"f9366eee-29f7-42e3-b0fe-1f577c8ae55c","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/7CE1E6C413F108AC","operationId":"7CE1E6C413F108AC","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.7755462Z","duration":"PT13.6793163S","trackingId":"ca83e042-a8c6-4ffb-9f2c-2e4a9f1bbd7c","serviceRequestId":"12a02fc5-02a7-4d40-a4b5-903a8dc79922","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/76F60549C9B601F7","operationId":"76F60549C9B601F7","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.0295771Z","duration":"PT12.9355177S","trackingId":"7fb0a493-ee8a-4d59-86f3-f435a2e1deba","serviceRequestId":"cd42e571-c085-4c3e-b89a-d86568b2e289","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/E142660DAD24486A","operationId":"E142660DAD24486A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.101236Z","duration":"PT12.9593617S","trackingId":"68e1b6fa-040c-450f-bd16-0426d5af0f9f","serviceRequestId":"57c68449-35f3-409e-8f51-f4cd9b65a3ab","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/08587432848725863745","operationId":"08587432848725863745","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.1079152Z","duration":"PT1.6252469S","trackingId":"229c4e55-24ce-4126-b6ff-de2aba268ff3","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:56 GMT
+  recorded_at: Mon, 09 May 2016 17:16:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2016-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2367,11 +2546,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2388,24 +2567,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14780'
       X-Ms-Request-Id:
-      - 935a2a8f-618b-4ed7-af96-8ffa888f10ed
+      - 8e7b0866-d3d6-41ae-84f5-f3bacb15663b
       X-Ms-Correlation-Request-Id:
-      - 935a2a8f-618b-4ed7-af96-8ffa888f10ed
+      - 8e7b0866-d3d6-41ae-84f5-f3bacb15663b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152456Z:935a2a8f-618b-4ed7-af96-8ffa888f10ed
+      - NORTHCENTRALUS:20160509T171610Z:8e7b0866-d3d6-41ae-84f5-f3bacb15663b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:24:56 GMT
+      - Mon, 09 May 2016 17:16:09 GMT
       Content-Length:
-      - '6514'
+      - '7624'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:56 GMT
+  recorded_at: Mon, 09 May 2016 17:16:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
@@ -2418,11 +2597,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2443,20 +2622,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - f038a399-9add-41a7-8a94-2c90425d262c
+      - 50d58fd0-422c-4f4e-b2f5-b83b0470cfd2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14792'
       X-Ms-Correlation-Request-Id:
-      - e572ac47-acd2-4321-99f2-77a829727062
+      - 40a57346-f6ea-4a5c-9fa7-7990ba2394e5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152457Z:e572ac47-acd2-4321-99f2-77a829727062
+      - NORTHCENTRALUS:20160509T171610Z:40a57346-f6ea-4a5c-9fa7-7990ba2394e5
       Date:
-      - Fri, 08 Apr 2016 15:24:57 GMT
+      - Mon, 09 May 2016 17:16:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\":
@@ -2608,7 +2787,7 @@ http_interactions:
         \     \"name\": \"spec0deply1vm1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
         \     \"location\": \"eastus\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:57 GMT
+  recorded_at: Mon, 09 May 2016 17:16:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
@@ -2621,11 +2800,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2644,31 +2823,31 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8be465c9-e271-485e-86e5-b72c206e3be9
+      - 1ca7c564-1994-48d2-bd7b-931cdb4d7d62
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14822'
       X-Ms-Correlation-Request-Id:
-      - d6864b5f-ae85-49af-af69-17c6f3811700
+      - ee4b9d06-8bc9-408d-9a05-ee279e38ef90
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152458Z:d6864b5f-ae85-49af-af69-17c6f3811700
+      - NORTHCENTRALUS:20160509T171611Z:ee4b9d06-8bc9-408d-9a05-ee279e38ef90
       Date:
-      - Fri, 08 Apr 2016 15:24:57 GMT
+      - Mon, 09 May 2016 17:16:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1390\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \     \"etag\": \"W/\\\"be9db298-404b-48b5-8e0c-63380d9804e5\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"be9db298-404b-48b5-8e0c-63380d9804e5\\\"\",\r\n
+        \           \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.16.0.4\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -2679,19 +2858,19 @@ http_interactions:
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
         {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
         \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-13-FA-EC\",\r\n        \"enableIPForwarding\":
+        \       },\r\n        \"macAddress\": \"00-0D-3A-12-CE-C0\",\r\n        \"enableIPForwarding\":
         false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
         \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
         \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1989\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\",\r\n
-        \     \"etag\": \"W/\\\"6d12eaea-c831-4bc1-aeb0-731bb624193f\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"134a6669-ac4a-4d08-a0db-387bc4c49537\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"6d12eaea-c831-4bc1-aeb0-731bb624193f\\\"\",\r\n
+        \           \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.17.0.4\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -2700,21 +2879,19 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\"\r\n
         \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"fgekpbyth0luvg2bjbwzhttehb.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-12-7B-2C\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\"\r\n
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
+        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\"\r\n
+        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12610\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\",\r\n
-        \     \"etag\": \"W/\\\"e9af206a-fc17-489c-b479-6a6168907ff6\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"5c2eef2c-0b36-4277-a940-957ed4d13be0\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"e9af206a-fc17-489c-b479-6a6168907ff6\\\"\",\r\n
+        \           \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.18.0.4\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -2723,12 +2900,10 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\"\r\n
         \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"odsypf5qp3jedifl1jx0cc3eng.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-10-02-DD\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\"\r\n
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
+        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\"\r\n
+        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg241\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\",\r\n
         \     \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n      \"type\":
@@ -2774,13 +2949,13 @@ http_interactions:
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1611\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \     \"etag\": \"W/\\\"995abf1f-cef0-4b19-bddd-9203f157cffd\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"995abf1f-cef0-4b19-bddd-9203f157cffd\\\"\",\r\n
+        \           \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.16.0.5\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -2789,8 +2964,7 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
         \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
         \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
         \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
@@ -2840,7 +3014,7 @@ http_interactions:
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
         \       }\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:58 GMT
+  recorded_at: Mon, 09 May 2016 17:16:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2016-03-30
@@ -2853,11 +3027,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2874,37 +3048,37 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"140c206e-8ebe-48bf-870d-55c9144137eb"
+      - W/"e68a3d66-4215-4cf1-8f0f-65364da57c65"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2cf05c7d-6707-43cf-8038-324eb6bf6122
+      - d0b7d317-b6b5-4080-87cc-b2f569bae0db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14803'
       X-Ms-Correlation-Request-Id:
-      - b7ec0231-925c-4689-a912-292462758333
+      - 2d02d2b3-f633-4edf-a1d5-2a3c5ecaa623
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152459Z:b7ec0231-925c-4689-a912-292462758333
+      - NORTHCENTRALUS:20160509T171611Z:2d02d2b3-f633-4edf-a1d5-2a3c5ecaa623
       Date:
-      - Fri, 08 Apr 2016 15:24:58 GMT
+      - Mon, 09 May 2016 17:16:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
-        \ \"etag\": \"W/\\\"140c206e-8ebe-48bf-870d-55c9144137eb\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"e68a3d66-4215-4cf1-8f0f-65364da57c65\\\"\",\r\n  \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\": \"13.92.188.218\",\r\n
+        \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\": \"13.92.253.245\",\r\n
         \   \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
         \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
         {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:24:59 GMT
+  recorded_at: Mon, 09 May 2016 17:16:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2016-03-30
@@ -2917,11 +3091,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -2942,52 +3116,50 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - 97e92b50-97fb-42cd-b524-33e34aac85b8
+      - a886e5dd-2807-4a95-86c0-d6c4ed199e1f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14819'
       X-Ms-Correlation-Request-Id:
-      - 9d06e31b-8ada-415c-9c0d-d43ac754262b
+      - a8f8ab00-ee94-43be-a600-56e9b2dab1c3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152500Z:9d06e31b-8ada-415c-9c0d-d43ac754262b
+      - NORTHCENTRALUS:20160509T171612Z:a8f8ab00-ee94-43be-a600-56e9b2dab1c3
       Date:
-      - Fri, 08 Apr 2016 15:25:00 GMT
+      - Mon, 09 May 2016 17:16:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
         \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2016-04-08T15:24:41+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        \       \"time\": \"2016-05-09T17:16:04+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
         [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3.5\",\r\n        \"status\": {\r\n          \"code\":
+        \       \"typeHandlerVersion\": \"2.3.7\",\r\n        \"status\": {\r\n          \"code\":
         \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
         \"Ready\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n
         \     \"name\": \"miq-test-rhel1\",\r\n      \"statuses\": [\r\n        {\r\n
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2016-03-18T17:25:57.5435279+00:00\"\r\n        }\r\n
+        \         \"time\": \"2016-05-09T16:45:14.7963153+00:00\"\r\n        }\r\n
         \     ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
         \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
-        \"2.3.5\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/failed/1\",\r\n
-        \         \"level\": \"Error\",\r\n          \"displayStatus\": \"Provisioning
-        failed\",\r\n          \"message\": \"mdsd stopped:MDSD crash:/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/mdsd:
-        error while loading shared libraries: libglibmm-2.4.so.1: cannot open shared
-        object file: No such file or directory\\n\"\r\n        }\r\n      ]\r\n    }\r\n
-        \ ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-03-18T17:28:50.4032706+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+        \"2.3.7\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
+        \     ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2016-05-09T16:48:15.5786655+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:00 GMT
+  recorded_at: Mon, 09 May 2016 17:16:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1?api-version=2016-03-30
@@ -3000,11 +3172,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3021,37 +3193,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"d470b043-afd0-4849-9dfb-f7e134bf802f"
+      - W/"8c14171e-afdb-469f-be79-e3c1c006be91"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6019463a-a824-4b7d-b63e-42690e83a635
+      - 7971f3c7-8033-4c77-9559-71d49cd9d639
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14800'
       X-Ms-Correlation-Request-Id:
-      - db1bb590-72be-4eae-b2ff-c21cf363ab80
+      - 029c096e-5d62-4511-b1b4-2268e0489086
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152501Z:db1bb590-72be-4eae-b2ff-c21cf363ab80
+      - NORTHCENTRALUS:20160509T171612Z:029c096e-5d62-4511-b1b4-2268e0489086
       Date:
-      - Fri, 08 Apr 2016 15:25:00 GMT
+      - Mon, 09 May 2016 17:16:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-ubuntu1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\",\r\n
-        \ \"etag\": \"W/\\\"d470b043-afd0-4849-9dfb-f7e134bf802f\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"8c14171e-afdb-469f-be79-e3c1c006be91\\\"\",\r\n  \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n    \"ipAddress\": \"13.92.188.25\",\r\n
-        \   \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
+        \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:01 GMT
+  recorded_at: Mon, 09 May 2016 17:16:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/instanceView?api-version=2016-03-30
@@ -3064,11 +3235,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3089,52 +3260,41 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - 21671658-1278-4b0d-85c2-c595040efc7f
+      - 5141f472-e616-4e8b-9390-629d4dcf5e57
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14791'
       X-Ms-Correlation-Request-Id:
-      - b7779b5c-5efc-458a-bb22-5cde013c9d35
+      - 66911995-dd88-4255-aa60-43fb65b9d750
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152503Z:b7779b5c-5efc-458a-bb22-5cde013c9d35
+      - NORTHCENTRALUS:20160509T171613Z:66911995-dd88-4255-aa60-43fb65b9d750
       Date:
-      - Fri, 08 Apr 2016 15:25:02 GMT
+      - Mon, 09 May 2016 17:16:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.1.2\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
-        \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2016-04-08T15:24:51+00:00\"\r\n
-        \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
-        \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n        \"typeHandlerVersion\":
-        \"2.3.5\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n
-        \       }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\":
-        \"miq-test-ubuntu1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
-        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
-        \"Provisioning succeeded\",\r\n          \"time\": \"2016-03-18T17:29:39.2002487+00:00\"\r\n
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-09T17:16:13+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-04-22T19:23:41.3113968+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e/miq-test-ubuntu1.c4d577ae-4be8-41c1-84f8-642320910a5e.screenshot.bmp\",\r\n
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e/miq-test-ubuntu1.c4d577ae-4be8-41c1-84f8-642320910a5e.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
-        \"2.3.5\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"message\": \"message in /var/log/mdsd.err:2016-04-04
-        12:07:31:S6_9_Task_ptrIT_E5_TypeERKNS0_IT0_EEEUlS4_E_St17integral_constantIbLb1EENS6_20_TypeSelectorNoAsyncEED0Ev+0x2e)[0x7f932cc0e77e]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvPFvPvENS3_5list1INS3_5valueIS5_EEEEEEE11do_completeEPNS1_15task_io_serviceEPNS1_25task_io_service_operationERKNS_6system10error_codeEm+0x51)[0x7f932d2c1e81]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN5boost4asio6detail15task_io_service3runERNS_6system10error_codeE+0x45f)[0x7f932d20ba2f]\\n/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.5/bin/libcpprest.so.2.7(_ZN9crossplat10threadpool12thread_startEPv+0x26)[0x7f932d27fd86]\\n/lib/x86_64-linux-gnu/libpthread.so.0(+0x76aa)[0x7f932b2476aa]\\n/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d)[0x7f932af7ce9d]\\n2016-03-31T05:11:07.2569700Z:
-        ===========\\n2016-04-04T12:07:31.5466830Z: XTR::DoContinuation(): Caught
-        exception: Retrieving message chunk header\\n\"\r\n        }\r\n      ]\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
         \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-03-18T17:30:51.7158734+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+        \     \"time\": \"2016-04-22T19:23:41.3582826+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:03 GMT
+  recorded_at: Mon, 09 May 2016 17:16:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12?api-version=2016-03-30
@@ -3147,11 +3307,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3168,37 +3328,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"5469b55d-f0ee-4538-bf96-2bb20c69c199"
+      - W/"e28a3b72-79ab-428e-9bd3-85a775af8e03"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - aeb6beed-c6dc-4dc1-995a-086d5fdfd2dd
+      - b023b6ba-0ff0-4fd5-95e1-66ee304cf61a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14793'
       X-Ms-Correlation-Request-Id:
-      - 0b401cf5-420f-4f1f-98bd-dde07349c60b
+      - 1037eec1-4ca8-44c5-9574-1f42fa3064d0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152503Z:0b401cf5-420f-4f1f-98bd-dde07349c60b
+      - NORTHCENTRALUS:20160509T171613Z:1037eec1-4ca8-44c5-9574-1f42fa3064d0
       Date:
-      - Fri, 08 Apr 2016 15:25:03 GMT
+      - Mon, 09 May 2016 17:16:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-win12\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\",\r\n
-        \ \"etag\": \"W/\\\"5469b55d-f0ee-4538-bf96-2bb20c69c199\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"e28a3b72-79ab-428e-9bd3-85a775af8e03\\\"\",\r\n  \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n    \"ipAddress\": \"13.92.95.165\",\r\n
-        \   \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
+        \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:03 GMT
+  recorded_at: Mon, 09 May 2016 17:16:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/instanceView?api-version=2016-03-30
@@ -3211,11 +3370,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3236,54 +3395,40 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - 4181698c-ed52-4498-ad1b-4e1b3d6ce080
+      - 2e499e2e-2028-4499-a6fa-2315457917d7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14849'
       X-Ms-Correlation-Request-Id:
-      - dd22e753-9f64-4922-8ede-1e778ef32d6c
+      - 00665406-49a1-4727-bd29-2ca0ffaa4918
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152504Z:dd22e753-9f64-4922-8ede-1e778ef32d6c
+      - NORTHCENTRALUS:20160509T171614Z:00665406-49a1-4727-bd29-2ca0ffaa4918
       Date:
-      - Fri, 08 Apr 2016 15:25:04 GMT
+      - Mon, 09 May 2016 17:16:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.7.1198.735\",\r\n
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
-        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
-        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2016-04-08T15:24:52+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
-        [\r\n      {\r\n        \"type\": \"Microsoft.Azure.Diagnostics.IaaSDiagnostics\",\r\n
-        \       \"typeHandlerVersion\": \"1.5.9.0\",\r\n        \"status\": {\r\n
-        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
-        \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
-        \"Diagnostics extension running\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n
-        \ \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n      \"statuses\":
-        [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-09T17:16:14+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-03-18T17:38:10.6534056+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-04-19T23:42:07.2666832+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-6e555b88-3fd4-4b72-a404-4bba5d11de93/miq-test-win12.6e555b88-3fd4-4b72-a404-4bba5d11de93.screenshot.bmp\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"type\": \"Microsoft.Azure.Diagnostics.IaaSDiagnostics\",\r\n      \"typeHandlerVersion\":
-        \"1.5.9.0\",\r\n      \"substatuses\": [\r\n        {\r\n          \"code\":
-        \"ComponentStatus//succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
-        \"Provisioning succeeded\",\r\n          \"message\": \"N/A\"\r\n        }\r\n
-        \     ],\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"message\": \"Diagnostic extension set successfully\",\r\n
-        \         \"time\": \"2016-03-22T03:15:48+00:00\"\r\n        }\r\n      ]\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
         \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-03-18T17:41:22.2315167+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+        \     \"time\": \"2016-04-19T23:42:07.3291564+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:04 GMT
+  recorded_at: Mon, 09 May 2016 17:16:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202?api-version=2016-03-30
@@ -3296,11 +3441,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3310,8 +3455,6 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -3321,20 +3464,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b99be043-5809-47e4-87e5-6a0977335a9c
+      - 6997011f-b3b4-4876-9996-0a20de1f6afd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14793'
       X-Ms-Correlation-Request-Id:
-      - a6b154fe-7f13-4a9c-ad6a-e46daef91c82
+      - ffb12c51-d4b8-494d-be61-aa1e9739f50b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152504Z:a6b154fe-7f13-4a9c-ad6a-e46daef91c82
+      - NORTHCENTRALUS:20160509T171614Z:ffb12c51-d4b8-494d-be61-aa1e9739f50b
       Date:
-      - Fri, 08 Apr 2016 15:25:04 GMT
+      - Mon, 09 May 2016 17:16:14 GMT
+      Connection:
+      - close
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miqtestwinimg6202\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\",\r\n
@@ -3346,7 +3491,7 @@ http_interactions:
         4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:05 GMT
+  recorded_at: Mon, 09 May 2016 17:16:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/instanceView?api-version=2016-03-30
@@ -3359,11 +3504,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3384,26 +3529,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - 9364b8e1-31e6-4c68-9014-ef36c4fba9b9
+      - ff9e528f-4dbc-46af-8b5e-b7b7d3283065
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14748'
       X-Ms-Correlation-Request-Id:
-      - 68095019-e3c1-4464-8e28-7dc2fc8cac4d
+      - 9fb45359-a4e5-4ab4-a69e-901b829fc5f5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152505Z:68095019-e3c1-4464-8e28-7dc2fc8cac4d
+      - NORTHCENTRALUS:20160509T171615Z:9fb45359-a4e5-4ab4-a69e-901b829fc5f5
       Date:
-      - Fri, 08 Apr 2016 15:25:05 GMT
+      - Mon, 09 May 2016 17:16:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-08T15:25:05+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-09T17:16:15+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3419,7 +3564,7 @@ http_interactions:
         \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:05 GMT
+  recorded_at: Mon, 09 May 2016 17:16:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2016-03-30
@@ -3432,11 +3577,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3453,28 +3598,28 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"ff9a2555-ac36-4f02-91aa-312bebc5e381"
+      - W/"734a3944-a880-444c-8c92-cace6e28e303"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - fb8caff0-3f67-439e-8bef-8aaa268e6d33
+      - d23a8af7-ca92-4f45-a0bd-2b4596660342
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14810'
       X-Ms-Correlation-Request-Id:
-      - 34750d4c-9699-4ce3-9351-f52fb18330ec
+      - fb08f3e5-d822-4f43-ad77-67f1066df2a1
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152506Z:34750d4c-9699-4ce3-9351-f52fb18330ec
+      - NORTHCENTRALUS:20160509T171616Z:fb08f3e5-d822-4f43-ad77-67f1066df2a1
       Date:
-      - Fri, 08 Apr 2016 15:25:05 GMT
+      - Mon, 09 May 2016 17:16:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \ \"etag\": \"W/\\\"ff9a2555-ac36-4f02-91aa-312bebc5e381\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
@@ -3482,7 +3627,7 @@ http_interactions:
         4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  }\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:06 GMT
+  recorded_at: Mon, 09 May 2016 17:16:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2016-03-30
@@ -3495,11 +3640,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3520,42 +3665,42 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - 66868d31-532b-42f7-b017-e721cd9cc674
+      - 51d53088-78c6-45ad-8b95-2441b4ef24ab
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14798'
       X-Ms-Correlation-Request-Id:
-      - ccd75648-8cc5-40ab-8b8a-ac2d6b32e64a
+      - 8ffac2f0-56d1-409a-ab2d-fcfca9729993
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152506Z:ccd75648-8cc5-40ab-8b8a-ac2d6b32e64a
+      - NORTHCENTRALUS:20160509T171616Z:8ffac2f0-56d1-409a-ab2d-fcfca9729993
       Date:
-      - Fri, 08 Apr 2016 15:25:06 GMT
+      - Mon, 09 May 2016 17:16:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-08T15:25:06+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-09T17:16:16+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-03-21T17:07:24.107916+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-04-22T19:08:11.7898141+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
         \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-03-21T17:07:24.1547266+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2016-04-22T19:08:11.8523162+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:06 GMT
+  recorded_at: Mon, 09 May 2016 17:16:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2016-03-30
@@ -3568,11 +3713,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3593,27 +3738,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - f89041d6-6fdf-4503-8b21-67fa0a4f7799
+      - ced025b0-cead-43af-b9a7-f1cdc2652d72
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14722'
       X-Ms-Correlation-Request-Id:
-      - 3110afda-084b-4095-8c56-d0b7b9f911c0
+      - 0d01aec1-2d6f-4f29-ad95-1b3922552c6b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152507Z:3110afda-084b-4095-8c56-d0b7b9f911c0
+      - NORTHCENTRALUS:20160509T171617Z:0d01aec1-2d6f-4f29-ad95-1b3922552c6b
       Date:
-      - Fri, 08 Apr 2016 15:25:06 GMT
+      - Mon, 09 May 2016 17:16:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-08T15:25:07+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-09T17:16:17+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3626,7 +3771,7 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:07 GMT
+  recorded_at: Mon, 09 May 2016 17:16:17 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2016-03-30
@@ -3639,11 +3784,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3664,27 +3809,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131006081444041502
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
       X-Ms-Request-Id:
-      - 1e5fb6b1-e2f2-4565-bb12-babc53688d5a
+      - 97c47f48-a37d-4440-8850-e97c89851b37
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14706'
       X-Ms-Correlation-Request-Id:
-      - 3eb6e5b0-8064-40b6-850d-e98274110be0
+      - 79c0bef3-428c-4202-b879-c914c0dd69eb
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152508Z:3eb6e5b0-8064-40b6-850d-e98274110be0
+      - NORTHCENTRALUS:20160509T171617Z:79c0bef3-428c-4202-b879-c914c0dd69eb
       Date:
-      - Fri, 08 Apr 2016 15:25:07 GMT
+      - Mon, 09 May 2016 17:16:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-04-08T15:25:08+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-09T17:16:17+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3697,10 +3842,10 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:08 GMT
+  recorded_at: Mon, 09 May 2016 17:16:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3710,11 +3855,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -3733,37 +3878,30 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7435f4a4-1532-4c8a-910d-4ce6a5dab984
+      - 1ffc297f-f1ec-4c4a-8ae0-9a076c1f9da2
       Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14786'
       X-Ms-Correlation-Request-Id:
-      - 7435f4a4-1532-4c8a-910d-4ce6a5dab984
+      - 1ffc297f-f1ec-4c4a-8ae0-9a076c1f9da2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152508Z:7435f4a4-1532-4c8a-910d-4ce6a5dab984
+      - NORTHCENTRALUS:20160509T171618Z:1ffc297f-f1ec-4c4a-8ae0-9a076c1f9da2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:25:07 GMT
+      - Mon, 09 May 2016 17:16:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"nextLink":"","value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","location":"East
-        US","name":"miqazuretest14047","properties":{"accountType":"Standard_LRS","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/"},"primaryLocation":"East
-        US","provisioningState":"Succeeded","statusOfPrimary":"available"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","location":"East
-        US","name":"miqazuretest16487","properties":{"accountType":"Standard_LRS","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/"},"primaryLocation":"East
-        US","provisioningState":"Succeeded","statusOfPrimary":"available"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","location":"East
-        US","name":"miqazuretest18686","properties":{"accountType":"Standard_LRS","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/"},"primaryLocation":"East
-        US","provisioningState":"Succeeded","statusOfPrimary":"available"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","location":"East
-        US","name":"spec0deply1stor","properties":{"accountType":"Standard_LRS","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/"},"primaryLocation":"East
-        US","provisioningState":"Succeeded","statusOfPrimary":"available"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","kind":"Storage","location":"eastus","name":"miqazuretest14047","properties":{"creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","kind":"Storage","location":"eastus","name":"miqazuretest16487","properties":{"creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","kind":"Storage","location":"eastus","name":"miqazuretest18686","properties":{"creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","kind":"Storage","location":"eastus","name":"spec0deply1stor","properties":{"creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
 
 '
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:08 GMT
+  recorded_at: Mon, 09 May 2016 17:16:18 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2016-01-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -3773,11 +3911,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
       Content-Length:
       - '0'
   response:
@@ -3789,6 +3927,8 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json
       Expires:
@@ -3796,28 +3936,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a5d3be7a-a383-4dfe-b92c-19ba0f65dfdf
+      - b612cfce-89b9-4a5b-ac6c-6390a7c8cc4b
       Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - a5d3be7a-a383-4dfe-b92c-19ba0f65dfdf
+      - b612cfce-89b9-4a5b-ac6c-6390a7c8cc4b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152509Z:a5d3be7a-a383-4dfe-b92c-19ba0f65dfdf
+      - NORTHCENTRALUS:20160509T171619Z:b612cfce-89b9-4a5b-ac6c-6390a7c8cc4b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:25:08 GMT
-      Connection:
-      - close
+      - Mon, 09 May 2016 17:16:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"key1":"FR27zlayw/BE6MkbBhzEI42zZWHZpXIowho9C0byefqW2AXiRHDn3rsUJSJEJ9UAy7bc5RN8NbhOyegpg5VP6Q==","key2":"cXASUkLCkGJbZ6urDq8U2Je11KT+Y9ihyatlZsX1bIPVGehwenUJrokY6AO+rFChPXYnEFJpYHbRqTMTkAnu/w=="}
+      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w=="},{"keyName":"key2","permissions":"Full","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:09 GMT
+  recorded_at: Mon, 09 May 2016 17:16:19 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
@@ -3830,15 +3969,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:09 GMT
+      - Mon, 09 May 2016 17:16:19 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:bJu7lF6tfFhLORg1xuNTfzr/OUXrFlpY2+UMz/0613I=
+      - SharedKey miqazuretest14047:c904cLvJif4oa3zl/TUTZ79zzHYNQBltY/6K2I7ZP/o=
   response:
     status:
       code: 200
@@ -3851,11 +3990,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a227611e-0001-0119-4aaa-914c42000000
+      - dca8dfda-0001-009f-1916-aa5ec5000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:08 GMT
+      - Mon, 09 May 2016 17:16:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3887,21 +4026,26 @@ http_interactions:
         NDA6MzEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzBBRURC
         NTBBQiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
         cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
-        aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+c3lzdGVtPC9OYW1l
-        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYg
-        MTc6MDg6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzQ4
-        NjUxNkJGOCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0
-        YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9w
-        ZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFt
-        ZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2
-        IDE3OjMwOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUz
-        MTI3NjQ5RUUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
-        dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
-        dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9D
-        b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
-        dGlvblJlc3VsdHM+
+        aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05h
+        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMCBBcHIgMjAx
+        NiAxNjowNDo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNjkz
+        NTgyRkJENTg0IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNl
+        U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
+        b3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5zeXN0ZW08
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIg
+        MjAxNiAxNzowODowMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQz
+        NTI3NDg2NTE2QkY4IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xl
+        YXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48
+        L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT52aGRz
+        PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFy
+        IDIwMTYgMTc6MzA6NTkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhE
+        MzRGNTMxMjc2NDlFRSI8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVh
+        c2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFz
+        ZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGll
+        cz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0Vu
+        dW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:09 GMT
+  recorded_at: Mon, 09 May 2016 17:16:20 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e?comp=list&restype=container
@@ -3914,15 +4058,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:09 GMT
+      - Mon, 09 May 2016 17:16:20 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:+GLpmGm7Zjo9reQYQXQ/GKQcy1j5lHKuqo6+bgBEy1Y=
+      - SharedKey miqazuretest14047:Y+FhJjSiql5VmQZBxUa8NNns8AaRZf8P9QCE3dwCBsA=
   response:
     status:
       code: 200
@@ -3935,11 +4079,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4832c2ec-0001-002f-5baa-91a745000000
+      - fa9f653b-0001-00fe-4416-aa1a1a000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:09 GMT
+      - Mon, 09 May 2016 17:16:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3950,8 +4094,8 @@ http_interactions:
         OGEtNDQ4ZC1iNjFjLTE2NTI3OWE3ZmIzZSI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcWF6dXJlLWNlbnRvczEuNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1
         Mjc5YTdmYjNlLnNjcmVlbnNob3QuYm1wPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
-        YXN0LU1vZGlmaWVkPk1vbiwgMjEgTWFyIDIwMTYgMTc6MDQ6NTcgR01UPC9M
-        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNTFBQUVFOEQ2Mzk5PC9FdGFnPjxD
+        YXN0LU1vZGlmaWVkPkZyaSwgMjIgQXByIDIwMTYgMTk6MDU6NDkgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkFFMTFERjAxOTNEPC9FdGFnPjxD
         b250ZW50LUxlbmd0aD42MTQ5MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
         LVR5cGU+aW1hZ2UvYm1wPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
         bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNo
@@ -3962,9 +4106,9 @@ http_interactions:
         YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXFh
         enVyZS1jZW50b3MxLjc5NmM1YmNjLTMzOGEtNDQ4ZC1iNjFjLTE2NTI3OWE3
         ZmIzZS5zZXJpYWxjb25zb2xlLmxvZzwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5Nb24sIDIxIE1hciAyMDE2IDE2OjU2OjU3IEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzUxQTlEMDc2ODgzQjwvRXRhZz48Q29u
-        dGVudC1MZW5ndGg+NTE3MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        dC1Nb2RpZmllZD5GcmksIDIyIEFwciAyMDE2IDE3OjMxOjQ4IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzZBRDNGQzA3ODQ5RDwvRXRhZz48Q29u
+        dGVudC1MZW5ndGg+NTA2ODg8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
         cGU+dGV4dC9wbGFpbjwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
         Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1z
@@ -3974,7 +4118,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:10 GMT
+  recorded_at: Mon, 09 May 2016 17:16:20 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-6e555b88-3fd4-4b72-a404-4bba5d11de93?comp=list&restype=container
@@ -3987,15 +4131,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:10 GMT
+      - Mon, 09 May 2016 17:16:20 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:2CM/UsuT7t/YLKKaQJE6JE67zAfC+dJ5oCvte6fsaQc=
+      - SharedKey miqazuretest14047:BKIDk6NxzZXW2s3Wewk3QJ5qzRUpxscCE1mBUXprIis=
   response:
     status:
       code: 200
@@ -4008,11 +4152,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3106e29e-0001-00a6-26aa-911e61000000
+      - b2852340-0001-00a2-5916-aaebe3000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:10 GMT
+      - Mon, 09 May 2016 17:16:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4023,8 +4167,8 @@ http_interactions:
         ZDQtNGI3Mi1hNDA0LTRiYmE1ZDExZGU5MyI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXdpbjEyLjZlNTU1Yjg4LTNmZDQtNGI3Mi1hNDA0LTRiYmE1
         ZDExZGU5My5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5GcmksIDA4IEFwciAyMDE2IDE1OjI0OjE1IEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzVGQzFEODQ2Nzk0NzwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5UdWUsIDE5IEFwciAyMDE2IDIzOjM5OjI2IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzY4QUJEN0ZGQ0U5RDwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -4035,7 +4179,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:10 GMT
+  recorded_at: Mon, 09 May 2016 17:16:20 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-b97ff488-e114-40ed-8d7a-f4500d73eec0?comp=list&restype=container
@@ -4048,15 +4192,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:10 GMT
+      - Mon, 09 May 2016 17:16:20 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:y9Ew6Z+kX3UQOBNf65aL5KNPqdX3l2S9gUub6EAfqj0=
+      - SharedKey miqazuretest14047:kJKoNS38s0LWsG9jiOKYHfCfZ5qtRGK23arErlszJ00=
   response:
     status:
       code: 200
@@ -4069,11 +4213,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ad8e3192-0001-0036-74aa-918b2d000000
+      - 1083c4af-0001-010e-0a16-aa8c21000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:10 GMT
+      - Mon, 09 May 2016 17:16:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4096,7 +4240,7 @@ http_interactions:
         c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:11 GMT
+  recorded_at: Mon, 09 May 2016 17:16:21 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-e17a95b0-f4fb-4196-93c5-0c8be7d5c536?comp=list&restype=container
@@ -4109,15 +4253,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:11 GMT
+      - Mon, 09 May 2016 17:16:21 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:mO+Cx5qz+nJRzKzI8/FelBvON2J7OuKwlUhfXqzLIAY=
+      - SharedKey miqazuretest14047:B6GJH0iLz2muBKtJvOfSE/S0PbQtwhCq97Sbu8R4qlU=
   response:
     status:
       code: 200
@@ -4130,11 +4274,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e771705c-0001-010d-1baa-918f26000000
+      - f762b303-0001-0012-4016-aa1263000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:10 GMT
+      - Mon, 09 May 2016 17:16:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4145,7 +4289,93 @@ http_interactions:
         ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNiI+PEJsb2JzIC8+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:11 GMT
+  recorded_at: Mon, 09 May 2016 17:16:21 GMT
+- request:
+    method: get
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 09 May 2016 17:16:21 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey miqazuretest14047:U3lrU8/66tqqFqReJ/eEB2wswK4wnrXLfD/kruhUOCY=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 0af97f98-0001-001a-6016-aa0910000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Mon, 09 May 2016 17:16:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
+        ZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmJyb25hZ2hy
+        c3BlYzNfMDM0YzkzOGItZWFhOS00Mzk5LThlZDItY2I3MjE2ZmFiZjBiLnZo
+        ZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDI4IEFw
+        ciAyMDE2IDE0OjEyOjQ5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzZGNkYyRTI5OTYyRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5
+        MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
+        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZO
+        T1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1u
+        dW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
+        PlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xl
+        YXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48
+        L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2h3aXRoc183
+        M2I5YTk1YS1kZGUxLTQzYjUtODEzOS0yYmIwNDY1ZDM5MWEudmhkPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMjggQXByIDIwMTYg
+        MTQ6NTY6MzUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkY3NTRC
+        NEI4NEU2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0Nv
+        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
+        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksv
+        dlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
+        bnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4z
+        PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxv
+        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
+        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
+        aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZWN0ZXN0Ml84NGFkN2IyYi05MTAw
+        LTQwZGItODk5Ny1hMzE5MTJjZjI3YzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVz
+        PjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgQXByIDIwMTYgMTg6MTg6MjYgR01U
+        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjk0ODJBOTI3Rjk1PC9FdGFn
+        PjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3Ro
+        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
+        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
+        ZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0Nv
+        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
+        b24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+
+        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
+        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
+        L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Mon, 09 May 2016 17:16:22 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
@@ -4158,15 +4388,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:11 GMT
+      - Mon, 09 May 2016 17:16:22 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:ma7DJqvgumi75HzDQmgqOXcptYWumug/UOyB3C6YTj4=
+      - SharedKey miqazuretest14047:h6XIajJNJDM9ruLGLEa6JpdHduRs6thiwF3rCK49svc=
   response:
     status:
       code: 200
@@ -4179,11 +4409,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d3ed6011-0001-001b-2eaa-9108ed000000
+      - 8754cc51-0001-0035-5216-aa882a000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:12 GMT
+      - Mon, 09 May 2016 17:16:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4220,7 +4450,7 @@ http_interactions:
         L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1
         bHRzPg==
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:12 GMT
+  recorded_at: Mon, 09 May 2016 17:16:22 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4233,15 +4463,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:12 GMT
+      - Mon, 09 May 2016 17:16:22 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:TXjoycKTOsPg6U6mxzUtKS/ZmkfeVvs2Bsu3SpVYPOc=
+      - SharedKey miqazuretest14047:UUtYlF5MUsQnVV62on8/usQIgAYeKUWbvVe6iPGmEoc=
   response:
     status:
       code: 200
@@ -4254,11 +4484,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 48b1e25e-0001-00e4-35aa-913575000000
+      - 01237735-0001-003d-2d16-aa9359000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:12 GMT
+      - Mon, 09 May 2016 17:16:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4267,106 +4497,319 @@ http_interactions:
         enVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2lu
         MTIuNmU1NTViODgtM2ZkNC00YjcyLWE0MDQtNGJiYTVkMTFkZTkzLnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDA4IEFw
-        ciAyMDE2IDE1OjI1OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzVGQzFGNzlGMjEzNTwvRXRhZz48Q29udGVudC1MZW5ndGg+ODg0PC9Db250
-        ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
-        cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WVN4L2ZuVVJZaU9nZGRralh0
-        V2pvdz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
-        LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
-        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
-        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
-        QmxvYj48TmFtZT5taXEtdGVzdC13aW4xMjIwMTYyMTgxMTMwMTQudmhkPC9O
-        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMDggQXByIDIw
-        MTYgMTU6MjU6MTIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNUZD
-        MUZBNjE5MERDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8
-        L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0
-        ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
-        Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpR
-        VksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENv
-        bnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
-        cj4xODE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBh
-        Z2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0
-        YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVy
-        YXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwv
-        QmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcuYjk3ZmY0ODgtZTEx
-        NC00MGVkLThkN2EtZjQ1MDBkNzNlZWMwLnN0YXR1czwvTmFtZT48UHJvcGVy
-        dGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjMwOjI5
-        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNkY0ODFFMkM0Nzwv
-        RXRhZz48Q29udGVudC1MZW5ndGg+ODg0PC9Db250ZW50LUxlbmd0aD48Q29u
-        dGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1U
-        eXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48
-        Q29udGVudC1NRDU+MUsrbExKenN1NEo1QW1uanFCdXVYQT09PC9Db250ZW50
-        LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+
-        PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVu
-        bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xl
-        YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEt
-        dGVzdC13aW5pbWcuZTE3YTk1YjAtZjRmYi00MTk2LTkzYzUtMGM4YmU3ZDVj
-        NTM2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5U
-        dWUsIDIyIE1hciAyMDE2IDE2OjU4OjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48
-        RXRhZz4weDhEMzUyNzMzN0VGQTA4MTwvRXRhZz48Q29udGVudC1MZW5ndGg+
-        ODg0PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
-        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
-        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+RFNCbitSZkhB
-        Z0JGRFgrUzh6OVd1QT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
-        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
-        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
-        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
-        PjwvQmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcyMDE2MjIyMTAx
-        NjQzLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUs
-        IDIyIE1hciAyMDE2IDE2OjM3OjQyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
-        Zz4weDhEMzUyNzA0QTNCMUVBNjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2
-        MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxp
-        Y2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVu
-        Y29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZ
-        aFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29u
-        dHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1
-        ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48Qmxv
-        YlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tl
-        ZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0
-        YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3Qt
-        d2luaW1nMjAxNjIyMjEwNDA3LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjU5OjAwIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNzM0M0JBMzE1MjwvRXRhZz48Q29u
-        dGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29u
-        dGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1U
-        eXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48
-        Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50
-        LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+
-        PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVl
-        bmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFz
-        ZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNl
-        ZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VE
-        dXJhdGlvbj48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcWF6
-        dXJlLWNlbnRvczEuNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1Mjc5YTdm
-        YjNlLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5N
-        b24sIDIxIE1hciAyMDE2IDE3OjA1OjE2IEdNVDwvTGFzdC1Nb2RpZmllZD48
-        RXRhZz4weDhEMzUxQUFGOTZCMTFEMzwvRXRhZz48Q29udGVudC1MZW5ndGg+
-        NjgzPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
-        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
-        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+QU5Bb2Y1S203
-        Q3VKamxVRG9aL0puZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
-        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
-        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
-        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
-        PjwvQmxvYj48QmxvYj48TmFtZT5taXFhenVyZS1jZW50b3MxMjAxNjIyMTEw
-        NDk0Ni52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9u
-        LCAyMSBNYXIgMjAxNiAxNzowNTozMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0
-        YWc+MHg4RDM1MUFCMDJEN0MwRTc8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMy
-        MjEyMjU1MjMyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxp
-        Y2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVu
-        Y29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+YkxL
-        N3JnVDdJZ01OWDJZeEw5QkN5Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29u
-        dHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1
-        ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48Qmxv
-        YlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8
-        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48
-        TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3Bl
-        cnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0
-        aW9uUmVzdWx0cz4=
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEFw
+        ciAyMDE2IDIzOjM5OjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzY4QUJFQkEyRDY0NDwvRXRhZz48Q29udGVudC1MZW5ndGg+NDIzOTwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pm5IL0ZtVUJOSFUrSjBUc3Ro
+        cjlxb3c9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luMTIyMDE2MjE4MTEzMDE0LnZoZDwv
+        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEFwciAy
+        MDE2IDIzOjQwOjIyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzY4
+        QUJGOTgxODdDMTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6
+        UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+Mjc0PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5Q
+        YWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1
+        cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48
+        L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luaW1nLmI5N2ZmNDg4LWUx
+        MTQtNDBlZC04ZDdhLWY0NTAwZDczZWVjMC5zdGF0dXM8L05hbWU+PFByb3Bl
+        cnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNjozMDoy
+        OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1MjZGNDgxRTJDNDc8
+        L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjg4NDwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PjFLK2xMSnpzdTRKNUFtbmpxQnV1WEE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        PjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
+        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
+        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlx
+        LXRlc3Qtd2luaW1nLmUxN2E5NWIwLWY0ZmItNDE5Ni05M2M1LTBjOGJlN2Q1
+        YzUzNi5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
+        VHVlLCAyMiBNYXIgMjAxNiAxNjo1ODo0MCBHTVQ8L0xhc3QtTW9kaWZpZWQ+
+        PEV0YWc+MHg4RDM1MjczMzdFRkEwODE8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
+        Pjg4NDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlv
+        bi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGlu
+        ZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkRTQm4rUmZI
+        QWdCRkRYK1M4ejlXdUE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wg
+        Lz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8
+        L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+
+        PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGll
+        cz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luaW1nMjAxNjIyMjEw
+        MTY0My52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVl
+        LCAyMiBNYXIgMjAxNiAxNjozNzo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0
+        YWc+MHg4RDM1MjcwNEEzQjFFQTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEz
+        NjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
+        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
+        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZi
+        WWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
+        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJs
+        b2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
+        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcS10ZXN0
+        LXdpbmltZzIwMTYyMjIxMDQwNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNjo1OTowMCBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1MjczNDNCQTMxNTI8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFz
+        ZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNl
+        RHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXFh
+        enVyZS1jZW50b3MxLjc5NmM1YmNjLTMzOGEtNDQ4ZC1iNjFjLTE2NTI3OWE3
+        ZmIzZS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
+        RnJpLCAyMiBBcHIgMjAxNiAxOTowNTo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+
+        PEV0YWc+MHg4RDM2QUUxMUM0Nzg5MTA8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
+        PjY4MzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlv
+        bi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGlu
+        ZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnhMUWcvRW1i
+        UTZ1UUdFRmkrYlhtM2c9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wg
+        Lz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8
+        L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+
+        PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGll
+        cz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxYXp1cmUtY2VudG9zMTIwMTYyMjEx
+        MDQ5NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZy
+        aSwgMjIgQXByIDIwMTYgMTk6MDU6NTggR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzNkFFMTIzOTU0QjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4z
+        MjIxMjI1NTIzMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
+        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
+        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmJM
+        SzdyZ1Q3SWdNTlgyWXhMOUJDeWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
+        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJs
+        b2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2Vk
+        PC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+
+        PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9w
+        ZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
+        dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:12 GMT
+  recorded_at: Mon, 09 May 2016 17:16:23 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghrspec3_034c938b-eaa9-4399-8ed2-cb7216fabf0b.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 09 May 2016 17:16:23 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey miqazuretest14047:0ttbLwmNiNpWxbsJznquZqRKRceOTP/aAeagRympXMI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 28 Apr 2016 14:12:49 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36F6F2E29962F"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 0b202b01-0001-010d-6416-aa8f26000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '13'
+      X-Ms-Copy-Id:
+      - 84b41d07-b6d7-4587-8016-53106261d597
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=LI47CT7Q5j8kE6chefTOnX%2BRMrjkSBD0aAcew1S4Zg4%3D&st=2016-04-27T19%3A20%3A13Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 27 Apr 2016 19:35:14 GMT
+      Date:
+      - Mon, 09 May 2016 17:16:23 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 09 May 2016 17:16:23 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghwiths_73b9a95a-dde1-43b5-8139-2bb0465d391a.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 09 May 2016 17:16:23 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey miqazuretest14047:unPfbMd6619Q2G1IFF+6iJp6KN9EhAW7vOwk+C/UtG8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 28 Apr 2016 14:56:35 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36F754B4B84E6"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 6f5736c1-0001-0061-7e16-aa62a0000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '3'
+      X-Ms-Copy-Id:
+      - 85aaddf0-542f-480f-a64f-d638bc392b51
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=VcM9HDnYJb6sA2neKdEfzKIpEI2lh%2BZ6rnZEVpFak2I%3D&st=2016-04-28T14%3A02%3A58Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 28 Apr 2016 14:17:59 GMT
+      Date:
+      - Mon, 09 May 2016 17:16:23 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 09 May 2016 17:16:24 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/sectest2_84ad7b2b-9100-40db-8997-a31912cf27c1.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 09 May 2016 17:16:24 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey miqazuretest14047:gklRw9r1v/5gvNanwJVwKdqZ3y3OowXer+qFYCQ2oeQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Wed, 20 Apr 2016 18:18:26 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D369482A927F95"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 69a1af7f-0001-00a5-4916-aa1d66000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - a46ba27d-357f-4abe-9af1-24fc8c741896
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=lYt%2BpYh8i9T8VnXGjGHlh4WiiQs%2B5wB%2BO6WhLOfAEjo%3D&st=2016-04-20T15%3A49%3A53Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 20 Apr 2016 16:04:56 GMT
+      Date:
+      - Mon, 09 May 2016 17:16:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 09 May 2016 17:16:24 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
@@ -4379,15 +4822,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:12 GMT
+      - Mon, 09 May 2016 17:16:24 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:3D/9qWp7TGEZLpcdZKGI/vzdbypLFtf8casuO15Cpr4=
+      - SharedKey miqazuretest14047:Q0qUK7reveN5ABrXeebWhlA0Q1doVR0pTbIG+k3bQ7E=
   response:
     status:
       code: 200
@@ -4408,7 +4851,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 17704d04-0001-004c-16aa-91e160000000
+      - a3b7db61-0001-0048-4416-aa14e2000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -4419,6 +4862,8 @@ http_interactions:
       - Generalized
       X-Ms-Meta-Microsoftazurecompute-Ostype:
       - Windows
+      X-Ms-Write-Protection:
+      - 'false'
       X-Ms-Lease-Status:
       - unlocked
       X-Ms-Lease-State:
@@ -4438,12 +4883,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 17:08:02 GMT
       Date:
-      - Fri, 08 Apr 2016 15:25:13 GMT
+      - Mon, 09 May 2016 17:16:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:13 GMT
+  recorded_at: Mon, 09 May 2016 17:16:24 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
@@ -4456,15 +4901,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:13 GMT
+      - Mon, 09 May 2016 17:16:24 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:yUpnb3j9U5jQK4Nv525mcmCeVoTgzqHMtzuhgozWjDU=
+      - SharedKey miqazuretest14047:y7rLyz9MJNdudYktNCdxzPzewpiEzQ1tn20NIX3p0CI=
   response:
     status:
       code: 200
@@ -4485,9 +4930,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 35d7ff40-0001-012f-59aa-91e110000000
+      - 41e82ed6-0001-0000-2b16-aa267f000000
       X-Ms-Version:
       - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
       X-Ms-Lease-Status:
       - unlocked
       X-Ms-Lease-State:
@@ -4507,15 +4954,15 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 16:17:06 GMT
       Date:
-      - Fri, 08 Apr 2016 15:25:13 GMT
+      - Mon, 09 May 2016 17:16:25 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:13 GMT
+  recorded_at: Mon, 09 May 2016 17:16:25 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2016-01-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -4525,11 +4972,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
       Content-Length:
       - '0'
   response:
@@ -4541,8 +4988,6 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json
       Expires:
@@ -4550,26 +4995,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6a99cab6-5a5a-42a6-9e6c-819b58e2eb25
+      - 7060655a-44dd-48a8-b483-642281930d3d
       Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - 6a99cab6-5a5a-42a6-9e6c-819b58e2eb25
+      - 7060655a-44dd-48a8-b483-642281930d3d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152514Z:6a99cab6-5a5a-42a6-9e6c-819b58e2eb25
+      - NORTHCENTRALUS:20160509T171625Z:7060655a-44dd-48a8-b483-642281930d3d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:25:14 GMT
+      - Mon, 09 May 2016 17:16:25 GMT
+      Connection:
+      - close
     body:
       encoding: ASCII-8BIT
-      string: '{"key1":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ==","key2":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA=="}
+      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ=="},{"keyName":"key2","permissions":"Full","value":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:14 GMT
+  recorded_at: Mon, 09 May 2016 17:16:25 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
@@ -4582,15 +5030,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:14 GMT
+      - Mon, 09 May 2016 17:16:25 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:laH6yMFt3ocrQo1iAJy8QN8oFx/EeWJiz1cnyiVHGt8=
+      - SharedKey miqazuretest16487:wEL3fEVPzDNHQdD1UkI7x8JsqvNmbeFoEENZG1XOUeg=
   response:
     status:
       code: 200
@@ -4603,11 +5051,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8d196e39-0001-0038-67aa-916726000000
+      - 0ee9953e-0001-00b0-4616-aadfff000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:14 GMT
+      - Mon, 09 May 2016 17:16:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4629,7 +5077,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:14 GMT
+  recorded_at: Mon, 09 May 2016 17:16:26 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e?comp=list&restype=container
@@ -4642,15 +5090,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:14 GMT
+      - Mon, 09 May 2016 17:16:26 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:hA3otIY5Ng9vo1U13ti3YA4UAfi/6ZqT5zrfd9nHNK8=
+      - SharedKey miqazuretest16487:HL+CrjPSG6CvjECC2L0VM7kFcq7hFw9bpft2zstV/Mg=
   response:
     status:
       code: 200
@@ -4663,11 +5111,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 75600a0d-0001-0116-71aa-91a1b4000000
+      - e2741ce2-0001-0018-2b16-aa0bea000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:14 GMT
+      - Mon, 09 May 2016 17:16:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4678,8 +5126,8 @@ http_interactions:
         ZTgtNDFjMS04NGY4LTY0MjMyMDkxMGE1ZSI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXVidW50dTEuYzRkNTc3YWUtNGJlOC00MWMxLTg0ZjgtNjQy
         MzIwOTEwYTVlLnNjcmVlbnNob3QuYm1wPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
-        YXN0LU1vZGlmaWVkPkZyaSwgMDggQXByIDIwMTYgMTU6MjQ6NDMgR01UPC9M
-        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNUZDMUU5NTdGREI5PC9FdGFnPjxD
+        YXN0LU1vZGlmaWVkPkZyaSwgMjIgQXByIDIwMTYgMTk6MjE6MjkgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkFFMzRFQUYzODUyPC9FdGFnPjxD
         b250ZW50LUxlbmd0aD42MTQ5MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
         LVR5cGU+aW1hZ2UvYm1wPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
         bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNo
@@ -4690,19 +5138,19 @@ http_interactions:
         YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEt
         dGVzdC11YnVudHUxLmM0ZDU3N2FlLTRiZTgtNDFjMS04NGY4LTY0MjMyMDkx
         MGE1ZS5zZXJpYWxjb25zb2xlLmxvZzwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5GcmksIDA4IEFwciAyMDE2IDE1OjIzOjQzIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzVGQzFDNTZEMkJFNzwvRXRhZz48Q29u
-        dGVudC1MZW5ndGg+MTcwNjQ5NjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
-        VHlwZT50ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
-        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNo
-        ZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9i
-        LXNlcXVlbmNlLW51bWJlcj4wPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        PjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVu
-        bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xl
-        YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFy
-        a2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+        dC1Nb2RpZmllZD5GcmksIDIyIEFwciAyMDE2IDE5OjIxOjI5IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzZBRTM0RTY0MTREQjwvRXRhZz48Q29u
+        dGVudC1MZW5ndGg+MTMzMTIwPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
+        eXBlPnRleHQvcGxhaW48L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGlu
+        ZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1IC8+PENhY2hl
+        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjA8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
+        PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5s
+        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVh
+        c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
+        ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:15 GMT
+  recorded_at: Mon, 09 May 2016 17:16:26 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4715,15 +5163,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:15 GMT
+      - Mon, 09 May 2016 17:16:26 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:lBu1r+Z42kpOkiYMKQsFk0amzouhCcBXakWetcJx0y0=
+      - SharedKey miqazuretest16487:0/vRo5m9PVBryPCuUswiBkhOKX6B58gygTp1yQD2eoY=
   response:
     status:
       code: 200
@@ -4736,11 +5184,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8a3612c8-0001-0052-5faa-913b8d000000
+      - 263cd9bf-0001-0034-5016-aa89d7000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:15 GMT
+      - Mon, 09 May 2016 17:16:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4749,36 +5197,36 @@ http_interactions:
         enVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1
         bnR1MS5jNGQ1NzdhZS00YmU4LTQxYzEtODRmOC02NDIzMjA5MTBhNWUuc3Rh
-        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMDgg
-        QXByIDIwMTYgMTU6MjQ6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
-        OEQzNUZDMUVERkREQkNGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY3PC9D
+        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIg
+        QXByIDIwMTYgMTk6MjE6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzNkFFMzREOTBCNzU0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY3PC9D
         b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
         LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
-        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+NGwra3BLUXVlb3BTcGc2
-        cWluRVV6dz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+U2dDM3RnVGcwOENGOVYw
+        ckYzVEdHUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
         ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
         cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
         dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
         Yj48QmxvYj48TmFtZT5taXEtdGVzdC11YnVudHUxMjAxNjIxODExMjY0Ny52
-        aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAwOCBB
-        cHIgMjAxNiAxNToyNTowMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
-        RDM1RkMxRjQ3MUM2MDk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3Mjgw
+        aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMiBB
+        cHIgMjAxNiAxOToyMTo1NyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDM2QUUzNUVERDRGMDU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3Mjgw
         NTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
         L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVw
         N3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
         PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1u
-        dW1iZXI+NjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
+        dW1iZXI+OTc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
         PlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFz
         ZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNl
         RHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVz
         PjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJl
         c3VsdHM+
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:15 GMT
+  recorded_at: Mon, 09 May 2016 17:16:26 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2016-01-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -4788,11 +5236,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
       Content-Length:
       - '0'
   response:
@@ -4813,26 +5261,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3a7ad3f8-92c6-4d82-82aa-de302f97f7c1
+      - 46c19149-340e-46e7-a3ce-ad84905d22bd
       Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - 3a7ad3f8-92c6-4d82-82aa-de302f97f7c1
+      - 46c19149-340e-46e7-a3ce-ad84905d22bd
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152516Z:3a7ad3f8-92c6-4d82-82aa-de302f97f7c1
+      - NORTHCENTRALUS:20160509T171627Z:46c19149-340e-46e7-a3ce-ad84905d22bd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:25:15 GMT
+      - Mon, 09 May 2016 17:16:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"key1":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","key2":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w=="}
+      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw=="},{"keyName":"key2","permissions":"Full","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:16 GMT
+  recorded_at: Mon, 09 May 2016 17:16:27 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
@@ -4845,15 +5294,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:16 GMT
+      - Mon, 09 May 2016 17:16:27 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:cEcWb/rh2yCmHi3q2+SEJjHtLU5pz+sPr7zjLY4OVwU=
+      - SharedKey miqazuretest18686:xIZNZjluGS3J8Fz8q3JIa8Be6IYR0IBC4vXnebak+Qo=
   response:
     status:
       code: 200
@@ -4866,11 +5315,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e93ec15f-0001-005a-40aa-9120fe000000
+      - 0f9c1a45-0001-002f-3716-aaa745000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:15 GMT
+      - Mon, 09 May 2016 17:16:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4892,7 +5341,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:16 GMT
+  recorded_at: Mon, 09 May 2016 17:16:28 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4?comp=list&restype=container
@@ -4905,15 +5354,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:16 GMT
+      - Mon, 09 May 2016 17:16:28 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:tT1sxYaB3lgIUbUHXvV44hVSbSzVqrY+3o0QorRRoEw=
+      - SharedKey miqazuretest18686:b1YPT9aqaL4cCRLaMcfcEtW2srwfTqOSrTwPjw05xH4=
   response:
     status:
       code: 200
@@ -4926,11 +5375,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a08e4f43-0001-00ea-3faa-91d97e000000
+      - 56539158-0001-00ff-6816-aa1be7000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:17 GMT
+      - Mon, 09 May 2016 17:16:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4941,8 +5390,8 @@ http_interactions:
         YWItNDg2Ny05Y2M0LTE1NzMzNmI3ZTJlNCI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXJoZWwxLjAzZTg0NjdiLWJhYWItNDg2Ny05Y2M0LTE1NzMz
         NmI3ZTJlNC5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5GcmksIDA4IEFwciAyMDE2IDE1OjI1OjAxIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzVGQzFGM0YzQzJCODwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5Nb24sIDA5IE1heSAyMDE2IDE3OjE2OjIxIEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzc4MkRBNDhFRDdBQTwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -4953,9 +5402,9 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRl
         c3QtcmhlbDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0
         LnNlcmlhbGNvbnNvbGUubG9nPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPkZyaSwgMDggQXByIDIwMTYgMTM6MzY6MDAgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQzNUZCMkI5NjFDNTk0PC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD45NTc0NDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
+        ZGlmaWVkPk1vbiwgMDkgTWF5IDIwMTYgMTY6NTQ6MjEgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzNzgyQTkxN0YyMjdEPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD40NjU5MjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
         ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
         Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNoZS1Db250
         cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVl
@@ -4965,7 +5414,7 @@ http_interactions:
         dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:17 GMT
+  recorded_at: Mon, 09 May 2016 17:16:28 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4978,15 +5427,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:17 GMT
+      - Mon, 09 May 2016 17:16:28 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:q6QG7Hg3Cz4lAbQ/xtUvLQwzIRmNr+Fj/ZSsb4Ay+8U=
+      - SharedKey miqazuretest18686:CG8ayune0Pc4XgvbrGhCYGqWe4ZHkmgAOjIEaqCfr3g=
   response:
     status:
       code: 200
@@ -4999,11 +5448,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 337e5b9e-0001-00c3-36aa-91af3c000000
+      - 55336b58-0001-0107-3d16-aa96af000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:17 GMT
+      - Mon, 09 May 2016 17:16:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5012,36 +5461,36 @@ http_interactions:
         enVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtcmhl
         bDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0LnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDA4IEFw
-        ciAyMDE2IDE1OjI1OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzVGQzFGNzk4QjZFQTwvRXRhZz48Q29udGVudC1MZW5ndGg+ODgwPC9Db250
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA5IE1h
+        eSAyMDE2IDE3OjE2OjA0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        Mzc4MkQ5QTRDRDkwQzwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250
         ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
         cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MC83K0pmL3ZkT1g2REpFSlpt
-        a3RUZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MXp0Q1hObS84WGdiSTh0Tzdt
+        c1BRUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
         LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
         PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
         ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
         QmxvYj48TmFtZT5taXEtdGVzdC1yaGVsMTIwMTYyMTgxMTIyNDMudmhkPC9O
-        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMDggQXByIDIw
-        MTYgMTU6MjU6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNUZD
-        MUZEODdFNTVEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDkgTWF5IDIw
+        MTYgMTc6MTI6MDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNzgy
+        RDBEODYxREQ5PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
         Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
         dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
         b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmRRTCtYSGpGTlBkb01F
         d2VJNjNmd1E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
         dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        Pjg4PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdl
-        QmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0
-        dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0
-        aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0Js
-        b2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRz
-        Pg==
+        PjEzNTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
+        dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
+        dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9C
+        bG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0
+        cz4=
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:17 GMT
+  recorded_at: Mon, 09 May 2016 17:16:29 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2016-01-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -5051,11 +5500,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
       Content-Length:
       - '0'
   response:
@@ -5076,26 +5525,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 091332ca-9309-4826-b435-72ef77c237bc
+      - d4515a67-7e5e-402f-b5f8-e92f363c016f
       Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - 091332ca-9309-4826-b435-72ef77c237bc
+      - d4515a67-7e5e-402f-b5f8-e92f363c016f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152519Z:091332ca-9309-4826-b435-72ef77c237bc
+      - NORTHCENTRALUS:20160509T171629Z:d4515a67-7e5e-402f-b5f8-e92f363c016f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:25:19 GMT
+      - Mon, 09 May 2016 17:16:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"key1":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","key2":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw=="}
+      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ=="},{"keyName":"key2","permissions":"Full","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:19 GMT
+  recorded_at: Mon, 09 May 2016 17:16:29 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
@@ -5108,15 +5558,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:19 GMT
+      - Mon, 09 May 2016 17:16:29 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:twh1iAyW0biW4t5d9P5IJMg8W73tYli492C4XngbZ6M=
+      - SharedKey spec0deply1stor:kT8UK7gIU50CkgR1ylArP/CR4evZGIewg96OU9HePYM=
   response:
     status:
       code: 200
@@ -5129,11 +5579,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ebafe4ca-0001-011f-1daa-91bb3a000000
+      - 4477b78f-0001-00da-0316-aa8354000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:19 GMT
+      - Mon, 09 May 2016 17:16:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5161,7 +5611,7 @@ http_interactions:
         b3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2Vy
         IC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:20 GMT
+  recorded_at: Mon, 09 May 2016 17:16:30 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68?comp=list&restype=container
@@ -5174,15 +5624,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:20 GMT
+      - Mon, 09 May 2016 17:16:30 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:6FgsD445mw+1i5G4xrnouPgbQ9tV3Uwg+EbUpCeOut4=
+      - SharedKey spec0deply1stor:u5qNQu5FYqodzHZW91em+H+CzTD14zK+kDze4nadbm0=
   response:
     status:
       code: 200
@@ -5195,11 +5645,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d4adb301-0001-00a8-74aa-91f26a000000
+      - 70f7f48a-0001-0092-7316-aab1c9000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:19 GMT
+      - Mon, 09 May 2016 17:16:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5222,7 +5672,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:20 GMT
+  recorded_at: Mon, 09 May 2016 17:16:30 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261?comp=list&restype=container
@@ -5235,15 +5685,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:20 GMT
+      - Mon, 09 May 2016 17:16:30 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:AFYVaNKY2mAPLKWNEyYgRkVHJanuv9zRdy8Uhs7EFVo=
+      - SharedKey spec0deply1stor:lxnGUP31Ya+GhhQTnIMDEuJ6vjZ4IGiLKg5rvFnKc/Q=
   response:
     status:
       code: 200
@@ -5256,11 +5706,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e0a0fe30-0001-0068-59aa-91782e000000
+      - c8a14497-0001-004a-7416-aa1618000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:20 GMT
+      - Mon, 09 May 2016 17:16:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5283,7 +5733,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:21 GMT
+  recorded_at: Mon, 09 May 2016 17:16:31 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5296,15 +5746,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 08 Apr 2016 15:25:21 GMT
+      - Mon, 09 May 2016 17:16:31 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:F3NYqMNtcLt0L0CP0KovreW8Hx2QS+Nyk44cDTd0dow=
+      - SharedKey spec0deply1stor:QzvI2XZKp+XxwwSLhM7asLxoMT5xtPgHrbVIcQEGiG8=
   response:
     status:
       code: 200
@@ -5317,11 +5767,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 31070635-0001-00a6-12aa-911e61000000
+      - 32964d13-0001-00f2-1516-aaf4eb000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 08 Apr 2016 15:25:22 GMT
+      - Mon, 09 May 2016 17:16:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5379,7 +5829,7 @@ http_interactions:
         PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4
         dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:22 GMT
+  recorded_at: Mon, 09 May 2016 17:16:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
@@ -5392,11 +5842,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -5413,22 +5863,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 72024057-d8d1-4d8f-a15c-c07e00e9b603
+      - 89001c15-a766-4c1d-aedf-87570d05a4cd
       X-Ms-Correlation-Request-Id:
-      - 72024057-d8d1-4d8f-a15c-c07e00e9b603
+      - 89001c15-a766-4c1d-aedf-87570d05a4cd
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152528Z:72024057-d8d1-4d8f-a15c-c07e00e9b603
+      - NORTHCENTRALUS:20160509T171635Z:89001c15-a766-4c1d-aedf-87570d05a4cd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 08 Apr 2016 15:25:27 GMT
+      - Mon, 09 May 2016 17:16:35 GMT
       Content-Length:
       - '566'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}}]}'
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:28 GMT
+  recorded_at: Mon, 09 May 2016 17:16:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
@@ -5441,11 +5891,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -5464,20 +5914,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 91310e26-a44f-49cd-baa7-598b4854a487
+      - 3f60768c-7710-4f0d-a91d-cef2b7005a3a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14819'
       X-Ms-Correlation-Request-Id:
-      - fe1b9837-6050-4934-a39b-a0204ba4ea10
+      - ff41879b-04ba-4686-8740-ab052af3c56e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152529Z:fe1b9837-6050-4934-a39b-a0204ba4ea10
+      - NORTHCENTRALUS:20160509T171636Z:ff41879b-04ba-4686-8740-ab052af3c56e
       Date:
-      - Fri, 08 Apr 2016 15:25:28 GMT
+      - Mon, 09 May 2016 17:16:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
@@ -5942,7 +6392,7 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\"\r\n
         \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:29 GMT
+  recorded_at: Mon, 09 May 2016 17:16:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
@@ -5955,11 +6405,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -5978,32 +6428,32 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2c29d162-ecef-40bd-a76e-53bbbc0b9418
+      - 0f45af2f-d008-45b8-943b-8235feeaf991
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14659'
       X-Ms-Correlation-Request-Id:
-      - 6e3edd42-0f4e-43c6-a0b5-24768e91d09e
+      - e92605a2-4bf4-4af4-8100-32bd2b7d3c4e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152529Z:6e3edd42-0f4e-43c6-a0b5-24768e91d09e
+      - NORTHCENTRALUS:20160509T171636Z:e92605a2-4bf4-4af4-8100-32bd2b7d3c4e
       Date:
-      - Fri, 08 Apr 2016 15:25:29 GMT
+      - Mon, 09 May 2016 17:16:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-azure-test1\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \     \"etag\": \"W/\\\"34df1975-22c8-4c87-9071-13a8f5c66279\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"fc474b6c-7052-4243-afdd-08cc5a294c82\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n        \"addressSpace\":
         {\r\n          \"addressPrefixes\": [\r\n            \"10.16.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"34df1975-22c8-4c87-9071-13a8f5c66279\\\"\",\r\n
+        \           \"etag\": \"W/\\\"fc474b6c-7052-4243-afdd-08cc5a294c82\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.16.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -6013,28 +6463,28 @@ http_interactions:
         \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
         \     }\r\n    },\r\n    {\r\n      \"name\": \"miqazuretest18687\",\r\n      \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687\",\r\n
-        \     \"etag\": \"W/\\\"b8b416e1-eb47-45d4-808a-b2291f03d495\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"90e05db2-0da6-4768-a07a-da2e928f143d\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"87a78829-3e13-4a97-9b81-486d93ce6439\",\r\n        \"addressSpace\":
         {\r\n          \"addressPrefixes\": [\r\n            \"10.17.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"b8b416e1-eb47-45d4-808a-b2291f03d495\\\"\",\r\n
+        \           \"etag\": \"W/\\\"90e05db2-0da6-4768-a07a-da2e928f143d\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.17.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
         \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
         \     }\r\n    },\r\n    {\r\n      \"name\": \"miqazuretest19881\",\r\n      \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881\",\r\n
-        \     \"etag\": \"W/\\\"8c36ba7f-8079-4319-804e-81cd4b183b02\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"ade5c8a7-0552-4003-b771-998e0aa8b49e\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"9787e570-7ff0-4152-a0ab-da6fa10ba46e\",\r\n        \"addressSpace\":
         {\r\n          \"addressPrefixes\": [\r\n            \"10.18.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"8c36ba7f-8079-4319-804e-81cd4b183b02\\\"\",\r\n
+        \           \"etag\": \"W/\\\"ade5c8a7-0552-4003-b771-998e0aa8b49e\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.18.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
@@ -6056,7 +6506,7 @@ http_interactions:
         \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
         \     }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:29 GMT
+  recorded_at: Mon, 09 May 2016 17:16:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
@@ -6069,11 +6519,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -6092,31 +6542,31 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9f77a74e-35ab-4f06-ae05-e3fb2b9e9222
+      - 487a473a-06cc-465a-9ef9-56b3a805d55d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14777'
       X-Ms-Correlation-Request-Id:
-      - 7ba4c2ff-ef77-4db0-b819-6fe24e89d011
+      - 2dbe0526-9456-4261-9cd3-37f6d98b67e5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152530Z:7ba4c2ff-ef77-4db0-b819-6fe24e89d011
+      - NORTHCENTRALUS:20160509T171637Z:2dbe0526-9456-4261-9cd3-37f6d98b67e5
       Date:
-      - Fri, 08 Apr 2016 15:25:29 GMT
+      - Mon, 09 May 2016 17:16:37 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1390\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \     \"etag\": \"W/\\\"be9db298-404b-48b5-8e0c-63380d9804e5\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"be9db298-404b-48b5-8e0c-63380d9804e5\\\"\",\r\n
+        \           \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.16.0.4\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -6127,19 +6577,19 @@ http_interactions:
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
         {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
         \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-13-FA-EC\",\r\n        \"enableIPForwarding\":
+        \       },\r\n        \"macAddress\": \"00-0D-3A-12-CE-C0\",\r\n        \"enableIPForwarding\":
         false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
         \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
         \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1989\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\",\r\n
-        \     \"etag\": \"W/\\\"6d12eaea-c831-4bc1-aeb0-731bb624193f\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"134a6669-ac4a-4d08-a0db-387bc4c49537\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"6d12eaea-c831-4bc1-aeb0-731bb624193f\\\"\",\r\n
+        \           \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.17.0.4\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -6148,21 +6598,19 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\"\r\n
         \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"fgekpbyth0luvg2bjbwzhttehb.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-12-7B-2C\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\"\r\n
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
+        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\"\r\n
+        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12610\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\",\r\n
-        \     \"etag\": \"W/\\\"e9af206a-fc17-489c-b479-6a6168907ff6\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"5c2eef2c-0b36-4277-a940-957ed4d13be0\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"e9af206a-fc17-489c-b479-6a6168907ff6\\\"\",\r\n
+        \           \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.18.0.4\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -6171,12 +6619,10 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\"\r\n
         \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"odsypf5qp3jedifl1jx0cc3eng.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-10-02-DD\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\"\r\n
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
+        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\"\r\n
+        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg241\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\",\r\n
         \     \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n      \"type\":
@@ -6222,13 +6668,13 @@ http_interactions:
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1611\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \     \"etag\": \"W/\\\"995abf1f-cef0-4b19-bddd-9203f157cffd\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n      \"type\":
         \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n        \"ipConfigurations\":
         [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"995abf1f-cef0-4b19-bddd-9203f157cffd\\\"\",\r\n
+        \           \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"privateIPAddress\": \"10.16.0.5\",\r\n              \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
@@ -6237,8 +6683,7 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
         \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
         \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
         \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
         \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
@@ -6288,7 +6733,7 @@ http_interactions:
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
         \       }\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:30 GMT
+  recorded_at: Mon, 09 May 2016 17:16:37 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
@@ -6301,11 +6746,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjAxMjg3NzksIm5iZiI6MTQ2MDEyODc3OSwiZXhwIjoxNDYwMTMyNjc5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.YF_fo19mmSed3zMpf3quXglR2n83PhUmc8B1XnLkwk54H7aw3Xui1oe6FCkZJE3-hwqlwktTGcqYPks7BR0hS3DUScMTnaykeR8ez6D4-nwp37dfqaayJe1Ra6DHNND1EcwZSB5D4pcCsw1IAixarl6hTNPG3gDdH2gkn4e9wGl_iP8R4VdOUuD3HmyN5oRVl-UEITVCK_6s-d6MhwgzRDSOyzNJ-oZ2aUe1jzOUi7pM_SUCT-qj6ikOjjcR6KZN_ccr4xsUB0se6xskHitdeGguw8QIy0sV3Zw1dJTNEoLn8H-iDQWQId3DpVjWFzDiE-O8uJUJmAB4QzgodQEwpg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
   response:
     status:
       code: 200
@@ -6324,49 +6769,47 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3856ceee-a2ac-4285-a7ba-13de5224ecc4
+      - e2bd0ed7-259a-4d01-80a1-5f65fb2d2057
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14788'
       X-Ms-Correlation-Request-Id:
-      - 42bf973c-880a-4aa2-b1af-717926b40e77
+      - fd3d5cd3-f76b-413d-a4fc-c6a5f69c3356
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20160408T152531Z:42bf973c-880a-4aa2-b1af-717926b40e77
+      - NORTHCENTRALUS:20160509T171638Z:fd3d5cd3-f76b-413d-a4fc-c6a5f69c3356
       Date:
-      - Fri, 08 Apr 2016 15:25:30 GMT
+      - Mon, 09 May 2016 17:16:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
-        \     \"etag\": \"W/\\\"140c206e-8ebe-48bf-870d-55c9144137eb\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"e68a3d66-4215-4cf1-8f0f-65364da57c65\\\"\",\r\n      \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n        \"ipAddress\":
-        \"13.92.188.218\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
+        \"13.92.253.245\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
         \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipConfiguration\":
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\",\r\n
-        \     \"etag\": \"W/\\\"d470b043-afd0-4849-9dfb-f7e134bf802f\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"8c14171e-afdb-469f-be79-e3c1c006be91\\\"\",\r\n      \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n        \"ipAddress\":
-        \"13.92.188.25\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipConfiguration\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
+        \       \"resourceGuid\": \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\",\r\n
-        \     \"etag\": \"W/\\\"5469b55d-f0ee-4538-bf96-2bb20c69c199\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"e28a3b72-79ab-428e-9bd3-85a775af8e03\\\"\",\r\n      \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n        \"ipAddress\":
-        \"13.92.95.165\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipConfiguration\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
+        \       \"resourceGuid\": \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg\",\r\n
         \     \"etag\": \"W/\\\"a091b576-4b02-4f33-81e8-6161b046fee5\\\"\",\r\n      \"type\":
@@ -6377,7 +6820,7 @@ http_interactions:
         4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \     \"etag\": \"W/\\\"ff9a2555-ac36-4f02-91aa-312bebc5e381\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n      \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n        \"publicIPAddressVersion\":
@@ -6401,7 +6844,14 @@ http_interactions:
         4,\r\n        \"dnsSettings\": {\r\n          \"domainNameLabel\": \"spec0deply1dns\",\r\n
         \         \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n        },\r\n
         \       \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"v-publicIp\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp\",\r\n
+        \     \"etag\": \"W/\\\"55b3c93d-de22-451b-ae6a-2f37d34c8dcb\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"b2dff9bd-173c-4e3e-b531-3e0e340bc07d\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 08 Apr 2016 15:25:31 GMT
+  recorded_at: Mon, 09 May 2016 17:16:38 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This updates the refresher specs for Azure to reflect updated counts for various resources as well as ems_ref changes for orchestration stacks.

This also updates the VCR cassette to reflect changes in the azure-armrest gem 0.2.6, which now potentially generates an extra http request.