### PR TITLE
Do not assume that NIC and PublicIP are in the same resource group.

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -275,8 +275,9 @@ module ManageIQ::Providers
             public_ip_obj = ipconfig.properties.try(:public_ip_address)
             next unless public_ip_obj
 
-            name = File.basename(public_ip_obj.id)
-            ip_profile = @ips.get(name, nic_profile.resource_group)
+            ip_profile = ip_addresses.find { |ip| ip.id == public_ip_obj.id }
+            next unless ip_profile
+
             public_ip_addr = ip_profile.properties.try(:ip_address)
             networks_array << {:description => "public", :ipaddress => public_ip_addr, :hostname => hostname}
           end

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -39,4 +39,8 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   def network_interfaces
     @network_interfaces ||= gather_data_for_this_region(@nis)
   end
+
+  def ip_addresses
+    @ip_addresses ||= gather_data_for_this_region(@ips)
+  end
 end

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 036c0728-b757-4974-991a-a86e5934a2c6
+      - 02cc105f-a0d7-4ac6-ad5f-88199b4692e0
       Client-Request-Id:
-      - 86c946c7-9f55-4f3e-a407-4dc314cda595
+      - 31d37268-743b-4201-9752-66b74e57cbb2
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_357
+      - ESTSFE_IN_200
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -45,7 +45,7 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AAABAAAAiL9Kn2Z27UubvWFPbm0gLT7GTSDTJG-2B1JrAOKllQvOWeSI2DpRzSjIdi6nwXI4-8HYTdcMqyq3CCof5bYKKYb-Z6-Gm3lWVQ0lBWnKdxpRLLe-JxbBjZSgP0MldrHQzOoqomxSBMoVzIf-4KvSXv3HcnrnMCmZ55Y2lyYnnWRGJCAynB9tCeAuJiXPA-03IAA;
+      - esctx=AAABAAAAiL9Kn2Z27UubvWFPbm0gLcILpvvjxVSoZXkWgb1sKe0lY73vUZ1zwiTiPblNbhej6eoN9qVUWDSEZNFJNzoXop9jFyjHWnUuOvUfOLyaxlnRHX9IZ1eb1oVzIWg6TLrEKNLXhJhqA7LgkUvSMjDK6h7CvWPwClBZzwj71CFHN7aThyc9csyZBYkxw5pThnLjIAA;
         domain=.login.windows.net; path=/; secure; HttpOnly
       - flight-uxoptin=true; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
@@ -53,14 +53,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 09 May 2016 17:15:58 GMT
+      - Wed, 18 May 2016 16:43:38 GMT
       Content-Length:
       - '1247'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1462817758","not_before":"1462813858","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ"}'
+      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1463593419","not_before":"1463589519","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw"}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:15:59 GMT
+  recorded_at: Wed, 18 May 2016 16:43:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -96,23 +96,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14999'
       X-Ms-Request-Id:
-      - bb17f499-bea4-45ad-9a58-084002bfc0ad
+      - a3867411-fefb-4b96-89a1-46b90ea09b3e
       X-Ms-Correlation-Request-Id:
-      - bb17f499-bea4-45ad-9a58-084002bfc0ad
+      - a3867411-fefb-4b96-89a1-46b90ea09b3e
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171559Z:bb17f499-bea4-45ad-9a58-084002bfc0ad
+      - NORTHCENTRALUS:20160518T164339Z:a3867411-fefb-4b96-89a1-46b90ea09b3e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:15:58 GMT
+      - Wed, 18 May 2016 16:43:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01"}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:15:59 GMT
+  recorded_at: Wed, 18 May 2016 16:43:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames?api-version=2015-01-01
@@ -129,7 +129,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -146,24 +146,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14851'
+      - '14919'
       X-Ms-Request-Id:
-      - a2aab27c-17ed-4ae7-80b5-f02385f11162
+      - 61c2d269-8cdf-4c58-a06a-3e129ff130bb
       X-Ms-Correlation-Request-Id:
-      - a2aab27c-17ed-4ae7-80b5-f02385f11162
+      - 61c2d269-8cdf-4c58-a06a-3e129ff130bb
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171559Z:a2aab27c-17ed-4ae7-80b5-f02385f11162
+      - NORTHCENTRALUS:20160518T164340Z:61c2d269-8cdf-4c58-a06a-3e129ff130bb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:15:59 GMT
+      - Wed, 18 May 2016 16:43:40 GMT
       Content-Length:
-      - '2903'
+      - '3190'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName","tagName":"displayName","count":{"type":"Total","value":19},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterVirtualMachine","tagValue":"OpenShiftMasterVirtualMachine","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/DeployOpenShift","tagValue":"DeployOpenShift","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodes","tagValue":"OpenShiftNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/PrepNodes","tagValue":"PrepNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/KeyVault","tagValue":"KeyVault","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLB","tagValue":"OpenShiftNodeLB","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterNetworkInterface","tagValue":"OpenShiftMasterNetworkInterface","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeNetworkInterfaces","tagValue":"OpenShiftNodeNetworkInterfaces","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLBPublicIP","tagValue":"OpenShiftNodeLBPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterPublicIP","tagValue":"OpenShiftMasterPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualNetwork","tagValue":"VirtualNetwork","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/StorageAccounts","tagValue":"StorageAccounts","count":{"type":"Total","value":2}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand","tagName":"on-demand","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand/tagValues/true","tagValue":"true","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test","tagName":"rlt_test","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test/tagValues/b","tagValue":"b","count":{"type":"Total","value":1}}]}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat","tagName":"redhat","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat/tagValues/True","tagValue":"True","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName","tagName":"displayName","count":{"type":"Total","value":19},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterVirtualMachine","tagValue":"OpenShiftMasterVirtualMachine","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/DeployOpenShift","tagValue":"DeployOpenShift","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodes","tagValue":"OpenShiftNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/PrepNodes","tagValue":"PrepNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/KeyVault","tagValue":"KeyVault","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLB","tagValue":"OpenShiftNodeLB","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterNetworkInterface","tagValue":"OpenShiftMasterNetworkInterface","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeNetworkInterfaces","tagValue":"OpenShiftNodeNetworkInterfaces","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLBPublicIP","tagValue":"OpenShiftNodeLBPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterPublicIP","tagValue":"OpenShiftMasterPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualNetwork","tagValue":"VirtualNetwork","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/StorageAccounts","tagValue":"StorageAccounts","count":{"type":"Total","value":2}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand","tagName":"on-demand","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand/tagValues/true","tagValue":"true","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test","tagName":"rlt_test","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test/tagValues/b","tagValue":"b","count":{"type":"Total","value":1}}]}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:00 GMT
+  recorded_at: Wed, 18 May 2016 16:43:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -180,7 +180,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -199,21 +199,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14997'
       X-Ms-Request-Id:
-      - 7b5fe41c-7e26-4967-bb37-58027269cdd7
+      - cc31dd15-b7ac-4db2-82dc-c946ea9c15ba
       X-Ms-Correlation-Request-Id:
-      - 7b5fe41c-7e26-4967-bb37-58027269cdd7
+      - cc31dd15-b7ac-4db2-82dc-c946ea9c15ba
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171601Z:7b5fe41c-7e26-4967-bb37-58027269cdd7
+      - NORTHCENTRALUS:20160518T164341Z:cc31dd15-b7ac-4db2-82dc-c946ea9c15ba
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:01 GMT
+      - Wed, 18 May 2016 16:43:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
-        US","West US (Partner)"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","Japan West","West US (Partner)"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":["West
         US (Partner)"],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":["West
         US (Partner)"],"apiVersions":["2016-03-25"]}]},{"namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["West
         US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]},{"namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
@@ -228,9 +229,9 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
         US"],"apiVersions":["2014-01-01"]}]},{"namespace":"Microsoft.ApiManagement","resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
-        US","South Central US","West US","North Europe","West Europe","East Asia","Southeast
-        Asia","Japan East","Japan West","Brazil South","Central India","South India","West
-        India"],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-09-15","2014-02-14"]}]},{"namespace":"Microsoft.AppService","resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","South Central US","West US","Canada Central","Canada East","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-09-15","2014-02-14"]}]},{"namespace":"Microsoft.AppService","resourceTypes":[{"resourceType":"apiapps","locations":["East
         US","West US","South Central US","North Europe","East Asia","Japan East","West
         Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
         South","East US 2","Australia Southeast","Australia East","West India","South
@@ -440,7 +441,7 @@ http_interactions:
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"disks","locations":["Southeast
+        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"disks","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
@@ -484,31 +485,25 @@ http_interactions:
         US","North Europe","East Asia","West US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast"],"apiVersions":["2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["East
         US","North Europe","East Asia","West US","West Europe","Southeast Asia","Japan
-        East","Japan West","Australia East","Australia Southeast"],"apiVersions":["2016-02-03","2015-08-15-preview"]}]},{"namespace":"Microsoft.DevTestLab","resourceTypes":[{"resourceType":"labs","locations":["Southeast
-        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
-        Central US","East US","West US","South Central US","West Europe","East Asia","East
-        US 2","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"environments","locations":["Southeast
-        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
-        Central US","East US","West US","West Europe","East Asia","East US 2","Japan
-        East","Japan West","Central US","South Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"labs/environments","locations":["Southeast
-        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
-        Central US","South Central US","East US","West US","West Europe","East Asia","East
-        US 2","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["Southeast
-        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
-        Central US","East US","West US","South Central US","West Europe","East Asia","East
-        US 2","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-05-21-preview","2015-05-01"]},{"resourceType":"locations/operations","locations":["Southeast
-        Asia","Australia East","Australia Southeast","Brazil South","North Europe","North
-        Central US","East US","East US 2","West US","South Central US","West Europe","East
-        Asia","Japan East","Japan West","Central US"],"apiVersions":["2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-05-21-preview"]}]},{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["West
+        East","Japan West","Australia East","Australia Southeast"],"apiVersions":["2016-02-03","2015-08-15-preview"]}]},{"namespace":"Microsoft.DevTestLab","resourceTypes":[{"resourceType":"labs","locations":["Australia
+        East","Australia Southeast","Brazil South","Central US","East Asia","East
+        US","East US 2","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West US"],"apiVersions":["2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["Australia
+        East","Australia Southeast","Brazil South","Central US","East Asia","East
+        US","East US 2","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West US","West Europe"],"apiVersions":["2016-05-15","2015-05-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Central US","East Asia","East
+        US","East US 2","Japan East","Japan West","North Central US","North Europe","Southeast
+        Asia","South Central US","West US","West Europe"],"apiVersions":["2016-05-15","2015-05-21-preview"]}]},{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["West
         US","North Europe","West Europe","East US","East US 2","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","South India","South
-        Central US","Central US","Japan East","Japan West"],"apiVersions":["2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["West
+        Central US","Central US","Japan East","Japan West","North Central US"],"apiVersions":["2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["West
         US","North Europe","West Europe","East US","East US 2","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","South India","South
-        Central US","Central US","Japan East","Japan West"],"apiVersions":["2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["West
+        Central US","Central US","Japan East","Japan West","North Central US"],"apiVersions":["2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["West
         US","North Europe","West Europe","East US","East US 2","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","South India","South
-        Central US","Central US","Japan East","Japan West"],"apiVersions":["2015-04-08","2014-04-01"]}]},{"namespace":"Microsoft.DomainRegistration","resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}]},{"namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        Central US","Central US","Japan East","Japan West","North Central US"],"apiVersions":["2015-04-08","2014-04-01"]}]},{"namespace":"Microsoft.DomainRegistration","resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}]},{"namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
@@ -532,10 +527,11 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["West
-        US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["West
-        US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["West
-        US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2015-03-01-preview"]}]},{"namespace":"microsoft.insights","resourceTypes":[{"resourceType":"components","locations":["Central
+        US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["West
+        US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["West
+        US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["West
+        US","Central US"],"apiVersions":["2015-03-01-preview"]}]},{"namespace":"microsoft.insights","resourceTypes":[{"resourceType":"components","locations":["Central
         US"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["Central
         US"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["Central
         US"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
@@ -552,15 +548,15 @@ http_interactions:
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Canada
         East","Canada Central","Central US","Australia East","Australia Southeast","Brazil
-        South","South India","Central India","West India"],"apiVersions":["2015-07-01"]},{"resourceType":"metricDefinitions","locations":["West
+        South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"metricDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Canada
         East","Canada Central","Central US","Australia East","Australia Southeast","Brazil
-        South","South India","Central India","West India"],"apiVersions":["2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Canada
         East","Canada Central","Central US","Australia East","Australia Southeast","Brazil
-        South","South India","Central India","West India"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]}]},{"namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]}]},{"namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -651,10 +647,16 @@ http_interactions:
         Central US","South Central US","East Asia","Southeast Asia","Brazil South","Japan
         East","Japan West","North Europe","West Europe"],"apiVersions":["2014-09-01"]}]},{"namespace":"Microsoft.OperationalInsights","resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast"],"apiVersions":["2015-11-01-preview","2015-03-20"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"linkTargets","locations":["East
-        US"],"apiVersions":["2015-03-20","2014-10-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]}]},{"namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
-        Central US"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
-        Central US"],"apiVersions":["2016-01-29"]}]},{"namespace":"Microsoft.ProjectOxford","resourceTypes":[{"resourceType":"accounts","locations":["West
-        US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.RemoteApp","resourceTypes":[{"resourceType":"collections","locations":["Australia
+        US"],"apiVersions":["2015-03-20","2014-10-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]}]},{"namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["East
+        US","South Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["East
+        US","South Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast"],"apiVersions":["2016-01-29"]}]},{"namespace":"Microsoft.ProjectOxford","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.RecoveryServices","resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}]},{"namespace":"Microsoft.RemoteApp","resourceTypes":[{"resourceType":"collections","locations":["Australia
         East","Australia Southeast","Brazil South","Central US","East Asia","East
         US","East US 2","Japan East","Japan West","North Central US","North Europe","Southeast
         Asia","South Central US","West Europe","West US"],"apiVersions":["2014-09-01"]},{"resourceType":"collections/applications","locations":["Australia
@@ -669,11 +671,11 @@ http_interactions:
         US","East Asia","Southeast Asia","East US","East US 2","West US","North Central
         US","South Central US","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","West India","South India","Central
-        India","UK North","UK South 2","Canada Central","Canada East"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","North Central
         US","South Central US","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","West India","South India","Central
-        India","UK North","UK South 2","Canada Central","Canada East"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -722,185 +724,185 @@ http_interactions:
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","East Asia","Southeast Asia","Brazil South","Japan
         East","Japan West","North Europe","West Europe","Central India","South India","West
-        India"],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2014-09-01"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["West
-        US","East US","West Europe","Australia East","Australia Southeast","North
-        Central US","Japan West","South Central US"],"apiVersions":["2016-03-01","2016-01-01-beta","2015-01-01-alpha"]}]},{"namespace":"Microsoft.Sql","resourceTypes":[{"resourceType":"operations","locations":["East
+        India","Canada Central","Canada East"],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2014-09-01"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","East US","East US 2","Central US","West Europe","Australia East","Australia
+        Southeast","North Central US","Japan West","South Central US"],"apiVersions":["2016-03-01","2016-01-01-beta","2015-01-01-alpha"]}]},{"namespace":"Microsoft.Sql","resourceTypes":[{"resourceType":"operations","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/capabilities","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/capabilities","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers","locations":["North
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers","locations":["North
         Europe","East US","West US","South Central US","East US 2","Central US","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/serviceObjectives","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/serviceObjectives","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/communicationLinks","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/communicationLinks","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/administrators","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/administrators","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/administratorOperationResults","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/administratorOperationResults","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/recoverableDatabases","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/recoverableDatabases","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/import","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/import","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/importExportOperationResults","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/importExportOperationResults","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/operationResults","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/operationResults","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/firewallrules","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/firewallrules","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/connectionPolicies","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/connectionPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["West
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["West
         Europe","West US","South Central US","East US 2","Central US","North Central
         US","East US","East Asia","Southeast Asia","Japan West","Japan East","North
         Europe","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["West
+        India","South India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["West
         US","South Central US","East US 2","Central US","North Central US","East US","East
         Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["West
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["West
         US","South Central US","East US 2","Central US","North Central US","East US","East
         Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["West
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["West
         US","South Central US","East US 2","Central US","North Central US","East US","East
         Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/resourcepools","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/resourcepools","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/usages","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/usages","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/metrics","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/metrics","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/topQueries","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/topQueries","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/advisors","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/advisors","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/advisors","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/advisors","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/extensions","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/extensions","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India"],"apiVersions":["2015-05-01-preview"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","East US 2 (Stage)","West US","West Europe","East Asia","Southeast
         Asia","Japan East","Japan West","North Central US","South Central US","Central
         US","North Europe","Brazil South","Australia East","Australia Southeast","South
@@ -918,10 +920,10 @@ http_interactions:
         South 2"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
         US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
         Asia","South Central US","East Asia","Japan West","North Central US","East
-        US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
         Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
         Asia","South Central US","East Asia","Japan West","North Central US","East
-        US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
         India","West US","Central US","South Central US","Japan East","Japan West","East
         Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
@@ -930,7 +932,7 @@ http_interactions:
         Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
         Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
         Asia","South Central US","East Asia","Japan West","North Central US","East
-        US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}]},{"namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}]},{"namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
@@ -1187,7 +1189,7 @@ http_interactions:
         US","Australia Southeast","Australia East","South Central US"],"apiVersions":["2014-04-01"]}]},{"namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["West
         US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:01 GMT
+  recorded_at: Wed, 18 May 2016 16:43:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
@@ -1204,7 +1206,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -1221,22 +1223,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 93b81ec9-69cc-4e64-aa72-0139d306abd3
+      - 5eff6f0d-39fc-434c-a6fd-a2aa40565b23
       X-Ms-Correlation-Request-Id:
-      - 93b81ec9-69cc-4e64-aa72-0139d306abd3
+      - 5eff6f0d-39fc-434c-a6fd-a2aa40565b23
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171602Z:93b81ec9-69cc-4e64-aa72-0139d306abd3
+      - NORTHCENTRALUS:20160518T164342Z:5eff6f0d-39fc-434c-a6fd-a2aa40565b23
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:01 GMT
+      - Wed, 18 May 2016 16:43:41 GMT
       Content-Length:
-      - '566'
+      - '750'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:02 GMT
+  recorded_at: Wed, 18 May 2016 16:43:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2016-03-30
@@ -1253,7 +1255,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -1274,20 +1276,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - dc999b4d-0603-4e62-a7d4-c122d9885d12
+      - fbe11119-be0d-4b3f-865b-a19aa0f9e4f4
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14811'
+      - '14954'
       X-Ms-Correlation-Request-Id:
-      - d0ea5872-23c7-4ee4-867a-33561c57b84c
+      - 48865e3e-b6d9-473e-a788-94a8e4c5719a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171602Z:d0ea5872-23c7-4ee4-867a-33561c57b84c
+      - NORTHCENTRALUS:20160518T164342Z:48865e3e-b6d9-473e-a788-94a8e4c5719a
       Date:
-      - Mon, 09 May 2016 17:16:02 GMT
+      - Wed, 18 May 2016 16:43:41 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n
@@ -1451,7 +1453,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 16\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:02 GMT
+  recorded_at: Wed, 18 May 2016 16:43:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments?api-version=2016-02-01
@@ -1468,7 +1470,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -1485,22 +1487,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14799'
+      - '14956'
       X-Ms-Request-Id:
-      - 5d6fc715-4efa-417c-9ba9-6c5a3bd295de
+      - 2bde0b0e-5c6d-4ad0-a1ea-35fd33004cb2
       X-Ms-Correlation-Request-Id:
-      - 5d6fc715-4efa-417c-9ba9-6c5a3bd295de
+      - 2bde0b0e-5c6d-4ad0-a1ea-35fd33004cb2
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171603Z:5d6fc715-4efa-417c-9ba9-6c5a3bd295de
+      - NORTHCENTRALUS:20160518T164343Z:2bde0b0e-5c6d-4ad0-a1ea-35fd33004cb2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:03 GMT
+      - Wed, 18 May 2016 16:43:43 GMT
       Content-Length:
-      - '43127'
+      - '44143'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme","name":"failedme","properties":{"parameters":{"virtualMachineName":{"type":"String","value":"anym"},"adminUserName":{"type":"String","value":"admins"},"adminPassword":{"type":"SecureString"},"userImageName":{"type":"String","value":"https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd"},"operatingSystemType":{"type":"String","value":"windows"},"virtualMachineSize":{"type":"String","value":"Basic_A0"}},"mode":"Incremental","provisioningState":"Failed","timestamp":"2016-04-19T20:51:24.3745709Z","duration":"PT16.2313747S","correlationId":"39221b07-016e-4f80-948e-fb44b64ba108","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/myVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myVNET"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/anym","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"anym"}],"error":{"code":"DeploymentFailed","message":"At
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731","name":"Microsoft.NetworkInterface-20160417102731","properties":{"parameters":{"networkInterfaceName":{"type":"String","value":"miqmismatch1"},"location":{"type":"String","value":"eastus"},"subnetId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Azurerhjb/providers/Microsoft.Network/virtualNetworks/Azurerhjb/subnets/default"},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-05-17T16:27:37.6666006Z","duration":"PT4.0933399S","correlationId":"7888827e-9fea-485b-98ba-49dc13a1fb43","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[],"outputResources":[{"id":"Microsoft.Network/networkInterfaces/miqmismatch1"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme","name":"failedme","properties":{"parameters":{"virtualMachineName":{"type":"String","value":"anym"},"adminUserName":{"type":"String","value":"admins"},"adminPassword":{"type":"SecureString"},"userImageName":{"type":"String","value":"https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd"},"operatingSystemType":{"type":"String","value":"windows"},"virtualMachineSize":{"type":"String","value":"Basic_A0"}},"mode":"Incremental","provisioningState":"Failed","timestamp":"2016-04-19T20:51:24.3745709Z","duration":"PT16.2313747S","correlationId":"39221b07-016e-4f80-948e-fb44b64ba108","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/myVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myVNET"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/anym","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"anym"}],"error":{"code":"DeploymentFailed","message":"At
         least one resource deployment operation failed. Please list deployment operations
         for details. Please see http://aka.ms/arm-debug for usage details.","details":[{"code":"BadRequest","message":"{\r\n  \"error\":
         {\r\n    \"code\": \"InvalidParameter\",\r\n    \"target\": \"adminPassword\",\r\n    \"message\":
@@ -1510,7 +1512,109 @@ http_interactions:
         Contains a numeric digit\\r\\n4) Contains a special character.\"\r\n  }\r\n}"}]}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010","name":"Microsoft.WindowsServer2012R2Datacenter-20160222104010","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A1"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg241"},"networkSecurityGroupName":{"type":"String","value":"miqtestwinimg3696"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqtestwinimg6202"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.5830069Z","duration":"PT10M55.2480986S","correlationId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg241"},{"id":"Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},{"id":"Microsoft.Network/publicIpAddresses/miqtestwinimg6202"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646","name":"Microsoft.WindowsServer2012R2Datacenter-20160222101646","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg724"},"networkSecurityGroupName":{"type":"String","value":"miq-test-winimg"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miq-test-winimg"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.8666296Z","duration":"PT10M47.5658692S","correlationId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg724"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-winimg"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-winimg"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019","name":"Microsoft.WindowsServer2012R2Datacenter-20160218113019","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-win12"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miqazuretest19881"},"networkInterfaceName":{"type":"String","value":"miq-test-win12610"},"networkSecurityGroupName":{"type":"String","value":"miq-test-win12"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest14047"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.18.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.18.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-win12"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.8337856Z","duration":"PT11M9.8080785S","correlationId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-win12"},{"id":"Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-win12610"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-win12"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-win12"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest19881"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest14047"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651","name":"Canonical.UbuntuServer1510-20160218112651","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-ubuntu1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest16487"},"virtualNetworkName":{"type":"String","value":"miqazuretest18687"},"networkInterfaceName":{"type":"String","value":"miq-test-ubuntu1989"},"networkSecurityGroupName":{"type":"String","value":"miq-test-ubuntu1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest16487"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.17.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.17.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-ubuntu1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.2528115Z","duration":"PT4M10.3614981S","correlationId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-ubuntu1"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest18687"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest16487"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:03 GMT
+  recorded_at: Wed, 18 May 2016 16:43:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments?api-version=2016-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14958'
+      X-Ms-Request-Id:
+      - caeb5e65-e617-4849-8bdf-d5307a7120c1
+      X-Ms-Correlation-Request-Id:
+      - caeb5e65-e617-4849-8bdf-d5307a7120c1
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164344Z:caeb5e65-e617-4849-8bdf-d5307a7120c1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 18 May 2016 16:43:44 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:43:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations?api-version=2016-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14957'
+      X-Ms-Request-Id:
+      - c7112d4e-77d9-46ef-b643-ace2ac045353
+      X-Ms-Correlation-Request-Id:
+      - c7112d4e-77d9-46ef-b643-ace2ac045353
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164345Z:c7112d4e-77d9-46ef-b643-ace2ac045353
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 18 May 2016 16:43:44 GMT
+      Content-Length:
+      - '1284'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations/9F5B589CD174DDD3","operationId":"9F5B589CD174DDD3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-05-17T16:27:37.3271271Z","duration":"PT2.0080487S","trackingId":"f712a792-6f75-4bf1-b01a-fefd65afc50e","serviceRequestId":"da737f57-474c-454c-a750-884421e3f2f8","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqmismatch1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations/08587381044319043881","operationId":"08587381044319043881","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-05-17T16:27:37.6273566Z","duration":"PT0.1814503S","trackingId":"710ac6bf-c100-4a10-a51c-21fd87fc0138","statusCode":"OK","statusMessage":null}}]}'
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:43:45 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations?api-version=2016-02-01
@@ -1527,7 +1631,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -1544,17 +1648,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14708'
+      - '14932'
       X-Ms-Request-Id:
-      - 5d6dc89c-551a-4865-b05d-23b98ca31abe
+      - 0d42a786-b581-4e63-a076-1fde86bc0085
       X-Ms-Correlation-Request-Id:
-      - 5d6dc89c-551a-4865-b05d-23b98ca31abe
+      - 0d42a786-b581-4e63-a076-1fde86bc0085
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171604Z:5d6dc89c-551a-4865-b05d-23b98ca31abe
+      - NORTHCENTRALUS:20160518T164346Z:0d42a786-b581-4e63-a076-1fde86bc0085
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:03 GMT
+      - Wed, 18 May 2016 16:43:45 GMT
       Content-Length:
       - '2551'
     body:
@@ -1565,7 +1669,7 @@ http_interactions:
         an uppercase character\r\n2) Contains a lowercase character\r\n3) Contains
         a numeric digit\r\n4) Contains a special character."}},"targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/anym","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"anym"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/F9F20A47A97EE080","operationId":"F9F20A47A97EE080","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:22.487592Z","duration":"PT0.9167668S","trackingId":"61348482-004f-46c0-88b3-65e3154b74ee","serviceRequestId":"170c3cfe-fffa-47ab-8e8b-815ece2e94e1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/3DCCD9CF9359AFF8","operationId":"3DCCD9CF9359AFF8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:21.4774538Z","duration":"PT12.4116622S","trackingId":"f38c5a77-b7dc-456d-811b-344f369b4484","serviceRequestId":"5205ab85-5f20-4302-bace-181cfd212c3e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/myVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myVNET"}}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:04 GMT
+  recorded_at: Wed, 18 May 2016 16:43:46 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2016-02-01
@@ -1582,7 +1686,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -1599,24 +1703,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14787'
+      - '14965'
       X-Ms-Request-Id:
-      - 561e42eb-bf7f-4ee3-90de-26c360fec938
+      - d3ea5b36-b985-46fc-857a-a7d2071bfb59
       X-Ms-Correlation-Request-Id:
-      - 561e42eb-bf7f-4ee3-90de-26c360fec938
+      - d3ea5b36-b985-46fc-857a-a7d2071bfb59
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171605Z:561e42eb-bf7f-4ee3-90de-26c360fec938
+      - NORTHCENTRALUS:20160518T164347Z:d3ea5b36-b985-46fc-857a-a7d2071bfb59
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:04 GMT
+      - Wed, 18 May 2016 16:43:46 GMT
       Content-Length:
       - '6866'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:05 GMT
+  recorded_at: Wed, 18 May 2016 16:43:47 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json
@@ -1652,33 +1756,33 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2C22:644F:1848941:5730C4B8
+      - 17EB2C22:651A:D5A9BC:573C9BC3
       Content-Length:
       - '10366'
       Accept-Ranges:
       - bytes
       Date:
-      - Mon, 09 May 2016 17:16:05 GMT
+      - Wed, 18 May 2016 16:43:48 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1845-DFW
+      - cache-dfw1835-DFW
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 293a24c4b36ea2afaeca6f6420942130d2186850
+      - 6fe618ccde1946c2c812d934959443751a4a7caf
       Expires:
-      - Mon, 09 May 2016 17:21:05 GMT
+      - Wed, 18 May 2016 16:48:48 GMT
       Source-Age:
-      - '285'
+      - '0'
     body:
       encoding: UTF-8
       string: |
@@ -2026,7 +2130,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:05 GMT
+  recorded_at: Wed, 18 May 2016 16:43:48 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2016-02-01
@@ -2043,7 +2147,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2060,24 +2164,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14772'
+      - '14948'
       X-Ms-Request-Id:
-      - cac9dd73-7e7c-48cf-a92d-33761596e462
+      - a911766b-a8c0-46a8-8b45-d92eda2fe39c
       X-Ms-Correlation-Request-Id:
-      - cac9dd73-7e7c-48cf-a92d-33761596e462
+      - a911766b-a8c0-46a8-8b45-d92eda2fe39c
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171606Z:cac9dd73-7e7c-48cf-a92d-33761596e462
+      - NORTHCENTRALUS:20160518T164348Z:a911766b-a8c0-46a8-8b45-d92eda2fe39c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:06 GMT
+      - Wed, 18 May 2016 16:43:48 GMT
       Content-Length:
       - '801'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:06 GMT
+  recorded_at: Wed, 18 May 2016 16:43:48 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json
@@ -2113,33 +2217,33 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2C1F:644E:AB6F06:5730C4B9
+      - 17EB2C1F:23BB:8C3644:573C9BC5
       Content-Length:
       - '3830'
       Accept-Ranges:
       - bytes
       Date:
-      - Mon, 09 May 2016 17:16:06 GMT
+      - Wed, 18 May 2016 16:43:49 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1845-DFW
+      - cache-dfw1823-DFW
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 8b77e34a78aa85dfec49139e85dd80373ae6d4a7
+      - 1f1e00c940cee7d324d1fb2b4f27d41fa1976fa1
       Expires:
-      - Mon, 09 May 2016 17:21:06 GMT
+      - Wed, 18 May 2016 16:48:49 GMT
       Source-Age:
-      - '285'
+      - '0'
     body:
       encoding: UTF-8
       string: |
@@ -2278,7 +2382,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:06 GMT
+  recorded_at: Wed, 18 May 2016 16:43:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations?api-version=2016-02-01
@@ -2295,7 +2399,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2312,24 +2416,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14831'
+      - '14954'
       X-Ms-Request-Id:
-      - cdc53616-0c69-4bb1-8745-9d5193ed0d06
+      - e59bdc0a-580f-4c63-a55b-790a4c1e9a0d
       X-Ms-Correlation-Request-Id:
-      - cdc53616-0c69-4bb1-8745-9d5193ed0d06
+      - e59bdc0a-580f-4c63-a55b-790a4c1e9a0d
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171607Z:cdc53616-0c69-4bb1-8745-9d5193ed0d06
+      - NORTHCENTRALUS:20160518T164349Z:e59bdc0a-580f-4c63-a55b-790a4c1e9a0d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:06 GMT
+      - Wed, 18 May 2016 16:43:49 GMT
       Content-Length:
       - '6166'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:06.7915034Z","duration":"PT3M1.4329712S","trackingId":"b747ec27-f04a-4dc5-a097-03b78d06b4f3","serviceRequestId":"0b164261-eee1-422e-b558-7cb959e795eb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:48:05.2174686Z","duration":"PT7M35.1627165S","trackingId":"dc765fff-be2e-485c-b812-26cbaf08492c","serviceRequestId":"b4e8ecc8-2e94-4423-b928-2c29900ed123","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/3FD73BA3A618D357","operationId":"3FD73BA3A618D357","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:29.9601151Z","duration":"PT2.604551S","trackingId":"280b442e-2010-45a6-b9b2-ac761d5dee7d","serviceRequestId":"ebbe21b7-a988-4950-9675-0d063e84b60e","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:18.3026417Z","duration":"PT4.8364985S","trackingId":"7d2f970a-57fc-40b4-9152-2c3c883d58c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/6CCA0B3A82197571","operationId":"6CCA0B3A82197571","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.0300385Z","duration":"PT13.4143548S","trackingId":"0830ff7f-fb77-44f0-a393-6003873380e8","serviceRequestId":"ea9c728c-70ba-4de3-a55c-8cf6cd310ca0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/291C0AC5D4F88BDB","operationId":"291C0AC5D4F88BDB","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.2645854Z","duration":"PT13.7950357S","trackingId":"bfd21915-f13e-4ece-a48c-19a5a9a58fcd","serviceRequestId":"60371f22-c3c6-4256-b204-0efc36c51aae","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:14.3483638Z","duration":"PT0.8769498S","trackingId":"54ee2082-f487-4f98-b5da-08f4fb8450ac","serviceRequestId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/08587429420731427531","operationId":"08587429420731427531","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.53375Z","duration":"PT0.5447355S","trackingId":"d4fae0de-498c-4177-8239-46a0f58e2ebf","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:07 GMT
+  recorded_at: Wed, 18 May 2016 16:43:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations?api-version=2016-02-01
@@ -2346,7 +2450,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2363,24 +2467,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14823'
+      - '14916'
       X-Ms-Request-Id:
-      - 94902cfa-8e1e-4ad3-9801-aa2c6d45548c
+      - 45def59a-e479-4863-a388-b21042a9a170
       X-Ms-Correlation-Request-Id:
-      - 94902cfa-8e1e-4ad3-9801-aa2c6d45548c
+      - 45def59a-e479-4863-a388-b21042a9a170
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171607Z:94902cfa-8e1e-4ad3-9801-aa2c6d45548c
+      - NORTHCENTRALUS:20160518T164350Z:45def59a-e479-4863-a388-b21042a9a170
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:07 GMT
+      - Wed, 18 May 2016 16:43:50 GMT
       Content-Length:
       - '6161'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.1806556Z","duration":"PT3M14.7317782S","trackingId":"2e8bc5df-290e-4427-9d7e-b07dc8b56157","serviceRequestId":"e6051ebe-75e3-4280-ad61-5c4928614ad2","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:24:20.3730557Z","duration":"PT7M15.3472227S","trackingId":"b15735ed-1f9c-4235-8554-0359a94d8021","serviceRequestId":"b90d407e-ca03-4efe-ac8c-a40133c4521a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/FAC43E00E60F40D6","operationId":"FAC43E00E60F40D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:04.9686575Z","duration":"PT1.7424043S","trackingId":"9cd93d46-01d3-4fcb-9d33-32d362efad6b","serviceRequestId":"5b900931-b60d-4e18-8e0e-ea23472a6911","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/4A34D86BCACDE87A","operationId":"4A34D86BCACDE87A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.172193Z","duration":"PT13.1694927S","trackingId":"f1189e74-dc7c-4a8e-9f87-f125c87fac6e","serviceRequestId":"f4510097-ff5e-4476-9d16-ef1b3233a77d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/857E6EBF700A64F8","operationId":"857E6EBF700A64F8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.1483554Z","duration":"PT13.0919048S","trackingId":"ca1bda1a-fda1-4270-8442-a3145bfbe1f2","serviceRequestId":"7f2145f1-40af-4b08-addc-8356a4ddc063","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:51.1217903Z","duration":"PT1.1217779S","trackingId":"76e77bc0-53a4-4df3-a941-4c5e007b6a66","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:50.9535836Z","duration":"PT0.9351894S","trackingId":"de79265b-c4a2-457b-807a-9e98060a82f6","serviceRequestId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/08587429434771769170","operationId":"08587429434771769170","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.7888649Z","duration":"PT0.5055897S","trackingId":"d03c7b95-d9d8-48bb-a526-41e9651ad971","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:07 GMT
+  recorded_at: Wed, 18 May 2016 16:43:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2016-02-01
@@ -2397,7 +2501,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2414,24 +2518,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14822'
+      - '14927'
       X-Ms-Request-Id:
-      - c3251e12-43e8-4e37-91bf-051201e7cdf6
+      - a10ad2e8-8f68-4d6b-a0ff-d6b1460a2cd4
       X-Ms-Correlation-Request-Id:
-      - c3251e12-43e8-4e37-91bf-051201e7cdf6
+      - a10ad2e8-8f68-4d6b-a0ff-d6b1460a2cd4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171608Z:c3251e12-43e8-4e37-91bf-051201e7cdf6
+      - NORTHCENTRALUS:20160518T164351Z:a10ad2e8-8f68-4d6b-a0ff-d6b1460a2cd4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:07 GMT
+      - Wed, 18 May 2016 16:43:50 GMT
       Content-Length:
       - '6818'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","serviceRequestId":"57d6085f-2656-460f-9fdc-391f3813ba9b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","serviceRequestId":"9e20cfcf-cf82-4053-8a96-ba1a60126341","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","serviceRequestId":"fac0cc26-0839-4302-9536-69cff4273fb9","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","serviceRequestId":"82cddf5c-1792-4498-9ed5-ccdfaf52d93c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","serviceRequestId":"f082fd2f-3170-4f36-b9ff-a635e33f5fcf","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","serviceRequestId":"7df6e0cb-b78b-47ff-b479-90a1aee5a885","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","serviceRequestId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:08 GMT
+  recorded_at: Wed, 18 May 2016 16:43:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations?api-version=2016-02-01
@@ -2448,7 +2552,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2465,24 +2569,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14662'
+      - '14925'
       X-Ms-Request-Id:
-      - 575bb77e-5116-4b03-bbd5-c4943829dddf
+      - 8879cf32-9b72-472d-a8ad-5ea4433da5c0
       X-Ms-Correlation-Request-Id:
-      - 575bb77e-5116-4b03-bbd5-c4943829dddf
+      - 8879cf32-9b72-472d-a8ad-5ea4433da5c0
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171608Z:575bb77e-5116-4b03-bbd5-c4943829dddf
+      - NORTHCENTRALUS:20160518T164352Z:8879cf32-9b72-472d-a8ad-5ea4433da5c0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:08 GMT
+      - Wed, 18 May 2016 16:43:51 GMT
       Content-Length:
       - '7718'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/15838BCFE46760A1","operationId":"15838BCFE46760A1","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:28.6222483Z","duration":"PT3M20.660116S","trackingId":"a6653508-59b3-4e4a-b796-f1cf431a9162","serviceRequestId":"9df73a78-c24e-444a-82cb-ec8632cb8775","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/DDBEEC376EA09F7E","operationId":"DDBEEC376EA09F7E","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:38:07.8075094Z","duration":"PT7M9.35647S","trackingId":"943dac3c-a98b-465d-b759-06506e599546","serviceRequestId":"21e68a17-9e60-4b90-b988-c524ac8db616","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.5055633Z","duration":"PT0.6114738S","trackingId":"1b754371-18ec-4517-bd38-46c9d2ef975d","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.3710882Z","duration":"PT0.4790524S","trackingId":"9dfcf1d7-6e4a-4a73-b17e-13b2afdf9d6b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/7F5153152761DD05","operationId":"7F5153152761DD05","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:38.3445066Z","duration":"PT1.6145978S","trackingId":"861a701b-3964-4754-954c-cb21d5e93db8","serviceRequestId":"2d4bd016-1a2d-4e33-ac21-27105e650564","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/F97EC162743B5FF4","operationId":"F97EC162743B5FF4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:57.7800754Z","duration":"PT34.9812759S","trackingId":"92865cda-40cb-41c9-9317-d864b2b3c309","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/EA21060B6C976C52","operationId":"EA21060B6C976C52","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.6308058Z","duration":"PT13.8442357S","trackingId":"e950697d-0ec6-40f5-8d14-7bfae0ecabf5","serviceRequestId":"edf1e84f-f9ac-4254-85fa-93f2dd649032","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/61B1466BCE99F9D3","operationId":"61B1466BCE99F9D3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.4233646Z","duration":"PT13.6985797S","trackingId":"fd76215f-8c01-4e2a-8068-636237270be4","serviceRequestId":"5803f928-b459-4872-b035-ae900c9c3eee","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/58705CE1AC7417FE","operationId":"58705CE1AC7417FE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.5145163Z","duration":"PT13.7848628S","trackingId":"31027583-c7fb-4302-9bbe-9d1f79502a4c","serviceRequestId":"cd05b456-afab-41a8-8952-43c02b657253","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/08587432846644519702","operationId":"08587432846644519702","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.7434262Z","duration":"PT2.0330234S","trackingId":"1bf25585-8cf8-4c99-9078-aa6f5c036128","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:08 GMT
+  recorded_at: Wed, 18 May 2016 16:43:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations?api-version=2016-02-01
@@ -2499,7 +2603,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2516,24 +2620,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14725'
+      - '14918'
       X-Ms-Request-Id:
-      - 9dfbf847-ec84-4847-9348-a4b2fe88f12d
+      - d38a433b-51fc-49e7-b51a-79f34acb998a
       X-Ms-Correlation-Request-Id:
-      - 9dfbf847-ec84-4847-9348-a4b2fe88f12d
+      - d38a433b-51fc-49e7-b51a-79f34acb998a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171609Z:9dfbf847-ec84-4847-9348-a4b2fe88f12d
+      - NORTHCENTRALUS:20160518T164353Z:d38a433b-51fc-49e7-b51a-79f34acb998a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:09 GMT
+      - Wed, 18 May 2016 16:43:52 GMT
       Content-Length:
       - '7609'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/056F4B33F11A3099","operationId":"056F4B33F11A3099","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:01.4236054Z","duration":"PT1M23.6187466S","trackingId":"70c620a7-2c3c-4743-ae6f-e3836270f2f1","serviceRequestId":"b592f413-95b5-42cb-84a1-817ab3f09275","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/62E621EEEC5E62EE","operationId":"62E621EEEC5E62EE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:29:37.7414996Z","duration":"PT2M9.3834226S","trackingId":"48044c61-7a07-4aff-be71-aeacc2471e7b","serviceRequestId":"e29ef1dc-4e0b-4a92-84f2-a3a746643bcd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.2125225Z","duration":"PT0.642269S","trackingId":"51ea1626-1a59-4e23-8590-445c4ca176d0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/34A4347ECF2A45BE","operationId":"34A4347ECF2A45BE","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.1112967Z","duration":"PT0.5497549S","trackingId":"ce1e6b19-7951-4c73-9005-20fe16d36036","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8F3051FDE964A700","operationId":"8F3051FDE964A700","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:09.9030716Z","duration":"PT2.0210551S","trackingId":"ed583a8c-7b18-4b99-a285-f09a67c14a3b","serviceRequestId":"c065af43-94f0-421b-a773-737f6584f645","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/9D251C6DB1BEEA3B","operationId":"9D251C6DB1BEEA3B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:27.4794736Z","duration":"PT33.3813549S","trackingId":"f9366eee-29f7-42e3-b0fe-1f577c8ae55c","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/7CE1E6C413F108AC","operationId":"7CE1E6C413F108AC","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.7755462Z","duration":"PT13.6793163S","trackingId":"ca83e042-a8c6-4ffb-9f2c-2e4a9f1bbd7c","serviceRequestId":"12a02fc5-02a7-4d40-a4b5-903a8dc79922","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/76F60549C9B601F7","operationId":"76F60549C9B601F7","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.0295771Z","duration":"PT12.9355177S","trackingId":"7fb0a493-ee8a-4d59-86f3-f435a2e1deba","serviceRequestId":"cd42e571-c085-4c3e-b89a-d86568b2e289","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/E142660DAD24486A","operationId":"E142660DAD24486A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.101236Z","duration":"PT12.9593617S","trackingId":"68e1b6fa-040c-450f-bd16-0426d5af0f9f","serviceRequestId":"57c68449-35f3-409e-8f51-f4cd9b65a3ab","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/08587432848725863745","operationId":"08587432848725863745","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.1079152Z","duration":"PT1.6252469S","trackingId":"229c4e55-24ce-4126-b6ff-de2aba268ff3","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:09 GMT
+  recorded_at: Wed, 18 May 2016 16:43:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2016-02-01
@@ -2550,7 +2654,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2567,24 +2671,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14780'
+      - '14958'
       X-Ms-Request-Id:
-      - 8e7b0866-d3d6-41ae-84f5-f3bacb15663b
+      - 12d66550-12bc-4228-9a28-90491c3408c6
       X-Ms-Correlation-Request-Id:
-      - 8e7b0866-d3d6-41ae-84f5-f3bacb15663b
+      - 12d66550-12bc-4228-9a28-90491c3408c6
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171610Z:8e7b0866-d3d6-41ae-84f5-f3bacb15663b
+      - NORTHCENTRALUS:20160518T164353Z:12d66550-12bc-4228-9a28-90491c3408c6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:09 GMT
+      - Wed, 18 May 2016 16:43:53 GMT
       Content-Length:
       - '7624'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:10 GMT
+  recorded_at: Wed, 18 May 2016 16:43:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
@@ -2601,7 +2705,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2622,20 +2726,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 50d58fd0-422c-4f4e-b2f5-b83b0470cfd2
+      - b72bd4fe-2ba1-4463-a9e4-c8edccbf6b16
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14792'
+      - '14967'
       X-Ms-Correlation-Request-Id:
-      - 40a57346-f6ea-4a5c-9fa7-7990ba2394e5
+      - 531994a3-7ff8-4434-82fd-fc50b899ff8c
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171610Z:40a57346-f6ea-4a5c-9fa7-7990ba2394e5
+      - NORTHCENTRALUS:20160518T164354Z:531994a3-7ff8-4434-82fd-fc50b899ff8c
       Date:
-      - Mon, 09 May 2016 17:16:10 GMT
+      - Wed, 18 May 2016 16:43:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\":
@@ -2787,10 +2891,10 @@ http_interactions:
         \     \"name\": \"spec0deply1vm1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
         \     \"location\": \"eastus\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:10 GMT
+  recorded_at: Wed, 18 May 2016 16:43:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2804,7 +2908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -2822,21 +2926,96 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 1ca7c564-1994-48d2-bd7b-931cdb4d7d62
+      - 0feb61e2-de79-43b0-be29-5544781fd53c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14961'
+      X-Ms-Correlation-Request-Id:
+      - 590f3fcb-7471-43e4-96d9-6b527cd66010
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164355Z:590f3fcb-7471-43e4-96d9-6b527cd66010
+      Date:
+      - Wed, 18 May 2016 16:43:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\":
+        \"9b746cf3-2e11-4c65-8bd5-4c83b7d9a5a4\",\r\n        \"hardwareProfile\":
+        {\r\n          \"vmSize\": \"Standard_A1\"\r\n        },\r\n        \"storageProfile\":
+        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"canonical\",\r\n
+        \           \"offer\": \"ubuntuserver\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n
+        \           \"version\": \"16.04.201604203\"\r\n          },\r\n          \"osDisk\":
+        {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"miqazuretest26611\",\r\n
+        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
+        \             \"uri\": \"https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_8021743a-5957-4dc1-a645-ca210d5d7fc5.vhd\"\r\n
+        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
+        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
+        \         \"computerName\": \"miqmismatch1\",\r\n          \"adminUsername\":
+        \"dberger\",\r\n          \"customData\": \"CiNjbG91ZC1jb25maWcKICB3cml0ZV9maWxlczoKICAgIC0gcGF0aDogL3Rlc3QudHh0CiAgICAgIHBlcm1pc3Npb25zOiAiMDY0NCIKICAgICAgb3duZXI6ICJkYmVyZ2VyIgogICAgICBjb250ZW50OiB8CiAgICAgICAgSGVsbG8gV29ybGQK\",\r\n
+        \         \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
+        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1\"}]},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1\",\r\n
+        \     \"name\": \"miqmismatch1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \     \"location\": \"eastus\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:43:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4d1c70ec-79b0-452e-b5a3-ffe742f191ce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14822'
+      - '14960'
       X-Ms-Correlation-Request-Id:
-      - ee4b9d06-8bc9-408d-9a05-ee279e38ef90
+      - 5b9b9cbe-200d-402f-b6f3-173b08670f7f
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171611Z:ee4b9d06-8bc9-408d-9a05-ee279e38ef90
+      - NORTHCENTRALUS:20160518T164355Z:5b9b9cbe-200d-402f-b6f3-173b08670f7f
       Date:
-      - Mon, 09 May 2016 17:16:10 GMT
+      - Wed, 18 May 2016 16:43:55 GMT
+      Connection:
+      - close
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1390\",\r\n
@@ -2968,6 +3147,28 @@ http_interactions:
         \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
         \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1\",\r\n
+        \     \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"23d804a8-b623-49e7-9c8d-1d64245bef1e\",\r\n        \"ipConfigurations\":
+        [\r\n          {\r\n            \"name\": \"miqmismatch1\",\r\n            \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\",\r\n
+        \           \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n
+        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"privateIPAddress\": \"10.16.0.8\",\r\n              \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\"\r\n
+        \             },\r\n              \"subnet\": {\r\n                \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
+        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
+        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
+        \       },\r\n        \"macAddress\": \"00-0D-3A-10-6F-F4\",\r\n        \"enableIPForwarding\":
+        false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
+        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic0\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
         \     \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n      \"type\":
@@ -3014,10 +3215,10 @@ http_interactions:
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
         \       }\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:11 GMT
+  recorded_at: Wed, 18 May 2016 16:43:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3031,7 +3232,58 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14808'
+      X-Ms-Request-Id:
+      - fd85c99b-e484-4223-8a47-1ac979b58609
+      X-Ms-Correlation-Request-Id:
+      - fd85c99b-e484-4223-8a47-1ac979b58609
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164356Z:fd85c99b-e484-4223-8a47-1ac979b58609
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 18 May 2016 16:43:55 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:43:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3047,38 +3299,160 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"e68a3d66-4215-4cf1-8f0f-65364da57c65"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d0b7d317-b6b5-4080-87cc-b2f569bae0db
+      - a9b03ced-7c0d-4f5b-be82-d4f5a53b1dd8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14803'
+      - '14918'
       X-Ms-Correlation-Request-Id:
-      - 2d02d2b3-f633-4edf-a1d5-2a3c5ecaa623
+      - ac699fad-7b00-4f47-86cc-b78ef43e9af4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171611Z:2d02d2b3-f633-4edf-a1d5-2a3c5ecaa623
+      - NORTHCENTRALUS:20160518T164357Z:ac699fad-7b00-4f47-86cc-b78ef43e9af4
       Date:
-      - Mon, 09 May 2016 17:16:11 GMT
+      - Wed, 18 May 2016 16:43:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
-        \ \"etag\": \"W/\\\"e68a3d66-4215-4cf1-8f0f-65364da57c65\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\": \"13.92.253.245\",\r\n
-        \   \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  }\r\n}"
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
+        \     \"etag\": \"W/\\\"e68a3d66-4215-4cf1-8f0f-65364da57c65\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n        \"ipAddress\":
+        \"13.92.253.245\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipConfiguration\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\",\r\n
+        \     \"etag\": \"W/\\\"8c14171e-afdb-469f-be79-e3c1c006be91\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\",\r\n
+        \     \"etag\": \"W/\\\"e28a3b72-79ab-428e-9bd3-85a775af8e03\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg\",\r\n
+        \     \"etag\": \"W/\\\"a091b576-4b02-4f33-81e8-6161b046fee5\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"410a657e-4107-4cf0-9447-1efd44e2363a\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \     \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqtestwinimg6202\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\",\r\n
+        \     \"etag\": \"W/\\\"b656279a-26ff-4021-94bb-263420cf494e\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"fb942169-855b-44f8-b12f-fd63e961b140\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1ip\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \     \"etag\": \"W/\\\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"dnsSettings\": {\r\n          \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \         \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n        },\r\n
+        \       \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"v-publicIp\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp\",\r\n
+        \     \"etag\": \"W/\\\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"b2dff9bd-173c-4e3e-b531-3e0e340bc07d\",\r\n        \"publicIPAddressVersion\":
+        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:11 GMT
+  recorded_at: Wed, 18 May 2016 16:43:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9cf2d2d4-1464-4c21-a88c-1958027d2685
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14956'
+      X-Ms-Correlation-Request-Id:
+      - fa5a7714-e4dd-4788-a6ad-7e9369679f57
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164357Z:fa5a7714-e4dd-4788-a6ad-7e9369679f57
+      Date:
+      - Wed, 18 May 2016 16:43:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\",\r\n
+        \     \"etag\": \"W/\\\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c\",\r\n        \"ipAddress\":
+        \"40.76.5.200\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"dnsSettings\":
+        {\r\n          \"domainNameLabel\": \"miqmismatch1\",\r\n          \"fqdn\":
+        \"miqmismatch1.eastus.cloudapp.azure.com\"\r\n        },\r\n        \"ipConfiguration\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:43:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2016-03-30
@@ -3095,7 +3469,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3116,27 +3490,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - a886e5dd-2807-4a95-86c0-d6c4ed199e1f
+      - 1a317ab6-2f9b-4a62-aa5e-0926f140adef
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14819'
+      - '14958'
       X-Ms-Correlation-Request-Id:
-      - a8f8ab00-ee94-43be-a600-56e9b2dab1c3
+      - d3a7cbf0-6a23-4496-a02d-dd679c7b63f6
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171612Z:a8f8ab00-ee94-43be-a600-56e9b2dab1c3
+      - NORTHCENTRALUS:20160518T164358Z:d3a7cbf0-6a23-4496-a02d-dd679c7b63f6
       Date:
-      - Mon, 09 May 2016 17:16:11 GMT
+      - Wed, 18 May 2016 16:43:57 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
         \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2016-05-09T17:16:04+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        \       \"time\": \"2016-05-18T16:43:40+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
         [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
         \       \"typeHandlerVersion\": \"2.3.7\",\r\n        \"status\": {\r\n          \"code\":
         \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
@@ -3159,70 +3533,7 @@ http_interactions:
         \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"8c14171e-afdb-469f-be79-e3c1c006be91"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7971f3c7-8033-4c77-9559-71d49cd9d639
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14800'
-      X-Ms-Correlation-Request-Id:
-      - 029c096e-5d62-4511-b1b4-2268e0489086
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171612Z:029c096e-5d62-4511-b1b4-2268e0489086
-      Date:
-      - Mon, 09 May 2016 17:16:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-ubuntu1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\",\r\n
-        \ \"etag\": \"W/\\\"8c14171e-afdb-469f-be79-e3c1c006be91\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:12 GMT
+  recorded_at: Wed, 18 May 2016 16:43:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/instanceView?api-version=2016-03-30
@@ -3239,7 +3550,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3260,26 +3571,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 5141f472-e616-4e8b-9390-629d4dcf5e57
+      - d76728b4-3a31-469a-816d-8212f5696be2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14791'
+      - '14953'
       X-Ms-Correlation-Request-Id:
-      - 66911995-dd88-4255-aa60-43fb65b9d750
+      - a66b92b8-6f66-4b10-a98e-526b8c175ffc
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171613Z:66911995-dd88-4255-aa60-43fb65b9d750
+      - NORTHCENTRALUS:20160518T164359Z:a66b92b8-6f66-4b10-a98e-526b8c175ffc
       Date:
-      - Mon, 09 May 2016 17:16:12 GMT
+      - Wed, 18 May 2016 16:43:58 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-09T17:16:13+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-18T16:43:59+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3294,70 +3605,7 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"e28a3b72-79ab-428e-9bd3-85a775af8e03"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b023b6ba-0ff0-4fd5-95e1-66ee304cf61a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14793'
-      X-Ms-Correlation-Request-Id:
-      - 1037eec1-4ca8-44c5-9574-1f42fa3064d0
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171613Z:1037eec1-4ca8-44c5-9574-1f42fa3064d0
-      Date:
-      - Mon, 09 May 2016 17:16:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-win12\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\",\r\n
-        \ \"etag\": \"W/\\\"e28a3b72-79ab-428e-9bd3-85a775af8e03\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:13 GMT
+  recorded_at: Wed, 18 May 2016 16:43:59 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/instanceView?api-version=2016-03-30
@@ -3374,7 +3622,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3395,26 +3643,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 2e499e2e-2028-4499-a6fa-2315457917d7
+      - 98bad9aa-7fdb-4b65-b95c-892f7b401bd2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14849'
+      - '14955'
       X-Ms-Correlation-Request-Id:
-      - 00665406-49a1-4727-bd29-2ca0ffaa4918
+      - a7633adc-5f5f-407c-8c62-87bd91c2a147
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171614Z:00665406-49a1-4727-bd29-2ca0ffaa4918
+      - NORTHCENTRALUS:20160518T164359Z:a7633adc-5f5f-407c-8c62-87bd91c2a147
       Date:
-      - Mon, 09 May 2016 17:16:13 GMT
+      - Wed, 18 May 2016 16:43:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-09T17:16:14+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-18T16:44:00+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3428,70 +3676,7 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"b656279a-26ff-4021-94bb-263420cf494e"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6997011f-b3b4-4876-9996-0a20de1f6afd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14793'
-      X-Ms-Correlation-Request-Id:
-      - ffb12c51-d4b8-494d-be61-aa1e9739f50b
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171614Z:ffb12c51-d4b8-494d-be61-aa1e9739f50b
-      Date:
-      - Mon, 09 May 2016 17:16:14 GMT
-      Connection:
-      - close
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqtestwinimg6202\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\",\r\n
-        \ \"etag\": \"W/\\\"b656279a-26ff-4021-94bb-263420cf494e\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"fb942169-855b-44f8-b12f-fd63e961b140\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:14 GMT
+  recorded_at: Wed, 18 May 2016 16:43:59 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/instanceView?api-version=2016-03-30
@@ -3508,7 +3693,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3529,26 +3714,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - ff9e528f-4dbc-46af-8b5e-b7b7d3283065
+      - 7ed707fb-90ac-4288-a218-710b09840c23
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14748'
+      - '14957'
       X-Ms-Correlation-Request-Id:
-      - 9fb45359-a4e5-4ab4-a69e-901b829fc5f5
+      - 34d6bdaf-65f8-4c53-b812-e60757a60c75
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171615Z:9fb45359-a4e5-4ab4-a69e-901b829fc5f5
+      - NORTHCENTRALUS:20160518T164400Z:34d6bdaf-65f8-4c53-b812-e60757a60c75
       Date:
-      - Mon, 09 May 2016 17:16:15 GMT
+      - Wed, 18 May 2016 16:44:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-09T17:16:15+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-18T16:44:01+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3564,70 +3749,7 @@ http_interactions:
         \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"734a3944-a880-444c-8c92-cace6e28e303"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d23a8af7-ca92-4f45-a0bd-2b4596660342
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14810'
-      X-Ms-Correlation-Request-Id:
-      - fb08f3e5-d822-4f43-ad77-67f1066df2a1
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171616Z:fb08f3e5-d822-4f43-ad77-67f1066df2a1
-      Date:
-      - Mon, 09 May 2016 17:16:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:16 GMT
+  recorded_at: Wed, 18 May 2016 16:44:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2016-03-30
@@ -3644,7 +3766,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3665,27 +3787,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 51d53088-78c6-45ad-8b95-2441b4ef24ab
+      - e0e25744-52f7-4537-af75-90ad5fec368b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14798'
+      - '14956'
       X-Ms-Correlation-Request-Id:
-      - 8ffac2f0-56d1-409a-ab2d-fcfca9729993
+      - 92e59ee1-a862-4547-ae1f-a31539193742
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171616Z:8ffac2f0-56d1-409a-ab2d-fcfca9729993
+      - NORTHCENTRALUS:20160518T164401Z:92e59ee1-a862-4547-ae1f-a31539193742
       Date:
-      - Mon, 09 May 2016 17:16:16 GMT
+      - Wed, 18 May 2016 16:44:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-09T17:16:16+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-18T16:44:02+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3700,7 +3822,7 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:16 GMT
+  recorded_at: Wed, 18 May 2016 16:44:01 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2016-03-30
@@ -3717,7 +3839,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3738,27 +3860,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - ced025b0-cead-43af-b9a7-f1cdc2652d72
+      - 6025d510-bf95-425c-b9f0-1afaa0309d56
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14722'
+      - '14928'
       X-Ms-Correlation-Request-Id:
-      - 0d01aec1-2d6f-4f29-ad95-1b3922552c6b
+      - f4ffe344-248f-455f-9226-27682e37235c
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171617Z:0d01aec1-2d6f-4f29-ad95-1b3922552c6b
+      - NORTHCENTRALUS:20160518T164401Z:f4ffe344-248f-455f-9226-27682e37235c
       Date:
-      - Mon, 09 May 2016 17:16:16 GMT
+      - Wed, 18 May 2016 16:44:01 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-09T17:16:17+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-18T16:44:02+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3771,7 +3893,7 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:17 GMT
+  recorded_at: Wed, 18 May 2016 16:44:02 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2016-03-30
@@ -3788,7 +3910,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3809,27 +3931,27 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131072134913196014
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 97c47f48-a37d-4440-8850-e97c89851b37
+      - 321d3031-d3af-44b9-8602-192dabf8f338
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14706'
+      - '14964'
       X-Ms-Correlation-Request-Id:
-      - 79c0bef3-428c-4202-b879-c914c0dd69eb
+      - 312af207-f94d-4287-b73a-8782928d7e0b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171617Z:79c0bef3-428c-4202-b879-c914c0dd69eb
+      - NORTHCENTRALUS:20160518T164403Z:312af207-f94d-4287-b73a-8782928d7e0b
       Date:
-      - Mon, 09 May 2016 17:16:17 GMT
+      - Wed, 18 May 2016 16:44:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-09T17:16:17+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-18T16:44:03+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3842,7 +3964,76 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:18 GMT
+  recorded_at: Wed, 18 May 2016 16:44:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1/instanceView?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      X-Ms-Request-Id:
+      - 4b7de528-715c-4dfb-a6b9-e53f4bf526df
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14946'
+      X-Ms-Correlation-Request-Id:
+      - eb7af77d-e2da-41ed-b592-36a9b8a58517
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164403Z:eb7af77d-e2da-41ed-b592-36a9b8a58517
+      Date:
+      - Wed, 18 May 2016 16:44:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.1.3\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
+        \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
+        \"Guest Agent is running\",\r\n        \"time\": \"2016-05-18T16:43:54+00:00\"\r\n
+        \     }\r\n    ],\r\n    \"extensionHandlers\": []\r\n  },\r\n  \"disks\":
+        [\r\n    {\r\n      \"name\": \"miqazuretest26611\",\r\n      \"statuses\":
+        [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-05-17T20:16:27.004737+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2016-05-17T20:18:31.9093759+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:44:04 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
@@ -3859,7 +4050,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -3878,27 +4069,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1ffc297f-f1ec-4c4a-8ae0-9a076c1f9da2
+      - 07540ec4-49c7-4dbe-90c0-420997782477
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14786'
+      - '14947'
       X-Ms-Correlation-Request-Id:
-      - 1ffc297f-f1ec-4c4a-8ae0-9a076c1f9da2
+      - 07540ec4-49c7-4dbe-90c0-420997782477
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171618Z:1ffc297f-f1ec-4c4a-8ae0-9a076c1f9da2
+      - NORTHCENTRALUS:20160518T164404Z:07540ec4-49c7-4dbe-90c0-420997782477
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:18 GMT
+      - Wed, 18 May 2016 16:44:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","kind":"Storage","location":"eastus","name":"miqazuretest14047","properties":{"creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","kind":"Storage","location":"eastus","name":"miqazuretest16487","properties":{"creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","kind":"Storage","location":"eastus","name":"miqazuretest18686","properties":{"creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","kind":"Storage","location":"eastus","name":"spec0deply1stor","properties":{"creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
 
 '
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:18 GMT
+  recorded_at: Wed, 18 May 2016 16:44:04 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2016-01-01
@@ -3915,7 +4106,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
       Content-Length:
       - '0'
   response:
@@ -3936,27 +4127,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b612cfce-89b9-4a5b-ac6c-6390a7c8cc4b
+      - 1cd2b80b-b248-4912-bffa-543d602db114
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - b612cfce-89b9-4a5b-ac6c-6390a7c8cc4b
+      - 1cd2b80b-b248-4912-bffa-543d602db114
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171619Z:b612cfce-89b9-4a5b-ac6c-6390a7c8cc4b
+      - NORTHCENTRALUS:20160518T164404Z:1cd2b80b-b248-4912-bffa-543d602db114
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:19 GMT
+      - Wed, 18 May 2016 16:44:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w=="},{"keyName":"key2","permissions":"Full","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg=="}]}
 
 '
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:19 GMT
+  recorded_at: Wed, 18 May 2016 16:44:04 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
@@ -3973,11 +4164,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:19 GMT
+      - Wed, 18 May 2016 16:44:04 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:c904cLvJif4oa3zl/TUTZ79zzHYNQBltY/6K2I7ZP/o=
+      - SharedKey miqazuretest14047:KXUDJMIcELnY83AT9VkNDRfM9v0XrndJ2rxEzX2GI6w=
   response:
     status:
       code: 200
@@ -3990,11 +4181,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - dca8dfda-0001-009f-1916-aa5ec5000000
+      - 8d1ffc0c-0001-0051-6224-b1388a000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:19 GMT
+      - Wed, 18 May 2016 16:44:04 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4045,7 +4236,7 @@ http_interactions:
         cz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0Vu
         dW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:20 GMT
+  recorded_at: Wed, 18 May 2016 16:44:05 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e?comp=list&restype=container
@@ -4062,11 +4253,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:20 GMT
+      - Wed, 18 May 2016 16:44:05 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:Y+FhJjSiql5VmQZBxUa8NNns8AaRZf8P9QCE3dwCBsA=
+      - SharedKey miqazuretest14047:X4iHRmXhxIdzIkUxi2PNt9brKi4j7KyJ25o5Qs76Myg=
   response:
     status:
       code: 200
@@ -4079,11 +4270,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - fa9f653b-0001-00fe-4416-aa1a1a000000
+      - ae3cc8a5-0001-001d-4a24-b1ff95000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:19 GMT
+      - Wed, 18 May 2016 16:44:05 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4118,7 +4309,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:20 GMT
+  recorded_at: Wed, 18 May 2016 16:44:05 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-6e555b88-3fd4-4b72-a404-4bba5d11de93?comp=list&restype=container
@@ -4135,11 +4326,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:20 GMT
+      - Wed, 18 May 2016 16:44:05 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:BKIDk6NxzZXW2s3Wewk3QJ5qzRUpxscCE1mBUXprIis=
+      - SharedKey miqazuretest14047:iTlrIhpWLwF70GoP1D/C2detGaRW7yOb29uEVNfZf/g=
   response:
     status:
       code: 200
@@ -4152,11 +4343,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b2852340-0001-00a2-5916-aaebe3000000
+      - 227ff7ab-0001-00e2-0624-b1c20d000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:20 GMT
+      - Wed, 18 May 2016 16:44:05 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4179,7 +4370,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:20 GMT
+  recorded_at: Wed, 18 May 2016 16:44:06 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-b97ff488-e114-40ed-8d7a-f4500d73eec0?comp=list&restype=container
@@ -4196,11 +4387,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:20 GMT
+      - Wed, 18 May 2016 16:44:06 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:kJKoNS38s0LWsG9jiOKYHfCfZ5qtRGK23arErlszJ00=
+      - SharedKey miqazuretest14047:O+Pr8SKtD8XOLKKB5LB9KesSWLL+gFfUwdrTRkHhgto=
   response:
     status:
       code: 200
@@ -4213,11 +4404,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1083c4af-0001-010e-0a16-aa8c21000000
+      - 07c4aba1-0001-0073-7624-b156bc000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:20 GMT
+      - Wed, 18 May 2016 16:44:06 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4240,7 +4431,7 @@ http_interactions:
         c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:21 GMT
+  recorded_at: Wed, 18 May 2016 16:44:06 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-e17a95b0-f4fb-4196-93c5-0c8be7d5c536?comp=list&restype=container
@@ -4257,11 +4448,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:21 GMT
+      - Wed, 18 May 2016 16:44:06 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:B6GJH0iLz2muBKtJvOfSE/S0PbQtwhCq97Sbu8R4qlU=
+      - SharedKey miqazuretest14047:4xwErAvTFz0OlA626pJhYaGfDjqyMnZyPfKwBqFr8PM=
   response:
     status:
       code: 200
@@ -4274,11 +4465,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f762b303-0001-0012-4016-aa1263000000
+      - d62dc109-0001-0053-6724-b13a70000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:21 GMT
+      - Wed, 18 May 2016 16:44:06 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4289,7 +4480,7 @@ http_interactions:
         ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNiI+PEJsb2JzIC8+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:21 GMT
+  recorded_at: Wed, 18 May 2016 16:44:07 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -4306,11 +4497,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:21 GMT
+      - Wed, 18 May 2016 16:44:07 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:U3lrU8/66tqqFqReJ/eEB2wswK4wnrXLfD/kruhUOCY=
+      - SharedKey miqazuretest14047:BQQ5izJ/d7mWC93qwqZDjGMct7ObxZ8XvJru63cCz0E=
   response:
     status:
       code: 200
@@ -4323,11 +4514,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0af97f98-0001-001a-6016-aa0910000000
+      - 04e4b2a1-0001-0123-6224-b10fe1000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:21 GMT
+      - Wed, 18 May 2016 16:44:06 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4347,35 +4538,48 @@ http_interactions:
         dW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
         PlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xl
         YXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48
-        L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2h3aXRoc183
-        M2I5YTk1YS1kZGUxLTQzYjUtODEzOS0yYmIwNDY1ZDM5MWEudmhkPC9OYW1l
-        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMjggQXByIDIwMTYg
-        MTQ6NTY6MzUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkY3NTRC
-        NEI4NEU2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0Nv
-        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
-        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
-        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksv
-        dlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
-        bnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4z
-        PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxv
-        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
-        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
-        aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZWN0ZXN0Ml84NGFkN2IyYi05MTAw
-        LTQwZGItODk5Ny1hMzE5MTJjZjI3YzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVz
-        PjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgQXByIDIwMTYgMTg6MTg6MjYgR01U
-        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjk0ODJBOTI3Rjk1PC9FdGFn
-        PjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3Ro
-        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
-        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
-        ZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0Nv
-        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
-        b24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2It
-        c2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+
-        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
-        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
-        L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+        L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2h0ZXN0MjNf
+        ZTIzNjA5ZmItOWM3Yy00MTNjLTliZTYtOWEwZTFjOWNkYmQ3LnZoZDwvTmFt
+        ZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDEzIE1heSAyMDE2
+        IDIxOjExOjQ4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzdCNzMz
+        MjcyOEUzQzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9D
+        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
+        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZL
+        L3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
+        MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJs
+        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
+        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHdpdGhzXzczYjlhOTVh
+        LWRkZTEtNDNiNS04MTM5LTJiYjA0NjVkMzkxYS52aGQ8L05hbWU+PFByb3Bl
+        cnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDo1Njoz
+        NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2Rjc1NEI0Qjg0RTY8
+        L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1M
+        ZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08
+        L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxh
+        bmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9
+        PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNw
+        b3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMt
+        YmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9i
+        VHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFz
+        ZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9C
+        bG9iPjxCbG9iPjxOYW1lPnNlY3Rlc3QyXzg0YWQ3YjJiLTkxMDAtNDBkYi04
+        OTk3LWEzMTkxMmNmMjdjMS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3Qt
+        TW9kaWZpZWQ+V2VkLCAyMCBBcHIgMjAxNiAxODoxODoyNiBHTVQ8L0xhc3Qt
+        TW9kaWZpZWQ+PEV0YWc+MHg4RDM2OTQ4MkE5MjdGOTU8L0V0YWc+PENvbnRl
+        bnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRl
+        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
+        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
+        bnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1N
+        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4
+        LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5j
+        ZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VT
+        dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
+        YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+
+        PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:22 GMT
+  recorded_at: Wed, 18 May 2016 16:44:07 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
@@ -4392,11 +4596,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:22 GMT
+      - Wed, 18 May 2016 16:44:07 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:h6XIajJNJDM9ruLGLEa6JpdHduRs6thiwF3rCK49svc=
+      - SharedKey miqazuretest14047:lxMgeImlXrGzESHYjFdMIMCuz40J91sR5Wbxu57s4XE=
   response:
     status:
       code: 200
@@ -4409,11 +4613,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8754cc51-0001-0035-5216-aa882a000000
+      - c39eee02-0001-0014-5024-b1e51b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:22 GMT
+      - Wed, 18 May 2016 16:44:06 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4450,7 +4654,7 @@ http_interactions:
         L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1
         bHRzPg==
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:22 GMT
+  recorded_at: Wed, 18 May 2016 16:44:08 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4467,11 +4671,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:22 GMT
+      - Wed, 18 May 2016 16:44:08 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:UUtYlF5MUsQnVV62on8/usQIgAYeKUWbvVe6iPGmEoc=
+      - SharedKey miqazuretest14047:p1P8OKnDNBoHZms8ruD/NLleg7YX+GAg/lzGqtd10AA=
   response:
     status:
       code: 200
@@ -4484,11 +4688,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 01237735-0001-003d-2d16-aa9359000000
+      - 006314bd-0001-001c-6524-b1fe68000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:22 GMT
+      - Wed, 18 May 2016 16:44:08 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4596,7 +4800,7 @@ http_interactions:
         ZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:23 GMT
+  recorded_at: Wed, 18 May 2016 16:44:08 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghrspec3_034c938b-eaa9-4399-8ed2-cb7216fabf0b.vhd
@@ -4613,11 +4817,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:23 GMT
+      - Wed, 18 May 2016 16:44:08 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:0ttbLwmNiNpWxbsJznquZqRKRceOTP/aAeagRympXMI=
+      - SharedKey miqazuretest14047:vU0lPp6WRw+DZ+ZXsUgWjg6GenQ5wib6r5duA9TU6qA=
   response:
     status:
       code: 200
@@ -4638,7 +4842,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0b202b01-0001-010d-6416-aa8f26000000
+      - 28571b15-0001-009d-7024-b15c3f000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4662,12 +4866,83 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 27 Apr 2016 19:35:14 GMT
       Date:
-      - Mon, 09 May 2016 17:16:23 GMT
+      - Wed, 18 May 2016 16:44:08 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:23 GMT
+  recorded_at: Wed, 18 May 2016 16:44:08 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghtest23_e23609fb-9c7c-413c-9be6-9a0e1c9cdbd7.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Wed, 18 May 2016 16:44:08 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey miqazuretest14047:2y52hZsT+7t+FVcmm7w+Ru7TpWJW0VUAQRzbNe899/o=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Fri, 13 May 2016 21:11:48 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D37B7332728E3C"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 443c61ae-0001-0055-2a24-b1cd08000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 66851399-f938-44ec-852f-210b5331e3e4
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=D6dgCT1L76l4aIk1Tjgo5Q34oXGG7%2FbEsDy6XagbI9o%3D&st=2016-05-13T20%3A47%3A18Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 13 May 2016 21:02:19 GMT
+      Date:
+      - Wed, 18 May 2016 16:44:08 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:44:09 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghwiths_73b9a95a-dde1-43b5-8139-2bb0465d391a.vhd
@@ -4684,11 +4959,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:23 GMT
+      - Wed, 18 May 2016 16:44:09 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:unPfbMd6619Q2G1IFF+6iJp6KN9EhAW7vOwk+C/UtG8=
+      - SharedKey miqazuretest14047:RE/gPxPtVKThC1BmsMb6z3ymgnS+Iu/iJYCYrFRDE64=
   response:
     status:
       code: 200
@@ -4709,7 +4984,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6f5736c1-0001-0061-7e16-aa62a0000000
+      - e355c7dc-0001-00d6-7c24-b16da5000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4733,12 +5008,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Thu, 28 Apr 2016 14:17:59 GMT
       Date:
-      - Mon, 09 May 2016 17:16:23 GMT
+      - Wed, 18 May 2016 16:44:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:24 GMT
+  recorded_at: Wed, 18 May 2016 16:44:09 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/sectest2_84ad7b2b-9100-40db-8997-a31912cf27c1.vhd
@@ -4755,11 +5030,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:24 GMT
+      - Wed, 18 May 2016 16:44:09 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:gklRw9r1v/5gvNanwJVwKdqZ3y3OowXer+qFYCQ2oeQ=
+      - SharedKey miqazuretest14047:iIHtofEONqil8zgPAXZxPmrrBHE0NHQUbfRC1LT6PkM=
   response:
     status:
       code: 200
@@ -4780,7 +5055,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 69a1af7f-0001-00a5-4916-aa1d66000000
+      - b9996683-0001-012e-0224-b1e0ed000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4804,12 +5079,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 20 Apr 2016 16:04:56 GMT
       Date:
-      - Mon, 09 May 2016 17:16:25 GMT
+      - Wed, 18 May 2016 16:44:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:24 GMT
+  recorded_at: Wed, 18 May 2016 16:44:10 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
@@ -4826,11 +5101,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:24 GMT
+      - Wed, 18 May 2016 16:44:10 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:Q0qUK7reveN5ABrXeebWhlA0Q1doVR0pTbIG+k3bQ7E=
+      - SharedKey miqazuretest14047:TYPPS2FFMRQ+aNl5YUx6cFYc/Qi1bh+UCvcT+zAMWLo=
   response:
     status:
       code: 200
@@ -4851,7 +5126,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a3b7db61-0001-0048-4416-aa14e2000000
+      - f991768a-0001-00d2-0d24-b19827000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -4883,12 +5158,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 17:08:02 GMT
       Date:
-      - Mon, 09 May 2016 17:16:24 GMT
+      - Wed, 18 May 2016 16:44:10 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:24 GMT
+  recorded_at: Wed, 18 May 2016 16:44:10 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
@@ -4905,11 +5180,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:24 GMT
+      - Wed, 18 May 2016 16:44:10 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:y7rLyz9MJNdudYktNCdxzPzewpiEzQ1tn20NIX3p0CI=
+      - SharedKey miqazuretest14047:nQFidvqxaV8yYxNEAxa3d1+gX1bePBsGuvfTIN+vYFg=
   response:
     status:
       code: 200
@@ -4930,7 +5205,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 41e82ed6-0001-0000-2b16-aa267f000000
+      - 81642200-0001-00c7-3024-b15abe000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4954,12 +5229,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 16:17:06 GMT
       Date:
-      - Mon, 09 May 2016 17:16:25 GMT
+      - Wed, 18 May 2016 16:44:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:25 GMT
+  recorded_at: Wed, 18 May 2016 16:44:10 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2016-01-01
@@ -4976,7 +5251,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
       Content-Length:
       - '0'
   response:
@@ -4988,6 +5263,8 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json
       Expires:
@@ -4995,29 +5272,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7060655a-44dd-48a8-b483-642281930d3d
+      - 3230f015-5ab7-4a34-bb2e-bc437e0c083d
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1197'
       X-Ms-Correlation-Request-Id:
-      - 7060655a-44dd-48a8-b483-642281930d3d
+      - 3230f015-5ab7-4a34-bb2e-bc437e0c083d
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171625Z:7060655a-44dd-48a8-b483-642281930d3d
+      - NORTHCENTRALUS:20160518T164411Z:3230f015-5ab7-4a34-bb2e-bc437e0c083d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:25 GMT
-      Connection:
-      - close
+      - Wed, 18 May 2016 16:44:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ=="},{"keyName":"key2","permissions":"Full","value":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA=="}]}
 
 '
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:25 GMT
+  recorded_at: Wed, 18 May 2016 16:44:11 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
@@ -5034,11 +5309,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:25 GMT
+      - Wed, 18 May 2016 16:44:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:wEL3fEVPzDNHQdD1UkI7x8JsqvNmbeFoEENZG1XOUeg=
+      - SharedKey miqazuretest16487:xox2t6e1gsca5fdYJxZYuIAbn+sNBB5eAoygLxcnB4s=
   response:
     status:
       code: 200
@@ -5051,11 +5326,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0ee9953e-0001-00b0-4616-aadfff000000
+      - 9333f4c5-0001-00b0-6224-b1dfff000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:26 GMT
+      - Wed, 18 May 2016 16:44:10 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5077,7 +5352,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:26 GMT
+  recorded_at: Wed, 18 May 2016 16:44:11 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e?comp=list&restype=container
@@ -5094,11 +5369,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:26 GMT
+      - Wed, 18 May 2016 16:44:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:HL+CrjPSG6CvjECC2L0VM7kFcq7hFw9bpft2zstV/Mg=
+      - SharedKey miqazuretest16487:o+ZXaXH5uKIaOD36euUCngXqeYf4tbls83oqjCYB5f4=
   response:
     status:
       code: 200
@@ -5111,11 +5386,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e2741ce2-0001-0018-2b16-aa0bea000000
+      - 7476e78e-0001-007c-0f24-b1bb4a000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:26 GMT
+      - Wed, 18 May 2016 16:44:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5150,7 +5425,7 @@ http_interactions:
         c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:26 GMT
+  recorded_at: Wed, 18 May 2016 16:44:12 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5167,11 +5442,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:26 GMT
+      - Wed, 18 May 2016 16:44:12 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:0/vRo5m9PVBryPCuUswiBkhOKX6B58gygTp1yQD2eoY=
+      - SharedKey miqazuretest16487:Z9roId4DOuSg3GOmGYo1X3aunlDLJDZu/0bD+0VT57k=
   response:
     status:
       code: 200
@@ -5184,11 +5459,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 263cd9bf-0001-0034-5016-aa89d7000000
+      - 8f8e9a01-0001-0125-5024-b1f899000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:26 GMT
+      - Wed, 18 May 2016 16:44:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5223,7 +5498,7 @@ http_interactions:
         PjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJl
         c3VsdHM+
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:26 GMT
+  recorded_at: Wed, 18 May 2016 16:44:12 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2016-01-01
@@ -5240,7 +5515,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
       Content-Length:
       - '0'
   response:
@@ -5261,27 +5536,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 46c19149-340e-46e7-a3ce-ad84905d22bd
+      - 5f6d402b-97b2-406a-b67b-2055d393880c
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1197'
       X-Ms-Correlation-Request-Id:
-      - 46c19149-340e-46e7-a3ce-ad84905d22bd
+      - 5f6d402b-97b2-406a-b67b-2055d393880c
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171627Z:46c19149-340e-46e7-a3ce-ad84905d22bd
+      - NORTHCENTRALUS:20160518T164412Z:5f6d402b-97b2-406a-b67b-2055d393880c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:26 GMT
+      - Wed, 18 May 2016 16:44:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw=="},{"keyName":"key2","permissions":"Full","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w=="}]}
 
 '
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:27 GMT
+  recorded_at: Wed, 18 May 2016 16:44:13 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
@@ -5298,11 +5573,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:27 GMT
+      - Wed, 18 May 2016 16:44:13 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:xIZNZjluGS3J8Fz8q3JIa8Be6IYR0IBC4vXnebak+Qo=
+      - SharedKey miqazuretest18686:b+yrRIyGG1AmG6zXG7bjGjRZvU/Mn5w0Q/z0wCxDMEs=
   response:
     status:
       code: 200
@@ -5315,11 +5590,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0f9c1a45-0001-002f-3716-aaa745000000
+      - 08e87f81-0001-00d1-1724-b19b20000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:28 GMT
+      - Wed, 18 May 2016 16:44:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5341,7 +5616,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:28 GMT
+  recorded_at: Wed, 18 May 2016 16:44:13 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4?comp=list&restype=container
@@ -5358,11 +5633,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:28 GMT
+      - Wed, 18 May 2016 16:44:13 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:b1YPT9aqaL4cCRLaMcfcEtW2srwfTqOSrTwPjw05xH4=
+      - SharedKey miqazuretest18686:3KoXT1Vx0YOyIdTjPe72QePTavE3Fuqvunl69bK1kzM=
   response:
     status:
       code: 200
@@ -5375,11 +5650,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 56539158-0001-00ff-6816-aa1be7000000
+      - 630a7a07-0001-009e-5224-b15f38000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:29 GMT
+      - Wed, 18 May 2016 16:44:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5390,8 +5665,8 @@ http_interactions:
         YWItNDg2Ny05Y2M0LTE1NzMzNmI3ZTJlNCI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXJoZWwxLjAzZTg0NjdiLWJhYWItNDg2Ny05Y2M0LTE1NzMz
         NmI3ZTJlNC5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5Nb24sIDA5IE1heSAyMDE2IDE3OjE2OjIxIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzc4MkRBNDhFRDdBQTwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5XZWQsIDE4IE1heSAyMDE2IDE2OjQzOjI1IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzdGM0I4ODI0QzExRTwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -5402,9 +5677,9 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRl
         c3QtcmhlbDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0
         LnNlcmlhbGNvbnNvbGUubG9nPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPk1vbiwgMDkgTWF5IDIwMTYgMTY6NTQ6MjEgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQzNzgyQTkxN0YyMjdEPC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD40NjU5MjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
+        ZGlmaWVkPldlZCwgMTggTWF5IDIwMTYgMTI6MDM6MjIgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzN0YxNDY4RERDRjk5PC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD42OTEyMDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
         ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
         Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNoZS1Db250
         cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVl
@@ -5414,7 +5689,7 @@ http_interactions:
         dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:28 GMT
+  recorded_at: Wed, 18 May 2016 16:44:13 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5431,11 +5706,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:28 GMT
+      - Wed, 18 May 2016 16:44:13 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:CG8ayune0Pc4XgvbrGhCYGqWe4ZHkmgAOjIEaqCfr3g=
+      - SharedKey miqazuretest18686:acCHWFL3pHVcC2RbQT+X0ch9pZe/tfku1uuFYf/83Bs=
   response:
     status:
       code: 200
@@ -5448,11 +5723,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 55336b58-0001-0107-3d16-aa96af000000
+      - 94472a81-0001-0092-4e24-b1b1c9000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:29 GMT
+      - Wed, 18 May 2016 16:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5461,33 +5736,33 @@ http_interactions:
         enVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtcmhl
         bDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0LnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA5IE1h
-        eSAyMDE2IDE3OjE2OjA0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        Mzc4MkQ5QTRDRDkwQzwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDE4IE1h
+        eSAyMDE2IDE2OjQ0OjA1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzdGM0JBMDU0M0EyNjwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250
         ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
         cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MXp0Q1hObS84WGdiSTh0Tzdt
-        c1BRUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MTVMeTlvWXAyNXhnVGVEYmlw
+        Rlc4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
         LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
         PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
         ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
         QmxvYj48TmFtZT5taXEtdGVzdC1yaGVsMTIwMTYyMTgxMTIyNDMudmhkPC9O
-        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDkgTWF5IDIw
-        MTYgMTc6MTI6MDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNzgy
-        RDBEODYxREQ5PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMTggTWF5IDIw
+        MTYgMTY6NDQ6MTAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0Yz
+        QkEzNTM0NEQ4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
         Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
         dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
         b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmRRTCtYSGpGTlBkb01F
         d2VJNjNmd1E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
         dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        PjEzNTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        PjE1NzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
         ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
         dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
         dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9C
         bG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0
         cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:29 GMT
+  recorded_at: Wed, 18 May 2016 16:44:14 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2016-01-01
@@ -5504,7 +5779,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
       Content-Length:
       - '0'
   response:
@@ -5525,27 +5800,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d4515a67-7e5e-402f-b5f8-e92f363c016f
+      - 1f266d27-7ad7-4a70-867c-df779cabe018
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1195'
+      - '1198'
       X-Ms-Correlation-Request-Id:
-      - d4515a67-7e5e-402f-b5f8-e92f363c016f
+      - 1f266d27-7ad7-4a70-867c-df779cabe018
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171629Z:d4515a67-7e5e-402f-b5f8-e92f363c016f
+      - NORTHCENTRALUS:20160518T164414Z:1f266d27-7ad7-4a70-867c-df779cabe018
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:28 GMT
+      - Wed, 18 May 2016 16:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ=="},{"keyName":"key2","permissions":"Full","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw=="}]}
 
 '
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:29 GMT
+  recorded_at: Wed, 18 May 2016 16:44:14 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
@@ -5562,11 +5837,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:29 GMT
+      - Wed, 18 May 2016 16:44:14 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:kT8UK7gIU50CkgR1ylArP/CR4evZGIewg96OU9HePYM=
+      - SharedKey spec0deply1stor:4KSdWDoD/xqRTKoiiUBegtTnqLc/WM+CJcxO3ShSK9Q=
   response:
     status:
       code: 200
@@ -5579,11 +5854,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4477b78f-0001-00da-0316-aa8354000000
+      - 44cc0c9a-0001-012f-1324-b1e110000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:30 GMT
+      - Wed, 18 May 2016 16:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5611,7 +5886,7 @@ http_interactions:
         b3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2Vy
         IC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:30 GMT
+  recorded_at: Wed, 18 May 2016 16:44:15 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68?comp=list&restype=container
@@ -5628,11 +5903,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:30 GMT
+      - Wed, 18 May 2016 16:44:15 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:u5qNQu5FYqodzHZW91em+H+CzTD14zK+kDze4nadbm0=
+      - SharedKey spec0deply1stor:MOvxSpyCZdGI93dB9vndGc0pjlH9fmKDD+Qm72forWc=
   response:
     status:
       code: 200
@@ -5645,11 +5920,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 70f7f48a-0001-0092-7316-aab1c9000000
+      - eeba862b-0001-010f-5224-b18ddc000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:30 GMT
+      - Wed, 18 May 2016 16:44:15 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5672,7 +5947,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:30 GMT
+  recorded_at: Wed, 18 May 2016 16:44:15 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261?comp=list&restype=container
@@ -5689,11 +5964,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:30 GMT
+      - Wed, 18 May 2016 16:44:15 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:lxnGUP31Ya+GhhQTnIMDEuJ6vjZ4IGiLKg5rvFnKc/Q=
+      - SharedKey spec0deply1stor:hnO+a4Xi2ydIY2w8KHg2h7FvFL09eqHRTFUOpvFXoTo=
   response:
     status:
       code: 200
@@ -5706,11 +5981,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c8a14497-0001-004a-7416-aa1618000000
+      - 38f3a437-0001-00a0-5724-b1e919000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:31 GMT
+      - Wed, 18 May 2016 16:44:14 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5733,7 +6008,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:31 GMT
+  recorded_at: Wed, 18 May 2016 16:44:16 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5750,11 +6025,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Mon, 09 May 2016 17:16:31 GMT
+      - Wed, 18 May 2016 16:44:16 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:QzvI2XZKp+XxwwSLhM7asLxoMT5xtPgHrbVIcQEGiG8=
+      - SharedKey spec0deply1stor:ITeOBYrY2pCrjbQ2DxVnQpGwyl5RRc5bHE/zgp0N/nU=
   response:
     status:
       code: 200
@@ -5767,11 +6042,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 32964d13-0001-00f2-1516-aaf4eb000000
+      - 6f26200c-0001-00d9-4f24-b18053000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Mon, 09 May 2016 17:16:31 GMT
+      - Wed, 18 May 2016 16:44:15 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5829,7 +6104,63 @@ http_interactions:
         PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4
         dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:32 GMT
+  recorded_at: Wed, 18 May 2016 16:44:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5e40838c-f58c-411e-8b64-3b0d90dcbd5d
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14917'
+      X-Ms-Correlation-Request-Id:
+      - 5e40838c-f58c-411e-8b64-3b0d90dcbd5d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164417Z:5e40838c-f58c-411e-8b64-3b0d90dcbd5d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 18 May 2016 16:44:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:44:17 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
@@ -5846,7 +6177,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -5863,22 +6194,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 89001c15-a766-4c1d-aedf-87570d05a4cd
+      - 96ce7645-4fd9-4a20-a047-5279ab353a3b
       X-Ms-Correlation-Request-Id:
-      - 89001c15-a766-4c1d-aedf-87570d05a4cd
+      - 96ce7645-4fd9-4a20-a047-5279ab353a3b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171635Z:89001c15-a766-4c1d-aedf-87570d05a4cd
+      - NORTHCENTRALUS:20160518T164420Z:96ce7645-4fd9-4a20-a047-5279ab353a3b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 09 May 2016 17:16:35 GMT
+      - Wed, 18 May 2016 16:44:20 GMT
       Content-Length:
-      - '566'
+      - '750'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}]}'
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:35 GMT
+  recorded_at: Wed, 18 May 2016 16:44:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
@@ -5895,7 +6226,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -5914,20 +6245,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3f60768c-7710-4f0d-a91d-cef2b7005a3a
+      - a9eaaa92-15b1-4529-b2fc-7a0efa8260b3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14819'
+      - '14965'
       X-Ms-Correlation-Request-Id:
-      - ff41879b-04ba-4686-8740-ab052af3c56e
+      - e633cea1-a666-4e7b-a2f0-96d56ddd71f5
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171636Z:ff41879b-04ba-4686-8740-ab052af3c56e
+      - NORTHCENTRALUS:20160518T164421Z:e633cea1-a666-4e7b-a2f0-96d56ddd71f5
       Date:
-      - Mon, 09 May 2016 17:16:36 GMT
+      - Wed, 18 May 2016 16:44:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
@@ -6392,7 +6723,58 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\"\r\n
         \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:36 GMT
+  recorded_at: Wed, 18 May 2016 16:44:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14958'
+      X-Ms-Request-Id:
+      - 61b98aa5-0db4-4fe1-a6b3-d3dd738d4abf
+      X-Ms-Correlation-Request-Id:
+      - 61b98aa5-0db4-4fe1-a6b3-d3dd738d4abf
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164421Z:61b98aa5-0db4-4fe1-a6b3-d3dd738d4abf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 18 May 2016 16:44:21 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:44:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
@@ -6409,7 +6791,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -6428,38 +6810,39 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0f45af2f-d008-45b8-943b-8235feeaf991
+      - dd206a46-adae-4484-b25e-1fca7c6c8491
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14659'
+      - '14959'
       X-Ms-Correlation-Request-Id:
-      - e92605a2-4bf4-4af4-8100-32bd2b7d3c4e
+      - bf4bda56-0122-41f5-b5de-83cb1323db10
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171636Z:e92605a2-4bf4-4af4-8100-32bd2b7d3c4e
+      - NORTHCENTRALUS:20160518T164422Z:bf4bda56-0122-41f5-b5de-83cb1323db10
       Date:
-      - Mon, 09 May 2016 17:16:36 GMT
+      - Wed, 18 May 2016 16:44:21 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-azure-test1\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \     \"etag\": \"W/\\\"fc474b6c-7052-4243-afdd-08cc5a294c82\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"0f86710b-e306-406d-9ae6-932fcd17e9dc\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n        \"addressSpace\":
         {\r\n          \"addressPrefixes\": [\r\n            \"10.16.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"fc474b6c-7052-4243-afdd-08cc5a294c82\\\"\",\r\n
+        \           \"etag\": \"W/\\\"0f86710b-e306-406d-9ae6-932fcd17e9dc\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.16.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
         \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
         \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\"\r\n
         \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
         \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
         \     }\r\n    },\r\n    {\r\n      \"name\": \"miqazuretest18687\",\r\n      \"id\":
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687\",\r\n
@@ -6506,7 +6889,58 @@ http_interactions:
         \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
         \     }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:36 GMT
+  recorded_at: Wed, 18 May 2016 16:44:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14807'
+      X-Ms-Request-Id:
+      - 87919dda-6715-4f73-89e0-d290da44ee04
+      X-Ms-Correlation-Request-Id:
+      - 87919dda-6715-4f73-89e0-d290da44ee04
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164422Z:87919dda-6715-4f73-89e0-d290da44ee04
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 18 May 2016 16:44:22 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:44:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
@@ -6523,7 +6957,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -6542,20 +6976,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 487a473a-06cc-465a-9ef9-56b3a805d55d
+      - 41e3f2e4-66da-402d-9ada-d7ec3157b3a5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14777'
+      - '14917'
       X-Ms-Correlation-Request-Id:
-      - 2dbe0526-9456-4261-9cd3-37f6d98b67e5
+      - 599dbaf9-bc89-4ddf-9dac-9add57ef80d3
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171637Z:2dbe0526-9456-4261-9cd3-37f6d98b67e5
+      - NORTHCENTRALUS:20160518T164423Z:599dbaf9-bc89-4ddf-9dac-9add57ef80d3
       Date:
-      - Mon, 09 May 2016 17:16:37 GMT
+      - Wed, 18 May 2016 16:44:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1390\",\r\n
@@ -6687,6 +7121,28 @@ http_interactions:
         \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
         \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1\",\r\n
+        \     \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"23d804a8-b623-49e7-9c8d-1d64245bef1e\",\r\n        \"ipConfigurations\":
+        [\r\n          {\r\n            \"name\": \"miqmismatch1\",\r\n            \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\",\r\n
+        \           \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n
+        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"privateIPAddress\": \"10.16.0.8\",\r\n              \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\"\r\n
+        \             },\r\n              \"subnet\": {\r\n                \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
+        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
+        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
+        \       },\r\n        \"macAddress\": \"00-0D-3A-10-6F-F4\",\r\n        \"enableIPForwarding\":
+        false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
+        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic0\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
         \     \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n      \"type\":
@@ -6733,7 +7189,58 @@ http_interactions:
         {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
         \       }\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:37 GMT
+  recorded_at: Wed, 18 May 2016 16:44:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14955'
+      X-Ms-Request-Id:
+      - 973f68de-a742-4032-82a6-549e769ee8a9
+      X-Ms-Correlation-Request-Id:
+      - 973f68de-a742-4032-82a6-549e769ee8a9
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164423Z:973f68de-a742-4032-82a6-549e769ee8a9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 18 May 2016 16:44:22 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:44:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
@@ -6750,7 +7257,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjI4MTM4NTgsIm5iZiI6MTQ2MjgxMzg1OCwiZXhwIjoxNDYyODE3NzU4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.UNXk69-bBd5s9BBXJD1S2ec5dY0RGt4FFVeND8jtIqvI4Gete9zycbw4c2iO4-XvpcJKPYC7UcElJnmnrGtcFQ4b6OxlUHcglHdtgg7LJcVriVZsibF4rid0v9kfzy2N14ao1pXH99eGbUSloTOpEC0QR-jvrxqpd0cSg6lKynIB41gGpkWQBPy_LGtR98zsWYv3q5lTfcAi6mcxFCK38GTeO_85W3TrEZn83qxbsypUcOyvX07TMpdvEZ9ohL6wNO6Aau4qDxuaF49gaJExoYAEl-CVdg84FkUmBP0frdVqMnwM4iTp4JRVnSWLr3ZHd5WGZI-mlLANypL11lRuXQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
   response:
     status:
       code: 200
@@ -6769,20 +7276,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e2bd0ed7-259a-4d01-80a1-5f65fb2d2057
+      - e890b167-7fe5-4746-8fe9-5783a4d00daf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14788'
+      - '14957'
       X-Ms-Correlation-Request-Id:
-      - fd3d5cd3-f76b-413d-a4fc-c6a5f69c3356
+      - 95546a34-1e1f-4b99-aad3-a85cdcfc48f2
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160509T171638Z:fd3d5cd3-f76b-413d-a4fc-c6a5f69c3356
+      - NORTHCENTRALUS:20160518T164423Z:95546a34-1e1f-4b99-aad3-a85cdcfc48f2
       Date:
-      - Mon, 09 May 2016 17:16:38 GMT
+      - Wed, 18 May 2016 16:44:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
@@ -6846,12 +7353,78 @@ http_interactions:
         \       \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"v-publicIp\",\r\n
         \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp\",\r\n
-        \     \"etag\": \"W/\\\"55b3c93d-de22-451b-ae6a-2f37d34c8dcb\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\\\"\",\r\n      \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"resourceGuid\": \"b2dff9bd-173c-4e3e-b531-3e0e340bc07d\",\r\n        \"publicIPAddressVersion\":
         \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4\r\n      }\r\n    }\r\n  ]\r\n}"
+        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1\"\r\n
+        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 09 May 2016 17:16:38 GMT
+  recorded_at: Wed, 18 May 2016 16:44:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b0d543e6-b4f0-4f0a-96a9-af220dc84272
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14951'
+      X-Ms-Correlation-Request-Id:
+      - de5d0dfe-68b4-4c63-b0d9-398247ad7d32
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160518T164424Z:de5d0dfe-68b4-4c63-b0d9-398247ad7d32
+      Date:
+      - Wed, 18 May 2016 16:44:23 GMT
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\",\r\n
+        \     \"etag\": \"W/\\\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c\",\r\n        \"ipAddress\":
+        \"40.76.5.200\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"dnsSettings\":
+        {\r\n          \"domainNameLabel\": \"miqmismatch1\",\r\n          \"fqdn\":
+        \"miqmismatch1.eastus.cloudapp.azure.com\"\r\n        },\r\n        \"ipConfiguration\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Wed, 18 May 2016 16:44:24 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
The refresh parser for Azure has a bug where it assumes that the NIC and its associated public IP address resource are in the same resource group. While this is the norm, it is not required, and the parser will fail because of this line if they are not:

https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb#L279

If the resource group of the NIC is not the same as the resource group of the public IP, an exception will be thrown because the `@ips.get` call will fail.

My solution is similar to what we did for network interfaces. Make a single call to get them all up front, then just use Ruby methods to find the one we want. While this does mean more data over the wire up front, it will result in significantly fewer http requests being made overall.

I also updated the cassette for the additional public IP collection http request.