### PR TITLE
Force CSS and JS compression in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,4 +74,7 @@ Vmdb::Application.configure do
   config.action_controller.include_all_helpers = false
 
   config.action_controller.allow_forgery_protection = true
+
+  config.assets.js_compressor = :uglifier
+  config.assets.css_compressor = :sass
 end


### PR DESCRIPTION
Enabling the minification will kick in uglifier's default settings for ASCII conversion in JS files.
https://github.com/lautis/uglifier/blob/a2a24cc93c3cd40c31bf9f23cc439222311c6631/lib/uglifier.rb#L26

https://bugzilla.redhat.com/show_bug.cgi?id=1333612