### PR TITLE
Miq report load 2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1553,7 +1553,7 @@ class ApplicationController < ActionController::Base
 
     # Get the current sort info, else get defaults from the view
     @sortcol = if session[sortcol_sym].nil?
-                 view.sortby.nil? ? view.col_order.index(view.col_order.first) : view.col_order.index(view.sortby.first)
+                 view.sort_col
                else
                  session[sortcol_sym].to_i
                end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1553,13 +1553,14 @@ class ApplicationController < ActionController::Base
 
     # Get the current sort info, else get defaults from the view
     @sortcol = session[sortcol_sym].try(:to_i) || view.sort_col
-    @sortdir = session[sortdir_sym] || (view.order == "Descending" ? "DESC" : "ASC")
+    @sortdir = session[sortdir_sym] || (view.ascending? ? "ASC" : "DESC")
+
     # Set/reset the sortby column and order
     get_sort_col                                  # set the sort column and direction
     session[sortcol_sym] = @sortcol               # Save the new sort values
     session[sortdir_sym] = @sortdir
     view.sortby = [view.col_order[@sortcol]]      # Set sortby array in the view
-    view.order = @sortdir.downcase == "desc" ? "Descending" : "Ascending" # Normalize sort order
+    view.ascending = @sortdir.to_s.downcase != "desc"
 
     @items_per_page = controller_name.downcase == "miq_policy" ? ONE_MILLION : get_view_pages_perpage(dbname)
     @items_per_page = ONE_MILLION if 'vm' == db_sym.to_s && controller_name == 'service'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1552,11 +1552,7 @@ class ApplicationController < ActionController::Base
     end
 
     # Get the current sort info, else get defaults from the view
-    @sortcol = if session[sortcol_sym].nil?
-                 view.sort_col
-               else
-                 session[sortcol_sym].to_i
-               end
+    @sortcol = session[sortcol_sym].try(:to_i) || view.sort_col
     @sortdir = session[sortdir_sym] || (view.order == "Descending" ? "DESC" : "ASC")
     # Set/reset the sortby column and order
     get_sort_col                                  # set the sort column and direction

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -158,6 +158,14 @@ class MiqReport < ApplicationRecord
     keys.each_with_object(attributes.to_hash) { |k, h| h[k] = send(k) }
   end
 
+  def ascending=(val)
+    self.order = val ? "Ascending" : "Descending"
+  end
+
+  def ascending?
+    order != "Descending"
+  end
+
   def sort_col
     sortby ? col_order.index(sortby.first) : 0
   end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -158,6 +158,10 @@ class MiqReport < ApplicationRecord
     keys.each_with_object(attributes.to_hash) { |k, h| h[k] = send(k) }
   end
 
+  def sort_col
+    sortby ? col_order.index(sortby.first) : 0
+  end
+
   def self.from_hash(h)
     new(h)
   end

--- a/app/models/miq_report/generator/sorting.rb
+++ b/app/models/miq_report/generator/sorting.rb
@@ -1,11 +1,10 @@
 module MiqReport::Generator::Sorting
   SORT_COL_SUFFIX = "_sort_"
 
+  # @param table [Ruport::Data::Table] Enumerable of Ruport::Data::Record
+  # @param col_names [Array<String>] Array of column names to be sorted
+  # @param order [Symbol] :ascending, :descending
   def sort_table(table, col_names, order)
-    # => Add special sorting logic here
-    # => table     - Ruport::Data::Table. This class includes enumerable so it can be accessed as a collection of Ruport::Data::Record objects
-    # => col_names - Array of column names to be sorted
-    # => order     - Sort order: "Ascending" | "Descending"
     table.sort_rows_by(col_names, order)
   end
 
@@ -34,8 +33,8 @@ module MiqReport::Generator::Sorting
       end
     end
 
-    order = self.order.blank? ? "Ascending" : self.order                        # Default to Ascending sort
-    @table = sort_table(@table, new_sortby, :order => order.downcase.to_sym)      # Sort the table
+    order = ascending? ? :ascending : :descending
+    @table = sort_table(@table, new_sortby, :order => order)
 
     # Remove any subtituted values we put in the table earlier
     new_sortby.each_with_index do |sb, idx|

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -47,9 +47,9 @@ module MiqReport::Search
       [:string, :text].include?(sql_type) ? Arel::Nodes::NamedFunction.new('LOWER', [sql_col]) : sql_col
     end
 
-    if (self.order && self.order.downcase == "descending")
+    if (self.order && !ascending?)
       order = order.map { |col| Arel::Nodes::Descending.new col }
-    elsif (self.order && self.order.downcase == "ascending")
+    elsif (self.order && ascending?)
       order = order.map { |col| Arel::Nodes::Ascending.new col }
     end
 

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -74,6 +74,20 @@ describe MiqReport do
           expect(stringify_arel(order)).to eq(%w{LOWER("vms"."name") LOWER("system_services"."name") LOWER("users"."name")})
         end
       end
+
+      it "adds ascending" do
+        @miq_report.sortby = ["name", "evm_owner.name"]
+        @miq_report.order = "Ascending"
+        order = @miq_report.get_order_info
+        expect(stringify_arel(order)).to eq(['LOWER("vms"."name") ASC', 'LOWER("users"."name") ASC'])
+      end
+
+      it "adds descending" do
+        @miq_report.sortby = ["name", "evm_owner.name"]
+        @miq_report.order = "Descending"
+        order = @miq_report.get_order_info
+        expect(stringify_arel(order)).to eq(['LOWER("vms"."name") DESC', 'LOWER("users"."name") DESC'])
+      end
     end
 
     it "is not sortable for a complex virtual column" do

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -595,4 +595,24 @@ describe MiqReport do
       end
     end
   end
+  describe ".sort_col" do
+    it "uses sort_by if available" do
+      report = MiqReport.new(
+        :db        => "Host",
+        :cols      => %w(name hostname smart),
+        :col_order => %w(name hostname smart),
+        :sortby    => ["hostname"]
+      )
+      expect(report.sort_col).to eq(1)
+    end
+
+    it "falls back to first column" do
+      report = MiqReport.new(
+        :db        => "Host",
+        :cols      => %w(name hostname smart),
+        :col_order => %w(name hostname smart),
+      )
+      expect(report.sort_col).to eq(0)
+    end
+  end
 end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -595,6 +595,38 @@ describe MiqReport do
       end
     end
   end
+
+  describe ".ascending?" do
+    it "handles nil" do
+      report = MiqReport.new(:order => nil)
+      expect(report).to be_ascending
+    end
+
+    it "handles ascending" do
+      report = MiqReport.new(:order => "Ascending")
+      expect(report).to be_ascending
+    end
+
+    it "handles descending" do
+      report = MiqReport.new(:order => "Descending")
+      expect(report).not_to be_ascending
+    end
+  end
+
+  describe ".ascending=" do
+    it "handles nil" do
+      report = MiqReport.new
+      report.ascending = true
+      expect(report).to be_ascending
+    end
+
+    it "handles ascending" do
+      report = MiqReport.new
+      report.ascending = false
+      expect(report).not_to be_ascending
+    end
+  end
+
   describe ".sort_col" do
     it "uses sort_by if available" do
       report = MiqReport.new(


### PR DESCRIPTION
The goal was to not change behavior, just move it into the report object and to remove a few of the string comparing logic.

The only related change would be to always state a column as ascending or descending. Active record behaves a little better if you are sorting by an arel node like one of those.
