### PR TITLE
Rbac actually check instances_are_derived

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -439,7 +439,7 @@ module Rbac
 
     user_filters['match_via_descendants'] = to_class(options[:match_via_descendants])
 
-    exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.respond_to?(:instances_are_derived?)
+    exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.try(:instances_are_derived?)
     conditions, include_for_find = MiqExpression.merge_where_clauses_and_includes([conditions, sub_filter, where_clause, exp_sql, ids_clause], [include_for_find, exp_includes])
 
     attrs[:apply_limit_in_sql] = (exp_attrs.nil? || exp_attrs[:supported_by_sql]) && user_filters["belongsto"].blank?


### PR DESCRIPTION
before:
This code checks if the method is defined, assuming that if it is,
then it will return true.

after:
actually call the method to see if it is derived.

Note: a few lines down, it actually calls