### PR TITLE
Copies of read_only policies should not be read only

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -101,7 +101,7 @@ module MiqPolicyController::Policies
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     else
-      new_pol = policy.copy(:description => new_desc, :created_by => session[:userid])
+      new_pol = policy.copy(:description => new_desc, :created_by => session[:userid], :read_only => nil)
       AuditEvent.success(:event        => "miqpolicy_copy",
                          :target_id    => new_pol.id,
                          :target_class => "MiqPolicy",


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/ManageIQ/manageiq/pull/7966#issuecomment-217520925

![34](https://cloud.githubusercontent.com/assets/3010449/15274470/f43e2360-1aba-11e6-8589-1b5ac9418cab.png)
