### PR TITLE
Don't double encode customdata when provisioning an Azure VM.

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -37,7 +37,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
   end
 
   def custom_data
-    Base64.encode64(userdata_payload.encode("UTF-8")).delete("\n")
+    userdata_payload.encode('UTF-8').delete("\n")
   end
 
   def prepare_for_clone_task


### PR DESCRIPTION
The userdata_payload used for init scripts for Azure (e.g. cloud init) is already Base64 encoded in cloud_manager/provision/configuration.rb. The net result was that the init scripts were getting double encoded and not running.

We may want to consider replacing encode64 with strict_encode64 in configuration.rb so we don't have to mess with newlines, but I don't know if that would negatively impact other providers, so I've left it alone for now. Something to think about for a separate PR.

Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1335895