### PR TITLE
Explicitly add internal Rails tables to replication excluded tables list

### DIFF
--- a/db/migrate/20160425161234_remove_deleted_tables_from_replication_settings.rb
+++ b/db/migrate/20160425161234_remove_deleted_tables_from_replication_settings.rb
@@ -6,10 +6,13 @@ class RemoveDeletedTablesFromReplicationSettings < ActiveRecord::Migration[5.0]
 
   def up
     deleted_tables = %w(miq_events miq_license_contents vim_performances)
+    added_tables   = %w(miq_event_definitions)
 
     changes = SettingsChange.where(:key => "/workers/worker_base/replication_worker/replication/exclude_tables")
     changes.each do |change|
       change.value -= deleted_tables
+      change.value += added_tables
+      change.value.uniq!
       change.save
     end
   end

--- a/db/migrate/20160425161234_remove_deleted_tables_from_replication_settings.rb
+++ b/db/migrate/20160425161234_remove_deleted_tables_from_replication_settings.rb
@@ -1,0 +1,16 @@
+class RemoveDeletedTablesFromReplicationSettings < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    serialize :value
+  end
+
+  def up
+    deleted_tables = %w(miq_events miq_license_contents vim_performances)
+
+    changes = SettingsChange.where(:key => "/workers/worker_base/replication_worker/replication/exclude_tables")
+    changes.each do |change|
+      change.value -= deleted_tables
+      change.save
+    end
+  end
+end

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -63,7 +63,7 @@ class MiqPglogical
   # Lists the tables configured to be excluded in the vmdb configuration
   # @return Array<String> the table list
   def configured_excludes
-    MiqServer.my_server.get_config.config.fetch_path(*SETTINGS_PATH, :exclude_tables)
+    MiqServer.my_server.get_config.config.fetch_path(*SETTINGS_PATH, :exclude_tables) | %w(ar_internal_metadata schema_migrations)
   end
 
   # Creates the 'miq' replication set and refreshes the excluded tables

--- a/lib/miq_rubyrep.rb
+++ b/lib/miq_rubyrep.rb
@@ -58,6 +58,7 @@ class MiqRubyrep
     config.include_tables /#{include_tables}/
 
     rp_conf[:exclude_tables] ||= %w(.+)
+    rp_conf[:exclude_tables] += %w(ar_internal_metadata schema_migrations)
     exclude_tables = rp_conf[:exclude_tables].to_a.join("|")
     exclude_tables = "^(#{exclude_tables})$"
     config.exclude_tables /#{exclude_tables}/

--- a/spec/migrations/20160425161234_remove_deleted_tables_from_replication_settings_spec.rb
+++ b/spec/migrations/20160425161234_remove_deleted_tables_from_replication_settings_spec.rb
@@ -1,0 +1,22 @@
+require_migration
+
+describe RemoveDeletedTablesFromReplicationSettings do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "removes deleted tables from an existing settings change" do
+      settings_change_stub.create!(
+        :resource_type => "MiqServer",
+        :key           => "/workers/worker_base/replication_worker/replication/exclude_tables",
+        :value         => %w(table1 vim_performances table2 miq_events table3 miq_license_contents table4)
+      )
+
+      migrate
+
+      expect(settings_change_stub.count).to eq(1)
+
+      change = settings_change_stub.where("key LIKE '%/exclude_tables'").last
+      expect(change.value).to eq %w(table1 table2 table3 table4)
+    end
+  end
+end

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -60,7 +60,7 @@ describe MiqPglogical do
     end
 
     it "adds a newly included table" do
-      table = subject.configured_excludes.first
+      table = subject.configured_excludes.last
       new_excludes = subject.configured_excludes - [table]
 
       c = MiqServer.my_server.get_config


### PR DESCRIPTION
This PR adds tables `ar_internal_metadata` and `schema_migrations` the the configured replication exclude_tables list in the rubyrep and pglogical replication startup code. This ensures that these tables, which will break replication, are always excluded.

Additionally, there are tables that were previously removed from the application that will remain in a legacy exclude_table list. So, a migration was added to remove these tables for an existing settings change if they exist.

https://bugzilla.redhat.com/show_bug.cgi?id=1331053

cc/ @Fryguy, @carbonin  