### PR TITLE
Changed value of :enabled for toolbar button from string to boolean

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -39,7 +39,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        t = N_('Attach selected Cloud Volume to an Instance'),
                        t,
                        :url_parms => 'main_div',
-                       :enabled   => 'false',
+                       :enabled   => false,
                        :onwhen    => '1'
                      ),
                      button(
@@ -48,7 +48,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        t = N_('Detach selected Cloud Volume from an Instance'),
                        t,
                        :url_parms => 'main_div',
-                       :enabled   => 'false',
+                       :enabled   => false,
                        :onwhen    => '1'
                      ),
                      button(
@@ -57,7 +57,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        t = N_('Edit selected Cloud Volume'),
                        t,
                        :url_parms => 'main_div',
-                       :enabled   => 'false',
+                       :enabled   => false,
                        :onwhen    => '1'
                      ),
                      button(
@@ -67,7 +67,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        t,
                        :url_parms => '&refresh=y',
                        :confirm   => 'Warning: The selected Cloud Volume and ALL of their components will be removed. Are you sure you want to remove these Cloud Volumes?',
-                       :enabled   => 'false',
+                       :enabled   => false,
                        :onwhen    => '1+'
                      ),
                    ]


### PR DESCRIPTION
Value of :enabled attribute in toolbars buttons should be a boolean, having it as string was causing buttons to be enabled all the time. Buttons should only be enabled when an item in the list view is selected to perform an action.

https://bugzilla.redhat.com/show_bug.cgi?id=1334202

@dclarizio please review. @mansam this was introduced in dedf4824c431d42b9697a3aae33e43efa6497f15

before:
![before](https://cloud.githubusercontent.com/assets/3450808/15125644/f3ce3442-15fb-11e6-9d8a-6563c6bf42fa.png)

after:
![after1](https://cloud.githubusercontent.com/assets/3450808/15125648/f9aa15b6-15fb-11e6-8270-77c55492a211.png)

After selecting an item in list view
![after2](https://cloud.githubusercontent.com/assets/3450808/15125654/ff73d842-15fb-11e6-8174-b837f9fb0cef.png)
