### PR TITLE
Gemfile - Changed the operator configured for the azure-armrest gem version

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -15,7 +15,7 @@ gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails
 # Not locally modified and not required
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.3",            :require => false
-gem "azure-armrest",           "~> 0.2.6"
+gem "azure-armrest",           "=0.2.6"
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false


### PR DESCRIPTION
This PR changes the gems/pending/Gemfile so we load a FIXED version of the azure-armrest gem instead of the latest version released on rubygems.org