### PR TITLE
Refactor MiqExpression#to_sql datetime

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -762,29 +762,6 @@ class MiqExpression
         end_val   = RelativeDatetime.normalize(end_val, tz, "end").utc
       end
       clause = field.between(start_val..end_val).to_sql
-    when "date_time_with_logical_operator"
-      exp = exp[operator]
-      operator = exp.keys.first
-
-      col_name = exp[operator]["field"]
-      col_type = self.class.get_col_type(col_name)
-      col_sql, dummy = self.class.operands2sqlvalue(operator, "field" => col_name)
-
-      normalized_operator = self.class.normalize_sql_operator(operator)
-      mode = case normalized_operator
-             when ">", "<="  then "end"        # (>  <date> 23::59:59), (<= <date> 23::59:59)
-             when "<", ">="  then "beginning"  # (<  <date> 00::00:00), (>= <date> 00::00:00)
-             end
-
-      if col_type == :date
-        val = RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode)
-
-        clause = "#{col_sql} #{normalized_operator} #{self.class.quote(val.to_date, :date, :sql)}"
-      else
-        val = RelativeDatetime.normalize(exp[operator]["value"], tz, mode)
-
-        clause = "#{col_sql} #{normalized_operator} #{self.class.quote(val.utc, :datetime, :sql)}"
-      end
     else
       raise _("operator '%{operator_name}' is not supported") % {:operator_name => operator}
     end

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -594,7 +594,7 @@ class MiqExpression
                 exp[operator]["value"]
               end
       clause = field.eq(value).to_sql
-    when ">"
+    when ">", "after"
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
@@ -616,7 +616,7 @@ class MiqExpression
                 exp[operator]["value"]
               end
       clause = field.gteq(value).to_sql
-    when "<"
+    when "<", "before"
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
@@ -649,28 +649,6 @@ class MiqExpression
                 exp[operator]["value"]
               end
       clause = field.not_eq(value).to_sql
-    when "before"
-      field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning")
-              else
-                exp[operator]["value"]
-              end
-      clause = field.lt(value).to_sql
-    when "after"
-      field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end")
-              else
-                exp[operator]["value"]
-              end
-      clause = field.gt(value).to_sql
     when "like", "includes"
       field = Field.parse(exp[operator]["field"])
       clause = field.matches("%#{exp[operator]["value"]}%").to_sql

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -607,8 +607,15 @@ class MiqExpression
       clause = field.gt(value).to_sql
     when ">="
       field = Field.parse(exp[operator]["field"])
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.gteq(exp[operator]["value"]).to_sql
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning")
+              else
+                exp[operator]["value"]
+              end
+      clause = field.gteq(value).to_sql
     when "<"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -640,8 +640,15 @@ class MiqExpression
       clause = field.lteq(value).to_sql
     when "!="
       field = Field.parse(exp[operator]["field"])
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.not_eq(exp[operator]["value"]).to_sql
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil)
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil)
+              else
+                exp[operator]["value"]
+              end
+      clause = field.not_eq(value).to_sql
     when "before", "after"
       return _to_sql({"date_time_with_logical_operator" => exp}, tz)
     when "like", "includes"

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -661,7 +661,16 @@ class MiqExpression
               end
       clause = field.lt(value).to_sql
     when "after"
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz)
+      field = Field.parse(exp[operator]["field"])
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end")
+              else
+                exp[operator]["value"]
+              end
+      clause = field.gt(value).to_sql
     when "like", "includes"
       field = Field.parse(exp[operator]["field"])
       clause = field.matches("%#{exp[operator]["value"]}%").to_sql

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -618,8 +618,15 @@ class MiqExpression
       clause = field.gteq(value).to_sql
     when "<"
       field = Field.parse(exp[operator]["field"])
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.lt(exp[operator]["value"]).to_sql
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning")
+              else
+                exp[operator]["value"]
+              end
+      clause = field.lt(value).to_sql
     when "<="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -649,7 +649,18 @@ class MiqExpression
                 exp[operator]["value"]
               end
       clause = field.not_eq(value).to_sql
-    when "before", "after"
+    when "before"
+      field = Field.parse(exp[operator]["field"])
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning")
+              else
+                exp[operator]["value"]
+              end
+      clause = field.lt(value).to_sql
+    when "after"
       return _to_sql({"date_time_with_logical_operator" => exp}, tz)
     when "like", "includes"
       field = Field.parse(exp[operator]["field"])

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -596,8 +596,15 @@ class MiqExpression
       clause = field.eq(value).to_sql
     when ">"
       field = Field.parse(exp[operator]["field"])
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.gt(exp[operator]["value"]).to_sql
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end")
+              else
+                exp[operator]["value"]
+              end
+      clause = field.gt(value).to_sql
     when ">="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -585,8 +585,15 @@ class MiqExpression
     case operator.downcase
     when "equal", "="
       field = Field.parse(exp[operator]["field"])
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.eq(exp[operator]["value"]).to_sql
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil)
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil)
+              else
+                exp[operator]["value"]
+              end
+      clause = field.eq(value).to_sql
     when ">"
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -629,8 +629,15 @@ class MiqExpression
       clause = field.lt(value).to_sql
     when "<="
       field = Field.parse(exp[operator]["field"])
-      return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?
-      clause = field.lteq(exp[operator]["value"]).to_sql
+      value = case
+              when field.date?
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
+              when field.datetime?
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end")
+              else
+                exp[operator]["value"]
+              end
+      clause = field.lteq(value).to_sql
     when "!="
       field = Field.parse(exp[operator]["field"])
       return _to_sql({"date_time_with_logical_operator" => exp}, tz) if field.date? || field.datetime?

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -223,7 +223,7 @@ describe MiqExpression do
       it "generates the SQL for a <= expression" do
         exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on <= '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" <= '2011-01-10 23:59:59.999999'")
       end
 
       it "generates the SQL for an AFTER expression with date/time" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -193,7 +193,7 @@ describe MiqExpression do
       it "generates the SQL for an AFTER expression" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on > '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10 23:59:59.999999'")
       end
 
       it "generates the SQL for a > expression" do
@@ -229,7 +229,7 @@ describe MiqExpression do
       it "generates the SQL for an AFTER expression with date/time" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
+        expect(sql).to eq("\"vms\".\"last_scan_on\" > '2011-01-10 09:00:00'")
       end
 
       it "generates the SQL for a > expression with date/time" do
@@ -279,13 +279,13 @@ describe MiqExpression do
       it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a date field" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on > '2011-01-09'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-09 23:59:59.999999'")
       end
 
       it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a datetime field" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.last_scan_on > '2011-01-09T23:59:59Z'")
+        expect(sql).to eq("\"vms\".\"last_scan_on\" > '2011-01-09 23:59:59.999999'")
       end
 
       it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a date field" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -217,7 +217,7 @@ describe MiqExpression do
       it "generates the SQL for a >= expression" do
         exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on >= '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" >= '2011-01-10 00:00:00'")
       end
 
       it "generates the SQL for a <= expression" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -211,7 +211,7 @@ describe MiqExpression do
       it "generates the SQL for a < expression" do
         exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on < '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10 00:00:00'")
       end
 
       it "generates the SQL for a >= expression" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -199,7 +199,7 @@ describe MiqExpression do
       it "generates the SQL for a > expression" do
         exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on > '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10 23:59:59.999999'")
       end
 
       it "generates the SQL for a BEFORE expression" do
@@ -235,7 +235,7 @@ describe MiqExpression do
       it "generates the SQL for a > expression with date/time" do
         exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
+        expect(sql).to eq("\"vms\".\"last_scan_on\" > '2011-01-10 09:00:00'")
       end
 
       it "generates the SQL for an IS expression" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -205,7 +205,7 @@ describe MiqExpression do
       it "generates the SQL for a BEFORE expression" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on < '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10 00:00:00'")
       end
 
       it "generates the SQL for a < expression" do
@@ -291,13 +291,13 @@ describe MiqExpression do
       it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a date field" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.retires_on < '2011-01-09'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-09 00:00:00'")
       end
 
       it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a datetime field" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("vms.last_scan_on < '2011-01-09T00:00:00Z'")
+        expect(sql).to eq("\"vms\".\"last_scan_on\" < '2011-01-09 00:00:00'")
       end
 
       it "generates the SQL for a FROM expression with a 'Last Hour'/'This Hour' value for a datetime field" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -182,12 +182,12 @@ describe MiqExpression do
     context "date/time support" do
       it "generates the SQL for an EQUAL expression" do
         sql, * = MiqExpression.new("EQUAL" => {"field" => "Vm-boot_time", "value" => "2016-01-01"}).to_sql
-        expect(sql).to eq("vms.boot_time = '2016-01-01T00:00:00Z'")
+        expect(sql).to eq("\"vms\".\"boot_time\" = '2016-01-01 00:00:00'")
       end
 
       it "generates the SQL for a = expression" do
         sql, * = MiqExpression.new("=" => {"field" => "Vm-boot_time", "value" => "2016-01-01"}).to_sql
-        expect(sql).to eq("vms.boot_time = '2016-01-01T00:00:00Z'")
+        expect(sql).to eq("\"vms\".\"boot_time\" = '2016-01-01 00:00:00'")
       end
 
       it "generates the SQL for an AFTER expression" do


### PR DESCRIPTION
Inlines the datetime normalization for each operator so that the `date_time_with_logical_operator` operator can be removed.