### PR TITLE
Ansible Tower credential validation issue

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -137,13 +137,8 @@ class ProviderForemanController < ApplicationController
 
   def add_provider_foreman
     find_or_build_provider
+    sync_form_to_instance
 
-    @provider_cfgmgmt.update_attributes(
-      :name       => params[:name],
-      :url        => params[:url],
-      :verify_ssl => params[:verify_ssl].eql?("on"),
-      :zone_id    => Zone.find_by_name(MiqServer.my_zone).id,
-    )
     update_authentication_provider(:save)
   end
 
@@ -496,6 +491,13 @@ class ProviderForemanController < ApplicationController
 
   def provider_class_from_provtype
     params[:provtype] == 'Ansible Tower' ? ManageIQ::Providers::AnsibleTower::Provider : ManageIQ::Providers::Foreman::Provider
+  end
+
+  def sync_form_to_instance
+    @provider_cfgmgmt.name       = params[:name]
+    @provider_cfgmgmt.url        = params[:url]
+    @provider_cfgmgmt.verify_ssl = params[:verify_ssl].eql?("on")
+    @provider_cfgmgmt.zone       = Zone.find_by_name(MiqServer.my_zone)
   end
 
   def features

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -136,8 +136,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def add_provider_foreman
-    @provider_cfgmgmt   = provider_class_from_provtype.new if params[:id] == "new"
-    @provider_cfgmgmt ||= find_record(ManageIQ::Providers::ConfigurationManager, params[:id]).provider # TODO: Why is params[:id] an ExtManagementSystem ID instead of Provider ID?
+    find_or_build_provider
 
     @provider_cfgmgmt.update_attributes(
       :name       => params[:name],
@@ -489,6 +488,11 @@ class ProviderForemanController < ApplicationController
   end
 
   private ###########
+
+  def find_or_build_provider
+    @provider_cfgmgmt   = provider_class_from_provtype.new if params[:id] == "new"
+    @provider_cfgmgmt ||= find_record(ManageIQ::Providers::ConfigurationManager, params[:id]).provider # TODO: Why is params[:id] an ExtManagementSystem ID instead of Provider ID?
+  end
 
   def provider_class_from_provtype
     params[:provtype] == 'Ansible Tower' ? ManageIQ::Providers::AnsibleTower::Provider : ManageIQ::Providers::Foreman::Provider

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -206,17 +206,8 @@ class ProviderForemanController < ApplicationController
   end
 
   def authentication_validate
-    @provider_cfgmgmt = if params[:log_password]
-                          provider_class_from_provtype.new(
-                            :name       => params[:name],
-                            :url        => params[:url],
-                            :verify_ssl => params[:verify_ssl].eql?("on"),
-                            :zone_id    => Zone.find_by_name(MiqServer.my_zone).id,
-                          )
-                        else
-                          find_record(ManageIQ::Providers::ConfigurationManager, params[:id]).provider
-                        end
-
+    find_or_build_provider
+    sync_form_to_instance
     update_authentication_provider
 
     begin

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -227,12 +227,7 @@ class ProviderForemanController < ApplicationController
 
     begin
       @provider_cfgmgmt.verify_credentials(params[:type])
-    rescue StandardError => bang
-      error = if bang.kind_of?(Faraday::Error::ClientError) # ansible uses faraday and returns a json as a response
-                JSON.parse(bang.to_s)['detail']
-              else
-                bang.to_s
-              end
+    rescue StandardError => error
       render_flash(_("Credential validation was not successful: %{details}") % {:details => error}, :error)
     else
       render_flash(_("Credential validation was successful"))

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
     end
 
     verify_ssl = options[:verify_ssl] || self.verify_ssl
-    base_url   = options[:base_url] || url
+    base_url   = options[:url] || url
     username   = options[:username] || authentication_userid(auth_type)
     password   = options[:password] || authentication_password(auth_type)
 

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -43,6 +43,8 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
     validity
   rescue Faraday::ConnectionFailed, Faraday::SSLError => err
     raise MiqException::MiqUnreachableError, err.message, err.backtrace
+  rescue Faraday::Error::ClientError => err
+    raise MiqException::MiqCommunicationsError, JSON.parse(err.message)['detail']
   end
 
   def self.process_tasks(options)

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -88,7 +88,7 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
     new_url  = "https://#{new_url}" unless new_url =~ %r{\Ahttps?:\/\/} # HACK: URI can't properly parse a URL with no scheme
     uri      = URI(new_url)
     uri.path = default_api_path if uri.path.blank?
-    default_endpoint.update_attributes(:url => uri.to_s)
+    default_endpoint.url = uri.to_s
   end
 
   private

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -10,7 +10,7 @@ class Provider < ApplicationRecord
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
 
-  has_many :endpoints, :through => :managers
+  has_many :endpoints, :through => :managers, :autosave => true
 
   delegate :verify_ssl,
            :verify_ssl?,

--- a/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
@@ -4,18 +4,20 @@ describe ManageIQ::Providers::AnsibleTower::Provider do
   subject { FactoryGirl.build(:provider_ansible_tower) }
 
   describe "#connect" do
-    let(:attrs) { {:base_url => "example.com", :username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_PEER} }
+    let(:attrs) { {:username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_PEER} }
 
     it "with no port" do
-      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs)
-      subject.connect(attrs)
+      url = "example.com"
+
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => url))
+      subject.connect(attrs.merge(:url => url))
     end
 
     it "with a port" do
-      attrs[:base_url] = "example.com:555"
+      url = "example.com:555"
 
-      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs)
-      subject.connect(attrs)
+      expect(AnsibleTowerClient::Connection).to receive(:new).with(attrs.merge(:base_url => url))
+      subject.connect(attrs.merge(:url => url))
     end
   end
 


### PR DESCRIPTION
Record used to be reloaded without any changes from the UI form before credentials were validated.
Change logic to first load the record, then apply changes from the form, then verify credentials.

https://bugzilla.redhat.com/show_bug.cgi?id=1337233