### PR TITLE
Fix Openstack Vm resize is not completed without refresh

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -61,7 +61,7 @@ class VmCloudController < ApplicationController
         begin
           old_flavor = @record.flavor
           @record.resize(flavor)
-          add_flash(_("Reconfiguring %{instance} \"%{name}\" from %{old_flavor} %{new_flavor}") % {
+          add_flash(_("Reconfiguring %{instance} \"%{name}\" from %{old_flavor} to %{new_flavor}") % {
             :instance   => ui_lookup(:table => 'vm_cloud'),
             :name       => @record.name,
             :old_flavor => old_flavor.name,

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
@@ -11,7 +11,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
       service.resize_server(ems_ref, new_flavor.ems_ref)
     end
     MiqQueue.put(:class_name  => self.class.name,
-                 :expires_on  => Time.now.utc + 4.hours,
+                 :expires_on  => Time.now.utc + 2.hours,
                  :instance_id => id,
                  :method_name => "raw_resize_finish")
   rescue => err
@@ -33,7 +33,8 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
   end
 
   def raw_resize_finish
-    raise MiqException::MiqQueueRetryLater.new(:deliver_on => Time.now.utc + 2.minutes) unless validate_resize_confirm
+    refresh_ems
+    raise MiqException::MiqQueueRetryLater.new(:deliver_on => Time.now.utc + 1.minute) unless validate_resize_confirm
     raw_resize_confirm
   end
 


### PR DESCRIPTION
Openstack Cloud Vm resize was not completed or took too long (hours).

Added Vm refresh into raw_resize_finish method to run method with (almost) up-to-date instance state.

Tiny typo fixed in resize flash message.

Issue #8720