### PR TITLE
Check for EMS existence before stopping event monitor

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -102,10 +102,11 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   end
 
   def stop_event_monitor_queue_on_change
-    if authentications.detect{ |x| x.previous_changes.present? } || endpoints.detect{ |x| x.previous_changes.present? }
+    if event_monitor_class && !self.new_record? && (authentications.detect{ |x| x.previous_changes.present? } ||
+                                                    endpoints.detect{ |x| x.previous_changes.present? })
       _log.info("EMS: [#{name}], Credentials or endpoints have changed, stopping Event Monitor. It will be restarted by the WorkerMonitor.")
       stop_event_monitor_queue
-      network_manager.stop_event_monitor_queue if respond_to?(:network_manager) && network_manager
+      network_manager.stop_event_monitor_queue if try(:network_manager) && !network_manager.new_record?
     end
   end
 


### PR DESCRIPTION
Check for EMS existence before stopping event monitor

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1336859