### PR TITLE
Fix Relationship links for a Middleware Provider

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,9 +71,18 @@ module ApplicationHelper
         end
       else
         out = content_tag(:li) do
-          link_to("#{plural} (#{count})",
-                  polymorphic_path(@record, :display => table_name.to_s.pluralize),
-                  :title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural})
+          if restful_routed?(record)
+            link_to("#{plural} (#{count})",
+                    polymorphic_path(record, :display => table_name.to_s.pluralize),
+                    :title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural})
+          else
+            link_to("#{plural} (#{count})",
+                    {:controller => controller_name,
+                     :action     => 'show',
+                     :id         => record.id,
+                     :display    => table_name.to_s.pluralize},
+                    :title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural})
+          end
         end
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,7 +81,7 @@ module ApplicationHelper
                      :action     => 'show',
                      :id         => record.id,
                      :display    => table_name.to_s.pluralize},
-                    :title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural})
+                    {:title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural}})
           end
         end
       end

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -1,0 +1,35 @@
+describe EmsMiddlewareController do
+  before(:each) do
+    set_user_privileges
+  end
+
+  it "#new" do
+    controller.instance_variable_set(:@breadcrumbs, [])
+    get :new
+
+    expect(response.status).to eq(200)
+    expect(allow(controller).to receive(:edit)).to_not be_nil
+  end
+
+  describe "#show" do
+    before do
+      session[:settings] = {:views => {}, :quadicons => {}}
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      @middleware = FactoryGirl.create(:ems_hawkular)
+      MiddlewareDatasource.create(:ext_management_system => @middleware, :name => "Test Middleware")
+    end
+
+    subject { get :show, :id => @middleware.id }
+
+    context "render" do
+      render_views
+      it { is_expected.to render_template('ems_middleware/show') }
+
+      it do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_ems_middleware")
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1641,4 +1641,23 @@ describe ApplicationHelper do
       ).to eq('host_services')
     end
   end
+
+  describe "#multiple_relationship_link" do
+    context "When record is a Container Provider" do
+      it "Uses polymorphic_path for the show action" do
+        ems = FactoryGirl.create(:ems_kubernetes)
+        ContainerProject.create(:ext_management_system => ems, :name => "Test Project")
+        expect(helper.multiple_relationship_link(ems, "container_project")).to eq("<li><a title=\"Show Projects\" href=\"/ems_container/#{ems.id}?display=container_projects\">Projects (1)</a></li>")
+      end
+    end
+
+    context "When record is a Middleware Provider" do
+      it "Routes to the controller's show action" do
+        allow(helper).to receive_messages(:controller_name => "ems_middleware")
+        ems = FactoryGirl.create(:ems_hawkular)
+        MiddlewareDatasource.create(:ext_management_system => ems, :name => "Test Middleware")
+        expect(helper.multiple_relationship_link(ems, "middleware_datasource")).to eq("<li><a title=\"Show Middleware Datasources\" href=\"/ems_middleware/show/#{ems.id}?display=middleware_datasources\">Middleware Datasources (1)</a></li>")
+      end
+    end
+  end
 end


### PR DESCRIPTION
The Middleware Provider controller (`ems_middleware`) does not support RESTful routing yet, therefore the Relationship links should be routed using `:controller`, `:action` and `:id`

Fixes #8803