### PR TITLE
Fix rendering of VM's snapshots

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -249,11 +249,11 @@ module VmCommon
     elsif @display == "snapshot_info"
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
+      build_snapshot_tree
+      @button_group = "snapshot"
     elsif @display == "devices"
       drop_breadcrumb(:name => @record.name + _(" (Devices)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
-      build_snapshot_tree
-      @button_group = "snapshot"
     elsif @display == "vmtree_info"
       @tree_vms = []                     # Capture all VM ids in the tree
       drop_breadcrumb({:name => @record.name, :url => "/#{rec_cls}/show/#{@record.id}"}, true)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -45,6 +45,16 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
+  it 'can render the snapshot info' do
+    ApplicationController.handle_exceptions = true
+    seed_session_trees('vm_infra', 'vms_instances_filter_tree')
+    post :show, :params => { :id => vm_vmware.id, :display => 'snapshot_info' }, :xhr => true
+    expect(response.status).to eq(200)
+    expect(response).to render_template('vm_common/_snapshots_desc')
+    expect(response).to render_template('vm_common/_snapshots_tree')
+    expect(assigns(:snaps)).to be_present
+  end
+
   it 'can open the right size tab' do
     get :show, :params => { :id => vm_vmware.id }
     expect(response).to redirect_to(:action => 'explorer')


### PR DESCRIPTION
The snapshot tree needs to be created when we click on snapshot info, not when we click on devices info.

https://bugzilla.redhat.com/show_bug.cgi?id=1333566