### PR TITLE
Simplify atStartups by removing uncalled or unused code

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -35,9 +35,6 @@ class MiqWorker < ApplicationRecord
   def self.atStartup
     # Delete and Kill all workers that were running previously
     clean_all_workers
-
-    # Clean queue of any worker startup entries
-    MiqQueue.where(:method_name => "start_event_monitor", :server_guid => MiqServer.my_guid).destroy_all
   end
 
   def self.atShutdown

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -7,12 +7,6 @@ class Picture < ApplicationRecord
   DEFAULT_DIRECTORY = File.join(URL_ROOT, "pictures")
   Dir.mkdir(DEFAULT_DIRECTORY) unless File.directory?(DEFAULT_DIRECTORY)
 
-  def self.atStartup
-    require 'fileutils'
-    pattern = File.join(directory, "*")
-    FileUtils.rm Dir.glob(pattern)
-  end
-
   def self.directory
     @directory || DEFAULT_DIRECTORY
   end


### PR DESCRIPTION
* MiqQueue's `@@delete_command_file` was used to delete rows at startup based on a YAML dumped hash of find options.  I believe this is completely unused.

* start_event_monitor does not go through the queue so don't worry about purging it

* Picture.atStartup is never called

More details in each commit message.