### PR TITLE
Changed value of :enabled for toolbar button from string to boolean

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -1,24 +1,4 @@
 class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolbar::Basic
-  button_group('cloud_volume_policy', [
-                 select(
-                   :cloud_volume_policy_choice,
-                   'fa fa-shield fa-lg',
-                   t = N_('Policy'),
-                   t,
-                   :enabled => "false",
-                   :onwhen  => "1+",
-                   :items   => [
-                     button(
-                       :cloud_volume_tag,
-                       'pficon pficon-edit fa-lg',
-                       N_('Edit tags for the selected items'),
-                       N_('Edit Tags'),
-                       :url_parms => "main_div",
-                       :enabled   => "false",
-                       :onwhen    => "1+"),
-                   ]
-                 ),
-               ])
   button_group('cloud_volume_vmdb', [
                  select(
                    :cloud_volume_vmdb_choice,
@@ -73,4 +53,24 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                    ]
                  )
                ])
+  button_group('cloud_volume_policy', [
+    select(
+      :cloud_volume_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => "false",
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :cloud_volume_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit tags for the selected items'),
+          N_('Edit Tags'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
 end


### PR DESCRIPTION
Value of :enabled attribute in toolbars buttons should be a boolean, having it as string was causing buttons to be enabled all the time. Buttons should only be enabled when an item in the list view is selected to perform an action.

https://bugzilla.redhat.com/show_bug.cgi?id=1334202

@dclarizio please review, had missed Edit Tags button in previous PR https://github.com/ManageIQ/manageiq/pull/8556

before:
![before](https://cloud.githubusercontent.com/assets/3450808/15216783/898feca6-1826-11e6-8860-c0758e8f0a31.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/15249335/03761830-18ed-11e6-932b-fe017d751319.png)


