### PR TITLE
Save job parameters when refresh with ems

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
@@ -42,6 +42,10 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job < ::Orchestra
   def update_with_provider_object(raw_job)
     self.ems_ref = raw_job.id
     self.status = raw_job.status
+    self.parameters =
+      raw_job.extra_vars_hash.collect do |para_key, para_val|
+        OrchestrationStackParameter.new(:name => para_key, :value => para_val, :ems_ref => "#{raw_job.id}_#{para_key}")
+      end if parameters.empty?
     save!
   end
   private :update_with_provider_object

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/job_spec.rb
@@ -12,9 +12,10 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job do
   let(:the_raw_job) do
     AnsibleTowerClient::Job.new(
       mock_api,
-      'id'     => '1',
-      'name'   => template.name,
-      'status' => 'Successful'
+      'id'         => '1',
+      'name'       => template.name,
+      'status'     => 'Successful',
+      'extra_vars' => {'param1' => 'val1'}.to_json
     )
   end
 
@@ -53,6 +54,7 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job do
         subject.refresh_ems
         expect(subject.ems_ref).to eq(the_raw_job.id)
         expect(subject.status).to  eq(the_raw_job.status)
+        expect(subject.parameters.first).to have_attributes(:name => 'param1', :value => 'val1')
       end
 
       it 'catches errors from provider' do

--- a/spec/models/service_ansible_tower_spec.rb
+++ b/spec/models/service_ansible_tower_spec.rb
@@ -65,9 +65,11 @@ describe ServiceAnsibleTower do
         expect(template).to be_kind_of ConfigurationScript
         expect(opts).to have_key(:limit)
         expect(opts).to have_key(:extra_vars)
-      end.and_return(double(:raw_job, :id => 1, :status => "completed"))
+      end.and_return(double(:raw_job, :id => 1, :status => "completed", :extra_vars_hash => {'var_name' => 'var_val'}))
 
-      expect(service_mix_dialog_setter.launch_job).to have_attributes(:ems_ref => "1", :status => "completed")
+      job_done = service_mix_dialog_setter.launch_job
+      expect(job_done).to have_attributes(:ems_ref => "1", :status => "completed")
+      expect(job_done.parameters[0]).to have_attributes(:name => 'var_name', :value => 'var_val', :ems_ref => '1_var_name')
     end
 
     it 'always saves options even when the manager fails to create a stack' do


### PR DESCRIPTION
Collect `extra_vars` from an AnsibleTower job and save them as instances of `OrchestrationStackParameter`

Parameters don't expected to change once the job is launched. So no update for parameters is needed when refresh is requested multiple times to the job.