### PR TITLE
Fix "Storage Pods" string in GTL settings

### DIFF
--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -196,7 +196,7 @@
             - if role_allows(:feature => "storage_pod")
               .form-group
                 %label.col-md-3.control-label
-                  = ui_lookup(:tables => "storage_pods")
+                  = ui_lookup(:tables => "container_group")
                 .col-md-8
                   %ul.list-inline= render_view_buttons(:storage_pod, @edit[:new][:views][:storage_pod])
             - if role_allows(:feature => "providers_accord")


### PR DESCRIPTION
storage_pod is incorrect table name, correct should be: container_group

https://bugzilla.redhat.com/show_bug.cgi?id=1337558