### PR TITLE
Allow a block to be passed to MiqProvisionVirtWorkflow#initialize

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -821,7 +821,7 @@ class MiqRequestWorkflow
     end
   end
 
-  def password_helper(values, encrypt = true)
+  def password_helper(values = @values, encrypt = true)
     self.class.encrypted_options_fields.each do |pwd_key|
       next if values[pwd_key].blank?
       if encrypt

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -145,7 +145,17 @@ module MiqRequestMixin
   end
 
   def workflow(request_options = options, flags = {})
-    workflow_class.new(request_options, get_user, flags) if workflow_class
+    if workflow_class
+      current_workflow = workflow_class.new(request_options, get_user, flags)
+      if block_given?
+        begin
+          yield(current_workflow)
+        ensure
+          current_workflow.password_helper
+        end
+      end
+      current_workflow
+    end
   end
 
   def request_dialog(action_name)

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -150,7 +150,7 @@ describe MiqProvision do
       expect(prov).to receive(:workflow) { |options, flags|
         expect(options[:placement_auto]).to eq([false, 0])
         expect(flags[:skip_dialog_load]).to be_truthy
-      }.and_return(workflow)
+      }.and_yield(workflow).and_return(workflow)
 
       prov.eligible_resources(:hosts)
     end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -1,6 +1,24 @@
 describe MiqProvisionVirtWorkflow do
   let(:workflow) { FactoryGirl.create(:miq_provision_virt_workflow) }
 
+  context "#new" do
+    let(:sdn)  { 'SysprepDomainName' }
+    let(:host) { double('Host', :id => 1, :name => 'my_host') }
+    let(:user) { FactoryGirl.create(:user_with_email) }
+
+    before do
+      allow(workflow).to receive_messages(:validate => true)
+      allow(workflow).to receive_messages(:get_dialogs => {})
+      workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => 123, :sysprep_enabled => 'fields',
+                                     :sysprep_domain_name => sdn)
+    end
+
+    it "calls password_helper once when a block is not passed in" do
+      expect_any_instance_of(MiqProvisionVirtWorkflow).to receive(:password_helper).with({:allowed_hosts => [host], :skip_dialog_load => true}, false).once
+      MiqProvisionVirtWorkflow.new({:allowed_hosts => [host]}, user, {:skip_dialog_load => true})
+    end
+  end
+
   context "#continue_request" do
     let(:sdn) { 'SysprepDomainName' }
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -1,4 +1,6 @@
 describe MiqRequest do
+  include MiqRequestMixin
+
   let(:fred)   { FactoryGirl.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred',   :email => "fred@example.com") }
   let(:barney) { FactoryGirl.create(:user_with_group, :name => 'Barney Rubble',   :userid => 'barney', :email => "barney@example.com") }
 
@@ -304,6 +306,18 @@ describe MiqRequest do
       request = FactoryGirl.create(:service_template_provision_request, :description => description, :requester => fred)
       request.post_create_request_tasks
       expect(request.description).to eq(description)
+    end
+  end
+
+  context '#workflow' do
+    let(:provision_request) { FactoryGirl.create(:miq_provision_request, :requester => fred, :src_vm_id => template.id) }
+    let(:ems)          { FactoryGirl.create(:ems_vmware) }
+    let(:template)     { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
+    let(:host) { double('Host', :id => 1, :name => 'my_host') }
+
+    it "calls password_helper when a block is passed in" do
+      expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow).to receive(:password_helper).twice
+      provision_request.workflow({}, {:allowed_hosts => [host], :skip_dialog_load => true}) { |_x| 'test' }
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1334684

This allows us to ensure password_helper is called twice
1. Decrypt passwords for Automate Requests
2. ReEncrypt passwords after the provision is finished

If a block isn't passed into the class - it will respond as normal
