### PR TITLE
Add GUI for Cloud Service enable/disable

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -228,6 +228,12 @@ class HostController < ApplicationController
     show_association('host_services', label, 'service', :host_services, SystemService, nil, condition)
   end
 
+  def host_cloud_services
+    @center_toolbar = 'host_cloud_services'
+    @no_checkboxes = false
+    show_association('host_cloud_services', _('Cloud Services'), 'service', :cloud_services, CloudService, nil, nil)
+  end
+
   def advanced_settings
     show_association('advanced_settings', _('Advanced Settings'), 'advancedsetting', :advanced_settings, AdvancedSetting)
   end
@@ -533,6 +539,7 @@ class HostController < ApplicationController
       edit_record if params[:pressed] == "host_edit"
       custom_buttons if params[:pressed] == "custom_button"
       prov_redirect if params[:pressed] == "host_miq_request_new"
+      toggleservicescheduling if params[:pressed] == "host_cloud_service_scheduling_toggle"
 
       # Handle Host power buttons
       if ["host_shutdown", "host_reboot", "host_standby", "host_enter_maint_mode", "host_exit_maint_mode",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -272,6 +272,7 @@ module ApplicationHelper
       when "host" then "host_services"
       when "vm"   then @lastaction
       end
+    when "CloudService" then "host_cloud_services"
     else view.scoped_association
     end
   end
@@ -747,6 +748,7 @@ module ApplicationHelper
       :sb             => @sb,
       :tabform        => @tabform,
       :view           => @view,
+      :center_toolbar => @center_toolbar
     )
   end
 

--- a/app/helpers/application_helper/toolbar/host_cloud_service_center.rb
+++ b/app/helpers/application_helper/toolbar/host_cloud_service_center.rb
@@ -1,0 +1,18 @@
+class ApplicationHelper::Toolbar::HostCloudServiceCenter < ApplicationHelper::Toolbar::Basic
+  button_group('host_cloud_services_vmdb', [select(
+    :host_cloud_services_choice,
+    'fa fa-cog fa-lg',
+    t = N_('Cloud Service Configuration'),
+    t,
+    :items => [
+      button(
+        :host_cloud_service_scheduling_toggle,
+        'pficon pficon-edit fa-lg',
+        N_('Toggle Scheduling'),
+        N_('Toggle Scheduling'),
+        :confirm   => N_("Toggle Scheduling for this Cloud Service?"),
+        :url_parms => "main_div",
+        :enabled   => true),
+    ]),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/host_cloud_services_center.rb
+++ b/app/helpers/application_helper/toolbar/host_cloud_services_center.rb
@@ -1,0 +1,19 @@
+class ApplicationHelper::Toolbar::HostCloudServicesCenter < ApplicationHelper::Toolbar::Basic
+  button_group('host_cloud_services_vmdb', [select(
+    :host_cloud_services_choice,
+    'fa fa-cog fa-lg',
+    t = N_('Cloud Service Configuration'),
+    t,
+    :items => [
+      button(
+        :host_cloud_service_scheduling_toggle,
+        'pficon pficon-edit fa-lg',
+        N_('Toggle Scheduling'),
+        N_('Toggle Scheduling'),
+        :confirm   => N_("Toggle Scheduling for this Cloud Service?"),
+        :url_parms => "main_div",
+        :enabled   => false,
+        :onwhen    => "1+"),
+    ]),
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -428,6 +428,8 @@ class ApplicationHelper::ToolbarChooser
 
   # Return non-explorer based toolbar file name
   def center_toolbar_filename_classic
+    return "#{@center_toolbar}_center_tb" if @center_toolbar
+
     # Original non vmx view code follows
     # toolbar buttons on sub-screens
     if ((@lastaction == "show" && @view) ||

--- a/app/models/cloud_service.rb
+++ b/app/models/cloud_service.rb
@@ -4,6 +4,8 @@ class CloudService < ApplicationRecord
   belongs_to :system_service
   belongs_to :availability_zone
 
+  alias_attribute :name, :executable_name
+
   def fog_service
     connection_options = {:service => source}
     ext_management_system.with_provider_connection(connection_options) do |service|

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -88,6 +88,9 @@ class Host < ApplicationRecord
   has_many                  :host_service_groups, :dependent => :destroy
 
   has_many                  :cloud_services, :dependent => :nullify
+  has_many                  :host_cloud_services, :class_name => "CloudService", :foreign_key => "host_id",
+                            :inverse_of => :host
+
 
   serialize :settings, Hash
 

--- a/app/views/host/_main.html.haml
+++ b/app/views/host/_main.html.haml
@@ -14,4 +14,5 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Custom Attributes"), :items => textual_group_miq_custom_attributes}
     = render :partial => "shared/summary/textual", :locals => {:title => _("VC Custom Attributes"), :items => textual_group_ems_custom_attributes}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Authentication Status"), :items => textual_group_authentications}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Cloud Services"), :items => textual_group_cloud_services}
     = render :partial => "shared/summary/textual_multilink", :locals => {:title => _("OpenStack Status"), :items => textual_group_openstack_status}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1391,6 +1391,7 @@ Vmdb::Application.routes.draw do
         guest_applications
         host_form_fields
         host_services
+        host_cloud_services
         index
         list
         new
@@ -1424,6 +1425,7 @@ Vmdb::Application.routes.draw do
         groups
         guest_applications
         host_services
+        host_cloud_services
         listnav_search_selected
         quick_search
         panel_control

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -923,6 +923,10 @@
       :description: Restart a Host / Node
       :feature_type: control
       :identifier: host_reboot
+    - :name: Cloud Service Scheduling toggle
+      :description: Cloud Service Scheduling toggle
+      :feature_type: control
+      :identifier: host_cloud_service_scheduling_toggle
   - :name: Modify
     :description: Modify Hosts / Nodes
     :feature_type: admin

--- a/product/views/CloudService.yaml
+++ b/product/views/CloudService.yaml
@@ -1,0 +1,66 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Services
+
+# Menu name
+name: Services
+
+# Main DB table report is based on
+db: CloudService
+
+# Columns to fetch from the main table
+cols:
+- name
+- scheduling_disabled
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- scheduling_disabled
+
+# Column titles, in order
+headers:
+- Name
+- Scheduling Disabled
+
+# Condition(s) string for the SQL query
+conditions: 
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph: 
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims: 

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1039 }
+  let(:expected_feature_count) { 1040 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
Add button into Host view to enable/disable Cloud Service Scheduling.

UI for Openstack nova scheduler enable/disable backend functionality which was introduced in #7996.