### PR TITLE
Rename container scan pod

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -48,7 +48,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
       :ems_id          => image.ext_management_system.id,
       :docker_image_id => image.docker_id,
       :image_full_name => image.full_name,
-      :pod_name        => "manageiq-img-scan-#{image.docker_id[0..11]}",
+      :pod_name        => "manageiq-img-scan-#{guid[0..4]}",
       :pod_port        => INSPECTOR_PORT,
       :pod_namespace   => namespace
     ))

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -186,7 +186,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         @job.signal(:start)
         expect(@job.state).to eq 'finished'
         expect(@job.status).to eq 'error'
-        expect(@job.message).to eq "pod creation for management-infra/manageiq-img-scan-3629a651e6c1" \
+        expect(@job.message).to eq "pod creation for management-infra/manageiq-img-scan-#{@job.guid[0..4]}" \
                                " failed: HTTP status code #{CODE}, #{CLIENT_MESSAGE}"
       end
     end


### PR DESCRIPTION
Proposing to rename container scanning pod name.
Implications:
- left behind pods will not interfere with future scans of the same image
- When one scan job is running for an entity another can run in parallel
 
evm.log:
```creating pod management-infra/manageiq-img-scan-9b507eac-ce5f-4f45-b16e-e764f5f6e839 to analyze docker image d78c9ef213722828e45feacc3bb2c93dd3d1cb66132a1b564325c49e769f0ca7:```