### PR TITLE
Fix container image condition creation

### DIFF
--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -168,7 +168,7 @@ module MiqPolicyController::Conditions
     if params[:id] && params[:typ] != "new"   # If editing existing condition, grab model
       @edit[:new][:towhat] = Condition.find(params[:id]).towhat
     else
-      @edit[:new][:towhat] = x_active_tree == :condition_tree ? @sb[:folder].titleize : MiqPolicy.find(from_cid(@sb[:node_ids][x_active_tree]["p"])).towhat
+      @edit[:new][:towhat] = x_active_tree == :condition_tree ? @sb[:folder].camelize : MiqPolicy.find(from_cid(@sb[:node_ids][x_active_tree]["p"])).towhat
     end
 
     @edit[:condition_id] = @condition.id


### PR DESCRIPTION
Bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1335095

With the fix:
![33](https://cloud.githubusercontent.com/assets/3010449/15274359/52fbaa6a-1ab8-11e6-957b-7f09e1cc7fd6.png)

Without this fix clicking "Add a new container image condition" results in the following error in the development.log:
```
[----] F, [2016-05-15T16:00:31.538622 #23231:18122d8] FATAL -- : Error caught: [NoMethodError] undefined method `name' for nil:NilClass
/home/mtayer/dev/manageiq/app/models/miq_expression.rb:1507:in `build_relats'
/home/mtayer/dev/manageiq/app/models/miq_expression.rb:1462:in `get_relats'
/home/mtayer/dev/manageiq/app/models/miq_expression.rb:1412:in `model_details'
/home/mtayer/dev/manageiq/app/models/miq_expression.rb:1481:in `miq_adv_search_lists'
/home/mtayer/dev/manageiq/app/views/layouts/exp_atom/_editor.html.haml:18:in `_app_views_layouts_exp_atom__editor_html_haml___2299849131716157625_162909240'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:158:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:166:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:348:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:156:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:21:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/helpers/rendering_helper.rb:32:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/haml-4.0.7/lib/haml/helpers/action_view_mods.rb:12:in `render_with_haml'
/home/mtayer/dev/manageiq/app/views/layouts/_exp_editor.html.haml:108:in `_app_views_layouts__exp_editor_html_haml__2427074717694821011_178972540'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:158:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:166:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:348:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:156:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:21:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/helpers/rendering_helper.rb:32:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/haml-4.0.7/lib/haml/helpers/action_view_mods.rb:12:in `render_with_haml'
/home/mtayer/dev/manageiq/app/views/miq_policy/_form_expression.html.haml:4:in `_app_views_miq_policy__form_expression_html_haml__4089499642944846784_180126360'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:158:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:166:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:348:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:156:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:21:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/helpers/rendering_helper.rb:32:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/haml-4.0.7/lib/haml/helpers/action_view_mods.rb:12:in `render_with_haml'
/home/mtayer/dev/manageiq/app/views/miq_policy/_condition_details.html.haml:44:in `_app_views_miq_policy__condition_details_html_haml___105351359056668147_179606680'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:158:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:166:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:348:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/template.rb:156:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:343:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:311:in `block in render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/partial_renderer.rb:310:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/renderer/renderer.rb:21:in `render'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/rendering.rb:103:in `_render_template'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/streaming.rb:217:in `_render_template'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/rendering.rb:83:in `render_to_body'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/renderers.rb:144:in `render_to_body'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/abstract_controller/rendering.rb:48:in `render_to_string'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/rendering.rb:41:in `render_to_string'
/home/mtayer/dev/manageiq/app/controllers/miq_policy_controller.rb:552:in `block in replace_right_cell'
/home/mtayer/dev/manageiq/app/controllers/miq_policy_controller.rb:669:in `[]'
/home/mtayer/dev/manageiq/app/controllers/miq_policy_controller.rb:669:in `replace_right_cell'
/home/mtayer/dev/manageiq/app/controllers/miq_policy_controller/conditions.rb:29:in `condition_edit'
/home/mtayer/dev/manageiq/app/controllers/miq_policy_controller.rb:136:in `x_button'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/abstract_controller/base.rb:181:in `process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/rendering.rb:30:in `process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:126:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:126:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:455:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:455:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:90:in `run_callbacks'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/abstract_controller/callbacks.rb:19:in `process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/rescue.rb:31:in `process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `block in instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/notifications.rb:164:in `instrument'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activerecord/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/abstract_controller/base.rb:126:in `process'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/rendering.rb:30:in `process'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal.rb:190:in `dispatch'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_controller/metal.rb:262:in `dispatch'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/routing/route_set.rb:32:in `serve'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/journey/router.rb:39:in `block in serve'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/journey/router.rb:26:in `each'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/journey/router.rb:26:in `serve'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/routing/route_set.rb:725:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/omniauth-1.3.1/lib/omniauth/strategy.rb:186:in `call!'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/omniauth-1.3.1/lib/omniauth/strategy.rb:164:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/omniauth-1.3.1/lib/omniauth/builder.rb:63:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/secure_headers-3.0.3/lib/secure_headers/middleware.rb:10:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionview/lib/action_view/digestor.rb:12:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/etag.rb:25:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/conditional_get.rb:38:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/head.rb:12:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/session/abstract/id.rb:222:in `context'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/session/abstract/id.rb:216:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/cookies.rb:613:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/callbacks.rb:38:in `block in call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:750:in `_run_call_callbacks'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/callbacks.rb:90:in `run_callbacks'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/callbacks.rb:36:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/executor.rb:12:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:49:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/railties/lib/rails/rack/logger.rb:36:in `call_app'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/railties/lib/rails/rack/logger.rb:26:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/request_store-1.3.1/lib/request_store/middleware.rb:9:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/request_id.rb:24:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/method_override.rb:22:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/runtime.rb:22:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/executor.rb:12:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/actionpack/lib/action_dispatch/middleware/static.rb:136:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/rack-2.0.0.rc1/lib/rack/sendfile.rb:111:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/bundler/gems/rails-0037ee72a58c/railties/lib/rails/engine.rb:522:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/puma-3.3.0/lib/puma/configuration.rb:224:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/puma-3.3.0/lib/puma/server.rb:561:in `handle_request'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/puma-3.3.0/lib/puma/server.rb:406:in `process_client'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/puma-3.3.0/lib/puma/server.rb:271:in `block in run'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/puma-3.3.0/lib/puma/thread_pool.rb:111:in `call'
/home/mtayer/.rvm/gems/ruby-2.2.2/gems/puma-3.3.0/lib/puma/thread_pool.rb:111:in `block in spawn_thread'
```