### PR TITLE
Fix for never ending spinner when creating service catalog item

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1697,5 +1697,7 @@ $(function () {
 
 function miqScrollToSelected(div_name) {
   var rowpos = $('tr.selected').position();
-  $('#' + div_name).scrollTop(rowpos.top);
+  if (rowpos) {
+    $('#' + div_name).scrollTop(rowpos.top);
+  }
 }

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -832,6 +832,7 @@ module ApplicationController::MiqRequestMethods
           @edit[:new][:start_min] = "00"
         end
       end
+      @edit[:new][:src_vm_id] = [nil, nil] unless @edit[:new][:src_vm_id]
       @edit[:new][tag_symbol_for_workflow] ||= []  # Initialize for new record
       @edit[:current] ||= {}
       @edit[:current] = copy_hash(@edit[:new])


### PR DESCRIPTION
In case we're creating a service catalog item for a provider type, which doesn't have any
vm templates available, we'd be getting an infinite spinner in UI.

This was caused by us relying on presence of `@edit[:new][:src_vm_id]` variable, which
in this particular case would be missing. This in the end would cause a javascript error
-> infinite spinner.

https://bugzilla.redhat.com/show_bug.cgi?id=1336888