### PR TITLE
[WIP] Add a test that lints factories

### DIFF
--- a/spec/factories/lint_factories_spec.rb
+++ b/spec/factories/lint_factories_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe "FactoryGirl factories", :lint do
+  example "linting factories" do
+    factories_to_lint = FactoryGirl.factories.reject do |factory|
+      factory.name =~ /rr_pending_change/
+    end
+
+    FactoryGirl.lint factories_to_lint
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,6 +100,8 @@ RSpec.configure do |config|
     EvmSpecHelper.clear_caches
   end
 
+  config.filter_run_excluding :lint
+
   if ENV["TRAVIS"] && ENV["TEST_SUITE"] == "vmdb"
     config.after(:suite) do
       require Rails.root.join("spec/coverage_helper.rb")


### PR DESCRIPTION
There are 80+ factories that are currently invalid, and it would be
great to get that number down. Adding this task will help with doing
that in small steps.

The `:rr_pending_change` factory causes some issues that break the
linter, so the linter will skip it for now.