### PR TITLE
Refresh the replication set when new worker config is saved

### DIFF
--- a/lib/vmdb/config/activator.rb
+++ b/lib/vmdb/config/activator.rb
@@ -44,6 +44,11 @@ module VMDB
       def server(data)
         MiqServer.my_server.config_activated(data) unless MiqServer.my_server.nil? rescue nil
       end
+
+      def workers(_data)
+        pgl = MiqPglogical.new
+        pgl.refresh_excludes if pgl.provider?
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #8190

This will become more targeted when we move replication settings out of the worker config, but for now the excludes will stay there while we still support rubyrep (and the replication worker)

@Fryguy please review