### PR TITLE
Fix creation of url ids for GTL view under config. providers

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -1078,8 +1078,6 @@ class ProviderForemanController < ApplicationController
   def list_row_id(row)
     if row['name'] == _("Unassigned Profiles Group") && row['id'].nil?
       "-#{row['manager_id']}-unassigned"
-    elsif row[:type]
-      TreeBuilder.get_prefix_for_model(row[:type]).to_s % to_cid(row['id'])
     else
       to_cid(row['id'])
     end


### PR DESCRIPTION
list_row_id(row) is supposed to return id for a given object for any of the GTL views.
Returning just prefix for the given model would lead to incorrect url being construted
and a silent error when clicking on the constructed url.

https://bugzilla.redhat.com/show_bug.cgi?id=1336953