### PR TITLE
Use decorators for icon names in conf. provider objects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -989,7 +989,7 @@ class ApplicationController < ActionController::Base
               item.decorate.try(:listicon_image) if item.decorator_class?
             end
 
-    list_row_image(image || default, item)
+    image || default
   end
 
   def get_host_for_vm(vm)
@@ -2392,10 +2392,6 @@ class ApplicationController < ActionController::Base
 
   def list_row_id(row)
     to_cid(row['id'])
-  end
-
-  def list_row_image(image, _item)
-    image
   end
 
   def render_flash_not_applicable_to_model(type, model_type = "items")

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -597,7 +597,6 @@ class ProviderForemanController < ApplicationController
 
   def configured_system_list(id, model)
     return configured_system_node(id, model) if id
-    @listicon = "configured_system"
     if x_active_tree == :cs_filter_tree
       options = {:model => model.to_s}
       @right_cell_text = _("All %{title} Configured Systems") % {:title => model_to_name(model)}
@@ -946,15 +945,6 @@ class ProviderForemanController < ApplicationController
       TreeBuilder.get_prefix_for_model(row[:type]).to_s % to_cid(row['id'])
     else
       to_cid(row['id'])
-    end
-  end
-
-  def list_row_image(_image, item = nil)
-    # Unassigned Profiles Group
-    if item.kind_of?(ConfigurationProfile) && empty_configuration_profile_record?(item)
-      'folder'
-    else
-      super
     end
   end
 

--- a/app/decorators/configuration_profile_decorator.rb
+++ b/app/decorators/configuration_profile_decorator.rb
@@ -1,0 +1,15 @@
+class ConfigurationProfileDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    if id.nil?
+      "100/folder.png"
+    else
+      "100/#{image_name.downcase}.png"
+    end
+  end
+end

--- a/app/decorators/configured_system_decorator.rb
+++ b/app/decorators/configured_system_decorator.rb
@@ -1,0 +1,11 @@
+class ConfiguredSystemDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/#{image_name.downcase}.png"
+  end
+end

--- a/app/decorators/manageiq/providers/configuration_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/configuration_manager_decorator.rb
@@ -1,0 +1,13 @@
+module ManageIQ::Providers
+  class ConfigurationManagerDecorator < Draper::Decorator
+    delegate_all
+
+    def fonticon
+      nil
+    end
+
+    def listicon_image
+      "100/vendor-#{image_name.downcase}.png"
+    end
+  end
+end

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -72,4 +72,8 @@ class ConfigurationProfile < ApplicationRecord
   def total_configured_systems
     Rbac.filtered(configured_systems, :match_via_descendants => ConfiguredSystem).count
   end
+
+  def image_name
+    "configuration_profile"
+  end
 end

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -86,4 +86,8 @@ class ConfiguredSystem < ApplicationRecord
     hosts = includes(:configuration_location, :configuration_organization).where(:id => ids)
     hosts.collect(&:available_configuration_profiles).inject(:&).presence
   end
+
+  def image_name
+    "configured_system"
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager.rb
@@ -24,6 +24,10 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager < ManageIQ::Provid
     @description ||= "Ansible Tower Configuration".freeze
   end
 
+  def image_name
+    "ansible_tower_configuration"
+  end
+
   private
 
   def connection_source(options = {})

--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -23,4 +23,8 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
   def self.description
     @description ||= "Foreman Configuration".freeze
   end
+
+  def image_name
+    "foreman_configuration"
+  end
 end

--- a/app/views/layouts/quadicon/_single_quad.html.haml
+++ b/app/views/layouts/quadicon/_single_quad.html.haml
@@ -1,21 +1,17 @@
 - if @listicon.nil?
   - if item.kind_of?(MiqCimInstance)
     - if item.kind_of?(CimStorageExtent)
-      - img = "cim_base_storage_extent"
+      - img_path = image_path("100/cim_base_storage_extent.png")
     - else
-      - img = item.class.to_s.underscore
-  - elsif item.kind_of?(ManageIQ::Providers::Foreman::ConfigurationManager) || item.kind_of?(ManageIQ::Providers::AnsibleTower::ConfigurationManager)
-    - img = "vendor-#{item.image_name}"
-  - elsif item.kind_of?(ConfigurationProfile)
-    - img = controller.send(:list_row_image, item.class.base_class.to_s.underscore, item)
+      - img_path = image_path("100/#{item.class.to_s.underscore}.png")
   - elsif item.decorator_class?
-    - img = item.decorate.try(:fonticon) || item.decorate.try(:listicon_image)
+    - img_path = image_path(item.decorate.try(:fonticon) || item.decorate.try(:listicon_image))
   - else
-    - img = item.class.base_class.to_s.underscore
+    - img_path = image_path("100/#{item.class.base_class.to_s.underscore}.png")
   .flobj
     %img{:src => image_path("#{size}/base-single.png"), :width => size, :height => size, :border => 0}
   .flobj{:class => "e#{size}"}
-    %img{:src => image_path("100/#{img}.png"), :border => 0}
+    %img{:src => img_path, :border => 0}
 
   - unless typ == :listnav
     -# Listnav, no clear image needed


### PR DESCRIPTION
This would allow us to get rid of `if(ModelName) ...` switches in views and controllers.

Also, it will fix some errors occuring when switching between GTL views.

https://bugzilla.redhat.com/show_bug.cgi?id=1330288

@himdel :-)