### PR TITLE
Reportable search

### DIFF
--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -6,20 +6,22 @@ module ReportableMixin
       filter = options.delete(:filter)
 
       # Do normal find
-      results = []
-      find(count, :conditions => conditions, :include => get_include_for_find(options[:include])).each do|obj|
+      records = find(count, :conditions => conditions, :include => get_include_for_find(options[:include]))
+      records = records.select do |obj|
         if filter
           expression = self.filter.to_ruby
           expr = Condition.subst(expression, obj)
-          next unless eval(expr)
+          eval(expr)
+        else
+          true
         end
-
-        entry = {:obj => obj}
-        build_search_includes(obj, entry, options[:include]) if options[:include]
-        results.push(entry)
       end
 
-      results
+      records.collect do |obj|
+        entry = {:obj => obj}
+        build_search_includes(obj, entry, options[:include]) if options[:include]
+        entry
+      end
     end
 
     # private

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -3,14 +3,7 @@ module ReportableMixin
   module ClassMethods
     def search(count = :all, options = {})
       records = find(count, :conditions => options[:conditions], :include => get_include_for_find(options[:include]))
-
-      if options.delete(:filter)
-        records = records.select do |obj|
-          expression = self.filter.to_ruby
-          expr = Condition.subst(expression, obj)
-          eval(expr)
-        end
-      end
+      records = records.select { |obj| eval(Condition.subst(filter.to_ruby, obj)) } if options.delete(:filter)
 
       records.collect do |obj|
         entry = {:obj => obj}

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -15,7 +15,7 @@ module ReportableMixin
         end
 
         entry = {:obj => obj}
-        obj.search_includes(entry, options[:include]) if options[:include]
+        build_search_includes(obj, entry, options[:include]) if options[:include]
         results.push(entry)
       end
 

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -2,17 +2,13 @@ module ReportableMixin
   extend ActiveSupport::Concern
   module ClassMethods
     def search(count = :all, options = {})
-      filter = options.delete(:filter)
-
       records = find(count, :conditions => options[:conditions], :include => get_include_for_find(options[:include]))
 
-      records = records.select do |obj|
-        if filter
+      if options.delete(:filter)
+        records = records.select do |obj|
           expression = self.filter.to_ruby
           expr = Condition.subst(expression, obj)
           eval(expr)
-        else
-          true
         end
       end
 

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -2,11 +2,10 @@ module ReportableMixin
   extend ActiveSupport::Concern
   module ClassMethods
     def search(count = :all, options = {})
-      conditions = options.delete(:conditions)
       filter = options.delete(:filter)
 
-      # Do normal find
-      records = find(count, :conditions => conditions, :include => get_include_for_find(options[:include]))
+      records = find(count, :conditions => options[:conditions], :include => get_include_for_find(options[:include]))
+
       records = records.select do |obj|
         if filter
           expression = self.filter.to_ruby


### PR DESCRIPTION
8b71482d69bd46035f958456d327466c255cc578 had renamed `search_includes` to `build_search_includes` but this one was not renamed. So this could call an invalid method.

I couldn't find any references to `search` but it is difficult to grep. So to play on the safe side, I fixed the reference.

didn't come up with a solution for the `eval`.