### PR TITLE
[Darga] Follow up to backport for https://github.com/ManageIQ/manageiq/pull/8729

### DIFF
--- a/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
@@ -1,5 +1,4 @@
 class TreeBuilderConfigurationManagerConfigurationScripts < TreeBuilder
-  has_kids_for ManageIQ::Providers::AnsibleTower::ConfigurationManager, [:x_get_tree_cmat_kids]
   attr_reader :tree_nodes
 
   private


### PR DESCRIPTION
Has_kids does not exist in Darga - the x_get_tree_cmat_kids is called directly from the treebuilder case instead