### PR TITLE
Fix Optimize/planning report when vm options are inputed manually

### DIFF
--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -552,7 +552,7 @@ module VimPerformanceAnalysis
   end
 
   def self.calc_slope_from_data(recs, x_attr, y_attr)
-    recs.sort! { |a, b| a.send(x_attr) <=> b.send(x_attr) } if recs.first.respond_to?(x_attr)
+    recs = recs.sort { |a, b| a.send(x_attr) <=> b.send(x_attr) } if recs.first.respond_to?(x_attr)
 
     y_array, x_array = recs.inject([]) do |arr, r|
       arr[0] ||= []; arr[1] ||= []

--- a/spec/models/vim_performance_planning_spec.rb
+++ b/spec/models/vim_performance_planning_spec.rb
@@ -1,0 +1,31 @@
+describe VimPerformancePlanning do
+  context '.vm_how_many_more_can_fit' do
+    let!(:local) { EvmSpecHelper.local_miq_server }
+    let(:cluster) { FactoryGirl.create(:ems_cluster) }
+    let(:compute_host) { FactoryGirl.create(:host, :ems_cluster => cluster) }
+    let(:time_profile) { TimeProfile.seed }
+    let!(:metrics) do
+      FactoryGirl.create(:metric_rollup, :with_data,
+                         :resource => compute_host, :capture_interval_name => 'daily', :time_profile => time_profile)
+    end
+    let(:options) do
+      {:vm_options     => {:cpu     => {:value => nil, :mode => :manual},
+                           :vcpus   => {:value => nil, :mode => :manual},
+                           :memory  => {:value => 400, :mode => :manual},
+                           :storage => {:value => nil, :mode => :manual}},
+       :target_tags    => {:compute_type => :EmsCluster},
+       :target_options => {:memory => {:mode => :perf_trend, :metric => :max_derived_memory_used,
+                                      :limit_col => :derived_memory_available, :limit_pct => 90}},
+       :range          => {:days => 7, :end_date => Time.current},
+       :ext_options    => {:tz => 'UTC', :time_profile => time_profile}
+      }
+    end
+
+    it 'calculates optimize/planning info for manually entered options' do
+      perfs, opts = described_class.build_results_for_report_planning(options)
+      expect(perfs.length).to eq(1)
+      expect(perfs[0]).to be_kind_of(VimPerformancePlanning)
+      expect(opts).to eq(:vm_profile => {:cpu => nil, :vcpus => nil, :memory => '400 MB', :storage => nil})
+    end
+  end
+end


### PR DESCRIPTION
Do not sort! ActiveRecord_Relation, use sort instead

Fixes #8276.
```
Addressing: ERROR -- : [NoMethodError]: undefined method sort!' for #MetricRollup::ActiveRecord_Relation
app/models/vim_performance_analysis.rb:556:in `calc_slope_from_data'
app/models/vim_performance_analysis.rb:598:in `calc_trend_value_at_timestamp'
app/models/vim_performance_analysis.rb:393:in `measure_object'
app/models/vim_performance_analysis.rb:370:in `offers'
app/models/vim_performance_analysis.rb:156:in `block (2 levels) in vm_how_many_more_can_fit'
app/models/vim_performance_analysis.rb:150:in `each'
app/models/vim_performance_analysis.rb:150:in `block in vm_how_many_more_can_fit'
```
@miq-bot add_label but, reporting, wip

Wip until I come-up with a spec.