### PR TITLE
Remove extraneous error message in advanced search

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1409,7 +1409,6 @@ module ApplicationController::Filter
       end
     else
       add_flash(_("Select an expression element type"), :error)
-      add_flash(_("Expression element type must be selected"), :error)
     end
   end
 


### PR DESCRIPTION
Strings "Select an expression element type" and
"Expression element type must be selected" say in fact the same thing
and one of them is extraneous.

https://bugzilla.redhat.com/show_bug.cgi?id=1334943