### PR TITLE
[WIP] Remove OwnershipMixin from ServiceTemplate model

### DIFF
--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -9,7 +9,6 @@ module ServiceMixin
     serialize  :options, Hash
 
     include UuidMixin
-    include OwnershipMixin
     include ReportableMixin
     acts_as_miq_taggable
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -29,6 +29,7 @@ module Rbac
     ResourcePool
     SecurityGroup
     Service
+    ServiceTemplate
     Storage
     VmOrTemplate
   )

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -1,7 +1,6 @@
 class ServiceTemplate < ApplicationRecord
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
   include ServiceMixin
-  include OwnershipMixin
   include NewWithTypeStiMixin
   include TenancyMixin
   include_concern 'Filter'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1335640

- we have no set ownership screen in UI and self_service user behaviour was applied on ServiceTemplate model
- add back ServiceTemplate to direct RBAC
- now we can use tenant's ancestor strategy independently if self_service user is logged or not.