### PR TITLE
Ansible job template report fixes

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,6 +724,7 @@ en:
       LdapServer:               LDAP Server
       ManageIQ::Providers::BaseManager:                                     Provider
       ManageIQ::Providers::AnsibleTower::ConfigurationManager:              Configuration Manager (Ansible Tower)
+      ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript: Job Template (Ansible Tower)
       ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
       ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem: Configured System (Ansible Tower)

--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript.yaml
@@ -38,7 +38,7 @@ col_order:
 
 # Column titles, in order
 headers:
-- Nname
+- Name
 - Type
 - Description
 - Created On


### PR DESCRIPTION
Fixes:
* typo in report column name
* missing nice model description for ansible job template

Before:
![ansible-report-before](https://cloud.githubusercontent.com/assets/6648365/15421059/9bbc6642-1e71-11e6-8062-07173aa25689.jpg)

After:
![ansible-report-after](https://cloud.githubusercontent.com/assets/6648365/15421057/951e2e42-1e71-11e6-8391-da289550b416.jpg)

