### PR TITLE
Fix - Make only_cols optional in LiveMetric model

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -203,6 +203,7 @@ module ApplicationController::Performance
     edate_daily = edate.hour < 23 ? edate - 1.day : edate
     options[:edate_daily] = edate_daily
 
+    options[:typ] = "Hourly" if options[:typ] == "Daily" && edate_daily < sdate_daily
     if options[:hourly_date] && # Need to clear hourly date if not nil so it will be reset below if
        (options[:hourly_date].to_date < sdate.to_date || options[:hourly_date].to_date > edate.to_date || # it is out of range
          (options[:typ] == "Hourly" && options[:time_profile] && !options[:time_profile_days].include?(options[:hourly_date].to_date.wday))) # or not in profile

--- a/app/models/live_metric.rb
+++ b/app/models/live_metric.rb
@@ -8,18 +8,20 @@ class LiveMetric < ActsAsArModel
     validate_raw_query(raw_query)
     processed = process_conditions(raw_query[:conditions])
     resource = fetch_resource(processed[:resource_type], processed[:resource_id])
+    ext_options = raw_query[:ext_options]
+    filtered_cols = ext_options ? ext_options[:only_cols] : nil
     if resource.nil?
       []
     else
-      filter_and_fetch_metrics(resource, raw_query[:ext_options][:only_cols], processed[:start_time],
+      filter_and_fetch_metrics(resource, filtered_cols, processed[:start_time],
                                processed[:end_time], processed[:interval_name])
     end
   end
 
   def self.validate_raw_query(raw)
-    unless raw && %i(conditions ext_options).all? { |k| raw.key?(k) }
-      _log.error("LiveMetric expression #{raw} doesn't contain 'conditions' or 'ext_options'.")
-      raise LiveMetricError, "LiveMetric expression doesn't contain 'conditions' or 'ext_options'"
+    unless raw && raw[:conditions]
+      _log.error("LiveMetric expression #{raw} doesn't contain 'conditions'.")
+      raise LiveMetricError, "LiveMetric expression doesn't contain 'conditions'"
     end
   end
 

--- a/spec/models/live_metric_spec.rb
+++ b/spec/models/live_metric_spec.rb
@@ -1,26 +1,48 @@
 describe LiveMetric do
-  context "parse finders methods" do
-    it "#resource_type" do
-      conditions = "resource_type = 'MiddlewareServer' and resource_id = 6 " \
-      "and timestamp >= '2016-04-05 00:00:00' and timestamp <= '2016-04-03 23:00:00' " \
-      "and capture_interval_name = 'daily'"
-      parsed = LiveMetric.parse_conditions(conditions)
-      expect(parsed.size).to eq(5)
-      expect(parsed[0][:column]).to eq("resource_type")
-      expect(parsed[0][:op]).to eq("=")
-      expect(parsed[0][:value]).to eq("MiddlewareServer")
-      expect(parsed[1][:column]).to eq("resource_id")
-      expect(parsed[1][:op]).to eq("=")
-      expect(parsed[1][:value]).to eq("6")
-      expect(parsed[2][:column]).to eq("timestamp")
-      expect(parsed[2][:op]).to eq(">=")
-      expect(parsed[2][:value]).to eq("2016-04-05 00:00:00")
-      expect(parsed[3][:column]).to eq("timestamp")
-      expect(parsed[3][:op]).to eq("<=")
-      expect(parsed[3][:value]).to eq("2016-04-03 23:00:00")
-      expect(parsed[4][:column]).to eq("capture_interval_name")
-      expect(parsed[4][:op]).to eq("=")
-      expect(parsed[4][:value]).to eq("daily")
-    end
+  let(:conditions) do
+    "resource_type = 'MiddlewareServer' and resource_id = 6 " \
+    "and timestamp >= '2016-04-03 00:00:00' and timestamp <= '2016-04-05 23:00:00' " \
+    "and capture_interval_name = 'daily'"
+  end
+
+  let(:incomplete_conditions) do
+    "resource_type = 'MiddlewareServer' " \
+    "and timestamp >= '2016-04-03 00:00:00' and timestamp <= '2016-04-05 23:00:00' " \
+    "and capture_interval_name = 'daily'"
+  end
+
+  it "#parse_conditions" do
+    parsed = LiveMetric.parse_conditions(conditions)
+    expect(parsed.size).to eq(5)
+    expect(parsed[0][:column]).to eq("resource_type")
+    expect(parsed[0][:op]).to eq("=")
+    expect(parsed[0][:value]).to eq("MiddlewareServer")
+    expect(parsed[1][:column]).to eq("resource_id")
+    expect(parsed[1][:op]).to eq("=")
+    expect(parsed[1][:value]).to eq("6")
+    expect(parsed[2][:column]).to eq("timestamp")
+    expect(parsed[2][:op]).to eq(">=")
+    expect(parsed[2][:value]).to eq("2016-04-03 00:00:00")
+    expect(parsed[3][:column]).to eq("timestamp")
+    expect(parsed[3][:op]).to eq("<=")
+    expect(parsed[3][:value]).to eq("2016-04-05 23:00:00")
+    expect(parsed[4][:column]).to eq("capture_interval_name")
+    expect(parsed[4][:op]).to eq("=")
+    expect(parsed[4][:value]).to eq("daily")
+  end
+
+  it "#process_conditions" do
+    processed = LiveMetric.process_conditions(conditions)
+    expect(processed[:resource_type]).to eq("MiddlewareServer")
+    expect(processed[:resource_id]).to eq("6")
+    expect(processed[:start_time]).to eq(Time.parse("2016-04-03 00:00:00 UTC").utc)
+    expect(processed[:end_time]).to eq(Time.parse("2016-04-05 23:00:00 UTC").utc)
+    expect(processed[:interval_name]).to eq("daily")
+  end
+
+  it "#process_conditions raises error on incomplete conditions" do
+    expect do
+      LiveMetric.process_conditions(incomplete_conditions)
+    end.to raise_error(LiveMetric::LiveMetricError, "LiveMetric expression must contain resource_id condition")
   end
 end


### PR DESCRIPTION
Fix - back to hourly date range if daily only has an incomplete day
Fixes #8769 and fixes #8822 

MiqReport::Generator._generate_table() included only_cols to choose the columns to be part of the performance reports. In a recent commit, this parameter is optional in _generate_table(). LiveMetrics used that parameter to optimize the metrics to fetch from the provider.
I can read in the code of MiqReport::Generator that only_cols will be added in a next iteration, so I move only_cols as an optional in LiveMetrics too, if present it will fetch only cols defined, but if not, it will fetch all metrics defined in the resource_type.metrics_available.