### PR TITLE
Add association Storage Clusters to Automate Storage Service Model.

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -27,6 +27,7 @@ class Storage < ApplicationRecord
   virtual_has_one   :file_share,           :class_name => 'SniaFileShare'
   virtual_has_many  :storage_volumes,      :class_name => 'CimStorageVolume'
   virtual_has_one   :logical_disk,         :class_name => 'CimLogicalDisk'
+  virtual_has_many  :storage_clusters
 
   validates_presence_of     :name
   # We can't uncomment this until the SmartProxy starts sending location when registering VMs

--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
@@ -6,6 +6,7 @@ module MiqAeMethodService
     expose :unregistered_vms,       :association => true
     expose :storage_files,          :association => true
     expose :files,                  :association => true
+    expose :storage_clusters,       :association => true
     expose :to_s
     expose :scan,                   :override_return => true
   end


### PR DESCRIPTION
Add association Storage Clusters to Automate Storage Service Model.

https://bugzilla.redhat.com/show_bug.cgi?id=1335658

/cc @gmcculloug 