### PR TITLE
Fix for Kerberos SSO UI Login

### DIFF
--- a/app/assets/javascripts/jquery_overrides.js
+++ b/app/assets/javascripts/jquery_overrides.js
@@ -1,6 +1,10 @@
 jQuery.evalLog = function (text) {
   try {
-    jQuery.globalEval(text.slice('throw "error";'.length));
+    if (text.match('^throw "error";')) {
+      jQuery.globalEval(text.slice('throw "error";'.length));
+    } else {
+      jQuery.globalEval(text);
+    }
   } catch (ex) {
     if (typeof console !== "undefined" && typeof console.error !== "undefined") {
       console.error('exception caught evaling RJS');

--- a/app/assets/javascripts/jquery_overrides.js
+++ b/app/assets/javascripts/jquery_overrides.js
@@ -1,10 +1,6 @@
 jQuery.evalLog = function (text) {
   try {
-    if (text.match('^throw "error";')) {
-      jQuery.globalEval(text.slice('throw "error";'.length));
-    } else {
-      jQuery.globalEval(text);
-    }
+    jQuery.globalEval(text.slice('throw "error";'.length));
   } catch (ex) {
     if (typeof console !== "undefined" && typeof console.error !== "undefined") {
       console.error('exception caught evaling RJS');

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -896,6 +896,20 @@ function miqAjaxAuth(url) {
   });
 }
 
+// Send SSO login authentication via ajax
+function miqAjaxAuthSso(url) {
+  miqEnableLoginFields(false);
+  miqSparkleOn();
+
+  // Note: /dashboard/kerberos_authenticate creates an API token
+  //       based on the authenticated external user
+  //       and stores it in sessionStore.miq_token
+
+  miqJqueryRequest(url || '/dashboard/kerberos_authenticate', {
+    beforeSend: true,
+  });
+}
+
 // add a flash message to an existing #flash_msg_div
 // levels are error, warning, info, success
 function add_flash(msg, level, options) {

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -116,11 +116,6 @@ class ApiController < ApplicationController
   ID_ATTRS = %w(href id)
 
   #
-  # Requester type token ttl's for authentication
-  #
-  REQUESTER_TTL_CONFIG = {"ui" => :ui_token_ttl}
-
-  #
   # To skip CSRF token verification as API clients would
   # not have these. They would instead dealing with the /api/auth
   # mechanism.
@@ -140,7 +135,7 @@ class ApiController < ApplicationController
     @prefix          = "/#{@module}"
     @req             = {}      # To store API request details by parse_api_request
     @api_config      = VMDB::Config.new("vmdb").config[@module.to_sym] || {}
-    @api_token_mgr   = TokenManager.new(@module)
+    @api_user_token_service = ApiUserTokenService.new(@config)
   end
 
   #

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -555,7 +555,7 @@ class DashboardController < ApplicationController
       miq_api_token = require_api_token ? generate_ui_api_token(user[:name]) : nil
       render :update do |page|
         page << javascript_prologue
-        page << "sessionStorage.miq_token = '#{miq_api_token}'" if miq_api_token
+        page << "sessionStorage.miq_token = '#{j_str miq_api_token}';" if miq_api_token
         page.redirect_to(validation.url)
       end
     when :fail
@@ -572,7 +572,8 @@ class DashboardController < ApplicationController
   end
 
   def generate_ui_api_token(userid)
-    (@ui_api_controller ||= ApiController.new).generate_user_token(userid, "ui")
+    @api_user_token_service ||= ApiUserTokenService.new
+    @api_user_token_service.generate_token(userid, "ui")
   end
 
   def timeline

--- a/app/services/api_user_token_service.rb
+++ b/app/services/api_user_token_service.rb
@@ -1,0 +1,75 @@
+class ApiUserTokenService
+  def initialize(config = YAML.load_file(Rails.root.join("config/api.yml")), args = {})
+    @config = config
+    @svc_options = args
+    @token_mgr = new_token_mgr(base_config[:module], base_config[:name], api_config)
+  end
+
+  attr_accessor :token_mgr
+
+  # Additional Requester type token ttl's for authentication
+  #
+  REQUESTER_TTL_CONFIG = {"ui" => :ui_token_ttl}.freeze
+
+  # API Settings with additional token ttl's
+  #
+  def api_config
+    @api_config ||= Settings[base_config[:module]].to_hash.merge(
+      REQUESTER_TTL_CONFIG["ui"] => Settings.session.timeout
+    )
+  end
+
+  def generate_token(userid, requester_type)
+    validate_userid(userid)
+    validate_requester_type(requester_type)
+
+    $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
+
+    token_mgr.gen_token(base_config[:module],
+                        :userid           => userid,
+                        :token_ttl_config => REQUESTER_TTL_CONFIG[requester_type])
+  end
+
+  def validate_requester_type(requester_type)
+    return unless requester_type
+    REQUESTER_TTL_CONFIG.fetch(requester_type) do
+      requester_types = REQUESTER_TTL_CONFIG.keys.join(', ')
+      raise "Invalid requester_type #{requester_type} specified, valid types are: #{requester_types}"
+    end
+  end
+
+  private
+
+  def base_config
+    @config[:base]
+  end
+
+  def log_kv(key, val, pref = "")
+    $api_log.info("#{pref}  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
+  end
+
+  def new_token_mgr(mod, name, api_config)
+    token_ttl    = api_config[:token_ttl]
+    ui_token_ttl = api_config[REQUESTER_TTL_CONFIG["ui"]]
+
+    options                = {}
+    options[:token_ttl]    = token_ttl.to_i_with_method if token_ttl
+    options[:ui_token_ttl] = ui_token_ttl.to_i_with_method if ui_token_ttl
+
+    log_init(mod, name, options) if @svc_options[:log_init]
+    TokenManager.new(mod, options)
+  end
+
+  def log_init(mod, name, options)
+    $api_log.info("")
+    $api_log.info("Creating new Token Manager for the #{name}")
+    $api_log.info("   Token Manager  module: #{mod}")
+    $api_log.info("   Token Manager options:")
+    options.each { |key, val| log_kv(key, val, "    ") }
+    $api_log.info("")
+  end
+
+  def validate_userid(userid)
+    raise "Invalid userid #{userid} specified" unless User.exists?(:userid => userid)
+  end
+end

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -14,6 +14,11 @@
         = render(:partial => "layouts/spinner",
                  :locals  => {:login => true})
 
+        #invalid_sso_credentials_flash{:style => "display: none"}
+          #flash_text_div{:title => "Click to remove message"}
+            .alert.alert-danger
+              %span.pficon.pficon-error-circle-o
+              %strong= _("Invalid Single Sign-On credentials")
         = render :partial => "layouts/flash_msg"
 
         - if ext_auth?(:saml_enabled)
@@ -101,7 +106,7 @@
                       :alt                   => "SSO Login",
                       :title                 => _("SSO Login"),
                       :style                 => "display: none;",
-                      :onclick              => "miqAjaxAuth('#{j sso_url}'); return false;")
+                      :onclick              => "miqAjaxAuthSso('#{j sso_url}'); return false;")
 
     .col-md-6.col-lg-7.details
       - if get_vmdb_config[:session][:show_login_info]

--- a/public/proxy_pages/invalid_sso_credentials.js
+++ b/public/proxy_pages/invalid_sso_credentials.js
@@ -1,0 +1,6 @@
+$('#invalid_sso_credentials_flash').click(function() {
+  $(this).text('');
+});
+$('#invalid_sso_credentials_flash').show()
+miqSparkle(false)
+miqEnableLoginFields(true);

--- a/public/proxy_pages/invalid_sso_credentials.js
+++ b/public/proxy_pages/invalid_sso_credentials.js
@@ -1,6 +1,7 @@
+throw "error";
 $('#invalid_sso_credentials_flash').click(function() {
-  $(this).text('');
+  $(this).hide();
 });
-$('#invalid_sso_credentials_flash').show()
-miqSparkle(false)
+$('#invalid_sso_credentials_flash').show();
+miqSparkle(false);
 miqEnableLoginFields(true);


### PR DESCRIPTION
- Brought back the #invalid_sso_credentials_flash div in login.html.haml
- New AjaxAuthSso Javascript to invoke the kerberos_authenticate but then do the API auth from
dashboard controller and sending the sessionStore.miq_token to javascript in the prologue
instead of doing the API authentication in javascript.
- Updated API to provide the generate_user_token which can be used outside
the context of an API request.
- Moved in the proxy_pages/invalid_sso_credentials.js to the main repo as
/var/www/html/miq/public is now the DocumentRoot
- Updated jquery_overrides.js to also handle proxy_pages javascripts which would not
have the throw error prologue.

Fixes #7634 

Requires: https://github.com/ManageIQ/manageiq-appliance/pull/72
