### PR TITLE
Remove useless exception handling

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -353,6 +353,8 @@ class MiqServer < ApplicationRecord
     Benchmark.realtime_block(:worker_monitor)          { monitor_workers }                  if threshold_exceeded?(:worker_monitor_frequency, now)
     Benchmark.realtime_block(:worker_dequeue)          { populate_queue_messages }          if threshold_exceeded?(:worker_dequeue_frequency, now)
   rescue SystemExit
+    # TODO: We're rescuing Exception below. WHY? :bomb:
+    # A SystemExit would be caught below, so we need to explicitly rescue/raise.
     raise
   rescue Exception => err
     _log.error("#{err.message}")

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -381,8 +381,6 @@ class MiqServer < ApplicationRecord
 
     shutdown_and_exit_queue
     wait_for_stopped if sync
-  rescue Exception => err
-    _log.error "#{err}"
   end
 
   def wait_for_stopped
@@ -409,8 +407,6 @@ class MiqServer < ApplicationRecord
     (pid == Process.pid) ? shutdown_and_exit : Process.kill(9, pid)
   rescue SystemExit
     raise
-  rescue Exception => err
-    _log.error "#{err}"
   end
 
   def self.kill

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -121,10 +121,6 @@ class MiqServer < ApplicationRecord
   def start
     begin
       MiqEvent.raise_evm_event(self, "evm_server_start")
-    rescue MiqException::PolicyPreventAction => err
-      _log.warn "#{err}"
-      # TODO: Need to decide what to do here. Should the cluster be stopped?
-      return
     rescue Exception => err
       _log.error "#{err}"
     end
@@ -431,9 +427,6 @@ class MiqServer < ApplicationRecord
     _log.info("initiated for #{format_full_log_msg}")
     begin
       MiqEvent.raise_evm_event(self, "evm_server_stop")
-    rescue MiqException::PolicyPreventAction => err
-      _log.warn "#{err}"
-      return
     rescue Exception => err
       _log.error "#{err}"
     end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -405,8 +405,6 @@ class MiqServer < ApplicationRecord
     _log.info("initiated for #{format_full_log_msg}")
     update_attributes(:stopped_on => Time.now.utc, :status => "killed", :is_master => false)
     (pid == Process.pid) ? shutdown_and_exit : Process.kill(9, pid)
-  rescue SystemExit
-    raise
   end
 
   def self.kill

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -448,14 +448,9 @@ class MiqServer < ApplicationRecord
 
   def quiesce
     update_attribute(:status, 'quiesce')
-    begin
-      deactivate_all_roles
-      quiesce_all_workers
-      update_attributes(:stopped_on => Time.now.utc, :status => "stopped", :is_master => false)
-    rescue => err
-      puts "#{err}"
-      puts "#{err.backtrace.join("\n")}"
-    end
+    deactivate_all_roles
+    quiesce_all_workers
+    update_attributes(:stopped_on => Time.now.utc, :status => "stopped", :is_master => false)
   end
 
   # Restart the local server

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -119,11 +119,7 @@ class MiqServer < ApplicationRecord
   end
 
   def start
-    begin
-      MiqEvent.raise_evm_event(self, "evm_server_start")
-    rescue Exception => err
-      _log.error "#{err}"
-    end
+    MiqEvent.raise_evm_event(self, "evm_server_start")
 
     msg = "Server starting in #{self.class.startup_mode} mode."
     _log.info("#{msg}")
@@ -425,11 +421,7 @@ class MiqServer < ApplicationRecord
 
   def shutdown
     _log.info("initiated for #{format_full_log_msg}")
-    begin
-      MiqEvent.raise_evm_event(self, "evm_server_stop")
-    rescue Exception => err
-      _log.error "#{err}"
-    end
+    MiqEvent.raise_evm_event(self, "evm_server_stop")
 
     quiesce
   end


### PR DESCRIPTION
These are all useless rescue handlers.
* raise_evm_event doesn't raise
* policies aren't written to deny server stop/start
* it's pointless to rescue and re-raise what was just rescued (don't rescue in the first place)
* stop/kill don't raise and swallowing an unlikely exception is not how it should be handled