### PR TITLE
Add link to user start page in logo image

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2472,7 +2472,7 @@ class ApplicationController < ActionController::Base
 
   def start_url_for_user(start_url)
     return url_for(start_url) unless start_url.nil?
-    return url_for(:controller => "dashboard", :action => "show") unless @settings[:display][:startpage]
+    return url_for(:controller => "dashboard", :action => "show") unless self.helpers.settings(:display, :startpage)
 
     first_allowed_url = nil
     startpage_already_set = nil
@@ -2485,7 +2485,7 @@ class ApplicationController < ActionController::Base
     end
 
     # user first_allowed_url in start_pages to be default page, if default startpage is not allowed
-    @settings[:display][:startpage] = first_allowed_url unless startpage_already_set
+    @settings.store_path(:display, :startpage, first_allowed_url) unless startpage_already_set
     @settings[:display][:startpage]
   end
   helper_method :start_url_for_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2469,4 +2469,24 @@ class ApplicationController < ActionController::Base
     matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
     matched_message ? matched_message[1] : ex
   end
+
+  def start_url_for_user(start_url)
+    return url_for(start_url) unless start_url.nil?
+    return url_for(:controller => "dashboard", :action => "show") unless @settings[:display][:startpage]
+
+    first_allowed_url = nil
+    startpage_already_set = nil
+    MiqShortcut.start_pages.each do |url, _description, rbac_feature_name|
+      allowed = start_page_allowed?(rbac_feature_name)
+      first_allowed_url ||= url if allowed
+      # if default startpage is set, check if it is allowed
+      startpage_already_set = true if @settings[:display][:startpage] == url && allowed
+      break if startpage_already_set
+    end
+
+    # user first_allowed_url in start_pages to be default page, if default startpage is not allowed
+    @settings[:display][:startpage] = first_allowed_url unless startpage_already_set
+    @settings[:display][:startpage]
+  end
+  helper_method :start_url_for_user
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -698,25 +698,6 @@ class DashboardController < ApplicationController
     UserValidationService.new(self).validate_user(user, task_id, request, authenticate_options)
   end
 
-  def start_url_for_user(start_url)
-    return url_for(start_url) unless start_url.nil?
-    return url_for(:action => "show") unless @settings[:display][:startpage]
-
-    first_allowed_url = nil
-    startpage_already_set = nil
-    MiqShortcut.start_pages.each do |url, _description, rbac_feature_name|
-      allowed = start_page_allowed?(rbac_feature_name)
-      first_allowed_url ||= url if allowed
-      # if default startpage is set, check if it is allowed
-      startpage_already_set = true if @settings[:display][:startpage] == url && allowed
-      break if startpage_already_set
-    end
-
-    # user first_allowed_url in start_pages to be default page, if default startpage is not allowed
-    @settings[:display][:startpage] = first_allowed_url unless startpage_already_set
-    @settings[:display][:startpage]
-  end
-
   def session_reset
     # save some fields to recover back into session hash after session is cleared
     keys_to_restore = [:winH, :winW, :browser, :user_TZO]

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,7 +6,7 @@
       %span.icon-bar
       %span.icon-bar
       %span.icon-bar
-    %a.navbar-brand{:href => start_url_for_user(nil), :style => "cursor: default"}
+    %a.navbar-brand{:href => start_url_for_user(nil), :style => "cursor: default", :title => "Go to my start page"}
       %img.navbar-brand-name{:src => image_path("brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,7 +6,7 @@
       %span.icon-bar
       %span.icon-bar
       %span.icon-bar
-    %a.navbar-brand{:href => "#", :style => "cursor: default"}
+    %a.navbar-brand{:href => start_url_for_user(nil), :style => "cursor: default"}
       %img.navbar-brand-name{:src => image_path("brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic


### PR DESCRIPTION
Many products have functionality to bring to the 'home' or 'main' page when clicking on the logo of the service. This is especially helpful for applications where you'd like to avoid hitting the back button to return to some main page.

We're using this method really awkwardly in service objects delegating to passed controllers, and I'd have loved to clean this up - but I purposefully left this as a simple move to make the helper method available to every controller without changing any implementation code because I'd really love it if we could please include this in the Darga release.

@miq-bot add_labels ui, enhancement