### PR TITLE
Slice legend in 3D charts

### DIFF
--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -28,6 +28,7 @@ module ReportFormatter
         mri.chart[:data][:names][series_id] = label
       else
         mri.chart[:data][:columns] = data.collect { |a| [a[:tooltip], a[:value]] }
+        data.each{ |a| mri.chart[:data][:names][a[:tooltip]] = slice_legend(a[:tooltip]) }
       end
 
       if chart_is_stacked?
@@ -47,12 +48,11 @@ module ReportFormatter
       type = c3_convert_type("#{mri.graph[:type]}")
       mri.chart = {
         :miqChart => type,
-        :data     => {:columns => []},
+        :data     => {:columns => [], :names => {}},
         :axis     => {}
       }
 
       if chart_is_2d?
-        mri.chart[:data][:names] = {}
         mri.chart[:axis] = {
           :x => {
             :categories => []


### PR DESCRIPTION
parent issue #6627
Slice legend in charts which was 3D, mostly pie charts.
![firefox_screenshot_2016-05-10t13-43-18 680z](https://cloud.githubusercontent.com/assets/9535558/15148548/f080771c-16c5-11e6-8c3e-2cff2be6717e.png)
