### PR TITLE
Openstack Resize UI's flavor dropdown should include flavor details.

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -21,7 +21,9 @@ class VmCloudController < ApplicationController
       ) unless @explorer
       @flavors = {}
       unless @record.ext_management_system.nil?
-        @record.ext_management_system.flavors.each { |f| @flavors[f.name] = f.id unless f == @record.flavor }
+        @record.ext_management_system.flavors.each do |f|
+          @flavors[f.name_with_details] = f.id unless f == @record.flavor
+        end
       end
       @edit = {}
       @edit[:new] ||= {}

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -22,7 +22,9 @@ class VmCloudController < ApplicationController
       @flavors = {}
       unless @record.ext_management_system.nil?
         @record.ext_management_system.flavors.each do |f|
-          @flavors[f.name_with_details] = f.id unless f == @record.flavor
+          unless f == @record.flavor || @record.flavor.root_disk_size > f.root_disk_size
+            @flavors[f.name_with_details] = f.id
+          end
         end
       end
       @edit = {}

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -21,9 +21,10 @@ class VmCloudController < ApplicationController
       ) unless @explorer
       @flavors = {}
       unless @record.ext_management_system.nil?
-        @record.ext_management_system.flavors.each do |f|
-          unless f == @record.flavor || @record.flavor.root_disk_size > f.root_disk_size
-            @flavors[f.name_with_details] = f.id
+        @record.ext_management_system.flavors.each do |ems_flavor|
+          # include only flavors with root disks at least as big as the instance's current root disk.
+          if (ems_flavor != @record.flavor) && (ems_flavor.root_disk_size >= @record.flavor.root_disk_size)
+            @flavors[ems_flavor.name_with_details] = ems_flavor.id
           end
         end
       end


### PR DESCRIPTION
The list of flavors on the Openstack Resize UI form should include details about the flavor (CPU, Memory, Disks). This was included at one point, but it looks like it got lost in a merge.

Additionally, this limits the list of available flavors to only those with disks equal in size or bigger than the current flavor of the instance.

@Loicavenel 
![flavordetails](https://cloud.githubusercontent.com/assets/628956/15366936/c324b0e6-1cf4-11e6-8545-4f21a4506845.png)
