### PR TITLE
Fix @gtl_url in cloud_volume_controller

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -79,7 +79,7 @@ class CloudVolumeController < ApplicationController
     @volume = @record = identify_record(params[:id])
     return if record_no_longer_exists?(@volume)
 
-    @gtl_url = "/cloud_volume/show/#{@volume.id}?"
+    @gtl_url = "/show"
     drop_breadcrumb({
                       :name => _("Cloud Volumes"),
                       :url  => "/cloud_volume/show_list?page=#{@current_page}&refresh=y"},


### PR DESCRIPTION
This is to fix the following error when clicking on GTL icons:

```
ActionController::RoutingError (No route matches [GET] "/cloud_volume/cloud_volume/show/1000000000017"):
```

The error is visible when navigating to Compute -> Clouds -> Volumes -> [cloud volume] -> Instances
and click on any of the gtl icons.

https://bugzilla.redhat.com/show_bug.cgi?id=1335384