### PR TITLE
Rbac: remove ActsAsArModel reference

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -484,7 +484,8 @@ module Rbac
   end
 
   def self.method_with_scope(ar_scope, options)
-    if ar_scope.respond_to?(:instances_are_derived?) ? ar_scope.instances_are_derived? : (ar_scope < ActsAsArModel)
+    # for the most part, it is just asking if it extends ActsAsArModel
+    if ar_scope.try(:instances_are_derived?)
       ar_scope.all(options)
     else
       ar_scope.apply_legacy_finder_options(options)


### PR DESCRIPTION
`ActAsArModel` implement `instances_are_derived?`.

if class extends `ActsAsArModel`
then it implements `instances_are_derived?`

contrapositive:

If a class doesn't implement `instances_are_derived?`
then it doesn't extend `ActsAsArModel`.

So in this case, `class < ActsAsArModel` will always be `false`.

`x ? y : false` ==> `x && y`