### PR TITLE
Don't translate configuration provider types

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -15,9 +15,9 @@ class ProviderForemanController < ApplicationController
 
   def self.model_to_name(provmodel)
     if provmodel.include?("ManageIQ::Providers::AnsibleTower")
-      ui_lookup(:ui_title => 'ansible_tower')
+      Dictionary.gettext('ansible_tower', :type => :ui_title, :translate => false)
     elsif provmodel.include?("ManageIQ::Providers::Foreman")
-      ui_lookup(:ui_title => 'foreman')
+      Dictionary.gettext('foreman', :type => :ui_title, :translate => false)
     end
   end
 


### PR DESCRIPTION
The result of `model_to_name()` are being used not just for presentation in UI, but also for
creating a json response or creating toolbar filename.

Therefore, we should not be translating these strings into any other locales.