### PR TITLE
Fix infinite reconnect loop caused by new bunny gem

### DIFF
--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -4,12 +4,15 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
     require 'openstack/openstack_event_monitor'
     unless @event_monitor_handle
       options = @ems.event_monitor_options
-      options[:topics]     = worker_settings[:topics]
-      options[:duration]   = worker_settings[:duration]
-      options[:capacity]   = worker_settings[:capacity]
-      options[:heartbeat]  = worker_settings[:amqp_heartbeat]
-      options[:ceilometer] = worker_settings[:ceilometer]
-      options[:ems]        = @ems
+      options[:topics]                        = worker_settings[:topics]
+      options[:duration]                      = worker_settings[:duration]
+      options[:capacity]                      = worker_settings[:capacity]
+      options[:heartbeat]                     = worker_settings[:amqp_heartbeat]
+      options[:ceilometer]                    = worker_settings[:ceilometer]
+      options[:automatic_recovery]            = true
+      options[:recover_from_connection_close] = true
+      options[:recovery_attempts]             = worker_settings[:amqp_recovery_attempts]
+      options[:ems]                           = @ems
 
       options[:client_ip] = server.ipaddress
       @event_monitor_handle = OpenstackEventMonitor.new(options)

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -70,7 +70,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
 
   def event_monitor_options
     @event_monitor_options ||= begin
-      opts = {:ems => self}
+      opts = {:ems => self, :automatic_recovery => false, :recover_from_connection_close => false}
 
       ceilometer = connection_configuration_by_role("ceilometer")
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1120,6 +1120,7 @@
         :capacity: 50
         :amqp_port: 5672
         :amqp_heartbeat: 30
+        :amqp_recovery_attempts: 4
         :ceilometer:
           :event_types_regex: '\A(?!firewall|floatingip|gateway|net|port|router|subnet|security-group|vpn)'
       :event_catcher_openstack_infra:
@@ -1134,6 +1135,7 @@
         :capacity: 50
         :amqp_port: 5672
         :amqp_heartbeat: 30
+        :amqp_recovery_attempts: 4
         :ceilometer:
           :event_types_regex: '\A(?!firewall|floatingip|gateway|net|port|router|subnet|security-group|vpn)'
       :event_catcher_openstack_network:
@@ -1144,6 +1146,7 @@
         :capacity: 50
         :amqp_port: 5672
         :amqp_heartbeat: 30
+        :amqp_recovery_attempts: 4
         :ceilometer:
           :event_types_regex: '\A(firewall|floatingip|gateway|net|port|router|subnet|security-group|vpn)'
       :event_catcher_amazon:

--- a/gems/pending/openstack/events/openstack_rabbit_event_monitor.rb
+++ b/gems/pending/openstack/events/openstack_rabbit_event_monitor.rb
@@ -22,8 +22,15 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
   # It creates a test mock point for specs
   def self.connect(options = {})
     connection_options = {:host => options[:hostname]}
-    connection_options[:port]      = options[:port] || DEFAULT_AMQP_PORT
-    connection_options[:heartbeat] = options[:heartbeat] || DEFAULT_AMQP_HEARTBEAT
+    connection_options[:port]               = options[:port] || DEFAULT_AMQP_PORT
+    connection_options[:heartbeat]          = options[:heartbeat] || DEFAULT_AMQP_HEARTBEAT
+    connection_options[:automatic_recovery] = options[:automatic_recovery] if options.key? :automatic_recovery
+    connection_options[:recovery_attempts]  = options[:recovery_attempts] if options.key? :recovery_attempts
+
+    if options.key? :recover_from_connection_close
+      connection_options[:recover_from_connection_close] = options[:recover_from_connection_close]
+    end
+
     if options.key? :username
       connection_options[:username] = options[:username]
       connection_options[:password] = options[:password]


### PR DESCRIPTION
If trying to connect to existing port, bunny is set to try
to reconnect infinite times, which will end up blocking the
worker. We need to set reconnect limit and we need to
disable reconnect for validation. So reconnect is set
only for connection created by worker, that should be consuming
events.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1336861