### PR TITLE
Render nice validation flash messages for configuration providers

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -214,11 +214,15 @@ class ProviderForemanController < ApplicationController
     begin
       @provider_cfgmgmt.verify_credentials(params[:type])
     rescue StandardError => bang
-      add_flash(bang.to_s, :error)
+      error = if bang.kind_of?(Faraday::Error::ClientError) # ansible uses faraday and returns a json as a response
+                JSON.parse(bang.to_s)['detail']
+              else
+                bang.to_s
+              end
+      render_flash(_("Credential validation was not successful: %{details}") % {:details => error}, :error)
     else
-      add_flash(_("Credential validation was successful"))
+      render_flash(_("Credential validation was successful"))
     end
-    render_flash
   end
 
   def show(id = nil)


### PR DESCRIPTION
Ansible uses faraday client and returns a json response.

Before:
![flash-before](https://cloud.githubusercontent.com/assets/6648365/15288317/014ca874-1b6a-11e6-9249-2c654ca5c38b.jpg)

After:
![flash-after](https://cloud.githubusercontent.com/assets/6648365/15288319/07c7f47e-1b6a-11e6-97cb-438e0b909253.jpg)
