### PR TITLE
Initialize select-picker for performance options

### DIFF
--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -7,6 +7,8 @@
       %dt
         = _("Interval")
       %dd
+        :javascript
+           miqInitSelectPicker();
         - if @perf_options[:index] && %w(host vm).include?(request.parameters["controller"])
           - rt_chart = YAML.load(File.open("#{CHARTS_LAYOUTS_FOLDER}/realtime_perf_charts/#{@perf_options[:model]}.yaml"))
           - @rt_hide = rt_chart[@perf_options[:index].to_i][:type] == "None"
@@ -19,7 +21,6 @@
                         "data-miq_sparkle_on" => true,
                         :class    => "selectpicker")
           :javascript
-             miqInitSelectPicker();
              miqSelectPickerEvent("perf_typ", "#{url}")
         - else
           = select_tag("perf_typ",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1336182

In PR #8316 `miqSelectPickerEvent` was introduced without adding `miqInitSelectPicker` for the majority of the cases.

One for all breaking the Hourly/Daily select picker for the majority of the pages (else case):

```ruby
- elsif %(Host VmOrTemplate ContainerNode Container ContainerGroup MiddlewareServer).include?(@perf_options[:model]) && !@rt_hide
  ...
- else
  = select_tag("perf_typ",
                options_for_select(%w(Hourly Daily), @perf_options[:typ]),
                 "data-miq_sparkle_on" => true,
                 :class    => "selectpicker")
  :javascript
     # MISSING: miqInitSelectPicker();
     miqSelectPickerEvent("perf_typ", "#{url}")
```

As you see the Select Picker for **Interval** is missing:

![screenshot from 2016-05-17 11-06-24](https://cloud.githubusercontent.com/assets/130393/15316926/78f5e132-1c1f-11e6-996a-e226c5c38a5e.png)

I can only verify that the fix in this PR is fixing the container pages:

![screenshot from 2016-05-17 11-05-00](https://cloud.githubusercontent.com/assets/130393/15316945/92f68faa-1c1f-11e6-8cdb-1942f0957f1e.png)

I am not sure if now there are redundant `miqInitSelectPicker` calls.

@PanSpagetka @dclarizio @h-kataria please review the other cases.