### PR TITLE
Display Forest Entries box when switching mode back to LDAP/LDAPS

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -732,9 +732,11 @@ module OpsController::Settings::Common
       if params[:authentication_mode] && params[:authentication_mode] != auth[:mode]
         if params[:authentication_mode] == "ldap"
           params[:authentication_ldapport] = "389"
+          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:get_direct_groups]
           @authldapport_reset = true
         elsif params[:authentication_mode] == "ldaps"
           params[:authentication_ldapport] = "636"
+          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:get_direct_groups]
           @authldapport_reset = true
         else
           @sb[:newrole] = auth[:ldap_role] = false    # setting it to false if database was selected to hide user_proxies box

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -76,9 +76,7 @@
                 %td{:onclick => remote_function(:url => {:action => 'forest_delete',
                 :ldaphost_id => forest[:ldaphost].to_s}, :confirm => _("Are you sure you want to delete forest %s ?") % forest[:ldaphost]),
                 :title => _("Click to delete this forest")}
-                  %ul#list
-                    %li
-                      = image_tag(image_path('toolbars/delete.png'))
+                  = image_tag(image_path('toolbars/delete.png'))
                 %td{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => forest[:ldaphost].to_s}), :title => _("Click to edit this forest")}
                   = h(forest[:ldaphost])
                 %td{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => forest[:ldaphost].to_s}), :title => _("Click to edit this forest")}


### PR DESCRIPTION
- Fixed code to show Forest Entries box when switching back to LDAP/LDAPS mode
- Added spec test to verify fix
- Fixed alignment of icons in Forest Entries box

https://bugzilla.redhat.com/show_bug.cgi?id=1326499

@dclarizio please review

screenshot for minor alignment fix that is also part of this PR.
before
![image_misalignment](https://cloud.githubusercontent.com/assets/3450808/15222036/f06749fa-183b-11e6-8267-b7ec8c106c73.png)

after
![alignment_fix](https://cloud.githubusercontent.com/assets/3450808/15222043/f844a5dc-183b-11e6-9272-1a007750d591.png)
