### PR TITLE
Azure metrics

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -3,6 +3,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :Flavor
+  require_nested :MetricsCapture
+  require_nested :MetricsCollectorWorker
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -1,11 +1,132 @@
 class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  INTERVAL_1_MINUTE = "PT1M".freeze
+
+  COUNTER_INFO = [
+    {
+      :native_counters       => ["\\Processor(_Total)\\% Processor Time"], # CPU percentage guest OS
+      :vim_style_counter_key => "cpu_usage_rate_average"
+    },
+  ].freeze
+
+  COUNTER_NAMES = COUNTER_INFO.flat_map { |i| i[:native_counters] }.uniq.to_set.freeze
+
+  VIM_STYLE_COUNTERS = {
+    "cpu_usage_rate_average" => {
+      :counter_key           => "cpu_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "percent",
+      :capture_interval_name => "realtime"
+    },
+  }.freeze
+
   def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
     raise "No EMS defined" if target.ext_management_system.nil?
 
     log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
 
-    # TODO: Actually collect the metrics
-    _log.warn("#{log_header} Metrics not yet being collected.")
-    return {}, {}
+    end_time   = (end_time || Time.now).utc
+    start_time = (start_time || end_time - 4.hours).utc # 4 hours for symmetry with VIM
+
+    begin
+      # This is just for consistency, to produce a :connect benchmark
+      Benchmark.realtime_block(:connect) {}
+      target.ext_management_system.with_provider_connection do |conn|
+        with_metrics_services(conn) do |metrics_conn, storage_conn|
+          perf_capture_data_azure(metrics_conn, storage_conn, start_time, end_time)
+        end
+      end
+    rescue Exception => err
+      _log.error("#{log_header} Unhandled exception during perf data collection: [#{err}], class: [#{err.class}]")
+      _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
+      _log.log_backtrace(err)
+      raise
+    end
+  end
+
+  private
+
+  def with_metrics_services(connection)
+    yield [
+      Azure::Armrest::Insights::MetricsService.new(connection),
+      Azure::Armrest::StorageAccountService.new(connection)
+    ]
+  end
+
+  def perf_capture_data_azure(metrics_conn, storage_conn, start_time, end_time)
+    start_time -= 1.minutes # Get one extra minute so we can build the 20-second intermediate values
+
+    counters                = get_counters(metrics_conn)
+    metrics_by_counter_name = metrics_by_counter_name(storage_conn, counters, start_time, end_time)
+    counter_values_by_ts    = counter_values_by_timestamp(metrics_by_counter_name)
+
+    counters_by_id              = {target.ems_ref => VIM_STYLE_COUNTERS}
+    counter_values_by_id_and_ts = {target.ems_ref => counter_values_by_ts}
+    return counters_by_id, counter_values_by_id_and_ts
+  end
+
+  def counter_values_by_timestamp(metrics_by_counter_name)
+    counter_values_by_ts = {}
+    COUNTER_INFO.each do |i|
+      timestamps = i[:native_counters].flat_map do |c|
+        metrics_by_counter_name[c].keys unless metrics_by_counter_name[c].nil?
+      end.uniq.compact.sort
+
+      timestamps.each_cons(2) do |last_ts, ts|
+        metrics = i[:native_counters].collect { |c| metrics_by_counter_name.fetch_path(c, ts) }
+        value = metrics.compact.first # assume only one of the native_counters returned a value
+
+        # For (temporary) symmetry with VIM API we create 20-second intervals.
+        (last_ts + 20.seconds..ts).step_value(20.seconds).each do |inner_ts|
+          counter_values_by_ts.store_path(inner_ts.iso8601, i[:vim_style_counter_key], value)
+        end
+      end
+    end
+    counter_values_by_ts
+  end
+
+  def metrics_by_counter_name(storage_conn, counters, start_time, end_time)
+    counters.each_with_object({}) do |c, h|
+      metrics = h[c.name.value] = {}
+
+      raw_metrics, _timings = Benchmark.realtime_block(:capture_counter_values) do
+        raw_metrics_for_counter(storage_conn, c, start_time, end_time)
+      end
+
+      raw_metrics.each { |m| metrics[Time.parse(m._timestamp)] = m.average }
+    end
+  end
+
+  def raw_metrics_for_counter(storage_conn, counter, start_time, end_time)
+    # TODO: We should really find the availabilities that
+    #       a) match the time range
+    #       b) are other sizes than 1-minute time grains
+    # TODO: This should live in the azure-armrest gem as a general method for
+    #       capturing metrics for a target.
+    availability = counter.metric_availabilities.detect { |ma| ma.time_grain == INTERVAL_1_MINUTE }
+    return [] if availability.nil?
+
+    table = availability.location.table_info.last
+    endpoint = availability.location.table_endpoint
+    storage_acct_name = URI.parse(endpoint).host.split('.').first
+    storage_account = storage_conn.get(storage_acct_name, target.resource_group)
+    storage_key = storage_conn.list_account_keys(storage_acct_name, target.resource_group).fetch('key1')
+
+    filter = "CounterName eq '#{counter.name.value}' and Timestamp ge datetime'#{start_time.iso8601}' and Timestamp le datetime'#{end_time.iso8601}'"
+    # TODO: The following needs to pass :all => true for proper paging in case
+    #       the time range is > 1000 metrics, but there seems to be a bug in
+    #       continuation tokens when doing this.
+    storage_account.table_data(table.table_name, storage_key, :filter => filter)
+  end
+
+  def get_counters(metrics_conn)
+    counters, _timings = Benchmark.realtime_block(:capture_counters) do
+      metrics_conn
+        .list('Microsoft.Compute', 'virtualMachines', target.name, target.resource_group)
+        .select { |m| m.name.value.in?(COUNTER_NAMES) }
+    end
+    counters
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
+    raise "No EMS defined" if target.ext_management_system.nil?
+
+    log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
+
+    # TODO: Actually collect the metrics
+    _log.warn("#{log_header} Metrics not yet being collected.")
+    return {}, {}
+  end
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_collector_worker.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::Azure::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
+  require_nested :Runner
+
+  self.default_queue_name = "azure"
+
+  def friendly_name
+    @friendly_name ||= "C&U Metrics Collector for Azure"
+  end
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::CloudManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -2,6 +2,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
   extend ActiveSupport::Concern
 
   MONITOR_CLASS_NAMES = %w(
+    ManageIQ::Providers::Azure::CloudManager::MetricsCollectorWorker
     ManageIQ::Providers::Amazon::CloudManager::MetricsCollectorWorker
     ManageIQ::Providers::Redhat::InfraManager::MetricsCollectorWorker
     ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
@@ -68,6 +69,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
 
   MONITOR_CLASS_NAMES_IN_KILL_ORDER = %w(
     MiqEmsMetricsProcessorWorker
+    ManageIQ::Providers::Azure::CloudManager::MetricsCollectorWorker
     ManageIQ::Providers::Amazon::CloudManager::MetricsCollectorWorker
     ManageIQ::Providers::Redhat::InfraManager::MetricsCollectorWorker
     ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1176,6 +1176,7 @@
           :count: 2
           :nice_delta: 3
           :poll_method: :escalate
+        :ems_metrics_collector_worker_azure: {}
         :ems_metrics_collector_worker_amazon: {}
         :ems_metrics_collector_worker_atomic: {}
         :ems_metrics_collector_worker_atomic_enterprise: {}


### PR DESCRIPTION
This PR adds collection of metrics for Azure.  At present, it only collects "CPU percentage guest OS" into "cpu_usage_rate_average".  The code is a bit of copy/paste from the Amazon metrics collector, so many of the idioms found there have also been copied here and I have not bothered to "update" them...that can be done in a follow up PR if necessary.

Some other things *not* done in this PR:
- Only "CPU percentage guest OS" is collected.  As such, I've left out the `:calculation` part that is in the amazon metrics, since it's was unneeded overhead.  It can be added back in if needed.
- I've only tried Windows VMs so far, but I think that the metric name for Linux VMs is slightly different.  I will have to check, but it's the reason I left in support for multiple `:native_counters`.  If I find it's not necessary, I will remove it.
- Each metric has multiple "availabilities" or as they are known elsewhere, "interval".  For now, I've hardcoded only capturing the "PT1M", or "1 minute" availabilities.  This should probably be changed to handle the most granular availability for a particular timespan.
- Each availabilities has multiple "tables" of data, but I am only looking at the most recent table.  The tables are roughly in 10-day chunks, so there is a possibility right now of losing some metrics if the capture occurs right on a table boundary.  This should probably be changed to check the most recent table, then the next recent table, until no records come back.
- When querying for the metrics, there seems to be a bug if `:all => true` is passed where the continuation tokens are constantly followed, even if the filter limits the set to under 1000 records.  Leaving out `:all => true` returns the first 1000 entries, which is fine for a 4 hour query, but may not work if the time gap becomes too large.
- I added a `with_metrics_services` method.  This really belongs on the EMS via a `:service` parameter to `connect`
- The entire `raw_metrics_for_counter` really belongs in the azure-armrest gem directly, as a caller should not need to know the intricacies of querying for metrics as is done in the method.

cc @blomquisg @bronaghs @blomquisg @chessbyte 