### PR TITLE
Start container scans from job_proxy_dispatcher

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -31,7 +31,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def initializing
-    queue_signal(:start)
+    # exactly like job.dispatch_start except for storage bits
+    _log.info "Dispatch Status is 'pending'"
+    update(:dispatch_status => "pending")
   end
 
   def start
@@ -45,7 +47,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     namespace = INSPECTOR_NAMESPACE_FALLBACK if namespace.blank?
 
     update!(:options => options.merge(
-      :ems_id          => image.ext_management_system.id,
       :docker_image_id => image.docker_id,
       :image_full_name => image.full_name,
       :pod_name        => "manageiq-img-scan-#{guid[0..4]}",
@@ -207,7 +208,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def finish(*_args)
-    # Dummy method, nothing to execute here. Job finished.
+    # exactly like job.dispatch_finish except for storage bits
+    _log.info "Dispatch Status is 'finished'"
+    update(:dispatch_status => "finished")
   end
 
   alias_method :abort_job, :cleanup

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -110,7 +110,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       :target_id       => entity_id,
       :zone            => my_zone,
       :miq_server_host => MiqServer.my_server.hostname,
-      :miq_server_guid => MiqServer.my_server.guid
+      :miq_server_guid => MiqServer.my_server.guid,
+      :ems_id          => id,
     )
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -76,6 +76,8 @@
   :concurrent_per_host: 1
   :scan_via_host: true
   :use_vim_broker: true
+:container_scanning:
+  :concurrent_per_ems: 3
 :database:
   :metrics_collection:
     :collection_schedule: "1 * * * *"

--- a/spec/models/job_proxy_dispatcher/job_proxy_dispatcher_helper.rb
+++ b/spec/models/job_proxy_dispatcher/job_proxy_dispatcher_helper.rb
@@ -1,6 +1,6 @@
 module JobProxyDispatcherHelper
-  def build_hosts_proxies_storages_vms(options = {})
-    options = {:hosts => 2, :storages => 2, :vms => 3, :repo_vms => 3}.merge(options)
+  def build_entities(options = {})
+    options = {:hosts => 2, :storages => 2, :vms => 3, :repo_vms => 3, :container_providers => [1, 2]}.merge(options)
 
     proxies = []
     storages = []
@@ -43,6 +43,15 @@ module JobProxyDispatcherHelper
       vm.save
       repo_vms << vm
     end
-    return hosts, proxies, storages, vms, repo_vms
+
+    container_providers = []
+    options[:container_providers].each_with_index do |images_count, i|
+      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :name => "test_container_provider_#{i}")
+      container_providers << ems_kubernetes
+      images_count.times do |idx|
+        FactoryGirl.create(:container_image, :name => "test_container_images_#{idx}", :ems_id => ems_kubernetes.id)
+      end
+    end
+    return hosts, proxies, storages, vms, repo_vms, container_providers
   end
 end

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -52,7 +52,12 @@ module JobProxyDispatcherEmbeddedScanSpec
         allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:authentication_status_ok? => true)
         allow_any_instance_of(Host).to receive_messages(:authentication_status_ok? => true)
 
-        @hosts, @proxies, @storages, @vms, @repo_vms = build_hosts_proxies_storages_vms(:hosts => NUM_HOSTS, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS)
+        @hosts, @proxies, @storages, @vms, @repo_vms = build_entities(
+          :hosts    => NUM_HOSTS,
+          :storages => NUM_STORAGES,
+          :vms      => NUM_VMS,
+          :repo_vms => NUM_REPO_VMS
+        )
       end
 
       context "and a scan job for each vm" do

--- a/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
@@ -13,7 +13,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
       before(:each) do
-        @hosts, @proxies, @storages, @vms = build_hosts_proxies_storages_vms
+        @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -1,41 +1,44 @@
-module JobProxyDispatcherSpec
-  describe "dispatch" do
-    require File.expand_path(File.join(File.dirname(__FILE__), 'job_proxy_dispatcher/job_proxy_dispatcher_helper'))
-    include JobProxyDispatcherHelper
+require File.expand_path(File.join(File.dirname(__FILE__), 'job_proxy_dispatcher/job_proxy_dispatcher_helper'))
+include JobProxyDispatcherHelper
 
-    DISPATCH_ONLY = false
-    if DISPATCH_ONLY
-      NUM_VMS = 200
-      NUM_REPO_VMS = 200
-      NUM_HOSTS = 10
-      NUM_SERVERS = 10
-      NUM_STORAGES = 30
-    else
-      NUM_VMS = 3
-      NUM_REPO_VMS = 3
-      NUM_HOSTS = 3
-      NUM_SERVERS = 3
-      NUM_STORAGES = 3
-    end
+describe JobProxyDispatcher do
+  DISPATCH_ONLY = false
+  if DISPATCH_ONLY
+    NUM_VMS = 200
+    NUM_REPO_VMS = 200
+    NUM_HOSTS = 10
+    NUM_SERVERS = 10
+    NUM_STORAGES = 30
+  else
+    NUM_VMS = 3
+    NUM_REPO_VMS = 3
+    NUM_HOSTS = 3
+    NUM_SERVERS = 3
+    NUM_STORAGES = 3
+  end
 
-    context "With a default zone, server, with hosts with a miq_proxy, vmware vms on storages" do
-      before(:each) do
-        @server = EvmSpecHelper.local_miq_server(:name => "test_server_main_server")
+  context "With a default zone, server, with hosts with a miq_proxy, vmware vms on storages" do
+    before(:each) do
+      @server = EvmSpecHelper.local_miq_server(:name => "test_server_main_server")
 
-        (NUM_SERVERS - 1).times do |i|
-          FactoryGirl.create(:miq_server, :zone => @server.zone, :name => "test_server_#{i}")
-        end
-
-        # TODO: We should be able to set values so we don't need to stub behavior
-        allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
-        allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
-        allow_any_instance_of(MiqServer).to receive_messages(:has_active_role? => true)
-        allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:missing_credentials? => false)
-        allow_any_instance_of(Host).to receive_messages(:missing_credentials? => false)
-
-        @hosts, @proxies, @storages, @vms, @repo_vms = build_hosts_proxies_storages_vms(:hosts => NUM_HOSTS, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS)
+      (NUM_SERVERS - 1).times do |i|
+        FactoryGirl.create(:miq_server, :zone => @server.zone, :name => "test_server_#{i}")
       end
 
+      # TODO: We should be able to set values so we don't need to stub behavior
+      allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:has_active_role? => true)
+      allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:missing_credentials? => false)
+      allow_any_instance_of(Host).to receive_messages(:missing_credentials? => false)
+
+      @hosts, @proxies, @storages, @vms, @repo_vms, @container_providers = build_entities(
+        :hosts => NUM_HOSTS, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS
+      )
+      @container_images = @container_providers.collect(&:container_images).flatten
+    end
+
+    describe "#dispatch" do
       # Don't run these tests if we only want to run dispatch for load testing
       unless DISPATCH_ONLY
         it "should have a server in default zone" do
@@ -170,6 +173,104 @@ module JobProxyDispatcherSpec
           expect(@job.state).to eq("finished")
           expect(@job.status).to eq("warn")
         end
+      end
+    end
+
+    context "with container and vms jobs" do
+      before(:each) do
+        @jobs = (@vms + @repo_vms + @container_images).collect(&:scan)
+        @dispatcher = JobProxyDispatcher.new
+      end
+
+      describe "#pending_jobs" do
+        it "returns only vm jobs by default" do
+          jobs = @dispatcher.pending_jobs
+          expect(jobs.count).to eq(@vms.count + @repo_vms.count)
+          jobs.each do |x|
+            expect(x.target_class).to eq 'VmOrTemplate'
+          end
+          expect(jobs.count).to be > 0 # in case something unexpected goes wrong
+        end
+
+        it "returns only container images jobs when requested" do
+          jobs = @dispatcher.pending_jobs(ContainerImage)
+          expect(jobs.count).to eq(@container_images.count)
+          jobs.each do |x|
+            expect(x.target_class).to eq 'ContainerImage'
+          end
+          expect(jobs.count).to be > 0 # in case something unexpected goes wrong
+        end
+      end
+
+      describe "#pending_container_jobs" do
+        it "returns container jobs by provider" do
+          jobs_by_ems, = @dispatcher.pending_container_jobs
+          expect(jobs_by_ems.keys).to match_array(@container_providers.map(&:id))
+
+          expect(jobs_by_ems[@container_providers.first.id].count).to eq(1)
+          expect(jobs_by_ems[@container_providers.second.id].count).to eq(2)
+        end
+      end
+
+      describe "#active_container_scans_by_zone_and_ems" do
+        it "returns active container acans for zone" do
+          job = @jobs.find { |j| j.target_class == ContainerImage.name }
+          job.update(:dispatch_status => "active")
+          provider = ExtManagementSystem.find(job.options[:ems_id])
+          @dispatcher.instance_variable_set(:@zone, MiqServer.my_zone) # memoized during pending_jobs call
+          expect(@dispatcher.active_container_scans_by_zone_and_ems).to eq(
+            job.zone => {provider.id => 1}
+          )
+        end
+      end
+
+      describe "#dispatch_container_scan_jobs" do
+        it "dispatches jobs until reaching limit" do
+          stub_settings(:container_scanning => {:concurrent_per_ems => 1})
+          @dispatcher.dispatch_container_scan_jobs
+          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(1)
+          # 1 per ems, one ems has 1 job and the other 2
+        end
+
+        it "does not dispach if limit is already reached" do
+          stub_settings(:container_scanning => {:concurrent_per_ems => 1})
+          @dispatcher.dispatch_container_scan_jobs
+          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(1)
+          @dispatcher.dispatch_container_scan_jobs
+          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(1)
+        end
+
+        it "does not apply limit when concurrent_per_ems is 0" do
+          stub_settings(:container_scanning => {:concurrent_per_ems => 0})
+          @dispatcher.dispatch_container_scan_jobs
+          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(0)
+          # 1 per ems, one ems has 1 job and the other 2
+        end
+
+        it "does not apply limit when concurrent_per_ems is -1" do
+          stub_settings(:container_scanning => {:concurrent_per_ems => -1})
+          @dispatcher.dispatch_container_scan_jobs
+          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(0)
+          # 1 per ems, one ems has 1 job and the other 2
+        end
+      end
+    end
+
+    describe "#active_vm_scans_by_zone" do
+      it "returns active vm scans for this zone" do
+        job = @vms.first.scan
+        dispatcher = JobProxyDispatcher.new
+        dispatcher.instance_variable_set(:@zone, MiqServer.my_zone) # memoized during pending_jobs call
+        job.update(:dispatch_status => "active")
+        expect(dispatcher.active_vm_scans_by_zone[job.zone]).to eq(1)
+      end
+
+      it "returns 0 for active vm scan for other zones" do
+        job = @vms.first.scan
+        dispatcher = JobProxyDispatcher.new
+        dispatcher.instance_variable_set(:@zone, MiqServer.my_zone) # memoized during pending_jobs call
+        job.update(:dispatch_status => "active")
+        expect(dispatcher.active_vm_scans_by_zone['defult']).to eq(0)
       end
     end
   end

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -11,7 +11,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
       before(:each) do
-        @hosts, @proxies, @storages, @vms = build_hosts_proxies_storages_vms
+        @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -11,7 +11,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
       before(:each) do
-        @hosts, @proxies, @storages, @vms = build_hosts_proxies_storages_vms
+        @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 

--- a/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
@@ -10,7 +10,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
       before(:each) do
-        @hosts, @proxies, @storages, @vms = build_hosts_proxies_storages_vms
+        @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -11,7 +11,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
     context "hosts with proxy and vmware vms," do
       before(:each) do
-        @hosts, @proxies, @storages, @vms = build_hosts_proxies_storages_vms
+        @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -63,11 +63,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     it "#initialize" do
       image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
       job = @ems.scan_job_create(image.class.name, image.id)
-
-      expect(MiqQueue.exists?(:method_name => 'signal',
-                              :class_name  => 'Job',
-                              :instance_id => job.id,
-                              :role        => 'smartstate')).to be true
+      expect(job).to have_attributes(
+        :dispatch_status => "pending",
+        :state           => "waiting_to_start",
+        :status          => "ok",
+        :message         => "process initiated",
+        :target_class    => "ContainerImage"
+      )
     end
   end
 


### PR DESCRIPTION
There is no current limit on the number of parallel scans. A large number of images can overload both the provider and ManageIQ.

Before this proposed change container scanning job would transition automatically from ''initializing" to "start".
This pr moves job starting into job_proxy_dispatcher in order to implement concurrent_per_ems for container scans.

Bug Url: https://bugzilla.redhat.com/show_bug.cgi?id=1340902 