### PR TITLE
Rake docs for evm rake tasks

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -30,6 +30,7 @@ namespace :evm do
 
   # update_start can be called in an environment where the database configuration is
   # not set, so we need to give it a dummy config
+  desc "Start updating the appliance"
   task :update_start do
     EvmRakeHelper.with_dummy_database_url_configuration do
       Rake::Task["environment"].invoke
@@ -37,6 +38,7 @@ namespace :evm do
     end
   end
 
+  desc "Stop updating the appliance"
   task :update_stop => :environment do
     EvmApplication.update_stop
   end
@@ -48,6 +50,7 @@ namespace :evm do
     end
   end
 
+  desc "Compile STI inheritance relationship cache"
   task :compile_sti_loader do
     EvmRakeHelper.with_dummy_database_url_configuration do
       Rake::Task["environment"].invoke

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -43,10 +43,14 @@ namespace :evm do
     EvmApplication.update_stop
   end
 
-  task :compile_assets do
-    EvmRakeHelper.with_dummy_database_url_configuration do
-      Rake::Task["assets:clobber"].invoke
-      Rake::Task["assets:precompile"].invoke
+  task :compile_assets => 'evm:assets:compile'
+  namespace :assets do
+    desc "Compile assets (clobber and precompile)"
+    task :compile do
+      EvmRakeHelper.with_dummy_database_url_configuration do
+        Rake::Task["assets:clobber"].invoke
+        Rake::Task["assets:precompile"].invoke
+      end
     end
   end
 


### PR DESCRIPTION
I can never remember how to precompile assets so I added docs to the rake tasks.

While `evm:compile_assets` still works, I added `evm:assets:compile` to be more consistent with the way that rails names the tasks `assets:precompile` / `assets:clobber`

cc @simaishi This will not change your workflow, but FYI