### PR TITLE
ApplicationRecord for newly added models

### DIFF
--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -1,4 +1,4 @@
-class ChargebackRateDetailCurrency < ActiveRecord::Base
+class ChargebackRateDetailCurrency < ApplicationRecord
   belongs_to :chargeback_rate_detail
 
   # YAML.load_file(File.join(Rails.root, "db/fixtures/chargeback_rate_detail_currencies.yml"))

--- a/app/models/container_build_pod.rb
+++ b/app/models/container_build_pod.rb
@@ -1,4 +1,4 @@
-class ContainerBuildPod < ActiveRecord::Base
+class ContainerBuildPod < ApplicationRecord
   include CustomAttributeMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,4 +1,4 @@
-class Endpoint < ActiveRecord::Base
+class Endpoint < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER

--- a/app/models/network_group.rb
+++ b/app/models/network_group.rb
@@ -1,4 +1,4 @@
-class NetworkGroup < ActiveRecord::Base
+class NetworkGroup < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/persistent_volume_claim.rb
+++ b/app/models/persistent_volume_claim.rb
@@ -1,4 +1,4 @@
-class PersistentVolumeClaim < ActiveRecord::Base
+class PersistentVolumeClaim < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :container_volumes
   serialize :capacity, Hash

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -1,4 +1,4 @@
-class ServiceOrder < ActiveRecord::Base
+class ServiceOrder < ApplicationRecord
   STATE_CART    = 'cart'.freeze
   STATE_WISH    = 'wish'.freeze
   STATE_ORDERED = 'ordered'.freeze

--- a/app/models/settings_change.rb
+++ b/app/models/settings_change.rb
@@ -1,4 +1,4 @@
-class SettingsChange < ActiveRecord::Base
+class SettingsChange < ApplicationRecord
   serialize :value
 
   belongs_to :resource, :polymorphic => true


### PR DESCRIPTION
After introducing ApplicationRecord we have newly added models with ActiveRecord::Base

These models were added after https://github.com/ManageIQ/manageiq/pull/6300

cc @jrafanie @Fryguy 