### PR TITLE
Validate schemas before enabling a subscription

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -71,6 +71,7 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def enable
+    assert_valid_schemas!
     pglogical.subscription_enable(id).check
   end
 


### PR DESCRIPTION
Disabling all subscriptions will likely be the way to allow users to run migrations in the future.

Validating the schemas before enabling a subscription will allow us to detect the situation where a user has failed to migrate both databases before restarting replication.