### PR TITLE
[api] Prevent user from seeing another's requests

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -71,6 +71,7 @@ class ApiController < ApplicationController
   include_concern 'ProvisionRequests'
   include_concern "Rates"
   include_concern "Reports"
+  include_concern 'Requests'
   include_concern 'RequestTasks'
   include_concern 'ResourceActions'
   include_concern 'Roles'

--- a/app/controllers/api_controller/requests.rb
+++ b/app/controllers/api_controller/requests.rb
@@ -1,0 +1,14 @@
+class ApiController
+  module Requests
+    def find_requests(id)
+      klass = collection_class(:requests)
+      return klass.find(id) if @auth_user_obj.admin?
+      klass.find_by!(:requester => @auth_user_obj, :id => id)
+    end
+
+    def requests_search_conditions
+      return {} if @auth_user_obj.admin?
+      {:requester => @auth_user_obj}
+    end
+  end
+end

--- a/app/controllers/api_controller/service_requests.rb
+++ b/app/controllers/api_controller/service_requests.rb
@@ -51,6 +51,17 @@ class ApiController
       action_result(false, err.to_s)
     end
 
+    def find_service_requests(id)
+      klass = collection_class(:service_requests)
+      return klass.find(id) if @auth_user_obj.admin?
+      klass.find_by!(:requester => @auth_user_obj, :id => id)
+    end
+
+    def service_requests_search_conditions
+      return {} if @auth_user_obj.admin?
+      {:requester => @auth_user_obj}
+    end
+
     private
 
     def service_request_ident(service_request)

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe "Requests API" do
+  let(:template) { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
+
+  context "authorization" do
+    it "is forbidden for a user without appropriate role" do
+      api_basic_authorize
+
+      run_get requests_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "does not list another user's requests" do
+      other_user = FactoryGirl.create(:user)
+      FactoryGirl.create(:service_template_provision_request,
+                         :requester   => other_user,
+                         :source_id   => template.id,
+                         :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:requests, :read, :get)
+
+      run_get requests_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include("name" => "requests", "count" => 1, "subcount" => 0)
+    end
+
+    it "does not show another user's request" do
+      other_user = FactoryGirl.create(:user)
+      service_request = FactoryGirl.create(:service_template_provision_request,
+                                           :requester   => other_user,
+                                           :source_id   => template.id,
+                                           :source_type => template.class.name)
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+
+      run_get requests_url(service_request.id)
+
+      expected = {
+        "error" => a_hash_including(
+          "message" => /Couldn't find MiqRequest/
+        )
+      }
+      expect(response).to have_http_status(:not_found)
+      expect(response_hash).to include(expected)
+    end
+
+    it "a user can list their own requests" do
+      _service_request = FactoryGirl.create(:service_template_provision_request,
+                                            :requester   => @user,
+                                            :source_id   => template.id,
+                                            :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:requests, :read, :get)
+
+      run_get requests_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include("name" => "requests", "count" => 1, "subcount" => 1)
+    end
+
+    it "a user can show their own request" do
+      service_request = FactoryGirl.create(:service_template_provision_request,
+                                           :requester   => @user,
+                                           :source_id   => template.id,
+                                           :source_type => template.class.name)
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+
+      run_get requests_url(service_request.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include("id"   => service_request.id,
+                                       "href" => a_string_matching(service_requests_url(service_request.id)))
+    end
+
+    it "lists all the service requests if you are admin" do
+      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      other_user = FactoryGirl.create(:user)
+      service_request_1 = FactoryGirl.create(:service_template_provision_request,
+                                             :requester   => other_user,
+                                             :source_id   => template.id,
+                                             :source_type => template.class.name)
+      service_request_2 = FactoryGirl.create(:service_template_provision_request,
+                                             :requester   => @user,
+                                             :source_id   => template.id,
+                                             :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:requests, :read, :get)
+
+      run_get requests_url
+
+      expected = {
+        "count"     => 2,
+        "subcount"  => 2,
+        "resources" => a_collection_containing_exactly(
+          {"href" => a_string_matching(requests_url(service_request_1.id))},
+          {"href" => a_string_matching(requests_url(service_request_2.id))},
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include(expected)
+    end
+
+    it "an admin can see another user's request" do
+      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      other_user = FactoryGirl.create(:user)
+      service_request = FactoryGirl.create(:service_template_provision_request,
+                                           :requester   => other_user,
+                                           :source_id   => template.id,
+                                           :source_type => template.class.name)
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+
+      run_get requests_url(service_request.id)
+
+      expected = {
+        "id"   => service_request.id,
+        "href" => a_string_matching(service_requests_url(service_request.id))
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include(expected)
+    end
+  end
+end

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -145,4 +145,120 @@ describe ApiController do
       )
     end
   end
+
+  context "authorization" do
+    it "is forbidden for a user without appropriate role" do
+      api_basic_authorize
+
+      run_get service_requests_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "does not list another user's requests" do
+      other_user = FactoryGirl.create(:user)
+      FactoryGirl.create(:service_template_provision_request,
+                         :requester   => other_user,
+                         :source_id   => template.id,
+                         :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include("name" => "service_requests", "count" => 1, "subcount" => 0)
+    end
+
+    it "does not show another user's request" do
+      other_user = FactoryGirl.create(:user)
+      service_request = FactoryGirl.create(:service_template_provision_request,
+                                           :requester   => other_user,
+                                           :source_id   => template.id,
+                                           :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url(service_request.id)
+
+      expected = {
+        "error" => a_hash_including(
+          "message" => /Couldn't find ServiceTemplateProvisionRequest/
+        )
+      }
+      expect(response).to have_http_status(:not_found)
+      expect(response_hash).to include(expected)
+    end
+
+    it "a user can list their own requests" do
+      _service_request = FactoryGirl.create(:service_template_provision_request,
+                                            :requester   => @user,
+                                            :source_id   => template.id,
+                                            :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include("name" => "service_requests", "count" => 1, "subcount" => 1)
+    end
+
+    it "a user can show their own request" do
+      service_request = FactoryGirl.create(:service_template_provision_request,
+                                           :requester   => @user,
+                                           :source_id   => template.id,
+                                           :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url(service_request.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include("id"   => service_request.id,
+                                       "href" => a_string_matching(service_requests_url(service_request.id)))
+    end
+
+    it "lists all the service requests if you are admin" do
+      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      other_user = FactoryGirl.create(:user)
+      service_request_1 = FactoryGirl.create(:service_template_provision_request,
+                                             :requester   => other_user,
+                                             :source_id   => template.id,
+                                             :source_type => template.class.name)
+      service_request_2 = FactoryGirl.create(:service_template_provision_request,
+                                             :requester   => @user,
+                                             :source_id   => template.id,
+                                             :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url
+
+      expected = {
+        "count"     => 2,
+        "subcount"  => 2,
+        "resources" => a_collection_containing_exactly(
+          {"href" => a_string_matching(service_requests_url(service_request_1.id))},
+          {"href" => a_string_matching(service_requests_url(service_request_2.id))},
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include(expected)
+    end
+
+    it "an admin can see another user's request" do
+      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      other_user = FactoryGirl.create(:user)
+      service_request = FactoryGirl.create(:service_template_provision_request,
+                                           :requester   => other_user,
+                                           :source_id   => template.id,
+                                           :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url(service_request.id)
+
+      expected = {
+        "id"   => service_request.id,
+        "href" => a_string_matching(service_requests_url(service_request.id))
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response_hash).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1297974

/cc @AparnaKarve @abellotti 
@miq-bot add-label api, bug