### PR TITLE
Pin actionpack to edge Rails 5

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -8,6 +8,7 @@ gem "rake",          "~>10.1"
 gem "iniparse"
 
 gem "activesupport",           "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
+gem "actionpack",              "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
 
 # ActiveRecord is used by appliance_console
 gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"


### PR DESCRIPTION
With https://github.com/rails/rails/commit/6b543166f7b0fd5712ffe831dad31d34f6de5dcd, we need to run bleeding edge actionpack and not just the latest release candidate.

Fixes CI errors of `undefined method 'index_of_handler_for_rescue'` (part of the old API)