### PR TITLE
Dynamic chart layout

### DIFF
--- a/app/views/layouts/_perf_chart_js.html.haml
+++ b/app/views/layouts/_perf_chart_js.html.haml
@@ -1,13 +1,11 @@
 - if chart_data[chart_index][:xml2]
-  %div{"style" => "width: #{width + 21}px; margin-bottom: 50px"}
-    .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}"}
-      %div
-        %h3= charts[chart_index][:title]
-        .overlay-container{"style" => "position: relative"}
-          = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}",
-                         :bgcolor => "#f2f2f2",
-                         :width   => width,
-                         :height  => height * 70 / 100)
+  %div{"style" => "margin-bottom: 50px"}
+    .card-pf
+      .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}"}
+        .card-pf-heading
+          %h2.card-pf-title= charts[chart_index][:title]
+        .card-pf-body
+          = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}")
           .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
       %ul.dropdown-menu{"role"            => "menu",
                         "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}",
@@ -18,35 +16,30 @@
           $("#miq_chartmenu_#{chart_set}_#{chart_index}").empty();
           $("#miq_chart_parent_#{chart_set}_#{chart_index} .overlay").hide();
         });
-    .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}_2"}
-      %div
-        .overlay-container{"style" => "position: relative"}
-          = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}_2",
-                         :bgcolor => "#f2f2f2",
-                         :width   => width,
-                         :height  => height * 30 / 100)
+      .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}_2"}
+        .card-pf-body
+          = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}_2")
           .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
       %ul.dropdown-menu{"role"            => "menu",
                         "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}_2",
                         "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}_2",
                         "style"           => "position: fixed;"}
       :javascript
+        $('body').addClass('cards-pf');
         $("#miq_chart_parent_#{chart_set}_#{chart_index}_2").on('hidden.bs.dropdown', function() {
           $("#miq_chartmenu_#{chart_set}_#{chart_index}_2").empty();
           $("#miq_chart_parent_#{chart_set}_#{chart_index}_2 .overlay").hide();
         });
 - else
-  .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}", "style" => "width: #{width + 20}px; margin-bottom: 50px"}
-    %div
-      %h3= charts[chart_index][:title]
-      .overlay-container{"style" => "position: relative"}
-        = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}",
-                       :bgcolor => "#f2f2f2",
-                       :width   => width,
-                       :height  => height)
+  .card-pf
+    .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}", "style" => "margin-bottom: 50px"}
+      .card-pf-heading
+        %h2.card-pf-title= charts[chart_index][:title]
+      .card-pf-body
+        = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}")
         .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
         - if chart_data[chart_index][:zoom_url]
-          %div{:style => 'bottom: 20px; left: 20px; z-index: 10000; position: absolute;'}
+          %div
             %a{:href => '#', :onClick => chart_data[chart_index][:zoom_url]}
               %img{:src => image_path(zoom_icon(chart_data[chart_index][:zoom_url]))}
     %ul.dropdown-menu{"role"            => "menu",
@@ -54,6 +47,7 @@
                       "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}",
                       "style"           => "position: fixed;"}
     :javascript
+      $('body').addClass('cards-pf');
       miqChartBindEvents("#{chart_set}", #{chart_index});
       $("#miq_chart_parent_#{chart_set}_#{chart_index}").on('hidden.bs.dropdown', function() {
         $("#miq_chartmenu_#{chart_set}_#{chart_index}").empty();

--- a/app/views/layouts/_perf_charts.html.haml
+++ b/app/views/layouts/_perf_charts.html.haml
@@ -1,7 +1,7 @@
 %div{:id => "#{chart_set}_charts_div", :onmousedown => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   - if @charts || @perf_options[:chart_type] != :performance
     - perf_options ||= @perf_options
-    - width, height = perf_options[:index] ? [1000, 700] : [350, 250]
+    - detailed_view = !!perf_options[:index]
     - charts ||= @charts
     - if chart_data
       - if !perf_parent? && !perf_compare_vm?
@@ -13,12 +13,14 @@
                                         :locals  => {:charts      => charts,
                                                      :chart_data  => chart_data,
                                                      :chart_set   => chart_set,
-                                                     :chart_index => c,
-                                                     :width       => width,
-                                                     :height      => height})
+                                                     :chart_index => c})
 
-                .col-md-6.col-lg-4
-                  = chart_render
+                - if detailed_view
+                  .col-md-12
+                    = chart_render
+                - else
+                  .col-md-6.col-lg-4
+                    = chart_render
         - else
           = render :partial => 'layouts/info_msg', :locals => {:message => _("No Capacity & Utilization data available.")}
         - if @html
@@ -37,17 +39,13 @@
                            :locals  => {:charts      => charts,
                                         :chart_data  => chart_data,
                                         :chart_set   => chart_set,
-                                        :chart_index => c,
-                                        :width       => width,
-                                        :height      => height})
+                                        :chart_index => c})
                 .col-md-6
                   = render(:partial => '/layouts/perf_chart',
                            :locals  => {:charts      => pcharts,
                                         :chart_data  => pchart_data,
                                         :chart_set   => "parent",
-                                        :chart_index => c,
-                                        :width       => width,
-                                        :height      => height})
+                                        :chart_index => c})
           - if @html
             .row
               .col-md-6
@@ -73,9 +71,7 @@
                              :locals  => {:charts      => charts,
                                           :chart_data  => chart_data,
                                           :chart_set   => chart_set,
-                                          :chart_index => c,
-                                          :width       => width,
-                                          :height      => height})
+                                          :chart_index => c})
               - else
                 = render :partial => 'layouts/info_msg', :locals => {:message => _("No Capacity & Utilization data available.")}
               - if @html
@@ -96,9 +92,7 @@
                            :locals  => {:charts      => ccharts,
                                         :chart_data  => cchart_data,
                                         :chart_set   => "comparevm",
-                                        :chart_index => c,
-                                        :width       => width,
-                                        :height      => height})
+                                        :chart_index => c})
             - else
               = render :partial => 'layouts/info_msg', :locals => {:message => _("No Capacity & Utilization data available.")}
 

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -1,6 +1,6 @@
 - url = url_for(:action => 'perf_chart_chooser',
                 :id     => @record.id)
-#perf_options_div{:onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
+#perf_options_div.card-pf{:onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   - if @charts || @perf_options[:chart_type] != :performance
     %h3= _("Options %s") % (@record != @perf_record ? "(#{ui_lookup(:model => @perf_record.class.to_s)}: #{@perf_record.name})" : "")
     %dl.dl-horizontal


### PR DESCRIPTION
Remove fixed div width from chart div. Whole layout is now dynamic and chart does not overlap in C&U when resizing.


![screenshot from 2016-05-18 15-29-39](https://cloud.githubusercontent.com/assets/9535558/15360322/67c5877a-1d0d-11e6-9837-c0d226822475.png)

Detailed view:
![screenshot from 2016-05-26 16-19-25](https://cloud.githubusercontent.com/assets/9535558/15577707/f1ba4370-235d-11e6-8c5d-5d227eb6da00.png)
![screenshot from 2016-05-26 16-20-50](https://cloud.githubusercontent.com/assets/9535558/15577706/f1b94c86-235d-11e6-9bec-3f2b0e852a4f.png)


(X tick labels are fixed in  #8480)
@epwinchell I try to use card from dashboard, but dont know if i used it right.