### PR TITLE
Fix for BZ1334938 - Service Dialogue Check box not changing to r/w

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -23,6 +23,7 @@ var dialogFieldRefresh = {
 
     $.post('dynamic_checkbox_refresh', {name: fieldName}, function(data) {
       $('.dynamic-checkbox-' + fieldId).prop('checked', data.values.checked);
+      dialogFieldRefresh.setReadOnly($('.dynamic-checkbox-' + fieldId), data.values.read_only);
       miqSparkle(false);
     });
   },
@@ -38,6 +39,8 @@ var dialogFieldRefresh = {
         $('.dynamic-date-min-' + fieldId).val(data.values.min);
       }
 
+      dialogFieldRefresh.setReadOnly($('.dynamic-date-' + fieldId), data.values.read_only);
+
       miqSparkle(false);
     });
   },
@@ -51,6 +54,7 @@ var dialogFieldRefresh = {
     })
     .done(function(data) {
       dialogFieldRefresh.addOptionsToDropDownList(data, fieldId);
+      dialogFieldRefresh.setReadOnly($('#' + fieldName), data.values.read_only);
       $('#' + fieldName).selectpicker('refresh');
       $('#' + fieldName).selectpicker('val', data.values.checked_value);
     });
@@ -134,6 +138,7 @@ var dialogFieldRefresh = {
 
     $.post('dynamic_text_box_refresh', {name: fieldName}, function(data) {
       $('.dynamic-text-area-' + fieldId).val(data.values.text);
+      dialogFieldRefresh.setReadOnly($('.dynamic-text-area-' + fieldId), data.values.read_only);
       miqSparkle(false);
     });
   },
@@ -143,6 +148,7 @@ var dialogFieldRefresh = {
 
     $.post('dynamic_text_box_refresh', {name: fieldName}, function(data) {
       $('.dynamic-text-box-' + fieldId).val(data.values.text);
+      dialogFieldRefresh.setReadOnly($('.dynamic-text-box-' + fieldId), data.values.read_only);
       miqSparkle(false);
     });
   },
@@ -150,6 +156,16 @@ var dialogFieldRefresh = {
   triggerAutoRefresh: function(fieldId, trigger) {
     if (trigger === "true") {
       parent.postMessage({fieldId: fieldId}, '*');
+    }
+  },
+
+  setReadOnly: function(field, readOnly) {
+    if (readOnly === true) {
+      field.attr('title', __('This element is disabled because it is read only'));
+      field.prop('disabled', true);
+    } else {
+      field.prop('disabled', false);
+      field.attr('title', '');
     }
   }
 };

--- a/app/models/dialog_field_check_box.rb
+++ b/app/models/dialog_field_check_box.rb
@@ -30,7 +30,7 @@ class DialogFieldCheckBox < DialogField
   def refresh_json_value
     @value = values_from_automate
 
-    {:checked => checked?}
+    {:checked => checked?, :read_only => read_only?}
   end
 
   def trigger_automate_value_updates

--- a/app/models/dialog_field_date_control.rb
+++ b/app/models/dialog_field_date_control.rb
@@ -42,7 +42,7 @@ class DialogFieldDateControl < DialogField
   def refresh_json_value
     @value = values_from_automate
 
-    {:date => Date.parse(@value).strftime("%m/%d/%Y")}
+    {:date => Date.parse(@value).strftime("%m/%d/%Y"), :read_only => read_only?}
   end
 
   def trigger_automate_value_updates

--- a/app/models/dialog_field_date_time_control.rb
+++ b/app/models/dialog_field_date_time_control.rb
@@ -18,9 +18,10 @@ class DialogFieldDateTimeControl < DialogFieldDateControl
     date_time_value = with_current_user_timezone { Time.parse(@value) }
 
     {
-      :date => date_time_value.strftime("%m/%d/%Y"),
-      :hour => date_time_value.strftime("%H"),
-      :min  => date_time_value.strftime("%M")
+      :date      => date_time_value.strftime("%m/%d/%Y"),
+      :hour      => date_time_value.strftime("%H"),
+      :min       => date_time_value.strftime("%M"),
+      :read_only => read_only?
     }
   end
 

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -27,7 +27,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
       @value = @default_value
     end
 
-    {:refreshed_values => refreshed_values, :checked_value => @value}
+    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only?}
   end
 
   private

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -27,7 +27,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
       @value = default_value
     end
 
-    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only}
+    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only?}
   end
 
   private

--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -68,7 +68,7 @@ class DialogFieldTextBox < DialogField
   def refresh_json_value
     @value = values_from_automate
 
-    {:text => @value}
+    {:text => @value, :read_only => read_only?}
   end
 
   def trigger_automate_value_updates

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -41,6 +41,38 @@ describe('dialogFieldRefresh', function() {
     });
   });
 
+  describe('#setReadOnly', function() {
+    beforeEach(function() {
+      var html = "";
+      html += '<input id="text-test" title="bogus title" type="text" />';
+      setFixtures(html);
+    });
+
+    context('when readOnly is true', function() {
+      it('sets the title', function() {
+        dialogFieldRefresh.setReadOnly($('#text-test'), true);
+        expect($('#text-test').attr('title')).toBe('This element is disabled because it is read only');
+      });
+
+      it('disables the element', function() {
+        dialogFieldRefresh.setReadOnly($('#text-test'), true);
+        expect($('#text-test').prop('disabled')).toBe(true);
+      });
+    });
+
+    context('when readOnly is false', function() {
+      it('clears the title', function() {
+        dialogFieldRefresh.setReadOnly($('#text-test'), false);
+        expect($('#text-test').attr('title')).toBe('');
+      });
+
+      it('enables the element', function() {
+        dialogFieldRefresh.setReadOnly($('#text-test'), false);
+        expect($('#text-test').prop('disabled')).toBe(false);
+      });
+    });
+  });
+
   describe('#refreshDropDownList', function() {
     beforeEach(function() {
       spyOn(dialogFieldRefresh, 'addOptionsToDropDownList');

--- a/spec/models/dialog_field_check_box_spec.rb
+++ b/spec/models/dialog_field_check_box_spec.rb
@@ -176,14 +176,14 @@ describe DialogFieldCheckBox do
   end
 
   describe "#refresh_json_value" do
-    let(:dialog_field) { described_class.new }
+    let(:dialog_field) { described_class.new(:read_only => true) }
 
     before do
       allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("f")
     end
 
     it "returns the checked value in a hash" do
-      expect(dialog_field.refresh_json_value).to eq(:checked => false)
+      expect(dialog_field.refresh_json_value).to eq(:checked => false, :read_only => true)
     end
 
     it "assigns the processed value to value" do

--- a/spec/models/dialog_field_date_control_spec.rb
+++ b/spec/models/dialog_field_date_control_spec.rb
@@ -127,14 +127,14 @@ describe DialogFieldDateControl do
   end
 
   describe "#refresh_json_value" do
-    let(:dialog_field) { described_class.new }
+    let(:dialog_field) { described_class.new(:read_only => true) }
 
     before do
       allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("2015-01-02")
     end
 
     it "returns the values from the value processor" do
-      expect(dialog_field.refresh_json_value).to eq(:date => "01/02/2015")
+      expect(dialog_field.refresh_json_value).to eq(:date => "01/02/2015", :read_only => true)
     end
 
     it "assigns the processed value to value" do

--- a/spec/models/dialog_field_date_time_control_spec.rb
+++ b/spec/models/dialog_field_date_time_control_spec.rb
@@ -136,7 +136,7 @@ describe DialogFieldDateTimeControl do
   end
 
   describe "#refresh_json_value" do
-    let(:dialog_field) { described_class.new }
+    let(:dialog_field) { described_class.new(:read_only => true) }
 
     before do
       allow(described_class).to receive(:server_timezone).and_return("UTC")
@@ -145,9 +145,10 @@ describe DialogFieldDateTimeControl do
 
     it "returns the default value in a hash" do
       expect(dialog_field.refresh_json_value).to eq(
-        :date => "02/03/2015",
-        :hour => "18",
-        :min  => "50"
+        :date      => "02/03/2015",
+        :hour      => "18",
+        :min       => "50",
+        :read_only => true
       )
     end
 

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -89,7 +89,7 @@ describe DialogFieldDropDownList do
   end
 
   describe "#refresh_json_value" do
-    let(:dialog_field) { described_class.new(:dynamic => dynamic) }
+    let(:dialog_field) { described_class.new(:dynamic => dynamic, :read_only => true) }
 
     context "when the dialog_field is dynamic" do
       let(:dynamic) { true }
@@ -109,7 +109,8 @@ describe DialogFieldDropDownList do
       it "returns the values from automate" do
         expect(dialog_field.refresh_json_value("789")).to eq(
           :refreshed_values => [["789", 101], ["123", 456]],
-          :checked_value    => "789"
+          :checked_value    => "789",
+          :read_only        => true
         )
       end
     end
@@ -130,7 +131,8 @@ describe DialogFieldDropDownList do
       it "returns the values" do
         expect(dialog_field.refresh_json_value("789")).to eq(
           :refreshed_values => [["789", 101], ["123", 456]],
-          :checked_value    => "789"
+          :checked_value    => "789",
+          :read_only        => true
         )
       end
     end

--- a/spec/models/dialog_field_radio_button_spec.rb
+++ b/spec/models/dialog_field_radio_button_spec.rb
@@ -143,7 +143,7 @@ describe DialogFieldRadioButton do
 
       it "returns the list of refreshed values and checked value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("123")).to eq(
-          :refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil
+          :refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => false
         )
       end
     end
@@ -153,7 +153,7 @@ describe DialogFieldRadioButton do
 
       it "returns the list of refreshed values and checked (default) value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("321")).to eq(
-          :refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => nil
+          :refreshed_values => refreshed_values_from_automate, :checked_value => "123", :read_only => false
         )
       end
     end

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -324,14 +324,14 @@ describe DialogFieldTextBox do
   end
 
   describe "#refresh_json_value" do
-    let(:dialog_field) { described_class.new(:value => "test") }
+    let(:dialog_field) { described_class.new(:value => "test", :read_only => true) }
 
     before do
       allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("processor")
     end
 
     it "returns the values from the value processor" do
-      expect(dialog_field.refresh_json_value).to eq(:text => "processor")
+      expect(dialog_field.refresh_json_value).to eq(:text => "processor", :read_only => true)
     end
 
     it "assigns the processed value to value" do


### PR DESCRIPTION
Previously, we were able to set the read_only flag via dynamic methods, but the UI didn't reflect that change when refreshing. This will ensure that the read_only property is recognized for all dynamic dialogs when they get refreshed, not just on the initial load.

https://bugzilla.redhat.com/show_bug.cgi?id=1334938

@gmcculloug Please review (or tag someone else for review :wink:)