### PR TITLE
Fixed code to start spinner when selecting values in drop down.

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1361,11 +1361,12 @@ function miqSelectPickerEvent(element, url, options) {
   $('#' + element).on('change', _.debounce(function() {
     var selected = $(this).val();
     var finalUrl = url + (firstarg ? '?' : '&') + element + '=' + escape(selected);
-    var is_sparkle_on = $(this).attr('data-miq_sparkle_on') == 'true'
-    var is_sparkle_off = $(this).attr('data-miq_sparkle_off') == 'true'
 
-    options.beforeSend = is_sparkle_on;
-    options.complete = is_sparkle_off;
+    if (typeof $(this).attr('data-miq_sparkle_on') != 'undefined')
+      options.beforeSend = $(this).attr('data-miq_sparkle_on') == 'true';
+
+    if(typeof $(this).attr('data-miq_sparkle_off') != 'undefined')
+      options.complete = $(this).attr('data-miq_sparkle_off') == 'true';
 
     if (options.callback) {
       options.done = function() {

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -392,9 +392,43 @@ describe('miq_application.js', function() {
       $('#miq-select-picker-1').val('quux').trigger('change');
 
       expect(miqObserveRequest).toHaveBeenCalledWith('/foo/?miq-select-picker-1=quux', {
+        no_encoding: true
+      });
+    });
+
+    it("sends beforeSend & complete options to miqObserveRequest", function() {
+      spyOn(window, 'miqObserveRequest');
+      spyOn(_, 'debounce').and.callFake(function(fn, opts) {
+        return fn;
+      });
+
+      miqSelectPickerEvent('miq-select-picker-1', '/foo/', {beforeSend: true, complete: true});
+
+      $('#miq-select-picker-1').val('1').trigger('change');
+
+      expect(miqObserveRequest).toHaveBeenCalledWith('/foo/?miq-select-picker-1=1', {
         no_encoding: true,
-        beforeSend: false,
-        complete: false,
+        beforeSend: true,
+        complete: true,
+      });
+    });
+
+    it("sets beforeSend & complete options using data-miq_sparkle_on & data-miq_sparkle_off", function() {
+      var html = '<select class="selectpicker bs-select-hidden" id="miq-select-picker-1" name="miq-select-picker-1" data-miq_sparkle_on="true" data-miq_sparkle_off="true"><option value="one">1</option> <option value="two" selected="selected">2</option></select>';
+      setFixtures(html);
+      spyOn(window, 'miqObserveRequest');
+      spyOn(_, 'debounce').and.callFake(function(fn, opts) {
+        return fn;
+      });
+
+      miqSelectPickerEvent('miq-select-picker-1', '/foo/');
+
+      $('#miq-select-picker-1').val('one').trigger('change');
+
+      expect(miqObserveRequest).toHaveBeenCalledWith('/foo/?miq-select-picker-1=one', {
+        no_encoding: true,
+        beforeSend: true,
+        complete: true,
       });
     });
   });


### PR DESCRIPTION
- Removed code that was setting options.beforeSend and options.complete based upon values from $(this).attr('data-miq_sparkle_on') & $(this).attr('data-miq_sparkle_off'). With new bootstrap drop downs we no longer set data-miq_sparkle_on & data-miq_sparkle_off, values for beforeSend & complete are being passed in along with options to miqSelectPickerEvent JS function from views.
- Added spec test to verify fix

https://bugzilla.redhat.com/show_bug.cgi?id=1337475

@dclarizio @himdel please review.

This code confusion started in commit a6288156f82f77c8388dc6fa5df9e6f71a0eb9df in https://github.com/ManageIQ/manageiq/pull/8316 where changes were instroduced to turn spinner on/off based upon $(this).attr('data-miq_sparkle_on')/$(this).attr('data-miq_sparkle_off') this code was further refactored/changed in latest commits assuming that spinner should be turned on/off solely based upon $(this).attr('data-miq_sparkle_on')/$(this).attr('data-miq_sparkle_off').