### PR TITLE
Different group for container project metric 

### DIFF
--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -1,27 +1,27 @@
 class ChargebackContainerProject < Chargeback
   set_columns_hash(
-    :start_date           => :datetime,
-    :end_date             => :datetime,
-    :interval_name        => :string,
-    :display_range        => :string,
-    :project_name         => :string,
-    :project_uid          => :string,
-    :provider_name        => :string,
-    :provider_uid         => :string,
-    :archived             => :string,
-    :cpu_used_cost        => :float,
-    :cpu_used_metric      => :float,
-    :fixed_compute_1_cost => :float,
-    :fixed_compute_2_cost => :float,
-    :fixed_2_cost         => :float,
-    :fixed_cost           => :float,
-    :memory_used_cost     => :float,
-    :memory_used_metric   => :float,
-    :net_io_used_cost     => :float,
-    :net_io_used_metric   => :float,
-    :net_io_cost          => :float,
-    :net_io_metric        => :float,
-    :total_cost           => :float
+    :start_date            => :datetime,
+    :end_date              => :datetime,
+    :interval_name         => :string,
+    :display_range         => :string,
+    :project_name          => :string,
+    :project_uid           => :string,
+    :provider_name         => :string,
+    :provider_uid          => :string,
+    :archived              => :string,
+    :cpu_cores_used_cost   => :float,
+    :cpu_cores_used_metric => :float,
+    :fixed_compute_1_cost  => :float,
+    :fixed_compute_2_cost  => :float,
+    :fixed_2_cost          => :float,
+    :fixed_cost            => :float,
+    :memory_used_cost      => :float,
+    :memory_used_metric    => :float,
+    :net_io_used_cost      => :float,
+    :net_io_used_metric    => :float,
+    :net_io_cost           => :float,
+    :net_io_metric         => :float,
+    :total_cost            => :float
   )
 
   def self.build_results_for_report_ChargebackContainerProject(options)
@@ -85,18 +85,18 @@ class ChargebackContainerProject < Chargeback
 
   def self.report_col_options
     {
-      "cpu_used_cost"        => {:grouping => [:total]},
-      "cpu_used_metric"      => {:grouping => [:total]},
-      "fixed_compute_1_cost" => {:grouping => [:total]},
-      "fixed_compute_2_cost" => {:grouping => [:total]},
-      "fixed_cost"           => {:grouping => [:total]},
-      "memory_used_cost"     => {:grouping => [:total]},
-      "memory_used_metric"   => {:grouping => [:total]},
-      "net_io_cost"          => {:grouping => [:total]},
-      "net_io_metric"        => {:grouping => [:total]},
-      "net_io_used_cost"     => {:grouping => [:total]},
-      "net_io_used_metric"   => {:grouping => [:total]},
-      "total_cost"           => {:grouping => [:total]}
+      "cpu_cores_used_cost"   => {:grouping => [:total]},
+      "cpu_cores_used_metric" => {:grouping => [:total]},
+      "fixed_compute_1_cost"  => {:grouping => [:total]},
+      "fixed_compute_2_cost"  => {:grouping => [:total]},
+      "fixed_cost"            => {:grouping => [:total]},
+      "memory_used_cost"      => {:grouping => [:total]},
+      "memory_used_metric"    => {:grouping => [:total]},
+      "net_io_cost"           => {:grouping => [:total]},
+      "net_io_metric"         => {:grouping => [:total]},
+      "net_io_used_cost"      => {:grouping => [:total]},
+      "net_io_used_metric"    => {:grouping => [:total]},
+      "total_cost"            => {:grouping => [:total]}
     }
   end
 end # class Chargeback

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -49,23 +49,7 @@ class ChargebackRateDetail < ApplicationRecord
     when "yearly"  then rate / 24 / 365
     else raise "rate time unit of '#{per_time}' not supported"
     end
-  end
 
-  def hourly_rate
-    _fixed_rate, variable_rate = find_rate(0.0)
-    return 0.0 if variable_rate.zero?
-
-    hr = case per_time
-         when "hourly"  then variable_rate
-         when "daily"   then variable_rate / 24
-         when "weekly"  then variable_rate / 24 / 7
-         when "monthly" then variable_rate / 24 / 30
-         when "yearly"  then variable_rate / 24 / 365
-         else raise _("rate time unit of '%{time_type}' not supported") % {:time_type => per_time}
-         end
-
-    # Handle cases where we need to adjust per_unit to a common value.
-    rate_adjustment(hr)
   end
 
   # Scale the rate in the unit difine by user to the default unit of the metric

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -18,7 +18,7 @@
           :fixed_rate: 0.0
           :variable_rate: 0.02
     - :description: Used CPU Cores
-      :group: cpu
+      :group: cpu_container
       :source: used
       :metric: v_derived_cpu_total_cores_used
       :per_time: daily

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -18,7 +18,7 @@
           :fixed_rate: 0.0
           :variable_rate: 0.02
     - :description: Used CPU Cores
-      :group: cpu_container
+      :group: cpu_cores
       :source: used
       :metric: v_derived_cpu_total_cores_used
       :per_time: daily

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -37,7 +37,7 @@ FactoryGirl.define do
 
   factory :chargeback_rate_detail_cpu_cores_used, :parent => :chargeback_rate_detail do
     description "Used CPU in Cores"
-    group       "cpu_container"
+    group       "cpu_cores"
     source      "used"
     metric      "cpu_usage_rate_average"
     per_unit    "cores"

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -37,7 +37,7 @@ FactoryGirl.define do
 
   factory :chargeback_rate_detail_cpu_cores_used, :parent => :chargeback_rate_detail do
     description "Used CPU in Cores"
-    group       "cpu"
+    group       "cpu_container"
     source      "used"
     metric      "cpu_usage_rate_average"
     per_unit    "cores"

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -87,8 +87,8 @@ describe ChargebackContainerProject do
                                :variable_rate             => @hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-      expect(subject.cpu_used_metric).to eq(@cpu_usage_rate * @metric_size)
-      expect(subject.cpu_used_cost).to eq(@cpu_usage_rate * @hourly_rate * @metric_size)
+      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate * @metric_size)
+      expect(subject.cpu_cores_used_cost).to eq(@cpu_usage_rate * @hourly_rate * @metric_size)
     end
 
     it "memory" do
@@ -176,8 +176,8 @@ describe ChargebackContainerProject do
                                :variable_rate             => @hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-      expect(subject.cpu_used_metric).to eq(@cpu_usage_rate * @metric_size)
-      expect(subject.cpu_used_cost).to eq(@cpu_usage_rate * @hourly_rate * @metric_size)
+      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate * @metric_size)
+      expect(subject.cpu_cores_used_cost).to eq(@cpu_usage_rate * @hourly_rate * @metric_size)
     end
 
     it "memory" do

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -119,6 +119,55 @@ describe ChargebackVm do
       expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
     end
 
+    it "cpu_vm_and_cpu_container_project" do
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :finish                    => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_allocated,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :finish                    => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @count_hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly")
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :finish                    => Float::INFINITY,
+                               :fixed_rate                => 1.0,
+                               :variable_rate             => @hourly_rate.to_s)
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+
+      expect(subject.cpu_allocated_metric).to eq(@cpu_count * @metric_size)
+      expect(subject.cpu_used_metric).to eq(@cpu_usagemhz_rate * @metric_size)
+      expect(subject.cpu_metric).to eq(subject.cpu_allocated_metric + subject.cpu_used_metric)
+
+      expect(subject.cpu_allocated_cost).to eq(@cpu_count * @count_hourly_rate * @metric_size)
+      expect(subject.cpu_used_cost).to eq(@cpu_usagemhz_rate * @hourly_rate * @metric_size)
+      expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
+    end
+
     it "memory" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_memory_allocated,
                                :chargeback_rate_id => @cbr.id,


### PR DESCRIPTION
Fixing bug [ 1337278](https://bugzilla.redhat.com/show_bug.cgi?id=1337278) and [1337298](https://bugzilla.redhat.com/show_bug.cgi?id=1337298) with @tledesma. The group for the metric "Used CPU Cores" must be different because cause disarray in the method calculate_costs of Chargeback when we try to generate a Chargeback Vm report. Values from cpu_usage_rate_average(that is a metric for container projects) are collected in chargeback VM report because has the same group that derived_vm_numvcpus and cpu_usagemhz_rate_average.  @zeari please review it, this changes affect the code that you created.

https://bugzilla.redhat.com/show_bug.cgi?id=1337278
https://bugzilla.redhat.com/show_bug.cgi?id=1337298