### PR TITLE
Add clarifying text to Capacity Planning report

### DIFF
--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -163,6 +163,8 @@
           - else
             = @sb[:planning][:options][:values][:storage]
           = _('GB')
+          %br{:clear => "all"}
+          = _('* Disk space not supported for OpenStack providers')
   %hr/
   %h3
     = _('Target Options / Limits')


### PR DESCRIPTION
The text explains that the disk space option is unsupported with
OpenStack providers