### PR TITLE
pluggable providers: removed hard coupling of cloudmanagers that support regions

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -267,14 +267,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
-  $scope.isRegionSupported = function() {
-    if ($scope.emsCommonModel.emstype === 'ec2' || $scope.emsCommonModel.emstype === 'azure') {
-      return true;
-    }
-
-    return false;
-  };
-
   $scope.providerTypeChanged = function() {
     $scope.emsCommonModel.default_api_port = "";
     $scope.emsCommonModel.default_security_protocol = "";

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -74,6 +74,7 @@ class ExtManagementSystem < ApplicationRecord
   include UuidMixin
   include EmsRefresh::Manager
   include TenancyMixin
+  include AvailabilityMixin
 
   after_destroy { |record| $log.info "MIQ(ExtManagementSystem.after_destroy) Removed EMS [#{record.name}] id [#{record.id}]" }
 

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -8,8 +8,6 @@ module ManageIQ::Providers
     require_nested :Vm
     require_nested :OrchestrationStack
 
-    include AvailabilityMixin
-
     class << model_name
       define_method(:route_key) { "ems_clouds" }
       define_method(:singular_route_key) { "ems_cloud" }
@@ -53,6 +51,14 @@ module ManageIQ::Providers
 
     def validate_timeline
       {:available => true, :message => nil}
+    end
+
+    def self.validate_regions
+      if "#{parent}::Regions".safe_constantize
+        {:available => true, :message => nil}
+      else
+        {:available => false, :message => nil}
+      end
     end
 
     def stop_event_monitor_queue_on_credential_change

--- a/app/models/mixins/availability_mixin.rb
+++ b/app/models/mixins/availability_mixin.rb
@@ -17,7 +17,12 @@ module AvailabilityMixin
 
   class_methods do
     def is_available?(request_type, *args)
-      send("validate_#{request_type}", *args)[:available]
+      validate_method = "validate_#{request_type}"
+      if respond_to?(validate_method)
+        send(validate_method, *args)[:available]
+      else
+        false
+      end
     end
 
     # Returns an error message string if there is an error.
@@ -25,6 +30,8 @@ module AvailabilityMixin
     def is_available_now_error_message(request_type, *args)
       send("validate_#{request_type}", *args)[:message]
     end
+
+    # FIXME: refactor validate_ call
   end
 
   included do

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -42,38 +42,18 @@
             = @emstype_display
 
 
-    .form-group{"ng-class" => "{'has-error': angularForm.provider_region.$invalid}", "ng-if" => "isRegionSupported()", "ng-switch" => "", "on" => "emsCommonModel.emstype"}
+    .form-group{"ng-class" => "{'has-error': angularForm.provider_region.$invalid}", "ng-if" => "#{@provider_regions.keys.to_json}.includes(emsCommonModel.emstype)", "ng-switch" => "", "on" => "emsCommonModel.emstype"}
       %label.col-md-2.control-label{"for" => "ems_region"}
         = _('Region')
       .col-md-8
-        = select_tag('provider_region',
-                     options_for_select([["<#{_('Choose')}>", nil]] + Array(@amazon_regions.invert).sort_by { |desc, _name| desc }, disabled: ["<#{_('Choose')}>", nil]),
-                     "ng-model"                    => "emsCommonModel.provider_region",
-                     "ng-switch-when"              => "ec2",
-                     "id"                          => "ems_region",
-                     "required"                    => "",
-                     "checkchange"                 => "",
-                     "selectpicker-for-select-tag" => "")
-        = select_tag('provider_region',
-                     options_for_select([["<#{_('Choose')}>", nil]] + Array(@azure_regions.invert).sort_by { |desc, _name| desc }, disabled: ["<#{_('Choose')}>", nil]),
-                     "ng-model"                    => "emsCommonModel.provider_region",
-                     "ng-switch-when"              => "azure",
-                     "id"                          => "ems_region",
-                     "required"                    => "",
-                     "checkchange"                 => "",
-                     "selectpicker-for-select-tag" => "")
-
-    .form-group{"ng-class" => "{'has-error': angularForm.provider_region.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
-      %label.col-md-2.control-label{"for" => "ems_preferred_region"}
-        = _('Preferred Region')
-      .col-md-8
-        = select_tag('provider_region',
-                     options_for_select([["<#{_('Choose')}>", nil]] + Array(@google_regions.invert).sort_by { |desc, _name| desc }, disabled: ["<#{_('Choose')}>", nil]),
-                     "ng-model"                    => "emsCommonModel.provider_region",
-                     "id"                          => "ems_preferred_region",
-                     "required"                    => "",
-                     "checkchange"                 => "",
-                     "selectpicker-for-select-tag" => "")
+        - @provider_regions.each do |name, regions|
+          = select_tag('provider_region',
+                       options_for_select([["<#{_('Choose')}>", nil]] + regions, disabled: ["<#{_('Choose')}>", nil]),
+                       "ng-model"                    => "emsCommonModel.provider_region",
+                       "ng-switch-when"              => name,
+                       "required"                    => "",
+                       "checkchange"                 => "",
+                       "selectpicker-for-select-tag" => "")
 
     .form-group{"ng-class" => "{'has-error': angularForm.project.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
       %label.col-md-2.control-label{"for" => "ems_project"}

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -43,6 +43,25 @@ describe EmsCloudController do
       end
     end
 
+    context "#new" do
+      before do
+        set_user_privileges
+        allow(controller).to receive(:drop_breadcrumb)
+      end
+
+      it "assigns provider_regions" do
+        controller.send(:new)
+
+        regions = {
+          # FIXME: (durandom) add a mock provider in order to remove this dependency on an actual provider
+          'azure' => ManageIQ::Providers::Azure::Regions.all.sort_by { |r| r[:description] }.map do |r|
+            [r[:description], r[:name]]
+          end
+        }
+        expect(assigns(:provider_regions)).to include(regions)
+      end
+    end
+
     context "#form_field_changed" do
       before :each do
         set_user_privileges


### PR DESCRIPTION
Instead of hard wiring EMS/CloudManagers we now ask all 
managers whether they support regions.

@Fryguy Not sure about the AvailabilityMixin. Either I continue using it 
and see what other requirements pop up, or we'll start naming it better now already.
Like here https://github.com/ManageIQ/manageiq/pull/3596

@miq-bot add_labels refactoring,ui