### PR TITLE
Show container image policies and container image conditions in respective tables

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -969,7 +969,7 @@ class MiqPolicyController < ApplicationController
         @right_cell_div = "policy_list"
       end
     elsif x_active_tree == :condition_tree
-      @conditions = Condition.where(:towhat => @sb[:folder].titleize).sort_by { |c| c.description.downcase }
+      @conditions = Condition.where(:towhat => @sb[:folder].camelize).sort_by { |c| c.description.downcase }
       set_search_text
       @conditions = apply_search_filter(@search_text, @conditions) unless @search_text.blank?
       @right_cell_text = _("All %{typ} Conditions") % {:typ => ui_lookup(:model => @sb[:folder])}

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -162,7 +162,7 @@ module MiqPolicyController::Policies
   end
 
   def policy_get_all
-    peca_get_all('policy', -> { get_view(MiqPolicy, :conditions => ["mode = ? and towhat = ?", @sb[:mode].downcase, @sb[:nodeid].titleize]) })
+    peca_get_all('policy', -> { get_view(MiqPolicy, :conditions => ["mode = ? and towhat = ?", @sb[:mode].downcase, @sb[:nodeid].camelize]) })
   end
 
   private


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1335093
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1335397

Fix right cell lists table that is empty for container images. 
In both conditions and miq policies, the objects where found in the tree
but the right cell table was empty.

before:
![bc](https://cloud.githubusercontent.com/assets/3010449/15321410/efeb033e-1c3e-11e6-88ea-370f2ec9a363.png)
![bp](https://cloud.githubusercontent.com/assets/3010449/15321409/efeabf96-1c3e-11e6-8897-64efd40403ec.png)

after:
![11](https://cloud.githubusercontent.com/assets/3010449/15321414/f5197278-1c3e-11e6-8039-408a8ab57909.png)
![22](https://cloud.githubusercontent.com/assets/3010449/15321415/f51c2d06-1c3e-11e6-8293-e8b2a34a931b.png)


