### PR TITLE
Allow appliance_console to progress if network scripts are missing

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -107,7 +107,7 @@ module ApplianceConsole
     begin
       dns = LinuxAdmin::Dns.new
       eth0.reload
-      eth0.parse_conf
+      eth0.parse_conf if eth0.respond_to?(:parse_conf)
 
       host       = LinuxAdmin::Hosts.new.hostname
       ip         = eth0.address


### PR DESCRIPTION
This will allow us to display network information, but not set any new configuration.

Workaround for #8562