### PR TITLE
Make root_tenant scope to the current region

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -260,7 +260,7 @@ class Tenant < ApplicationRecord
   #
   # @return [Tenant] the root tenant
   def self.root_tenant
-    roots.first
+    in_my_region.roots.first
   end
 
   # NOTE: returns the root tenant


### PR DESCRIPTION
Previously in a global database seeding would attach global region groups to tenants from replicated regions.

When the replicated data was removed due to uninstalling replication on the region (rubyrep) or removing the subscription (pglogical) the link from the group to tenant would be broken and many things would fail until the database was reseeded.

@kbrock please review

cc @chrisarcand @gtanzillo 

---
comments from @kbrock:
`Tenant` records are replicated while `MiqGroup` records are not. The rule of thumb is data that is managed in this region needs to be created in this region.

**before this PR:**

Local region `Tenant` records were not created if one existed from another region. Locally created "default tenant" `MiqGroup` records were linked to these foreign tenants.

**after this PR:**

`Tenant` records are created for each region. Locally created "default tenant" `MiqGroup` records are linked to these local tenants.

**future:**

There may come a time when groups are replicated across regions.