### PR TITLE
Use POST data (not query string params) for miq-observe with .interval

### DIFF
--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -101,10 +101,12 @@ $(document).ready(function () {
           });
         } else {
           // tack on the id and value to the URL
-          var urlstring = url + "?" + el.attr('id') + "=" + encodeURIComponent(el.prop('value'));
-          miqObserveRequest(urlstring, {
-            no_encoding: true,
+          var data = {};
+          data[el.attr('id')] = el.prop('value');
+
+          miqObserveRequest(url, {
             done: attemptAutoRefreshTrigger(parms),
+            data: data,
           });
         }
       });


### PR DESCRIPTION
This makes miq-observe with the .interval attribute specified send the data the same way as miq-observe without .interval - using POST data, instead of encoding it in the query string.

@jvlcek this is the one ;)