### PR TITLE
Check command_line return value for blank? rather than nil?

### DIFF
--- a/lib/pid_file.rb
+++ b/lib/pid_file.rb
@@ -34,7 +34,7 @@ class PidFile
     pid = self.pid
     return false if pid.nil?
     command_line = MiqProcess.command_line(pid)
-    return false if command_line.nil?
+    return false if command_line.blank?
     unless regexp.nil?
       regexp = Regexp.new(regexp) if regexp.kind_of?(String)
       return false if regexp.match(command_line).nil?

--- a/spec/lib/pid_file_spec.rb
+++ b/spec/lib/pid_file_spec.rb
@@ -78,6 +78,11 @@ describe PidFile do
         expect(@pid_file.running?).to be_falsey
       end
 
+      it "returns false if MiqProcess.command_line returns an empty string" do
+        allow(MiqProcess).to receive(:command_line).and_return("")
+        expect(@pid_file.running?).to be_falsey
+      end
+
       context "MiqProcess.command_line returns valid value" do
         before(:each) do
           @cmd_line = "my favorite program"


### PR DESCRIPTION
`MiqProcess.command_line` was changed to return an empty string rather than nil in #6305

This means that `PidFile.running?` would return true even if a process with the given pid was not found. This was preventing us from starting up the server after an unclean shutdown because the pid file would still exist.

https://bugzilla.redhat.com/show_bug.cgi?id=1337123

@jrafanie @psav