### PR TITLE
Fix displaying saved chargeback reports in chargeback menu

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -1,4 +1,6 @@
 class Chargeback < ActsAsArModel
+  DescendantLoader.instance.load_subclasses(self)
+
   VIRTUAL_COL_USES = {
     "v_derived_cpu_total_cores_used" => "cpu_usage_rate_average"
   }

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -350,6 +350,19 @@ class MiqReportResult < ApplicationRecord
     current_user.admin_user? ? all : where(:miq_group_id => current_user.miq_group_ids)
   end
 
+  def self.with_chargeback
+    includes(:miq_report).where(:miq_reports => {:db => Chargeback.subclasses})
+  end
+
+  def self.with_saved_chargeback_reports(report_id = nil)
+    with_report(report_id).auto_generated.with_current_user_groups.with_chargeback.order('LOWER(miq_reports.name)')
+  end
+
+  def self.select_distinct_results
+    select("DISTINCT ON(LOWER(miq_reports.name), miq_report_results.miq_report_id) LOWER(miq_reports.name), \
+            miq_report_results.miq_report_id")
+  end
+
   private
 
   def user_timezone

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -16,18 +16,18 @@ class TreeBuilderChargebackReports < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    items = MiqReportResult.auto_generated.select("miq_report_id, name").group("miq_report_id, name").where(
-      :db     => "Chargeback",
-      :userid => User.current_user.userid)
-
+    items = MiqReportResult.with_saved_chargeback_reports
+                           .select_distinct_results
+                           .group("miq_report_results.miq_report_id, miq_reports.name, miq_report_results.id, \
+                                   miq_reports.id")
     if count_only
       items.length
     else
       objects = []
-      items.sort_by { |item| item.name.downcase }.each_with_index do |item, idx|
+      items.each_with_index do |item, idx|
         objects.push(
           :id    => "#{to_cid(item.miq_report_id)}-#{idx}",
-          :text  => item.name,
+          :text  => item.miq_report.name,
           :image => "report",
           :tip   => item.name
         )
@@ -38,10 +38,9 @@ class TreeBuilderChargebackReports < TreeBuilder
 
   # Handle custom tree nodes (object is a Hash)
   def x_get_tree_custom_kids(object, count_only, _options)
-    objects = MiqReportResult.auto_generated.where(
-      :miq_report_id => from_cid(object[:id].split('-').first),
-      :userid        => User.current_user.userid
-    ).order("created_on DESC").select("id, miq_report_id, name, last_run_on, miq_task_id")
+    objects = MiqReportResult.with_saved_chargeback_reports(from_cid(object[:id].split('-').first))
+                             .select(:id, :miq_report_id, :name, :last_run_on, :miq_task_id)
+                             .order(:last_run_on)
 
     count_only_or_objects(count_only, objects, "name")
   end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -70,6 +70,23 @@ describe ChargebackController do
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.status).to                 eq(200)
     end
+
+    describe "#cb_rpt_build_folder_nodes" do
+      let!(:admin_user)        { FactoryGirl.create(:user_admin) }
+      let!(:chargeback_report) { FactoryGirl.create(:miq_report_chargeback_with_results) }
+
+      before { login_as admin_user }
+
+      it "returns list of saved chargeback report results" do
+        controller.send(:cb_rpt_build_folder_nodes)
+
+        parent_reports = controller.instance_variable_get(:@parent_reports)
+
+        tree_id = "#{ApplicationRecord.compress_id(chargeback_report.id)}-0"
+        expected_result = {chargeback_report.miq_report_results.first.name => tree_id}
+        expect(parent_reports).to eq(expected_result)
+      end
+    end
   end
 
   context "#explorer" do

--- a/spec/factories/miq_report.rb
+++ b/spec/factories/miq_report.rb
@@ -33,4 +33,15 @@ FactoryGirl.define do
     rpt_group       'Custom'
     association     :miq_group
   end
+
+  factory :miq_report_chargeback_with_results, :parent => :miq_report do
+    miq_report_results { [FactoryGirl.create(:miq_chargeback_report_result)] }
+    sequence(:name) { |n| "Test Report #{seq_padded_for_sorting(n)}" }
+    db              'ChargebackVm'
+    title           'some title'
+    rpt_type        'Default'
+    template_type   'report'
+    rpt_group       'Custom'
+    association     :miq_group
+  end
 end

--- a/spec/factories/miq_report_result.rb
+++ b/spec/factories/miq_report_result.rb
@@ -1,4 +1,10 @@
 FactoryGirl.define do
   factory :miq_report_result do
   end
+
+  factory :miq_chargeback_report_result, :parent => :miq_report_result do
+    sequence(:name) { |n| "Test Report #{seq_padded_for_sorting(n)}" }
+    db "ChargebackVm"
+    report_source "Requested by user"
+  end
 end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,3 +1,4 @@
+Chargeback
 describe ChargebackContainerProject do
   before do
     MiqRegion.seed

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,3 +1,4 @@
+Chargeback
 describe ChargebackVm do
   before do
     MiqRegion.seed


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1336978

Caused after separating chargeback for Vms and containers project in https://github.com/ManageIQ/manageiq/pull/7081

- `DescendantLoader` prepended for Chargeback class for getting subclasses by `Chargeback.descendants`
- moved where claused to MiqReportResult
- for non-admin users, they can see all saved report from all their groups
- fixed determing time used format_timezone method as it is done for list in tree (https://github.com/ManageIQ/manageiq/blob/master/app/presenters/tree_node_builder.rb#L114)
- listing only miq_report_results with any miq_report
- also query fixed for childs in tree in x_get_tree_custom_kids
- querying is based in MiqReport#db column instead of MiqReportResult#db
- fixed cases for report_results without finished of generation of report
- add ordering in trees and content by last_run_on