### PR TITLE
Fix Container Builds Grid View

### DIFF
--- a/app/controllers/container_build_controller.rb
+++ b/app/controllers/container_build_controller.rb
@@ -7,7 +7,6 @@ class ContainerBuildController < ApplicationController
   after_action :set_session_data
 
   def show_list
-    @listicon = "container_build"
     process_show_list
   end
 

--- a/spec/controllers/container_build_controller_spec.rb
+++ b/spec/controllers/container_build_controller_spec.rb
@@ -36,4 +36,27 @@ describe ContainerBuildController do
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
   end
+
+  it "renders grid view" do
+    EvmSpecHelper.create_guid_miq_server_zone
+    ems = FactoryGirl.create(:ems_openshift)
+    container_build = ContainerBuild.create(:ext_management_system => ems, :name => "Test Build")
+
+    session[:settings] = {
+      :views => {:containerbuild => "grid"}
+    }
+
+    post :show_list, :params => {:controller => 'container_build', :id => container_build.id}
+    expect(response).to render_template('layouts/gtl/_grid')
+    expect(response.status).to eq(200)
+  end
+
+  it "Controller method is called with correct parameters" do
+    controller.params[:type] = "tile"
+    controller.instance_variable_set(:@settings, :views => {:containerbuild => "list"})
+    expect(controller).to receive(:get_view_calculate_gtl_type).with(:containerbuild) do
+      expect(controller.instance_variable_get(:@settings)).to include(:views => {:containerbuild => "tile"})
+    end
+    controller.send(:get_view, "ContainerBuild", :gtl_dbname => :containerbuild)
+  end
 end


### PR DESCRIPTION
Fixes: UI crashed on displaying Container Builds in a grid (or a tile) view.
Bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1335220
cc @enoodle @simon3z 

![grid_build](https://cloud.githubusercontent.com/assets/11769555/15275238/a5a5780c-1ace-11e6-86d5-af231ba4ec0c.png)