### PR TITLE
Middleware datasources: topology graph

### DIFF
--- a/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
@@ -1,27 +1,29 @@
 miqHttpInject(angular.module('mwTopologyApp', ['kubernetesUI', 'ui.bootstrap', 'ManageIQ']))
     .controller('middlewareTopologyController', MiddlewareTopologyCtrl);
 
-MiddlewareTopologyCtrl.$inject = ['$scope', '$http', '$interval', "$location", 'topologyService'];
+MiddlewareTopologyCtrl.$inject = ['$scope', '$http', '$interval', '$location', 'topologyService'];
 
 function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologyService) {
     var self = this;
     $scope.vs = null;
     var d3 = window.d3;
+    var icons;
 
     $scope.refresh = function() {
         var id;
-        if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
+        if ($location.absUrl().match('show/$') || $location.absUrl().match('show$')) {
             id = '';
         }
         else {
-            id = '/'+ (/middleware_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
+            id = '/' + (/middleware_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
         }
         var currentSelectedKinds = $scope.kinds;
-        var url = '/middleware_topology/data'+id;
+        var url = '/middleware_topology/data' + id;
         $http.get(url).success(function(data) {
             $scope.items = data.data.items;
             $scope.relations = data.data.relations;
             $scope.kinds = data.data.kinds;
+            icons = data.data.icons;
             if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !=  Object.keys($scope.kinds).length)) {
                 $scope.kinds = currentSelectedKinds;
             }
@@ -32,19 +34,18 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
     $scope.checkboxModel = {
         value : false
     };
-    $scope.legendTooltip = "Click here to show/hide entities of this type";
+    $scope.legendTooltip = 'Click here to show/hide entities of this type';
 
     $scope.show_hide_names = function() {
-       var vertices = $scope.vs;
+        var vertices = $scope.vs;
 
-       if($scope.checkboxModel.value) {
-            vertices.selectAll("text")
-               .style("display", "block");
-       }
-       else {
-           vertices.selectAll("text")
-              .style("display", "none");
-       }
+        if ($scope.checkboxModel.value) {
+            vertices.selectAll("text.attached-label")
+                    .classed("visible", true);
+        } else {
+            vertices.selectAll("text.attached-label")
+                    .classed("visible", false);
+        }
     };
 
     $scope.refresh();
@@ -54,37 +55,65 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
         $interval.cancel(promise);
     });
 
-    $scope.$on("render", function(ev, vertices, added) {
+    $scope.$on('render', function(ev, vertices, added) {
         /*
          * We are passed two selections of <g> elements:
          * vertices: All the elements
          * added: Just the ones that were added
          */
-        added.attr("class", function(d) { return d.item.kind; });
-        added.append("circle")
-            .attr("r", function(d) { return self.getDimensions(d).r})
-            .attr('class' , function(d) {
-              return topologyService.getItemStatusClass(d);
-            });
-        added.append("title");
-        added.on("dblclick", function(d) {
-            return self.dblclick(d);});
-        added.append("image")
-            .attr("xlink:href",function(d) {
-                return "/assets/svg/" + self.class_name(d) + ".svg";
-            })
-            .attr("y", function(d) { return self.getDimensions(d).y})
-            .attr("x", function(d) { return self.getDimensions(d).x})
-            .attr("height", function(d) { return self.getDimensions(d).height})
-            .attr("width", function(d) { return self.getDimensions(d).width});
-        added.append("text")
-            .attr("x", 26)
-            .attr("y", 24)
-            .text(function(d) { return d.item.name }).style("font-size", function(d) {return "12px"}).style("fill", function(d) {return "black"})
-            .style("display", function(d) {if ($scope.checkboxModel.value) {return "block"} else {return "none"}});
+        added.attr('class', function(d) {
+            return d.item.kind;
+        });
+        added.append('circle')
+             .attr('r', function(d) {
+                 return self.getCircleDimensions(d).r;
+             })
+             .attr('class' , function(d) {
+                 return topologyService.getItemStatusClass(d);
+             });
+        added.append('title');
+        added.on('dblclick', function(d) {
+            return self.dblclick(d);
+        });
+        added.append('image')
+             .each(function(d) {
+                 var iconInfo = self.getIcon(d);
+                 if (iconInfo.type != 'image') {
+                     return;
+                 }
+                 $(this).attr('href', iconInfo.icon)
+                        .attr('y', self.getCircleDimensions(d).y)
+                        .attr('x', self.getCircleDimensions(d).x)
+                        .attr('height', self.getCircleDimensions(d).height)
+                        .attr('width', self.getCircleDimensions(d).width)
+             });
 
-        added.selectAll("title").text(function(d) {
-            return topologyService.tooltip(d).join("\n");
+        // attached labels
+        added.append('text')
+             .attr('x', 26)
+             .attr('y', 24)
+             .text(function(d) {
+                 return d.item.name;
+             })
+             .attr('class', 'attached-label' + ($scope.checkboxModel.value ? ' visible' : ''));
+
+        // possible glyphs
+        added.append('text')
+             .each(function(d) {
+                 var iconInfo = self.getIcon(d);
+                 if (iconInfo.type != 'glyph') {
+                     return;
+                 }
+                 $(this).text(iconInfo.icon)
+                        .attr('class', 'glyph')
+                        .attr('style', 'font-family:' + iconInfo.fontfamily + ';')
+                        .attr('x', 0)
+                        .attr('y', 8);
+             })
+
+
+        added.selectAll('title').text(function(d) {
+            return topologyService.tooltip(d).join('\n');
         });
         $scope.vs = vertices;
 
@@ -92,28 +121,32 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
         ev.preventDefault();
     });
 
-    self.class_name = function class_name(d) {
-        var class_name = d.item.icon;
-        return class_name;
+    self.getIcon = function getIcon(d) {
+        if (d.item.icon) {
+            return {
+                'type': 'image',
+                'icon': '/assets/svg/' + d.item.icon + '.svg'
+            }
+        }
+        return icons[d.item.kind]
     };
 
     this.dblclick = function dblclick(d) {
       window.location.assign(topologyService.geturl(d));
     };
 
-    self.getDimensions = function getDimensions(d) {
+    self.getCircleDimensions = function getCircleDimensions(d) {
         switch (d.item.kind) {
-            case "MiddlewareManager":
+            case 'MiddlewareManager':
                 return { x: -20, y: -20, height: 40, width: 40, r: 28};
-            case "Container" :
+            case 'Container' :
                 return { x: -7, y: -7,height: 14, width: 14, r: 13};
-            case "MiddlewareServer" :
+            case 'MiddlewareServer' :
                 return { x: -12, y: -12, height: 23, width: 23, r: 19};
             default :
                 return { x: -9, y: -9, height: 18, width: 18, r: 17};
         }
-
-    };
+    }
 
     $scope.searchNode = function() {
       var svg = topologyService.getSVG(d3);
@@ -126,7 +159,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
         topologyService.resetSearch(d3);
 
         // Reset the search term in search input
-        $scope.search.query = "";
+        $scope.search.query = '';
     };
 
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,6 +22,7 @@
  *= require template
  *= require topology
  *= require container_topology
+ *= require middleware_topology
  *= require service_dialogs
  *= require xml_display
 */

--- a/app/assets/stylesheets/middleware_topology.css
+++ b/app/assets/stylesheets/middleware_topology.css
@@ -1,0 +1,4 @@
+.middleware .kube-topology g.MiddlewareDatasource text.glyph {
+    font-size: 20px;
+    fill: #81B0C8;
+}

--- a/app/models/mixins/ui_service_mixin.rb
+++ b/app/models/mixins/ui_service_mixin.rb
@@ -1,19 +1,20 @@
 module UiServiceMixin
   def icons
     {
-      :ContainerReplicator => {:type => "glyph", :icon => "\uE624", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-replicator
-      :ContainerGroup      => {:type => "glyph", :icon => "\uF1B3", :fontfamily => "FontAwesome"},             # fa-cubes
-      :ContainerNode       => {:type => "glyph", :icon => "\uE621", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-container-node
-      :ContainerService    => {:type => "glyph", :icon => "\uE61E", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-service
-      :ContainerRoute      => {:type => "glyph", :icon => "\uE625", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-route
-      :Container           => {:type => "glyph", :icon => "\uF1B2", :fontfamily => "FontAwesome"},             # fa-cube
-      :Host                => {:type => "glyph", :icon => "\uE600", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-screen
-      :Vm                  => {:type => "glyph", :icon => "\uE90f", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-virtual-machine
-      :Kubernetes          => {:type => "image", :icon => provider_icon(:Kubernetes)},
-      :Openshift           => {:type => "image", :icon => provider_icon(:Openshift)},
-      :OpenshiftEnterprise => {:type => "image", :icon => provider_icon(:OpenshiftEnterprise)},
-      :Atomic              => {:type => "image", :icon => provider_icon(:Atomic)},
-      :AtomicEnterprise    => {:type => "image", :icon => provider_icon(:AtomicEnterprise)}
+      :ContainerReplicator  => {:type => "glyph", :icon => "\uE624", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-replicator
+      :ContainerGroup       => {:type => "glyph", :icon => "\uF1B3", :fontfamily => "FontAwesome"},             # fa-cubes
+      :ContainerNode        => {:type => "glyph", :icon => "\uE621", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-container-node
+      :ContainerService     => {:type => "glyph", :icon => "\uE61E", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-service
+      :ContainerRoute       => {:type => "glyph", :icon => "\uE625", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-route
+      :Container            => {:type => "glyph", :icon => "\uF1B2", :fontfamily => "FontAwesome"},             # fa-cube
+      :Host                 => {:type => "glyph", :icon => "\uE600", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-screen
+      :Vm                   => {:type => "glyph", :icon => "\uE90f", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-virtual-machine
+      :MiddlewareDatasource => {:type => "glyph", :icon => "\uF1C0", :fontfamily => "FontAwesome"},             # fa-database
+      :Kubernetes           => {:type => "image", :icon => provider_icon(:Kubernetes)},
+      :Openshift            => {:type => "image", :icon => provider_icon(:Openshift)},
+      :OpenshiftEnterprise  => {:type => "image", :icon => provider_icon(:OpenshiftEnterprise)},
+      :Atomic               => {:type => "image", :icon => provider_icon(:Atomic)},
+      :AtomicEnterprise     => {:type => "image", :icon => provider_icon(:AtomicEnterprise)},
     }
   end
 

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -3,7 +3,7 @@
   .row.toolbar-pf
     .col-md-12
       = render :partial => "shared/topology_header"
-  .legend
+  .legend.middleware
     %label#selected
     %div{'ng-if' => "kinds"}
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareServer"}
@@ -20,6 +20,14 @@
             %image{:height => "18", :width => "18", :x => "-9", "xlink:href" => image_path('/assets/100/middleware_deployment.png'), :y => "-9"}
         %label
           = _("Middleware Deployments")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDatasource"}
+        %svg.kube-topology
+          %g.MiddlewareDatasource{:transform => "translate(21, 21)"}
+            %circle{:r => "17"}
+            -# fa-database
+            %text{:x => "0", :y => "6", :class => "fa fa-database glyph"} &#xF1C0;
+        %label
+          = _("Middleware Datasources")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}
@@ -27,5 +35,5 @@
     %span.pficon.pficon-info
     %strong
       = _("Click on the legend to show/hide entities, and double click on the entities in the graph to navigate to their summary pages.")
-  %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
+  %kubernetes-topology-graph.middleware{:items => "items", :relations => "relations", :kinds => "kinds"}
 

--- a/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
+++ b/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
@@ -3,39 +3,47 @@ describe('middlewareTopologyController', function () {
   var mock_data = getJSONFixture('middleware_topology_response.json');
 
   var mw_manager = {
-    id: "1", item: {
-      "name": "Hawkular",
+    id: "MiddlewareManager1", item: {
+      "name": "livingontheedge.hawkular.org",
       "kind": "MiddlewareManager",
       "miq_id": 1,
       "status": "Unknown",
       "display_kind": "Hawkular",
-      "icon": "vendor-hawkular",
-      "id": "1"
+      "icon": "vendor-hawkular"
     }
   };
 
   var mw_server = {
-    id: "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~", item: {
+    id: "MiddlewareServer1", item: {
       "name": "Local",
       "kind": "MiddlewareServer",
-      "miq_id": 4,
+      "miq_id": 1,
       "status": "Unknown",
       "display_kind": "MiddlewareServer",
-      "icon": "vendor-hawkular",
-      "id": "Local~~"
+      "icon": "vendor-hawkular"
     }
   };
 
   var mw_deployment = {
-    id: "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
+    id: "MiddlewareDeployment1",
     item: {
       "name": "hawkular-command-gateway-war.war",
       "kind": "MiddlewareDeployment",
-      "miq_id": 49,
+      "miq_id": 1,
       "status": "Unknown",
       "display_kind": "MiddlewareDeployment",
-      "icon": "middleware_deployment_war",
-      "id": "Local~/deployment=hawkular-command-gateway-war.war"
+      "icon": "middleware_deployment_war"
+    }
+  };
+
+  var mw_datasource = {
+    id: "MiddlewareDatasource1",
+    item: {
+      "name": "ExampleDS",
+      "kind": "MiddlewareDatasource",
+      "miq_id": 1,
+      "status": "Unknown",
+      "display_kind": "MiddlewareDatasource"
     }
   };
 
@@ -65,28 +73,42 @@ describe('middlewareTopologyController', function () {
     });
   });
 
+
   describe('kinds contains all expected mw kinds', function () {
     it('in all main objects', function () {
-      expect(Object.keys(scope.kinds).length).toBe(3);
+      expect(Object.keys(scope.kinds).length).toBe(4);
       expect(scope.kinds["MiddlewareManager"]).toBeDefined();
       expect(scope.kinds["MiddlewareServer"]).toBeDefined();
       expect(scope.kinds["MiddlewareDeployment"]).toBeDefined();
+      expect(scope.kinds["MiddlewareDatasource"]).toBeDefined();
     });
   });
 
+
   describe('the mw topology gets correct icons', function () {
     it('in graph elements', function () {
-      expect($controller.class_name(mw_manager)).toContain("vendor-hawkular");
-      expect($controller.class_name(mw_server)).toContain("vendor-hawkular");
-      expect($controller.class_name(mw_deployment)).toContain("middleware_deployment_war");
+      expect($controller.getIcon(mw_manager).icon).toContain("vendor-hawkular");
+      expect($controller.getIcon(mw_server).icon).toContain("vendor-hawkular");
+      expect($controller.getIcon(mw_deployment).icon).toContain("middleware_deployment_war");
+      expect($controller.getIcon(mw_datasource).fontfamily).toEqual("FontAwesome")
     });
   });
 
   describe('dimensions are returned correctly', function () {
     it('for all objects', function () {
-      expect($controller.getDimensions(mw_manager)).toEqual({x: -20, y: -20, height: 40, width: 40, r: 28});
-      expect($controller.getDimensions(mw_server)).toEqual({x: -12, y: -12, height: 23, width: 23, r: 19});
-      expect($controller.getDimensions(mw_deployment)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect($controller.getCircleDimensions(mw_manager)).toEqual({x: -20, y: -20, height: 40, width: 40, r: 28});
+      expect($controller.getCircleDimensions(mw_server)).toEqual({x: -12, y: -12, height: 23, width: 23, r: 19});
+      expect($controller.getCircleDimensions(mw_deployment)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect($controller.getCircleDimensions(mw_datasource)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+    });
+  });
+
+  describe('icon types are returned correctly', function () {
+    it('for all objects', function () {
+      expect($controller.getIcon(mw_manager).type).toEqual("image");
+      expect($controller.getIcon(mw_server).type).toEqual("image");
+      expect($controller.getIcon(mw_deployment).type).toEqual("image");
+      expect($controller.getIcon(mw_datasource).type).toEqual("glyph");
     });
   });
 

--- a/spec/javascripts/fixtures/json/middleware_topology_response.json
+++ b/spec/javascripts/fixtures/json/middleware_topology_response.json
@@ -1,512 +1,527 @@
 {
-  "data": {
-    "items": {
-      "1": {
-        "name": "Hawkular",
-        "kind": "MiddlewareManager",
-        "miq_id": 1,
-        "status": "Unknown",
-        "display_kind": "Hawkular",
-        "icon": "vendor-hawkular",
-        "id": "1"
+  "data":{
+    "items":{
+      "MiddlewareManager1":{
+        "name":"livingontheedge.hawkular.org",
+        "kind":"MiddlewareManager",
+        "miq_id":1,
+        "status":"Unknown",
+        "display_kind":"Hawkular",
+        "icon":"vendor-hawkular"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~": {
-        "name": "Local",
-        "kind": "MiddlewareServer",
-        "miq_id": 4,
-        "status": "Unknown",
-        "display_kind": "MiddlewareServer",
-        "icon": "vendor-hawkular",
-        "id": "Local~~"
+      "MiddlewareServer1":{
+        "name":"Local",
+        "kind":"MiddlewareServer",
+        "miq_id":1,
+        "status":"Unknown",
+        "display_kind":"MiddlewareServer",
+        "icon":"vendor-hawkular"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war": {
-        "name": "hawkular-command-gateway-war.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 49,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-command-gateway-war.war"
+      "MiddlewareDeployment1":{
+        "name":"hawkular-command-gateway-war.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":1,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war": {
-        "name": "hawkular-alerts-actions-email.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 50,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-alerts-actions-email.war"
+      "MiddlewareDeployment2":{
+        "name":"hawkular-alerts-actions-email.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":2,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war": {
-        "name": "hawkular-avail-creator.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 51,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-avail-creator.war"
+      "MiddlewareDeployment3":{
+        "name":"hawkular-avail-creator.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":3,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war": {
-        "name": "hawkular-wildfly-agent-download.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 52,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-wildfly-agent-download.war"
+      "MiddlewareDeployment4":{
+        "name":"hawkular-wildfly-agent-download.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":4,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war": {
-        "name": "secret-store.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 53,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=secret-store.war"
+      "MiddlewareDeployment5":{
+        "name":"secret-store.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":5,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war": {
-        "name": "hawkular-alerts-rest.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 54,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-alerts-rest.war"
+      "MiddlewareDeployment6":{
+        "name":"hawkular-alerts-rest.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":6,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war": {
-        "name": "hawkular-inventory-dist.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 55,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-inventory-dist.war"
+      "MiddlewareDeployment7":{
+        "name":"hawkular-inventory-dist.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":7,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts-events-backend.war": {
-        "name": "hawkular-accounts-events-backend.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 56,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-accounts-events-backend.war"
+      "MiddlewareDeployment8":{
+        "name":"hawkular-accounts-events-backend.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":8,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-pinger.war": {
-        "name": "hawkular-pinger.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 57,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-pinger.war"
+      "MiddlewareDeployment9":{
+        "name":"hawkular-pinger.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":9,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war": {
-        "name": "hawkular-rest-api.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 58,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-rest-api.war"
+      "MiddlewareDeployment10":{
+        "name":"hawkular-rest-api.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":10,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war": {
-        "name": "hawkular-metrics-component.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 59,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-metrics-component.war"
+      "MiddlewareDeployment11":{
+        "name":"hawkular-metrics-component.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":11,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear": {
-        "name": "hawkular-commons-embedded-cassandra-ear.ear",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 60,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_ear",
-        "id": "Local~/deployment=hawkular-commons-embedded-cassandra-ear.ear"
+      "MiddlewareDeployment12":{
+        "name":"hawkular-commons-embedded-cassandra-ear.ear",
+        "kind":"MiddlewareDeployment",
+        "miq_id":12,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_ear"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war": {
-        "name": "hawkular-accounts.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 61,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-accounts.war"
+      "MiddlewareDeployment13":{
+        "name":"hawkular-accounts.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":13,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war": {
-        "name": "hawkular-btm-server.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 62,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-btm-server.war"
+      "MiddlewareDeployment14":{
+        "name":"hawkular-btm-server.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":14,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dkeycloak-server.war": {
-        "name": "keycloak-server.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 63,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=keycloak-server.war"
+      "MiddlewareDeployment15":{
+        "name":"keycloak-server.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":15,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war": {
-        "name": "hawkular-console.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 64,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-console.war"
+      "MiddlewareDeployment16":{
+        "name":"hawkular-console.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":16,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "2": {
-        "name": "LivingOnTheEdge",
-        "kind": "MiddlewareManager",
-        "miq_id": 2,
-        "status": "Unknown",
-        "display_kind": "Hawkular",
-        "icon": "vendor-hawkular",
-        "id": "2"
+      "MiddlewareManager2":{
+        "name":"localhost",
+        "kind":"MiddlewareManager",
+        "miq_id":2,
+        "status":"Unknown",
+        "display_kind":"Hawkular",
+        "icon":"vendor-hawkular"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~": {
-        "name": "Local",
-        "kind": "MiddlewareServer",
-        "miq_id": 3,
-        "status": "Unknown",
-        "display_kind": "MiddlewareServer",
-        "icon": "vendor-hawkular",
-        "id": "Local~~"
+      "MiddlewareServer2":{
+        "name":"Local",
+        "kind":"MiddlewareServer",
+        "miq_id":2,
+        "status":"Unknown",
+        "display_kind":"MiddlewareServer",
+        "icon":"vendor-hawkular"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;80e265ffdc23/r;Local~~": {
-        "name": "Local",
-        "kind": "MiddlewareServer",
-        "miq_id": 5,
-        "status": "Unknown",
-        "display_kind": "MiddlewareServer",
-        "icon": "vendor-wildfly",
-        "id": "Local~~"
+      "MiddlewareDeployment17":{
+        "name":"hawkular-command-gateway-war.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":17,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;709634b7ac17/r;Local~~": {
-        "name": "Local",
-        "kind": "MiddlewareServer",
-        "miq_id": 6,
-        "status": "Unknown",
-        "display_kind": "MiddlewareServer",
-        "icon": "vendor-wildfly",
-        "id": "Local~~"
+      "MiddlewareDeployment18":{
+        "name":"hawkular-alerts-actions-email.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":18,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~": {
-        "name": "Local",
-        "kind": "MiddlewareServer",
-        "miq_id": 7,
-        "status": "Unknown",
-        "display_kind": "MiddlewareServer",
-        "icon": "vendor-wildfly",
-        "id": "Local~~"
+      "MiddlewareDeployment19":{
+        "name":"hawkular-wildfly-agent-download.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":19,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war": {
-        "name": "hawkular-command-gateway-war.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 33,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-command-gateway-war.war"
+      "MiddlewareDeployment20":{
+        "name":"hawkular-avail-creator.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":20,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war": {
-        "name": "hawkular-alerts-actions-email.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 34,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-alerts-actions-email.war"
+      "MiddlewareDeployment21":{
+        "name":"secret-store.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":21,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war": {
-        "name": "hawkular-avail-creator.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 35,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-avail-creator.war"
+      "MiddlewareDeployment22":{
+        "name":"hawkular-inventory-dist.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":22,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war": {
-        "name": "hawkular-wildfly-agent-download.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 36,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-wildfly-agent-download.war"
+      "MiddlewareDeployment23":{
+        "name":"hawkular-alerts-rest.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":23,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war": {
-        "name": "secret-store.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 37,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=secret-store.war"
+      "MiddlewareDeployment24":{
+        "name":"hawkular-accounts-events-backend.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":24,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war": {
-        "name": "hawkular-alerts-rest.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 38,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-alerts-rest.war"
+      "MiddlewareDeployment25":{
+        "name":"hawkular-pinger.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":25,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war": {
-        "name": "hawkular-inventory-dist.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 39,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-inventory-dist.war"
+      "MiddlewareDeployment26":{
+        "name":"hawkular-rest-api.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":26,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts-events-backend.war": {
-        "name": "hawkular-accounts-events-backend.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 40,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-accounts-events-backend.war"
+      "MiddlewareDeployment27":{
+        "name":"hawkular-metrics-component.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":27,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-pinger.war": {
-        "name": "hawkular-pinger.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 41,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-pinger.war"
+      "MiddlewareDeployment28":{
+        "name":"hawkular-commons-embedded-cassandra-ear.ear",
+        "kind":"MiddlewareDeployment",
+        "miq_id":28,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_ear"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war": {
-        "name": "hawkular-rest-api.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 42,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-rest-api.war"
+      "MiddlewareDeployment29":{
+        "name":"hawkular-accounts.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":29,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war": {
-        "name": "hawkular-metrics-component.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 43,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-metrics-component.war"
+      "MiddlewareDeployment30":{
+        "name":"hawkular-btm-server.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":30,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear": {
-        "name": "hawkular-commons-embedded-cassandra-ear.ear",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 44,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_ear",
-        "id": "Local~/deployment=hawkular-commons-embedded-cassandra-ear.ear"
+      "MiddlewareDeployment31":{
+        "name":"keycloak-server.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":31,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war": {
-        "name": "hawkular-accounts.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 45,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-accounts.war"
+      "MiddlewareDeployment32":{
+        "name":"hawkular-console.war",
+        "kind":"MiddlewareDeployment",
+        "miq_id":32,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDeployment",
+        "icon":"middleware_deployment_war"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war": {
-        "name": "hawkular-btm-server.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 46,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-btm-server.war"
+      "MiddlewareDatasource1":{
+        "name":"ExampleDS",
+        "kind":"MiddlewareDatasource",
+        "miq_id":1,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDatasource"
       },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dkeycloak-server.war": {
-        "name": "keycloak-server.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 47,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=keycloak-server.war"
-      },
-      "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war": {
-        "name": "hawkular-console.war",
-        "kind": "MiddlewareDeployment",
-        "miq_id": 48,
-        "status": "Unknown",
-        "display_kind": "MiddlewareDeployment",
-        "icon": "middleware_deployment_war",
-        "id": "Local~/deployment=hawkular-console.war"
+      "MiddlewareDatasource2":{
+        "name":"KeycloakDS",
+        "kind":"MiddlewareDatasource",
+        "miq_id":2,
+        "status":"Unknown",
+        "display_kind":"MiddlewareDatasource"
       }
     },
-    "relations": [
+    "relations":[
       {
-        "source": "1",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~"
+        "source":"MiddlewareManager1",
+        "target":"MiddlewareServer1"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment1"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment2"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment3"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment4"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment5"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment6"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment7"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts-events-backend.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment8"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-pinger.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment9"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment10"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment11"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment12"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment13"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment14"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dkeycloak-server.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment15"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;91044f79-156e-4076-8056-ac3ac44ffff9/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war"
+        "source":"MiddlewareServer1",
+        "target":"MiddlewareDeployment16"
       },
       {
-        "source": "2",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~"
+        "source":"MiddlewareManager2",
+        "target":"MiddlewareServer2"
       },
       {
-        "source": "2",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;80e265ffdc23/r;Local~~"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment17"
       },
       {
-        "source": "2",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;709634b7ac17/r;Local~~"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment18"
       },
       {
-        "source": "2",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment19"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment20"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment21"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment22"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment23"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment24"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment25"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment26"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts-events-backend.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment27"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-pinger.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment28"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment29"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment30"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment31"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDeployment32"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDatasource1"
       },
       {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dkeycloak-server.war"
-      },
-      {
-        "source": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;6849976c44e6/r;Local~~",
-        "target": "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;66276c8e-35f6-4a17-9d54-3f8d08cf9802/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war"
+        "source":"MiddlewareServer2",
+        "target":"MiddlewareDatasource2"
       }
     ],
-    "kinds": {
-      "MiddlewareServer": true,
-      "MiddlewareDeployment": true,
-      "MiddlewareManager": true
+    "kinds":{
+      "MiddlewareServer":true,
+      "MiddlewareDeployment":true,
+      "MiddlewareDatasource":true,
+      "MiddlewareManager":true
+    },
+    "icons":{
+      "ContainerReplicator":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"PatternFlyIcons-webfont"
+      },
+      "ContainerGroup":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"FontAwesome"
+      },
+      "ContainerNode":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"PatternFlyIcons-webfont"
+      },
+      "ContainerService":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"PatternFlyIcons-webfont"
+      },
+      "ContainerRoute":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"PatternFlyIcons-webfont"
+      },
+      "Container":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"FontAwesome"
+      },
+      "Host":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"PatternFlyIcons-webfont"
+      },
+      "Vm":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"PatternFlyIcons-webfont"
+      },
+      "MiddlewareDatasource":{
+        "type":"glyph",
+        "icon":"",
+        "fontfamily":"FontAwesome"
+      },
+      "Kubernetes":{
+        "type":"image",
+        "icon":"/assets/svg/vendor-kubernetes-72d5f7ebb2b7162e35b2ff33e0d7e094a7d2c23d662e99835735d3350401f088.svg"
+      },
+      "Openshift":{
+        "type":"image",
+        "icon":"/assets/svg/vendor-openshift-1d618a8a9b84a545ce01bf41e996f2614b8cf433e1845fcf953af8ff43788707.svg"
+      },
+      "OpenshiftEnterprise":{
+        "type":"image",
+        "icon":"/assets/svg/vendor-openshift_enterprise-1d618a8a9b84a545ce01bf41e996f2614b8cf433e1845fcf953af8ff43788707.svg"
+      },
+      "Atomic":{
+        "type":"image",
+        "icon":"/assets/svg/vendor-atomic-95bd9f968d89cf797db7c62abfd49d60c2cbfaf925653c9e763d153a0bf00ef8.svg"
+      },
+      "AtomicEnterprise":{
+        "type":"image",
+        "icon":"/assets/svg/vendor-atomic_enterprise-17db41265b1c7e2722e63241c9762d391e9ed9384113ddf48642e777c8c0b6c7.svg"
+      }
     }
   }
 }

--- a/spec/services/middleware_topology_service_spec.rb
+++ b/spec/services/middleware_topology_service_spec.rb
@@ -1,12 +1,14 @@
 describe MiddlewareTopologyService do
   let(:middleware_topology_service) { described_class.new(nil) }
-  let(:long_id_1) { "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;e055631d-c1a5-4a2d-926a-1dfdcff5137c/r;Local~~/r;Local~%2Fdeployment=hawkular-command-gateway-war.war" }
-  let(:long_id_2) { "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;e055631d-c1a5-4a2d-926a-1dfdcff5137c/r;Local~~/r;Local~%2Fdeployment=hawkular-wildfly-agent-download.war" }
-  let(:long_id_3) { "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;e055631d-c1a5-4a2d-926a-1dfdcff5137c/r;Local~~" }
+  let(:long_id_0) { "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;e055631d-c1a5-4a2d-926a-1dfdcff5137c/r;Local~~" }
+  let(:long_id_1) { "#{long_id_0}/r;Local~%2Fdeployment=hawkular-command-gateway-war.war" }
+  let(:long_id_2) { "#{long_id_0}/r;Local~%2Fdeployment=hawkular-wildfly-agent-download.war" }
+  let(:long_id_3) { "#{long_id_0}/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS" }
 
   describe "#build_kinds" do
     it "creates the expected number of entity types" do
-      expect(middleware_topology_service.build_kinds.keys).to match_array([:MiddlewareServer, :MiddlewareDeployment, :MiddlewareManager])
+      expect(middleware_topology_service.build_kinds.keys).to match_array([:MiddlewareServer, :MiddlewareDeployment,
+                                                                           :MiddlewareDatasource, :MiddlewareManager])
     end
   end
 
@@ -14,13 +16,14 @@ describe MiddlewareTopologyService do
     subject { middleware_topology_service.build_topology }
 
     let(:ems_hawkular) { FactoryGirl.create(:ems_hawkular) }
-    let(:middleware_server) { FactoryGirl.create(:hawkular_middleware_server,
-                                                 :name                  => 'Local',
-                                                 :feed                  => 'cda13e2a-e206-4e87-8bca-8cfdd5aea484',
-                                                 :ems_ref               => long_id_3,
-                                                 :nativeid              => 'Local~~',
-                                                 :ext_management_system => ems_hawkular)
-    }
+    let(:middleware_server) do
+      FactoryGirl.create(:hawkular_middleware_server,
+                         :name                  => 'Local',
+                         :feed                  => 'cda13e2a-e206-4e87-8bca-8cfdd5aea484',
+                         :ems_ref               => long_id_0,
+                         :nativeid              => 'Local~~',
+                         :ext_management_system => ems_hawkular)
+    end
 
     it "topology contains the expected structure and content" do
       allow(middleware_topology_service).to receive(:retrieve_providers).and_return([ems_hawkular])
@@ -34,6 +37,13 @@ describe MiddlewareTopologyService do
                                                            :ems_ref               => long_id_1,
                                                            :name                  => "hawkular-command-gateway-war.war",
                                                            :nativeid              => "Local~/deployment=hawkular-command-gateway-war.war")
+
+      mddlwr_datasource = MiddlewareDatasource.create(:ext_management_system => ems_hawkular,
+                                                      :middleware_server     => middleware_server,
+                                                      :ems_ref               => long_id_3,
+                                                      :name                  => "ExampleDS",
+                                                      :nativeid              => "Local~/subsystem=datasources/"\
+                                                            "data-source=ExampleDS")
       expect(subject[:items]).to eq(
         "MiddlewareManager" + ems_hawkular.compressed_id.to_s              => {:name         => ems_hawkular.name,
                                                                                :status       => "Unknown",
@@ -63,13 +73,23 @@ describe MiddlewareTopologyService do
                                                                                :miq_id       => middleware_deployment2.id,
                                                                                :icon         => "middleware_deployment_war"},
 
+        "MiddlewareDatasource" + mddlwr_datasource.compressed_id.to_s      => {:name         => mddlwr_datasource.name,
+                                                                               :status       => "Unknown",
+                                                                               :kind         => "MiddlewareDatasource",
+                                                                               :display_kind => "MiddlewareDatasource",
+                                                                               :miq_id       => mddlwr_datasource.id},
       )
 
-      expect(subject[:relations].size).to eq(3)
+      expect(subject[:relations].size).to eq(4)
       expect(subject[:relations]).to include(
-        {:source => "MiddlewareManager" + ems_hawkular.compressed_id.to_s,     :target => "MiddlewareServer" + middleware_server.compressed_id.to_s},
-        {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s, :target => "MiddlewareDeployment" + middleware_deployment1.compressed_id.to_s},
-        {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s, :target => "MiddlewareDeployment" + middleware_deployment2.compressed_id.to_s}
+        {:source => "MiddlewareManager" + ems_hawkular.compressed_id.to_s,
+         :target => "MiddlewareServer" + middleware_server.compressed_id.to_s},
+        {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s,
+         :target => "MiddlewareDeployment" + middleware_deployment1.compressed_id.to_s},
+        {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s,
+         :target => "MiddlewareDeployment" + middleware_deployment2.compressed_id.to_s},
+        {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s,
+         :target => "MiddlewareDatasource" + mddlwr_datasource.compressed_id.to_s}
       )
     end
   end


### PR DESCRIPTION
fixes issue #8628 

![screenshot from 2016-05-11 19-38-06](https://cloud.githubusercontent.com/assets/535866/15190403/fe8f1a30-17af-11e6-96c6-ab03878b531a.png)

Most of the changed lines is due to re-recording the JSON that is returned from the server. The data was stale, because the commit f48dce286d9d0080a0d63475532cdddd0b0c8857 that adds the tests for middleware topology graph wasn't reflecting the commit c063ed1fea40e8486b90fd26dd879fc9572a3caa that changed the JSON data (the data was recorded before the commit). Hopefully, it makes sense.

@miq-bot add_label topology, providers/hawkular, wip
@miq-bot remove_label gem changes