### PR TITLE
VmdbTable doesn't implement atStartup so remove it

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -31,7 +31,7 @@ class MiqServer < ApplicationRecord
 
   virtual_column :zone_description, :type => :string
 
-  RUN_AT_STARTUP  = %w( MiqRegion MiqWorker MiqQueue MiqReportResult VmdbTable )
+  RUN_AT_STARTUP  = %w( MiqRegion MiqWorker MiqQueue MiqReportResult )
 
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -2,9 +2,13 @@ describe MiqServer do
   include_examples ".seed called multiple times"
 
   it ".invoke_at_startups" do
+    MiqRegion.seed
     described_class::RUN_AT_STARTUP.each do |klass|
+      next unless klass.respond_to?(:atStartup)
       expect(klass.constantize).to receive(:atStartup)
     end
+
+    expect(Vmdb.logger).to receive(:log_backtrace).never
     described_class.invoke_at_startups
   end
 


### PR DESCRIPTION
It turns out 20c6091c42c13d (#8705) was correct:  we'll log classes that don't respond
to atStartup.

Unfortuntately, due to mocking atStartup in the test, VmdbTable
did respond to atStartup, but only in test.  In production/development, it silently
logged a NoMethodError warning.

Fix the test to only mock atStartup for classes that respond to it and assert
we don't call log_backtrace.  These two changes would have detected the bug that
VmdbTable was still in the RUN_AT_STARTUP list.

Related to but separate from #8704