### PR TITLE
Add crosslink to service for orchestration stack

### DIFF
--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -12,7 +12,7 @@ module OrchestrationStackHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(ems_cloud orchestration_template instances security_groups cloud_networks parameters outputs resources)
+    %i(ems_cloud service orchestration_template instances security_groups cloud_networks parameters outputs resources)
   end
 
   def textual_group_tags
@@ -51,6 +51,19 @@ module OrchestrationStackHelper::TextualSummary
 
   def textual_ems_cloud
     textual_link(@record.ext_management_system)
+  end
+
+  def textual_service
+    h = {:label => _("Service"), :image => "service"}
+    service = @record.service
+    if service.nil?
+      h[:value] = _("None")
+    else
+      h[:value] = service.name
+      h[:title] = _("Show this Service")
+      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => service)
+    end
+    h
   end
 
   def textual_orchestration_template

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -333,7 +333,7 @@ module VmHelper::TextualSummary
 
   def textual_service
     h = {:label => _("Service"), :image => "service"}
-    service = @record.service
+    service = @record.service || @record.try(:orchestration_stack).try(:service)
     if service.nil?
       h[:value] = _("None")
     else

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -22,6 +22,11 @@ class OrchestrationStack < ApplicationRecord
   has_many   :direct_vms,             :class_name => "ManageIQ::Providers::CloudManager::Vm"
   has_many   :direct_security_groups, :class_name => "SecurityGroup"
   has_many   :direct_cloud_networks,  :class_name => "CloudNetwork"
+  has_many   :service_resources, :as => :resource
+  has_many   :direct_services, :through => :service_resources, :source => :service
+
+  virtual_has_one  :direct_service,       :class_name => 'Service'
+  virtual_has_one  :service,              :class_name => 'Service'
 
   virtual_has_many :vms, :class_name => "ManageIQ::Providers::CloudManager::Vm"
   virtual_has_many :security_groups
@@ -34,6 +39,14 @@ class OrchestrationStack < ApplicationRecord
   alias_method :orchestration_stack_parameters, :parameters
   alias_method :orchestration_stack_outputs,    :outputs
   alias_method :orchestration_stack_resources,  :resources
+
+  def direct_service
+    direct_services.first
+  end
+
+  def service
+    direct_service.try(:root_service)
+  end
 
   def tenant_identity
     if ext_management_system


### PR DESCRIPTION
Add crosslink to service for orchestration stack, also for VMs
that were deployed by stack in a service

![image](https://cloud.githubusercontent.com/assets/1737058/15145147/3d77a58e-16b4-11e6-8cc0-35a703a1d064.png)


![image](https://cloud.githubusercontent.com/assets/1737058/15145128/23e7179e-16b4-11e6-9da6-73cddbc37e2f.png)


