### PR TITLE
Assign attributes to endpoint instead of update

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -632,9 +632,8 @@ class ExtManagementSystem < ApplicationRecord
   def build_endpoint_by_role(options)
     return if options.blank?
     endpoint = endpoints.detect { |e| e.role == options[:role].to_s }
-    # update or create
     if endpoint
-      endpoint.update(options)
+      endpoint.assign_attributes(options)
     else
       endpoints.build(options)
     end


### PR DESCRIPTION
Given that for create we do build, for update we should do
assign_attributes of the endpoints. Otherwise endpoint is being
saved e.g. as part of validate action.

A correct way is, that the endpoint is being saved by autosave,
when we invoke saving of the parent EMS.