### PR TITLE
Save and restore the connection pool name in with_remote_connection

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -100,19 +100,21 @@ class MiqRegionRemote < ApplicationRecord
       end
     end
 
-    pool = establish_connection({
-      :adapter  => adapter,
-      :host     => host,
-      :port     => port,
-      :username => username,
-      :password => password,
-      :database => database
-    }.delete_blanks)
     begin
+      old_spec_name = connection_specification_name
+      pool = establish_connection({
+        :adapter  => adapter,
+        :host     => host,
+        :port     => port,
+        :username => username,
+        :password => password,
+        :database => database
+      }.delete_blanks)
       conn = pool.connection
       yield conn
     ensure
       remove_connection
+      self.connection_specification_name = old_spec_name
     end
   end
 end

--- a/spec/models/miq_region_remote_spec.rb
+++ b/spec/models/miq_region_remote_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MiqRegionRemote do
   end
 
   describe ".with_remote_connection" do
-    it "removes the temporary connection pool", :skip => "need to fix" do
+    it "removes the temporary connection pool" do
       original = described_class.connection.raw_connection.conninfo_hash[:dbname]
 
       config = Rails.configuration.database_configuration[Rails.env]


### PR DESCRIPTION
A change in rails connection handling prevents us from discovering the connection pool from the parent class after having created a pool with `establish_connection` to connect to an alternate database.

Paired with @jrafanie 

https://github.com/rails/rails/pull/24844

@kbrock @Fryguy @chessbyte 