### PR TITLE
ssa: always pull image-inspector's image

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -308,6 +308,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
           {
             :name            => "image-inspector",
             :image           => inspector_image,
+            :imagePullPolicy => "Always",
             :command         => [
               "/usr/bin/image-inspector",
               "--chroot",
@@ -353,6 +354,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def inspector_image
-    'docker.io/openshift/image-inspector:v2.0.z'
+    'docker.io/openshift/image-inspector:2.0'
   end
 end


### PR DESCRIPTION
This will force OpenShift to pull the image of image-inspector every time to check if there is an updated image.

Also bumping / changing image-inspector's image to 2.0 (Always pull will allow for rolling updates more easily)

reference: http://kubernetes.io/docs/user-guide/images/
code: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/container/image_puller.go#L57