### PR TITLE
Fix Container Replicator default view

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -183,6 +183,7 @@ module UiConstants
       :containerservice                         => "list",
       :containerroute                           => "list",
       :containerproject                         => "list",
+      :containerreplicator                      => "list",
       :containerimage                           => "list",
       :containerimageregistry                   => "list",
       :persistentvolume                         => "list",


### PR DESCRIPTION
Fixes: Cannot change the default view for Container Replicators. 
Bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1336778
cc @simon3z 

![rep](https://cloud.githubusercontent.com/assets/11769555/15353575/78549a9c-1cf2-11e6-8006-8a7ae3612005.png)
