### PR TITLE
Rbac: klass always implements find

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -448,12 +448,7 @@ module Rbac
 
     _log.debug("Find options: #{find_options.inspect}")
 
-    if klass.respond_to?(:find)
-      targets, total_count, auth_count = find_targets_with_rbac(klass, scope, user_filters, find_options, user, miq_group)
-    else
-      total_count = targets.length
-      auth_count  = targets.length
-    end
+    targets, total_count, auth_count = find_targets_with_rbac(klass, scope, user_filters, find_options, user, miq_group)
 
     if search_filter && targets && (!exp_attrs || !exp_attrs[:supported_by_sql])
       rejects     = targets.reject { |obj| self.matches_search_filters?(obj, search_filter, tz) }


### PR DESCRIPTION
`ActiveRecord::Base` and `ActsAsActiveRecord` implement find

If that is not the case, then rbac only filters (shouldn't even call)

---

I haven't found any callers that would call with a `:class` that does not respond to `find`
Probably more relevant, couldn't find a model in an array passed in to `Rbac` that is just an object (not `AAAR` or `AR::Base`.