### PR TITLE
Fix memory bloat in EmsRefresh

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -115,6 +115,7 @@ module EmsRefresh::SaveInventory
 
         found.save!
         h[:id] = found.id
+        found.reload # reload to clear caches and lower memory usage
         h[:_object] = found
       rescue => err
         # If a vm failed to process, mark it as invalid and log an error


### PR DESCRIPTION
reload saved record to clear caches and free memory

before a amazon refresh with public images would consume up to 4 gig of ram
after that it stays below 1 gig