### PR TITLE
Issue 8418 - link to deployments was not working

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -34,6 +34,8 @@ class MiddlewareServerController < ApplicationController
 
     if @display == 'middleware_datasources'
       show_container_display(@record, 'middleware_datasource', MiddlewareDatasource)
+    elsif @display == 'middleware_deployments'
+      show_container_display(@record, 'middleware_deployment', MiddlewareDeployment)
     else
       show_container(@record, controller_name, display_name)
     end

--- a/app/views/middleware_server/show.html.haml
+++ b/app/views/middleware_server/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(middleware_datasources).include?(@display)
+- if %w(middleware_datasources middleware_deployments).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "performance"
   = render(:partial => "layouts/performance")


### PR DESCRIPTION
Fixing the link in the relationship section for middleware deployments (on the middleware server page)
This fixes issue #8418

@miq-bot add_label providers/hawkular
cc @abonas 