### PR TITLE
Unify property attribute names and types

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -5,15 +5,6 @@ class GenericObject < ApplicationRecord
   validates :name, :presence => true, :uniqueness => true
   validate  :must_be_defined_attributes
 
-  TYPE_MAP = {
-    :boolean  => ActiveRecord::Type::Boolean.new,
-    :datetime => ActiveRecord::Type::DateTime.new,
-    :time     => ActiveRecord::Type::Time.new,
-    :float    => ActiveRecord::Type::Float.new,
-    :integer  => ActiveRecord::Type::Integer.new,
-    :string   => ActiveRecord::Type::String.new,
-  }.freeze
-
   def must_be_defined_attributes
     return errors.add(:base, "must specify a GenericObjectDefinition.") unless generic_object_definition
 
@@ -59,7 +50,7 @@ class GenericObject < ApplicationRecord
   def custom_attribute_getter(name)
     @custom_attributes ||= custom_attributes
     found = @custom_attributes.detect { |ca| ca.name == name }
-    found ? type_cast(found.name, found.value) : nil
+    found ? generic_object_definition.type_cast(name, found.value) : nil
   end
 
   def custom_attribute_setter(name, value)
@@ -75,9 +66,5 @@ class GenericObject < ApplicationRecord
     else
       value.inspect
     end
-  end
-
-  def type_cast(attr_name, value)
-    TYPE_MAP.fetch(generic_object_definition.defined_attributes[attr_name].to_sym).cast(value)
   end
 end

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -1,4 +1,13 @@
 class GenericObjectDefinition < ApplicationRecord
+  TYPE_MAP = {
+    :boolean  => ActiveRecord::Type::Boolean.new,
+    :datetime => ActiveRecord::Type::DateTime.new,
+    :time     => ActiveRecord::Type::Time.new,
+    :float    => ActiveRecord::Type::Float.new,
+    :integer  => ActiveRecord::Type::Integer.new,
+    :string   => ActiveRecord::Type::String.new,
+  }.freeze
+
   validates :name, :presence => true, :uniqueness => true
 
   serialize :properties, Hash
@@ -7,6 +16,21 @@ class GenericObjectDefinition < ApplicationRecord
   has_many  :generic_objects
 
   def defined_attributes
-    @defined_attributes ||= properties[:attributes].stringify_keys
+    properties[:attributes]
+  end
+
+  def properties=(props)
+    props = props.symbolize_keys
+    if props.key?(:attributes)
+      props[:attributes] = props[:attributes].each_with_object({}) do |(name, type), hash|
+        raise ArgumentError, "#{type} is not a recognized type" unless TYPE_MAP.key?(type.to_sym)
+        hash[name.to_s] = type.to_sym
+      end
+    end
+    super
+  end
+
+  def type_cast(attr_name, value)
+    TYPE_MAP.fetch(defined_attributes[attr_name]).cast(value)
   end
 end

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -1,0 +1,37 @@
+describe GenericObjectDefinition do
+  let(:definition) do
+    FactoryGirl.create(
+      :generic_object_definition,
+      :name       => "test_definition",
+      :properties => {
+        :attributes => {
+          :max_number => "integer",
+          :server     => "string",
+          :flag       => "boolean",
+          :data_read  => "float",
+          :s_time     => "datetime"
+        }
+      }
+    )
+  end
+
+  it 'requires name attribute present' do
+    expect(described_class.new).not_to be_valid
+  end
+
+  it 'requires name attribute to be unique' do
+    described_class.create!(:name => 'myclass')
+    expect(described_class.new(:name => 'myclass')).not_to be_valid
+  end
+
+  it 'raises an error if any property attribute is not of a recognized type' do
+    testdef = described_class.new(:name => 'test')
+    expect { testdef.properties = {:attributes => {'myattr' => :strange_type}} }.to raise_error(ArgumentError)
+  end
+
+  describe '#type_cast' do
+    it 'casts a string to a predefined type' do
+      expect(definition.type_cast('max_number', '100')).to eq(100)
+    end
+  end
+end


### PR DESCRIPTION
Unify property attribute name as string and type as symbol
Also validate the property attribute type at setter