### PR TITLE
Fix javascript error in diagnostics timelines tab

### DIFF
--- a/app/views/ops/_diagnostics_timelines_tab.html.haml
+++ b/app/views/ops/_diagnostics_timelines_tab.html.haml
@@ -4,7 +4,7 @@
     :javascript
       // Create from/to date JS vars to limit calendar selection range
       ManageIQ.calendar.calDateFrom = new Date(#{@tl_options[:sdate]});
-      var ManageIQ.calendar.calDateTo = new Date(#{@tl_options[:edate]});
+      ManageIQ.calendar.calDateTo = new Date(#{@tl_options[:edate]});
     = render :partial => 'layouts/tl_options'
     = render :partial => 'layouts/tl_detail'
   - else


### PR DESCRIPTION
We're accessing a hash / object, not a variable.

https://bugzilla.redhat.com/show_bug.cgi?id=1205492