### PR TITLE
Replicate current rows when adding a new table to the replication set

### DIFF
--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -81,7 +81,7 @@ class MiqPglogical
 
     # add tables to the set which are no longer excluded (or new)
     newly_included_tables.each do |table|
-      pglogical.replication_set_add_table(REPLICATION_SET_NAME, table)
+      pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
     end
   end
 


### PR DESCRIPTION
When a new table is added to the replication set (removed from the excluded tables) we want to be sure that any existing data is replicated.

Before this change the data inserted when the table was excluded would be ignored and would cause conflicts as those rows were updated.