### PR TITLE
adding middleware_datasource feature identifier among the (non-super) admin role

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -48,6 +48,7 @@
   - ems_middleware
   - middleware_server
   - middleware_deployment
+  - middleware_datasource
   - middleware_topology
   - host
   - job_all_smartproxy


### PR DESCRIPTION
This is based on https://github.com/ManageIQ/manageiq/pull/8517

datasources have been already added to `miq_product_features.yml`

@miq-bot add_label providers/hawkular
cc @abonas