### PR TITLE
Dashboard active view toggle button

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1447,6 +1447,8 @@ class ApplicationHelper::ToolbarBuilder
     return true if id == "drift_all"
     return true if id.starts_with?("comparemode_") && id.ends_with?(@settings[:views][:compare_mode])
     return true if id.starts_with?("driftmode_") && id.ends_with?(@settings[:views][:drift_mode])
+    return true if id == "view_dashboard" && @showtype == "dashboard"
+    return true if id == "view_summary" && @showtype == "main"
     false
   end
 


### PR DESCRIPTION
The relevant button wasnt active when the view type changed in containers dashboard
Before:
![screencapture-localhost-3000-ems_container-show-1-1463486949213](https://cloud.githubusercontent.com/assets/11256940/15321801/78d46580-1c41-11e6-83e8-a4184b3e2333.png)

After:
![screencapture-localhost-3000-ems_container-show-1-1463486902828](https://cloud.githubusercontent.com/assets/11256940/15322265/5763dee6-1c44-11e6-8b0d-46fd246fb06e.png)

@epwinchell @martinpovolny Please review
cc @simon3z 