### PR TITLE
[API] reports scheduled

### DIFF
--- a/app/controllers/api_controller/reports.rb
+++ b/app/controllers/api_controller/reports.rb
@@ -8,6 +8,14 @@ class ApiController
       object.miq_report_results
     end
 
+    def schedules_query_resource(object)
+      klass = collection_class(:schedules)
+      exp = {}
+      exp["="] = {"field" => "MiqReport.id", "value" => object.id}
+      exp = MiqExpression.new(exp)
+      object ? klass.where(:filter => exp) : {}
+    end
+
     def show_reports
       if @req.subcollection == "results" && (@req.s_id || expand?(:resources)) && attribute_selection == "all"
         @additional_attributes = %w(result_set)

--- a/app/controllers/api_controller/reports.rb
+++ b/app/controllers/api_controller/reports.rb
@@ -9,8 +9,7 @@ class ApiController
     end
 
     def schedules_query_resource(object)
-      klass = collection_class(:schedules)
-      object ? klass.find_by_report_id(object.id) : {}
+      object ? object.list_schedules : {}
     end
 
     def show_reports

--- a/app/controllers/api_controller/reports.rb
+++ b/app/controllers/api_controller/reports.rb
@@ -1,6 +1,6 @@
 class ApiController
   module Reports
-    SCHEDULE_BODY_ATTR = %w(start_date interval time_zone send_email).freeze
+    SCHEDULE_ATTRS_TO_TRANSFORM = %w(start_date interval time_zone send_email).freeze
     #
     # Reports Supporting Methods
     #
@@ -72,7 +72,7 @@ class ApiController
     end
 
     def fetch_schedule_data(data)
-      schedule_data = data.except(*SCHEDULE_BODY_ATTR)
+      schedule_data = data.except(*SCHEDULE_ATTRS_TO_TRANSFORM)
 
       schedule_data['userid'] = @auth_user_obj.userid
       schedule_data['run_at'] = {
@@ -84,10 +84,9 @@ class ApiController
 
       email_url_prefix = url_for(:controller => "report",
                                  :action     => "show_saved") + "/"
-      data['send_email'] ||= false
 
       schedule_options = {
-        :send_email       => data['send_email'],
+        :send_email       => data['send_email'] || false,
         :email_url_prefix => email_url_prefix,
         :miq_group_id     => @auth_user_obj.current_group_id
       }

--- a/app/controllers/api_controller/results.rb
+++ b/app/controllers/api_controller/results.rb
@@ -49,7 +49,7 @@ class ApiController
 
     def add_report_schedule_to_result(hash, schedule_id, report_id)
       hash[:schedule_id] = schedule_id
-      hash[:schedule_href] = "#{@req[:api_prefix]}/reports/#{report_id}/schedules/#{schedule_id}"
+      hash[:schedule_href] = "#{@req.api_prefix}/reports/#{report_id}/schedules/#{schedule_id}"
       hash
     end
 

--- a/app/controllers/api_controller/results.rb
+++ b/app/controllers/api_controller/results.rb
@@ -47,6 +47,12 @@ class ApiController
       hash
     end
 
+    def add_report_schedule_to_result(hash, schedule_id, report_id)
+      hash[:schedule_id] = schedule_id
+      hash[:schedule_href] = "#{@req[:api_prefix]}/reports/#{report_id}/schedules/#{schedule_id}"
+      hash
+    end
+
     def log_result(hash)
       hash.each { |k, v| api_log_info("Result: #{k}=#{v}") }
     end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -151,15 +151,16 @@ class MiqReport < ApplicationRecord
   end
 
   def add_schedule(data)
-    data['name'] ||= name
-    data['description'] ||= title
+    params = data
+    params['name'] ||= name
+    params['description'] ||= title
 
-    data['filter'] = MiqExpression.new("=" => {"field" => "MiqReport.id",
-                                               "value" => id})
-    data['towhat'] = "MiqReport"
-    data['prod_default'] = "system"
+    params['filter'] = MiqExpression.new("=" => {"field" => "MiqReport.id",
+                                                 "value" => id})
+    params['towhat'] = "MiqReport"
+    params['prod_default'] = "system"
 
-    MiqSchedule.create! data
+    MiqSchedule.create! params
   end
 
   def db_class

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -83,6 +83,19 @@ class MiqReport < ApplicationRecord
     q
   end
 
+  def add_schedule(data)
+    data['name'] ||= name
+    data['description'] ||= title
+
+    exp = {}
+    exp["="] = {"field" => "MiqReport.id", "value" => id}
+    data['filter'] = MiqExpression.new(exp)
+    data['towhat'] = "MiqReport"
+    data['prod_default'] = "system"
+
+    MiqSchedule.create! data
+  end
+
   def view_filter_columns
     col_order.collect { |c| [headers[col_order.index(c)], c] }
   end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -87,9 +87,8 @@ class MiqReport < ApplicationRecord
     data['name'] ||= name
     data['description'] ||= title
 
-    exp = {}
-    exp["="] = {"field" => "MiqReport.id", "value" => id}
-    data['filter'] = MiqExpression.new(exp)
+    data['filter'] = MiqExpression.new("=" => {"field" => "MiqReport.id",
+                                               "value" => id})
     data['towhat'] = "MiqReport"
     data['prod_default'] = "system"
 

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -83,18 +83,6 @@ class MiqReport < ApplicationRecord
     q
   end
 
-  def add_schedule(data)
-    data['name'] ||= name
-    data['description'] ||= title
-
-    data['filter'] = MiqExpression.new("=" => {"field" => "MiqReport.id",
-                                               "value" => id})
-    data['towhat'] = "MiqReport"
-    data['prod_default'] = "system"
-
-    MiqSchedule.create! data
-  end
-
   def view_filter_columns
     col_order.collect { |c| [headers[col_order.index(c)], c] }
   end
@@ -154,6 +142,24 @@ class MiqReport < ApplicationRecord
       multi = relats.fetch_path(*path)
       multi == true ? r << c : r
     end
+  end
+
+  def list_schedules
+    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
+                                    "value" => id})
+    MiqSchedule.filter_matches_with exp
+  end
+
+  def add_schedule(data)
+    data['name'] ||= name
+    data['description'] ||= title
+
+    data['filter'] = MiqExpression.new("=" => {"field" => "MiqReport.id",
+                                               "value" => id})
+    data['towhat'] = "MiqReport"
+    data['prod_default'] = "system"
+
+    MiqSchedule.create! data
   end
 
   def db_class

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -21,6 +21,10 @@ class MiqSchedule < ApplicationRecord
     where("updated_at > ?", time)
   }
 
+  scope :filter_matches_with, lambda { |exp|
+    where(:filter => exp)
+  }
+
   serialize :sched_action
   serialize :filter
   serialize :run_at
@@ -425,11 +429,5 @@ class MiqSchedule < ApplicationRecord
   def v_zone_name
     return "" if zone.nil?
     zone.name
-  end
-
-  def self.find_by_report_id(report_id)
-    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
-                                    "value" => report_id})
-    where(:filter => exp)
   end
 end # class MiqSchedule

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -21,9 +21,7 @@ class MiqSchedule < ApplicationRecord
     where("updated_at > ?", time)
   }
 
-  scope :filter_matches_with, lambda { |exp|
-    where(:filter => exp)
-  }
+  scope :filter_matches_with, -> (exp) { where(:filter => exp) }
 
   serialize :sched_action
   serialize :filter

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -426,4 +426,10 @@ class MiqSchedule < ApplicationRecord
     return "" if zone.nil?
     zone.name
   end
+
+  def self.find_by_report_id(report_id)
+    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
+                                    "value" => report_id})
+    where(:filter => exp)
+  end
 end # class MiqSchedule

--- a/config/api.yml
+++ b/config/api.yml
@@ -867,7 +867,7 @@
     :identifier: miq_report_reports
     :options:
     - :subcollection
-    :methods: *70174834086080
+    :verbs: *70174834086080
     :klass: MiqSchedule
     :collection_actions:
       :get:

--- a/config/api.yml
+++ b/config/api.yml
@@ -762,6 +762,8 @@
       :post:
       - :name: run
         :identifier: miq_report_run
+      - :name: schedule
+        :identifier: miq_report_run
     :subcollections:
     - :results
     :collection_actions:

--- a/config/api.yml
+++ b/config/api.yml
@@ -763,7 +763,7 @@
       - :name: run
         :identifier: miq_report_run
       - :name: schedule
-        :identifier: miq_report_run
+        :identifier: miq_report_schedule_add
     :subcollections:
     - :results
     - :schedules

--- a/config/api.yml
+++ b/config/api.yml
@@ -766,6 +766,7 @@
         :identifier: miq_report_run
     :subcollections:
     - :results
+    - :schedules
     :collection_actions:
       :get:
       - :name: read
@@ -858,6 +859,21 @@
       - :name: read
         :identifier: miq_report_view
     :resource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_report_view
+  :schedules:
+    :description: Report schedules
+    :identifier: miq_report_reports
+    :options:
+    - :subcollection
+    :methods: *70174834086080
+    :klass: MiqSchedule
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_report_view
+    :subresource_actions:
       :get:
       - :name: read
         :identifier: miq_report_view

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -137,9 +137,9 @@ RSpec.describe "reports API" do
 
     expect_result_to_match_hash(
       response_hash,
-      "href"      => "/api/reports/#{report.id}/schedules/#{schedule.id}",
-      "id"        => schedule.id,
-      "name"      => 'unit_test'
+      "href" => "/api/reports/#{report.id}/schedules/#{schedule.id}",
+      "id"   => schedule.id,
+      "name" => 'unit_test'
     )
     expect_request_success
   end
@@ -175,16 +175,20 @@ RSpec.describe "reports API" do
 
       expect do
         api_basic_authorize action_identifier(:reports, :schedule)
-        run_post "#{reports_url(report.id)}",
-          :action => 'schedule',
-          name: 'schedule_name',
-          enabled: true,
-          description: 'unit test',
-          start_date: '05/05/2016',
-          interval: {unit: 'daily', value: '110'},
-          time_zone: 'UTC'
+        run_post reports_url(report.id),
+                 :action      => 'schedule',
+                 :name        => 'schedule_name',
+                 :enabled     => true,
+                 :description => 'unit test',
+                 :start_date  => '05/05/2016',
+                 :interval    => {:unit => 'daily', :value => '110'},
+                 :time_zone   => 'UTC'
       end.to change(MiqSchedule, :count).by(1)
-      expect_request_success
+      expect_single_action_result(
+        :href    => reports_url(report.id),
+        :success => true,
+        :message => "scheduling of report #{report.id}"
+      )
     end
 
     it "can import a report" do

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -126,6 +126,23 @@ RSpec.describe "reports API" do
       )
     end
 
+    it "can schedule a run" do
+      report = FactoryGirl.create(:miq_report)
+
+      expect do
+        api_basic_authorize action_identifier(:reports, :schedule)
+        run_post "#{reports_url(report.id)}",
+          :action => 'schedule',
+          name: 'schedule_name',
+          enabled: true,
+          description: 'unit test',
+          start_date: '05/05/2016',
+          interval: {unit: 'daily', value: '110'},
+          time_zone: 'UTC'
+      end.to change(MiqSchedule, :count).by(1)
+      expect_request_success
+    end
+
     it "can import a report" do
       serialized_report = {
         :menu_name => "Test Report",

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -103,9 +103,8 @@ RSpec.describe "reports API" do
   it "can fetch all the schedule" do
     report = FactoryGirl.create(:miq_report)
 
-    exp = {}
-    exp["="] = {"field" => "MiqReport.id", "value" => report.id}
-    exp = MiqExpression.new(exp)
+    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
+                                    "value" => report.id})
 
     schedule_1 = FactoryGirl.create(:miq_schedule, :filter => exp)
     schedule_2 = FactoryGirl.create(:miq_schedule, :filter => exp)
@@ -126,9 +125,8 @@ RSpec.describe "reports API" do
   it "can show a single schedule" do
     report = FactoryGirl.create(:miq_report)
 
-    exp = {}
-    exp["="] = {"field" => "MiqReport.id", "value" => report.id}
-    exp = MiqExpression.new(exp)
+    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
+                                    "value" => report.id})
 
     schedule = FactoryGirl.create(:miq_schedule, :name => 'unit_test', :filter => exp)
 

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe "reports API" do
   it "can fetch all the schedule" do
     report = FactoryGirl.create(:miq_report)
 
-    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
-                                    "value" => report.id})
+    exp = {}
+    exp["="] = {"field" => "MiqReport.id", "value" => report.id}
+    exp = MiqExpression.new(exp)
 
     schedule_1 = FactoryGirl.create(:miq_schedule, :filter => exp)
     schedule_2 = FactoryGirl.create(:miq_schedule, :filter => exp)
@@ -119,14 +120,15 @@ RSpec.describe "reports API" do
         "/api/reports/#{report.id}/schedules/#{schedule_2.id}",
       ]
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can show a single schedule" do
     report = FactoryGirl.create(:miq_report)
 
-    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
-                                    "value" => report.id})
+    exp = {}
+    exp["="] = {"field" => "MiqReport.id", "value" => report.id}
+    exp = MiqExpression.new(exp)
 
     schedule = FactoryGirl.create(:miq_schedule, :name => 'unit_test', :filter => exp)
 
@@ -139,7 +141,7 @@ RSpec.describe "reports API" do
       "id"   => schedule.id,
       "name" => 'unit_test'
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "returns an empty result set if none has been run" do


### PR DESCRIPTION
Hi guys !

Just a PR to add actions on Reports schedule through the api :
- create schedule (implemented like an action on route `/reports`)
- list schedules (on route `reports/:report_id/schedules`)

I'm not sure that is the best way for implement this functionality, I will be listening you, feel free to tell me if I'm doing something wrong.
Thanks.