### PR TITLE
JS API.* - use fetch instead of $.ajax

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require miq_global
 //= require es6-shim
+//= require fetch
 //= require jquery
 //= require jquery_overrides
 //= require i18n

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -1,16 +1,16 @@
 /* functions to use the API from our JS/Angular:
  *
- * API.get(url, options) - use API.get('/api'), returns promise
+ * API.get(url, options) - use API.get('/api'), returns a Promise
  * API.delete - (the same)
- * API.post(url, data, options) - returns promise
+ * API.post(url, data, options) - returns Promise
  * API.put - (the same)
  * API.patch - (the same)
- * API.login(login, password) - performs initial authentication, saves token on success, returns promise
+ * API.login(login, password) - performs initial authentication, saves token on success, returns Promise
  * API.logout() - clears login info, no return
  * API.autorenew() - registers a 60second interval to query /api, returns a function to clear the interval
  *
  * can also be used from angular - depend on miq.api module and use the API service
- * when used as an angular service, all the promises are $q, so work within the angular digest cycle
+ * when used as an angular service, all the promises are $q, so they work within the angular digest cycle
  *
  * the API token is persisted into sessionStorage
  */
@@ -20,36 +20,41 @@
   }
 
   API.get = function(url, options) {
-    return $.ajax(url, _.extend({
+    return fetch(url, _.extend({
       method: 'GET',
-    }, process_options(options)));
+    }, process_options(options)))
+    .then(process_response);
   };
 
   API.post = function(url, data, options) {
-    return $.ajax(url, _.extend({
+    return fetch(url, _.extend({
       method: 'POST',
-      data: data,
-    }, process_options(options)));
+      body: process_data(data),
+    }, process_options(options)))
+    .then(process_response);
   };
 
   API.delete = function(url, options) {
-    return $.ajax(url, _.extend({
+    return fetch(url, _.extend({
       method: 'DELETE',
-    }, process_options(options)));
+    }, process_options(options)))
+    .then(process_response);
   };
 
   API.put = function(url, data, options) {
-    return $.ajax(url, _.extend({
+    return fetch(url, _.extend({
       method: 'PUT',
-      data: data,
-    }, process_options(options)));
+      body: process_data(data),
+    }, process_options(options)))
+    .then(process_response);
   };
 
   API.patch = function(url, data, options) {
-    return $.ajax(url, _.extend({
+    return fetch(url, _.extend({
       method: 'PATCH',
-      data: data,
-    }, process_options(options)));
+      body: process_data(data),
+    }, process_options(options)))
+    .then(process_response);
   };
 
   var base64encode = window.btoa; // browser api
@@ -98,6 +103,7 @@
     delete o.method;
     delete o.url;
     delete o.data;
+    delete o.body;
 
     if (o.skipTokenRenewal) {
       o.headers = o.headers || {};
@@ -109,7 +115,29 @@
       o.headers['X-Auth-Token'] = sessionStorage.miq_token;
     }
 
+    if (o.headers) {
+      o.headers = new Headers(o.headers);
+    }
+
     return o;
+  }
+
+  function process_data(o) {
+    if (!o || _.isString(o))
+      return o;
+
+    if (_.isPlainObject(o))
+      return JSON.stringify(o);
+
+    // fetch supports more types but we aren't using any of those yet..
+    console.warning('Unknown type for request data - please provide a plain object or a string', o);
+  }
+
+  function process_response(response) {
+    if (response.status === 204)  // No content
+      return null;
+
+    return response.json();
   }
 })(window);
 

--- a/bower.json
+++ b/bower.json
@@ -41,6 +41,7 @@
     "xml_display": "^0.1.1",
     "spice-html5-bower": "himdel/spice-html5-bower#^0.1.5",
     "es6-shim": "^0.35.0",
-    "phantomjs-polyfill": "^0.0.2"
+    "phantomjs-polyfill": "^0.0.2",
+    "fetch": "^1.0.0"
   }
 }


### PR DESCRIPTION
Without this, calling `miqSparkle(false)` (for example from miqJqueryRequest on complete) will not remove the spinner if an API request is running at the same time.

By using the [fetch api](https://fetch.spec.whatwg.org/) (either native, or polyfilled on top of XMLHttpRequest), instead of jQuery ajax, the API requests won't get counted in `$.active`, thus, `miqSparkle(false)` works.

https://bugzilla.redhat.com/show_bug.cgi?id=1334954