### PR TITLE
Gracefully handle instances that don't support the resize action

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -53,13 +53,6 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-edit fa-lg',
           t = N_('Edit Management Engine Relationship'),
           t),
-        separator,
-        button(
-          :instance_resize,
-          'pficon pficon-edit fa-lg',
-          t = N_('Reconfigure this Instance'),
-          t,
-          :klass => ApplicationHelper::Button::InstanceReconfigure)
       ]
     ),
   ])


### PR DESCRIPTION
* Remove the `resize` button from the generic instance toolbar.
* Flash a message if the `resize` action was selected for an instance that doesn't support it. 