### PR TITLE
Show percentages in 'Registered VMs with Free Space <35%' report

### DIFF
--- a/product/reports/400_Operations- Virtual Machines/015_Registered Free Space _35%.yaml
+++ b/product/reports/400_Operations- Virtual Machines/015_Registered Free Space _35%.yaml
@@ -47,6 +47,8 @@ cols:
 - v_datastore_path
 - name
 - updated_on
+- v_pct_free_disk_space
+- v_pct_used_disk_space
 template_type: report
 group: 
 sortby: 

--- a/product/reports/400_Operations- Virtual Machines/016_Unregistered Free Space _35%.yaml
+++ b/product/reports/400_Operations- Virtual Machines/016_Unregistered Free Space _35%.yaml
@@ -47,6 +47,8 @@ cols:
 - v_datastore_path
 - name
 - updated_on
+- v_pct_free_disk_space
+- v_pct_used_disk_space
 template_type: report
 group: 
 sortby: 


### PR DESCRIPTION
Before:
![scrot_before](https://cloud.githubusercontent.com/assets/6666052/15221790/2b2f5e02-186d-11e6-94e9-800cd9a17429.jpg)

After:
![scrot_after](https://cloud.githubusercontent.com/assets/6666052/15221798/333a00e8-186d-11e6-8c17-55f719a76a90.jpg)

I will put together a sanity spec for this in another pr.

@miq-bot add_label bug, reporting

/cc @martinpovolny 

