### PR TITLE
Resolve the name conflict for Set in VimTypes

### DIFF
--- a/gems/pending/VMwareWebService/VimTypes.rb
+++ b/gems/pending/VMwareWebService/VimTypes.rb
@@ -1,4 +1,5 @@
 require 'VMwareWebService/VimConstants'
+require 'set'
 autoload :VimMappingRegistry, 'VMwareWebService/VimMappingRegistry'
 
 module VimType


### PR DESCRIPTION
The new introduced VimClass adds dependency on the Ruby set library. But the forked process VixDiskLibServer cannot resolve it and reject all the connection requests. 

https://bugzilla.redhat.com/show_bug.cgi?id=1334865