### PR TITLE
Remove MiqExpression.evaluate Part Deux

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1007,8 +1007,8 @@ class MiqExpression
     Metric::Rollup.excluded_col_for_expression?(col.to_sym)
   end
 
-  def self.evaluate(expression, obj, tz = nil)
-    ruby_exp = expression.kind_of?(Hash) ? new(expression).to_ruby(tz) : expression.to_ruby(tz)
+  def evaluate(obj, tz = nil)
+    ruby_exp = to_ruby(tz)
     _log.debug("Expression before substitution: #{ruby_exp}")
     subst_expr = Condition.subst(ruby_exp, obj)
     _log.debug("Expression after substitution: #{subst_expr}")
@@ -1017,13 +1017,9 @@ class MiqExpression
     result
   end
 
-  def evaluate(obj, tz = nil)
-    self.class.evaluate(self, obj, tz)
-  end
-
   def self.evaluate_atoms(exp, obj)
     exp = exp.kind_of?(self) ? copy_hash(exp.exp) : exp
-    exp["result"] = evaluate(exp, obj)
+    exp["result"] = new(exp).evaluate(obj)
 
     operators = exp.keys
     operators.each do|k|

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,25 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dangerous Eval",
+      "warning_code": 13,
+      "fingerprint": "fc0b8f868d1623b918b9b8cbde69c330ebb229483744a3e5cf54e27ba504f2af",
+      "message": "User input in eval",
+      "file": "app/models/miq_expression.rb",
+      "line": 800,
+      "link": "http://brakemanscanner.org/docs/warning_types/dangerous_eval/",
+      "code": "eval(Condition.subst(to_ruby(tz), obj))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MiqExpression",
+        "method": "evaluate"
+      },
+      "user_input": "Condition.subst(to_ruby(tz), obj)",
+      "confidence": "High",
+      "note": ""
+    }
+  ],
+  "updated": "2016-05-13 11:16:37 -0400",
+  "brakeman_version": "3.1.5"
+}

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,6 +1,4 @@
 ---
-:rails3: true
-:rails4: true
 :safe_methods:
 - :j
 - :escape_javascript

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,5 +1,2 @@
 ---
-:safe_methods:
-- :j
-- :escape_javascript
 :table_width: 400

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -2094,4 +2094,16 @@ describe MiqExpression do
       expect(obj.evaluate(@data_hash)).to eq(false)
     end
   end
+
+  describe ".evaluate_atoms" do
+    it "adds mapping 'result'=>false to expression if expression evaluates to false on supplied object" do
+      expression = {">=" => {"field" => "Vm-num_cpu",
+                             "value" => "2"}}
+      result = described_class.evaluate_atoms(expression, FactoryGirl.build(:vm))
+      expect(result).to include(
+        ">="     => {"field" => "Vm-num_cpu",
+                     "value" => "2"},
+        "result" => false)
+    end
+  end
 end


### PR DESCRIPTION
Updates the Brakeman config and adds a fingerprinted ignore for the eval in question, reverts the revert.

@miq-bot add_labels core, darga/no