### PR TITLE
[api] Adding support for Automation Request approve/deny

### DIFF
--- a/app/controllers/api_controller/automation_requests.rb
+++ b/app/controllers/api_controller/automation_requests.rb
@@ -13,5 +13,27 @@ class ApiController
 
       AutomationRequest.create_from_ws(version_str, @auth_user_obj, uri_parts, parameters, requester)
     end
+
+    def approve_resource_automation_requests(type, id, data)
+      raise "Must specify a reason for approving an automation request" unless data["reason"].present?
+      api_action(type, id) do |klass|
+        request = resource_search(id, type, klass)
+        request.approve(@auth_user, data["reason"])
+        action_result(true, "Automation request #{id} approved")
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def deny_resource_automation_requests(type, id, data)
+      raise "Must specify a reason for denying an automation request" unless data["reason"].present?
+      api_action(type, id) do |klass|
+        request = resource_search(id, type, klass)
+        request.deny(@auth_user, data["reason"])
+        action_result(true, "Automation request #{id} denied")
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -59,6 +59,16 @@
     :collection_actions:
       :post:
       - :name: create
+      - :name: approve
+        :identifier: miq_request_approval
+      - :name: deny
+        :identifier: miq_request_approval
+    :resource_actions:
+      :post:
+      - :name: approve
+        :identifier: miq_request_approval
+      - :name: deny
+        :identifier: miq_request_approval
   :availability_zones:
     :description: Availability Zones
     :identifier: availability_zone


### PR DESCRIPTION
- Support approving or denying automation requests
 * on multiple requests when targeting /api/automation_requests
 * or single request when targeting /api/automation_requests/:id
- support action "approve"
- support action "deny"
- updated spec/requests/api/automation_requests_spec.rb

https://bugzilla.redhat.com/show_bug.cgi?id=1229818