### PR TITLE
Enable building from branches using ADD via GIT tarballs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ENV APP_ROOT /var/www/miq/vmdb
 ENV APPLIANCE_ROOT /opt/manageiq/manageiq-appliance
 ENV SSUI_ROOT /opt/manageiq/manageiq-ui-self_service
 
+# Set Docker build ARGs
+ARG REF=master
+ARG APP_REPO=.
+
 # Fetch postgresql 9.4 COPR and pglogical repos
 RUN curl -sSLko /etc/yum.repos.d/rhscl-rh-postgresql94-epel-7.repo \
 https://copr-fe.cloud.fedoraproject.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo && \
@@ -73,13 +77,16 @@ RUN curl -sL https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz | tar xz
     rm -rf /chruby-* && rm -rf /usr/local/src/* && yum clean all
 
 ## GIT clone manageiq-appliance and self-service UI repo (SSUI)
-RUN git clone --depth 1 https://github.com/ManageIQ/manageiq-appliance.git ${APPLIANCE_ROOT} && \
-git clone --depth 1 https://github.com/ManageIQ/manageiq-ui-self_service.git ${SSUI_ROOT} && \
+RUN git clone --depth 1 --branch ${REF} https://github.com/ManageIQ/manageiq-appliance.git ${APPLIANCE_ROOT} && \
+git clone --depth 1 --branch ${REF} https://github.com/ManageIQ/manageiq-ui-self_service.git ${SSUI_ROOT} && \
 ln -vs ${APP_ROOT} /opt/manageiq/manageiq
 
 ## Create approot, ADD miq
 RUN mkdir -p ${APP_ROOT}
-ADD . ${APP_ROOT}
+ADD ${APP_REPO} ${APP_ROOT}
+RUN if [ -f ${APP_ROOT}/${REF} ]; then  \
+tar -xf ${APP_ROOT}/${REF} -C ${APP_ROOT} --strip-components=1; \
+rm -f ${APP_ROOT}/${REF}; fi
 
 ## Setup environment
 
@@ -132,8 +139,8 @@ EXPOSE 80 443
 
 LABEL name="manageiq" \
           vendor="ManageIQ" \
-          version="Capablanca" \
-          release="latest" \
+          version="Darga" \
+          release="${REF}" \
           architecture="x86_64" \
           url="http://manageiq.org/" \
           summary="ManageIQ appliance image" \


### PR DESCRIPTION
This is an alternative way to build specific branches taking advantage of github's tarballs and dockerfile ADD support to download compressed tarballs

A few considerations :

- Dockerfile's ADD does not support automatic untar/uncompress of remote URLs, an additional layer was added to handle this
- Docker will build on current cloned repo "." and using the master branch by default
- APP_REPO and REF must both be set in order to maintain consistency on builds, as REF is applied to all 3 repos cloned (miq/appliance/ssui)
- An untar is launched *only* if a tarball (REF) is found on (APP_ROOT) after the clone/download layer

Example build Darga :

docker build -t miq:darga --build-arg APP_REPO=https://github.com/ManageIQ/manageiq/tarball/darga --build-arg REF=darga .