### PR TITLE
Unify workload and cloud_vm relationships textual summary

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2548,6 +2548,13 @@ Vmdb::Application.routes.draw do
         retire
         scan_histories
         sections_field_changed
+        security_groups
+        floating_ips
+        network_routers
+        network_ports
+        cloud_subnets
+        cloud_networks
+        cloud_volumes
         show
         sort_ds_grid
         sort_host_grid


### PR DESCRIPTION
Unify workload and cloud_vm relationships textual summary, the
relationships should be the same in both pages, since they
both show cloud_vm. Moving code to vm_helper that is
consumed in both pages.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1204930


Screens relations ships are the same across vm_cloud and workloads:

vm_cloud:
![image](https://cloud.githubusercontent.com/assets/1737058/15145237/b2085a1a-16b4-11e6-8806-a37809b9cba1.png)

vm_cloud in workload:
![image](https://cloud.githubusercontent.com/assets/1737058/15145268/e086677e-16b4-11e6-8552-f6d31b41a457.png)

cloud template:
![image](https://cloud.githubusercontent.com/assets/1737058/15145320/25c7de9e-16b5-11e6-94d1-1212c5261927.png)

cloud template in workload:
![image](https://cloud.githubusercontent.com/assets/1737058/15145290/02d39e0a-16b5-11e6-93c8-8685488f557a.png)
