### PR TITLE
evm.pid / process existence is the safe way to ask if we're running?

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -115,7 +115,7 @@ class MiqServer < ApplicationRecord
 
   def self.running?
     p = PidFile.new(pidfile)
-    p.running?(/evm_server\.rb/) ? p.pid : false
+    p.running? ? p.pid : false
   end
 
   def start

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -384,6 +384,15 @@ describe MiqServer do
     end
   end
 
+  it "detects already .running?" do
+    Tempfile.open("evmpid") do |file|
+      allow(MiqServer).to receive(:pidfile).and_return(file.path)
+      File.write(file.path, Process.pid)
+
+      expect(MiqServer.running?).to be_truthy
+    end
+  end
+
   describe "#active?" do
     context "Active status returns true" do
       ["starting", "started"].each do |status|


### PR DESCRIPTION
When we changed the process title using setproctitle to "MIQ Server", we broke
rake evm:start's detection of a previously running server.

While a process title/command line is somewhat helpful to check, only the server
should be writing to evm.pid so checking for a process from evm.pid is enough.