### PR TITLE
UI constants need to be ran through gettext dynamically

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -398,21 +398,21 @@ module UiConstants
   VALID_PLANNING_VM_MODES = PLANNING_VM_MODES.keys.index_by(&:to_s)
 
   TASK_TIME_PERIODS = {
-    0 => _("Today"),
-    1 => _("1 Day Ago"),
-    2 => _("2 Days Ago"),
-    3 => _("3 Days Ago"),
-    4 => _("4 Days Ago"),
-    5 => _("5 Days Ago"),
-    6 => _("6 Days Ago")
+    0 => N_("Today"),
+    1 => N_("1 Day Ago"),
+    2 => N_("2 Days Ago"),
+    3 => N_("3 Days Ago"),
+    4 => N_("4 Days Ago"),
+    5 => N_("5 Days Ago"),
+    6 => N_("6 Days Ago")
   }
-  SP_STATES = [[_("Initializing"), "initializing"], [_("Waiting to Start"), "waiting_to_start"],
-               [_("Cancelling"), "cancelling"], [_("Aborting"), "aborting"], [_("Finished"), "finished"],
-               [_("Snapshot Create"), "snapshot_create"], [_("Scanning"), "scanning"],
-               [_("Snapshot Delete"), "snapshot_delete"], [_("Synchronizing"), "synchronizing"],
-               [_("Deploy Smartproxy"), "deploy_smartproxy"]].freeze
-  UI_STATES = [[_("Initialized"), "Initialized"], [_("Queued"), "Queued"], [_("Active"), "Active"],
-               [_("Finished"), "Finished"]].freeze
+  SP_STATES = [[N_("Initializing"), "initializing"], [N_("Waiting to Start"), "waiting_to_start"],
+               [N_("Cancelling"), "cancelling"], [N_("Aborting"), "aborting"], [N_("Finished"), "finished"],
+               [N_("Snapshot Create"), "snapshot_create"], [N_("Scanning"), "scanning"],
+               [N_("Snapshot Delete"), "snapshot_delete"], [N_("Synchronizing"), "synchronizing"],
+               [N_("Deploy Smartproxy"), "deploy_smartproxy"]].freeze
+  UI_STATES = [[N_("Initialized"), "Initialized"], [N_("Queued"), "Queued"], [N_("Active"), "Active"],
+               [N_("Finished"), "Finished"]].freeze
 
   PROV_STATES = {
     "pending_approval" => _("Pending Approval"),

--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -32,7 +32,7 @@
         = _("24 Hour Time Period")
       .col-md-8
         = select_tag("time_period",
-          options_for_select(Array(TASK_TIME_PERIODS.invert).sort_by(&:last), @tasks_options[@tabform][:time_period]),
+          options_for_select(Array(TASK_TIME_PERIODS.invert).sort_by(&:last).map{|x| [_(x[0]), x[1]]}, @tasks_options[@tabform][:time_period]),
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();
@@ -65,7 +65,7 @@
         = _("Task State")
       .col-md-8
         = select_tag("state_choice",
-          options_for_select([["#{_('All')}", "all"]] + @tasks_options[@tabform][:states].sort, @tasks_options[@tabform][:state_choice]),
+          options_for_select([["#{_('All')}", "all"]] + @tasks_options[@tabform][:states].sort.map{|x| [_(x[0]), x[1]]}, @tasks_options[@tabform][:state_choice]),
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
UI constants are loaded to the appliance at startup and won't be re-evaluated again,
so we need to use `N_()` for these strings and use `_()` dynamically whenever
they're being used.

There are more issues like this, more pull requests fixing this will come later.

https://bugzilla.redhat.com/show_bug.cgi?id=1337563