### PR TITLE
Ensure schema consistency when configuring replication

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -137,7 +137,7 @@ class EvmDatabase
         next if compare_schema[table] == expected_columns
 
         errors << <<-ERROR.gsub!(/^ +/, "")
-          Schema validation failed:
+          Schema validation failed for host #{db_connection_host(connection)}:
 
           Columns for table #{table} in the current schema do not match the columns listed in #{SCHEMA_FILE}
 
@@ -161,14 +161,14 @@ class EvmDatabase
       diff_in_expected = expected_tables - current_tables
       if diff_in_current.empty? && diff_in_expected.empty?
         <<-ERROR.gsub!(/^ +/, "")
-          Schema validation failed:
+          Schema validation failed for host #{db_connection_host(connection)}:
 
           Expected schema table order does not match sorted current tables.
           Use 'rake evm:db:write_schema' to generate the new expected schema when making changes.
         ERROR
       else
         <<-ERROR.gsub!(/^ +/, "")
-          Schema validation failed:
+          Schema validation failed for host #{db_connection_host(connection)}:
 
           Current schema tables do not match expected
 
@@ -176,6 +176,10 @@ class EvmDatabase
           Missing tables in current schema: #{diff_in_expected}
         ERROR
       end
+    end
+
+    def db_connection_host(connection)
+      connection.raw_connection.conninfo_hash[:host] || "localhost"
     end
   end
 end

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -32,7 +32,7 @@ describe EvmDatabase do
 
   context "schema checking" do
     def stub_test_database(db_hash)
-      conn = double(:connection)
+      conn = double(:connection, :raw_connection => double(:raw_conn, :conninfo_hash => {:host => "192.168.1.2"}))
       allow(conn).to receive(:tables).and_return(db_hash.keys)
       db_hash.each do |table, col_names|
         col_objs = col_names.map { |c| double(:name => c) }
@@ -84,7 +84,7 @@ describe EvmDatabase do
           conn = stub_test_database(current_db)
           stub_expected_schema(expected_db)
 
-          expect(subject.check_schema(conn)).to match(/Schema validation failed:.*/)
+          expect(subject.check_schema(conn)).to match(/Schema validation failed for host 192\.168\.1\.2:\.*/)
         end
 
         it "an extra table is in the schema" do
@@ -97,7 +97,7 @@ describe EvmDatabase do
           conn = stub_test_database(current_db)
           stub_expected_schema(expected_db)
 
-          expect(subject.check_schema(conn)).to match(/Schema validation failed:.*/)
+          expect(subject.check_schema(conn)).to match(/Schema validation failed for host 192\.168\.1\.2:.*/)
         end
 
         it "the expected tables are out of order" do
@@ -114,7 +114,7 @@ describe EvmDatabase do
           conn = stub_test_database(current_db)
           stub_expected_schema(expected_db)
 
-          expect(subject.check_schema(conn)).to match(/Schema validation failed:.*/)
+          expect(subject.check_schema(conn)).to match(/Schema validation failed for host 192\.168\.1\.2:.*/)
         end
 
         it "the columns in a table are out of order" do
@@ -131,7 +131,7 @@ describe EvmDatabase do
           conn = stub_test_database(current_db)
           stub_expected_schema(expected_db)
 
-          expect(subject.check_schema(conn)).to match(/Schema validation failed:.*/)
+          expect(subject.check_schema(conn)).to match(/Schema validation failed for host 192\.168\.1\.2:.*/)
         end
 
         it "a table has an extra column" do
@@ -148,7 +148,7 @@ describe EvmDatabase do
           conn = stub_test_database(current_db)
           stub_expected_schema(expected_db)
 
-          expect(subject.check_schema(conn)).to match(/Schema validation failed:.*/)
+          expect(subject.check_schema(conn)).to match(/Schema validation failed for host 192\.168\.1\.2:.*/)
         end
 
         it "a table is missing a column" do
@@ -165,7 +165,7 @@ describe EvmDatabase do
           conn = stub_test_database(current_db)
           stub_expected_schema(expected_db)
 
-          expect(subject.check_schema(conn)).to match(/Schema validation failed:.*/)
+          expect(subject.check_schema(conn)).to match(/Schema validation failed for host 192\.168\.1\.2:.*/)
         end
       end
     end


### PR DESCRIPTION
Before this change we would attempt to subscribe to any database that we were pointed at if we could connect to it

If the local and remote databases had different schemas we would likely fail to complete the data sync as in https://bugzilla.redhat.com/show_bug.cgi?id=1331114

This change will check both the local and remote databases against schema.yml file before attempting to save the subscription and will raise an exception if either does not match