### PR TITLE
Only mount the WebsocketServer route if run through Rails::Server

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2650,7 +2650,7 @@ Vmdb::Application.routes.draw do
   resources :ems_container, :as => :ems_containers
   match "/auth/:provider/callback" => "sessions#create", :via => :get
 
-  if Rails.env.development?
+  if Rails.env.development? && defined?(Rails::Server)
     mount WebsocketServer.new => '/ws'
   end
   # rubocop:enable MultilineOperationIndentation


### PR DESCRIPTION
I noticed I had a thread allocated here:
Thread  <xxx>/manageiq/lib/websocket_server.rb:8

It turns out, we were instantiating a WebsockerServer and creating a thread
in rails console, runner, and all workers in development mode.

It was added here: c8f85b15bac92a in #8083