### PR TITLE
When creating ChargebackVm report then model in options[:cb_model] is not stored

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1188,9 +1188,10 @@ module ReportController::Reports::Editor
           options[:tag] = "/managed/#{@edit[:new][:cb_tag_cat]}/#{@edit[:new][:cb_tag_value]}"
         end
       elsif @edit[:new][:cb_show_typ] == "entity"
-        options[:cb_model] = @edit[:new][:cb_model]
         options[:entity_id] = @edit[:new][:cb_entity_id]
       end
+
+      options[:cb_model] = @edit[:new][:cb_model]
       rpt.db_options[:options] = options
     end
 


### PR DESCRIPTION
`MiqReport.db_optionsoptions[:cb_model]` is not stored when the report is based on `ChargebackVm` model.
This leads to error when you edit created report and then click on "Filter" tab.

It fixes similar issue https://github.com/ManageIQ/manageiq/issues/8608. (but this is not final fix)

This issue is present in darga branch.





