### PR TITLE
UI fixes for attach/detach volume

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -270,10 +270,9 @@ class VmCloudController < ApplicationController
       end
       @breadcrumbs.pop if @breadcrumbs
       session[:edit] = nil
-      session[:flash_msgs] = @flash_array.dup if @flash_array
-      render :update do |page|
-        page.redirect_to :action => "show", :id => @vm.id.to_s
-      end
+      @record = @sb[:action] = nil
+      replace_right_cell
+
     end
   end
 
@@ -310,10 +309,8 @@ class VmCloudController < ApplicationController
       end
       @breadcrumbs.pop if @breadcrumbs
       session[:edit] = nil
-      session[:flash_msgs] = @flash_array.dup if @flash_array
-      render :update do |page|
-        page.redirect_to :action => "show", :id => @vm.id.to_s
-      end
+      @record = @sb[:action] = nil
+      replace_right_cell
     end
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume/operations.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume/operations.rb
@@ -8,6 +8,7 @@ module ManageIQ::Providers::Openstack::CloudManager::CloudVolume::Operations
   end
 
   def raw_attach_volume(server_ems_ref, device = nil)
+    device = nil if device.try(:empty?)
     ext_management_system.with_provider_connection(connection_options) do |service|
       service.servers.get(server_ems_ref).attach_volume(ems_ref, device)
     end


### PR DESCRIPTION
This fixes two problems with attach/detach from the instance
details page:
1) Don't pass in empty string to fog for device path. If the user
   leaves path blank, pass in nil not "".
2) Fixed a bug in redirect handling for both attach and detach
   actions