### PR TITLE
Allowing the ems_common/_show.html.haml partial to display datasources

### DIFF
--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -1,7 +1,7 @@
 #main_div
   - arr = %w(container_images container_image_registries containers container_replicators container_routes)
   - arr.concat(%w(container_builds container_projects container_nodes container_services container_groups availability_zones))
-  - arr.concat(%w(middleware_servers middleware_deployments))
+  - arr.concat(%w(middleware_servers middleware_deployments middleware_datasources))
   - arr.concat(%w(security_groups floating_ips cloud_subnets network_routers network_ports cloud_networks))
   - arr.concat(%w(cloud_tenants ems_clusters flavors resource_group hosts instances images miq_templates cloud_volumes))
   - arr.concat(%w(cloud_volume_snapshots orchestration_stacks vms storages miq_proxies persistent_volumes cloud_object_store_containers))


### PR DESCRIPTION
Allowing the `ems_common/_show.html.haml` partial to display also the `middleware_datasource` entities.

This fixes issue #8618 

todo: missing icon

@miq-bot add_label providers/hawkular, wip, bug