### PR TITLE
API Token for Classic UI for SAML authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1124,8 +1124,6 @@ class ApplicationController < ActionController::Base
 
     return if action_name == 'auth_error'
 
-    session[:saml_login_request] = nil
-
     pass = %w(button x_button).include?(action_name) ? handle_button_rbac : handle_generic_rbac
     $audit_log.failure("Username [#{current_userid}], Role ID [#{current_user.miq_user_role.try(:id)}] attempted to access area [#{controller_name}], type [Action], task [#{action_name}]") unless pass
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -470,7 +470,6 @@ class DashboardController < ApplicationController
 
   # Login support for SAML - GET /saml_login
   def saml_login
-    session[:saml_login_request] = nil
     if @user_name.blank? && request.env.key?("HTTP_X_REMOTE_USER").present?
       @user_name = params[:user_name] = request.env["HTTP_X_REMOTE_USER"].split("@").first
     else
@@ -483,8 +482,10 @@ class DashboardController < ApplicationController
 
     case validation.result
     when :pass
-      session[:saml_login_request] = true
-      redirect_to validation.url
+      render :template => "dashboard/saml_login",
+             :layout   => false,
+             :locals   => {:api_auth_token => generate_ui_api_token(@user_name),
+                           :validation_url => validation.url}
       return
     when :fail
       session[:user_validation_error] = validation.flash_msg || "User validation failed"

--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -1,0 +1,15 @@
+<!--[if IE 9]><html class="ie9 login-pf"><![endif]-->
+%html.login-pf{:class => get_vmdb_config[:server][:custom_login_logo] ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
+  %head
+    = favicon_link_tag
+    = stylesheet_link_tag 'application'
+    = javascript_include_tag 'application'
+
+  %body
+    - if api_auth_token && validation_url
+      :javascript
+        sessionStorage.miq_token = '#{j_str api_auth_token}';
+        window.location.href = '#{j_str validation_url}';
+    - else
+      :javascript
+        window.location.href = '/dashboard/logout';

--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -9,7 +9,7 @@
     - if api_auth_token && validation_url
       :javascript
         sessionStorage.miq_token = '#{j_str api_auth_token}';
-        window.location.href = '#{j_str validation_url}';
+        window.location = '#{j_str validation_url}';
     - else
       :javascript
-        window.location.href = '/dashboard/logout';
+        window.location = '/dashboard/logout';


### PR DESCRIPTION
SAML Authenticated Applicance needs an API token for the Classic UI.
    
   * Updated saml_login method in controller to generate an API token for the authenticated user in the Classic UI
   * Added app/views/dashboard/saml_login.html.haml to set the API Token in javascript before redirecting to the validation url.
   * Removed the no longer needed clearing of saml_login_request in the session as the referer validation service was removed.
    
Fixes: #8641
