### PR TITLE
Spec for col_order for stock MiqReports

### DIFF
--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -24,4 +24,32 @@ describe 'YAML reports' do
       expect(report.table).to be_kind_of(Ruport::Data::Table)
     end
   end
+
+  it 'defines headers that match col_order' do
+    report_yamls.each do |yaml|
+      report_data = YAML.load(File.open(yaml))
+      col_order = report_data['col_order'].length
+      headers = report_data['headers'].length
+      expect(headers).to eq(col_order)
+    end
+  end
+
+  it 'defines correct (existing) col_order columns' do
+    report_yamls.each do |yaml|
+      report_data = YAML.load(File.open(yaml))
+      cols = report_data['cols'] + collect_columns(report_data['include'])
+      dangling = report_data['col_order'].reject do |col|
+        cols.include?(col) || %w(max avg).include?(col.split('__')[-1])
+      end
+      expect(dangling).to eq([])
+    end
+  end
+
+  def collect_columns(include_hash)
+    return [] if include_hash.nil?
+    include_hash.inject([]) do |cols, (table_name, data)|
+      cols += data["columns"].collect { |col_name| "#{table_name}.#{col_name}" } if data['columns']
+      cols + collect_columns(data['include'])
+    end
+  end
 end


### PR DESCRIPTION
Wip until #8657 and #8660 merged.

The upper mentioned bugs were discovered by this spec.

@miq-bot add_label wip, reporting