### PR TITLE
Schedule job & pod cleanup on unexpected exceptions

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -66,6 +66,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     end
 
     queue_signal(:pod_wait)
+  rescue
+    queue_abort("unexpected exception, see log")
+    raise
   end
 
   def pod_wait
@@ -103,6 +106,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     end
 
     queue_signal(:analyze)
+  rescue
+    queue_abort("unexpected exception, see log")
+    raise
   end
 
   def analyze
@@ -133,6 +139,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
                         "taskid" => jobid,
                         "host"   => MiqServer.my_server,
                         "args"   => [YAML.dump(scan_args)])
+  rescue
+    queue_abort("unexpected exception, see log")
+    raise
   end
 
   def collect_compliance_data(image)
@@ -350,6 +359,11 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     pod_def[:spec][:volumes].append(
       :name   => "inspector-admin-secret",
       :secret => {:secretName => inspector_admin_secret_name})
+  end
+
+  def queue_abort(error_msg)
+    _log.error(error_msg)
+    queue_signal(:abort_job, error_msg, "error")
   end
 
   def inspector_image


### PR DESCRIPTION
Proposed change:
- ```queue_abort(error_msg)``` is a new method that logs an error and schedules a cleanup
- for each method that represents a state, if there is an unexpected exception we call ```queue_abort("unexpected exception, see log")``` and raise the exception
- as a result unexpected exceptions will cause a job with a failed state and a generic error message
