### PR TITLE
Add new table to schema.yml file

### DIFF
--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4387,6 +4387,16 @@ metrics_23:
 - derived_host_sockets
 - derived_host_count_total
 - derived_vm_count_total
+middleware_datasources:
+- id
+- name
+- ems_ref
+- nativeid
+- server_id
+- properties
+- ems_id
+- created_at
+- updated_at
 middleware_deployments:
 - id
 - name


### PR DESCRIPTION
New tables need to be added to the `schema.yml` file

The PR that added the table (https://github.com/ManageIQ/manageiq/pull/8257) went green before the spec to check the schema was added.

This will fix the replication spec.