### PR TITLE
Don't call find_entries as a scope in rbac

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -268,16 +268,18 @@ module MiqReport::Generator
       # TODO: need to enhance only_cols to better support virtual columns
       # only_cols += conditions.columns_for_sql if conditions # Add cols references in expression to ensure they are present for evaluation
       # NOTE: using search to get user property "managed", otherwise this is overkill
+      targets = db_class
+      targets = db_class.find_entries(ext_options) if targets.respond_to?(:find_entries)
+      # TODO: add once only_cols is fixed
+      # targets = targets.select(only_cols)
+
       results, attrs = Rbac.search(
         options.merge(
-          # TODO: add once only_cols is fixed
-          # :targets          => klass.select(only_cols),
-          :class            => db,
+          :targets          => targets,
           :filter           => conditions,
           :include_for_find => includes,
           :where_clause     => where_clause,
           :results_format   => :objects,
-          :ext_options      => ext_options
         )
       )
       results = Metric::Helper.remove_duplicate_timestamps(results)


### PR DESCRIPTION
Currently `ext_options` flows through `Rbac#search` to `Rbac#method_with_scope` to `VimPerformanceDaily.all`

`VimPerformanceDaily.find_entries` is the only one that uses `ext_options`

The issue is not `ext_options` per se, but the use of an `all` method
that needs all parameters passed into it. With this, the cond can't use basic AR method
(e.g.: `where`, `limit`) and forces sql string manipulation.

After this change, we have more flexibility in Rbac to use scopes.

---

This fixes the travis deprecation warning around `VimPerformanceDaily.all`.
I was tempted to remove `VimPerformanceDaily.all` since it should be dead code, but am a little gunshy right now. There are a number of places where `VimPerformanceDaily` is set at the class of interest.

/cc @Fryguy FYI