### PR TITLE
Fix double slash in button url

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1479,6 +1479,8 @@ function miqToolbarOnClick(e) {
       // If url starts with / it is non-ajax
       tb_url = "/" + ManageIQ.controller + button.data('url');
       if (ManageIQ.record.recordId !== null) {
+        // remove last "/" if exist
+        tb_url = tb_url.replace(/\/$/, "");
         tb_url += "/" + ManageIQ.record.recordId;
       }
       if (button.data("url_parms")) {


### PR DESCRIPTION
Fix double slash in button url

With restful url's buttons that only change `url-params` like `?display=dashboard` introduce an artefact of double slash `//` into the url.

This PR is safe because we only remove an extra slash, line after it we always add a slash.

before:
![screenshot from 2016-05-19 15-57-45 jpg](https://cloud.githubusercontent.com/assets/2181522/15394593/9441d892-1ddc-11e6-9c19-9e92d3e3e8c2.png)

after:
![screenshot from 2016-05-19 15-57-28 jpg](https://cloud.githubusercontent.com/assets/2181522/15394608/a0b3fcfe-1ddc-11e6-9682-efb44ae3664f.png)
