### PR TITLE
Sync the server config before assigning roles

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -133,13 +133,13 @@ module MiqServer::WorkerManagement::Monitor
         sync_message = "sync_active_roles"
       end
 
+      sync_config                if config_changed
       set_assigned_roles         if config_changed
       log_role_changes           if roles_changed
       sync_active_roles          if roles_changed
       set_active_role_flags      if roles_changed
       stop_apache                if roles_changed && !apache_needed?
 
-      sync_config                if config_changed
       reset_queue_messages       if config_changed || roles_changed
     end
 


### PR DESCRIPTION
This change allows for newly added roles to get activated.

Before, we would attempt to set the new roles before retrieving the updated config which would lead to us missing the role update.

https://bugzilla.redhat.com/show_bug.cgi?id=1335947

@Fryguy @jrafanie 