### PR TITLE
Gracefully handle instances/volumes that don't support volume attach and detach

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2464,4 +2464,9 @@ class ApplicationController < ActionController::Base
     @accords = allowed_features.map(&:accord_hash)
     set_active_elements(allowed_features.first)
   end
+
+  def get_error_message_from_fog(ex)
+    matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
+    matched_message ? matched_message[1] : ex
+  end
 end

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -245,9 +245,9 @@ class VmCloudController < ApplicationController
       })
     when "attach"
       volume = find_by_id_filtered(CloudVolume, params[:volume_id])
-      if @record.is_available?(:attach_volume)
+      if volume.is_available?(:attach_volume)
         begin
-          @volume.raw_attach_volume(@vm.ems_ref, params[:device_path])
+          volume.raw_attach_volume(@vm.ems_ref, params[:device_path])
           add_flash(_("Attaching %{volume} \"%{volume_name}\" to %{vm_name}") % {
             :volume      => ui_lookup(:table => 'cloud_volume'),
             :volume_name => volume.name,
@@ -257,10 +257,10 @@ class VmCloudController < ApplicationController
             :volume      => ui_lookup(:table => 'cloud_volume'),
             :volume_name => volume.name,
             :vm_name     => @vm.name,
-            :details     => ex}, :error)
+            :details     => get_error_message_from_fog(ex)}, :error)
         end
       else
-        add_flash(_(@record.is_available_now_error_message(:attach_volume)), :error)
+        add_flash(_(volume.is_available_now_error_message(:attach_volume)), :error)
       end
       @breadcrumbs.pop if @breadcrumbs
       session[:edit] = nil
@@ -285,7 +285,7 @@ class VmCloudController < ApplicationController
 
     when "detach"
       volume = find_by_id_filtered(CloudVolume, params[:volume_id])
-      if @record.is_available?(:detach_volume)
+      if volume.is_available?(:detach_volume)
         begin
           volume.raw_detach_volume(@vm.ems_ref)
           add_flash(_("Detaching %{volume} \"%{volume_name}\" from %{vm_name}") % {
@@ -297,10 +297,10 @@ class VmCloudController < ApplicationController
             :volume      => ui_lookup(:table => 'cloud_volume'),
             :volume_name => volume.name,
             :vm_name     => @vm.name,
-            :details     => ex}, :error)
+            :details     => get_error_message_from_fog(ex)}, :error)
         end
       else
-        add_flash(_(@record.is_available_now_error_message(:detach_volume)), :error)
+        add_flash(_(volume.is_available_now_error_message(:detach_volume)), :error)
       end
       @breadcrumbs.pop if @breadcrumbs
       session[:edit] = nil

--- a/app/helpers/application_helper/button/instance_detach.rb
+++ b/app/helpers/application_helper/button/instance_detach.rb
@@ -1,0 +1,16 @@
+class ApplicationHelper::Button::InstanceDetach < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @record.number_of(:cloud_volumes) == 0
+      self[:title] = _("%{model} \"%{name}\" has no attached %{volumes}") % {
+        :model   => ui_lookup(:table => 'vm_cloud'),
+        :name    => @record.name,
+        :volumes => ui_lookup(:tables => 'cloud_volumes')
+      }
+    end
+  end
+
+  def disabled?
+    @record.number_of(:cloud_volumes) == 0
+  end
+end

--- a/app/helpers/application_helper/button/volume_attach.rb
+++ b/app/helpers/application_helper/button/volume_attach.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::VolumeAttach < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self[:title] = @record.is_available_now_error_message(:attach_volume) if disabled?
+  end
+
+  def disabled?
+    !@record.is_available?(:attach_volume)
+  end
+end

--- a/app/helpers/application_helper/button/volume_detach.rb
+++ b/app/helpers/application_helper/button/volume_detach.rb
@@ -1,0 +1,18 @@
+class ApplicationHelper::Button::InstanceDetach < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if !@record.is_available?(:detach_volume)
+      self[:title] = @record.is_available_now_error_message(:detach_volume)
+    elsif @record.number_of(:attachments) == 0
+      self[:title] = _("%{model} \"%{name}\" is not attached to any %{instances}") % {
+        :model     => ui_lookup(:table => 'cloud_volume'),
+        :name      => @record.name,
+        :instances => ui_lookup(:tables => 'vm_cloud')
+      }
+    end
+  end
+
+  def disabled?
+    !@record.is_available?(:detach_volume) || @record.number_of(:attachments) == 0
+  end
+end

--- a/app/helpers/application_helper/button/volume_detach.rb
+++ b/app/helpers/application_helper/button/volume_detach.rb
@@ -1,9 +1,9 @@
-class ApplicationHelper::Button::InstanceDetach < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::VolumeDetach < ApplicationHelper::Button::Basic
   def calculate_properties
     super
     if !@record.is_available?(:detach_volume)
       self[:title] = @record.is_available_now_error_message(:detach_volume)
-    elsif @record.number_of(:attachments) == 0
+    elsif @record.number_of(:vms) == 0
       self[:title] = _("%{model} \"%{name}\" is not attached to any %{instances}") % {
         :model     => ui_lookup(:table => 'cloud_volume'),
         :name      => @record.name,
@@ -13,6 +13,6 @@ class ApplicationHelper::Button::InstanceDetach < ApplicationHelper::Button::Bas
   end
 
   def disabled?
-    !@record.is_available?(:detach_volume) || @record.number_of(:attachments) == 0
+    !@record.is_available?(:detach_volume) || @record.number_of(:vms) == 0
   end
 end

--- a/app/helpers/application_helper/toolbar/cloud_volume_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_center.rb
@@ -26,14 +26,16 @@ class ApplicationHelper::Toolbar::CloudVolumeCenter < ApplicationHelper::Toolbar
                        'pficon pficon-volume fa-lg',
                        t = N_('Attach this Cloud Volume to an Instance'),
                        t,
-                       :url_parms => 'main_div',
+                       :klass     => ApplicationHelper::Button::VolumeAttach,
+                       :url_parms => 'main_div'
                      ),
                      button(
                        :cloud_volume_detach,
                        'pficon pficon-volume fa-lg',
                        t = N_('Detach this Cloud Volume from an Instance'),
                        t,
-                       :url_parms => 'main_div',
+                       :klass     => ApplicationHelper::Button::VolumeDetach,
+                       :url_parms => 'main_div'
                      ),
                      button(
                        :cloud_volume_edit,

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -41,6 +41,17 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           'pficon pficon-edit fa-lg',
           t = N_('Edit Management Engine Relationship'),
           t),
+        button(
+          :instance_attach,
+          'pficon pficon-volume fa-lg',
+          t = N_('Attach a Cloud Volume to this Instance'),
+          t),
+        button(
+          :instance_detach,
+          'pficon pficon-volume fa-lg',
+          t = N_('Detach a Cloud Volume from this Instance'),
+          t,
+          :klass => ApplicationHelper::Button::InstanceDetach),
         separator,
         button(
           :instance_resize,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -53,25 +53,6 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :onwhen    => "1+"),
         separator,
         button(
-          :instance_attach,
-          'pficon pficon-volume fa-lg',
-          t = N_('Attach a Cloud Volume to the selected Instance'),
-          t,
-          :url_parms => 'main_div',
-          :enabled   => 'false',
-          :onwhen    => '1'
-        ),
-        button(
-          :instance_detach,
-          'pficon pficon-volume fa-lg',
-          t = N_('Detach a Cloud Volume from the selected Instance'),
-          t,
-          :url_parms => 'main_div',
-          :enabled   => 'false',
-          :onwhen    => '1'
-        ),
-        separator,
-        button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Remove selected items from the VMDB'),

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -31,17 +31,6 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           N_('Set Ownership')),
         separator,
         button(
-          :instance_attach,
-          'pficon pficon-volume fa-lg',
-          t = N_('Attach a Cloud Volume to this Instance'),
-          t),
-        button(
-          :instance_detach,
-          'pficon pficon-volume fa-lg',
-          t = N_('Detach a Cloud Volume from this Instance'),
-          t),
-        separator,
-        button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
           N_('Remove this Instance from the VMDB'),

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -5,6 +5,7 @@ class CloudVolume < ApplicationRecord
   include ReportableMixin
   include ProviderObjectMixin
   include AsyncDeleteMixin
+  include AvailabilityMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :availability_zone

--- a/spec/helpers/application_helper/buttons/instance_attach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_attach_spec.rb
@@ -1,0 +1,40 @@
+describe ApplicationHelper::Button::InstanceAttach do
+  describe '#disabled?' do
+    it "when the attach action is available then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true)}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the attach action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the attach action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :is_available? => false, :is_available_now_error_message => "unavailable")}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("unavailable")
+    end
+
+    it "when the action is avaiable, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true)}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_detach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_detach_spec.rb
@@ -1,0 +1,65 @@
+describe ApplicationHelper::Button::InstanceDetach do
+  describe '#disabled?' do
+    it "when the detach action is available and volumes are attached then the button is enabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :number_of => 1)}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the detach action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false, :number_of => 1)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+
+    it "when the record has no attached volumes then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :number_of => 0)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the detach action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :is_available? => false, :number_of => 1, :is_available_now_error_message => "unavailable"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("unavailable")
+    end
+
+    it "when there are no volumes to detach the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :is_available? => true, :number_of => 0, :name => "TestVM"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq(_("%{model} \"TestVM\" has no attached %{volumes}") % {
+        :model   => ui_lookup(:table => 'vm_cloud'),
+        :volumes => ui_lookup(:tables => 'cloud_volumes')
+      })
+    end
+
+    it "when there are volumes to detach and the action is avaiable, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :is_available? => true, :number_of => 1
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_detach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_detach_spec.rb
@@ -1,47 +1,28 @@
 describe ApplicationHelper::Button::InstanceDetach do
   describe '#disabled?' do
-    it "when the detach action is available and volumes are attached then the button is enabled" do
+    it "when volumes are attached then the button is enabled" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :number_of => 1)}, {}
+        view_context, {}, {"record" => object_double(VmCloud.new, :number_of => 1)}, {}
       )
       expect(button.disabled?).to be false
-    end
-
-    it "when the detach action is unavailable then the button is disabled" do
-      view_context = setup_view_context_with_sandbox({})
-      button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false, :number_of => 1)}, {}
-      )
-      expect(button.disabled?).to be true
     end
 
     it "when the record has no attached volumes then the button is disabled" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :number_of => 0)}, {}
+        view_context, {}, {"record" => object_double(VmCloud.new, :number_of => 0)}, {}
       )
       expect(button.disabled?).to be true
     end
   end
 
   describe '#calculate_properties' do
-    it "when the detach action is unavailable the button has the error in the title" do
-      view_context = setup_view_context_with_sandbox({})
-      button = described_class.new(
-        view_context, {}, {"record" => object_double(
-          VmCloud.new, :is_available? => false, :number_of => 1, :is_available_now_error_message => "unavailable"
-        )}, {}
-      )
-      button.calculate_properties
-      expect(button[:title]).to eq("unavailable")
-    end
-
     it "when there are no volumes to detach the button has the error in the title" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
         view_context, {}, {"record" => object_double(
-          VmCloud.new, :is_available? => true, :number_of => 0, :name => "TestVM"
+          VmCloud.new, :number_of => 0, :name => "TestVM"
         )}, {}
       )
       button.calculate_properties
@@ -51,11 +32,11 @@ describe ApplicationHelper::Button::InstanceDetach do
       })
     end
 
-    it "when there are volumes to detach and the action is avaiable, the button has no error in the title" do
+    it "when there are volumes to detach, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
         view_context, {}, {"record" => object_double(
-          VmCloud.new, :is_available? => true, :number_of => 1
+          VmCloud.new, :number_of => 1
         )}, {}
       )
       button.calculate_properties

--- a/spec/helpers/application_helper/buttons/volume_attach_spec.rb
+++ b/spec/helpers/application_helper/buttons/volume_attach_spec.rb
@@ -1,9 +1,9 @@
-describe ApplicationHelper::Button::InstanceAttach do
+describe ApplicationHelper::Button::VolumeAttach do
   describe '#disabled?' do
     it "when the attach action is available then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true)}, {}
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => true)}, {}
       )
       expect(button.disabled?).to be false
     end
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::InstanceAttach do
     it "when the attach action is unavailable then the button is disabled" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false)}, {}
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => false)}, {}
       )
       expect(button.disabled?).to be true
     end
@@ -22,7 +22,7 @@ describe ApplicationHelper::Button::InstanceAttach do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
         view_context, {}, {"record" => object_double(
-          VmCloud.new, :is_available? => false, :is_available_now_error_message => "unavailable")}, {}
+          CloudVolume.new, :is_available? => false, :is_available_now_error_message => "unavailable")}, {}
       )
       button.calculate_properties
       expect(button[:title]).to eq("unavailable")
@@ -31,7 +31,7 @@ describe ApplicationHelper::Button::InstanceAttach do
     it "when the action is avaiable, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true)}, {}
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => true)}, {}
       )
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/volume_detach_spec.rb
+++ b/spec/helpers/application_helper/buttons/volume_detach_spec.rb
@@ -1,0 +1,65 @@
+describe ApplicationHelper::Button::VolumeDetach do
+  describe '#disabled?' do
+    it "when the detach action is available and the volume is attached to instances then the button is enabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => true, :number_of => 1)}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the detach action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => false, :number_of => 1)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+
+    it "when the volume is not attached to any instances then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => true, :number_of => 0)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the detach action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          CloudVolume.new, :is_available? => false, :number_of => 1, :is_available_now_error_message => "unavailable"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("unavailable")
+    end
+
+    it "when there are no instances to detach from the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          CloudVolume.new, :is_available? => true, :number_of => 0, :name => "TestVolume"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq(_("%{model} \"TestVolume\" is not attached to any %{instances}") % {
+        :model     => ui_lookup(:table => 'cloud_volume'),
+        :instances => ui_lookup(:tables => 'vm_cloud')
+      })
+    end
+
+    it "when there are instances to detach from and the action is available, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          CloudVolume.new, :is_available? => true, :number_of => 1
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
* Move the instance-level volume attach and detach buttons to the openstack specific instance toolbar
* Gracefully handle the cases where attach or detach aren't supported
* Add specs for the attach/detach buttons