### PR TITLE
Fix load order bug in the fix_auth spec

### DIFF
--- a/spec/tools/fix_auth/fix_auth_spec.rb
+++ b/spec/tools/fix_auth/fix_auth_spec.rb
@@ -1,7 +1,6 @@
 $LOAD_PATH << Rails.root.join("tools")
 
-require "fix_auth/fix_auth"
-require "fix_auth/models"
+require "fix_auth"
 
 describe FixAuth::FixAuth do
   describe "#fix_database_yml" do


### PR DESCRIPTION
We need to require the fix_auth scripts in the correct order to get the constants
loaded, so require the fix_auth tool launcher script.

Fixes running the fix_auth_spec in isolation (or first):

```
$ be rspec spec/tools/fix_auth/fix_auth_spec.rb
bundler: failed to load command: rspec (/Users/joerafaniello/.gem/ruby/2.2.4/bin/rspec)
NameError: uninitialized constant FixAuth::FixAuth::AuthModel
  <...>/manageiq/tools/fix_auth/models.rb:8:in `<class:FixAuthentication>'
  <...>/manageiq/tools/fix_auth/models.rb:7:in `<module:FixAuth>'
  <...>/manageiq/tools/fix_auth/models.rb:6:in `<top (required)>'
  <...>/manageiq/spec/tools/fix_auth/fix_auth_spec.rb:4:in `<top (required)>'
```

@kbrock Please review