### PR TITLE
Delete pending changes rows that correspond to deleted triggers

### DIFF
--- a/tools/purge_duplicate_rubyrep_triggers.rb
+++ b/tools/purge_duplicate_rubyrep_triggers.rb
@@ -51,7 +51,7 @@ conn.async_exec(TRIGGER_QUERY).each do |tt|
   triggers = sql_array_to_ruby(tt["triggers"])
   table = tt["relname"]
 
-  to_drop = triggers.reject { |t| t =~ /rr\d_#{table}/ }
+  to_drop = triggers.reject { |t| t =~ /rr\d+_#{table}/ }
   next if to_drop.empty?
 
   puts "This operation will drop the following trigger(s) on #{table}:"


### PR DESCRIPTION
This is a followup to #7834.
In that PR, triggers are deleted for tables that no longer exist.
This will also delete change records non-existing tables, created by the removed triggers, from the pending changes table.

/cc @carbonin 