### PR TITLE
Collect inventory based for Azure based on resource location, not resource group location.

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -80,7 +80,7 @@ module ManageIQ::Providers
       def get_stacks
         # deployments are realizations of a template in the Azure provider
         # they are parsed and converted to stacks in vmdb
-        deployments = gather_data_for_this_region(@tds)
+        deployments = gather_data_for_this_region(@tds, 'list')
         process_collection(deployments, :orchestration_stacks) { |dp| parse_stack(dp) }
         update_nested_stack_relations
       end
@@ -149,7 +149,7 @@ module ManageIQ::Providers
       end
 
       def get_images
-        images = gather_data_for_this_region(@sas, "list_private_images")
+        images = gather_data_for_this_region(@sas, 'list_private_images')
         process_collection(images, :vms) { |image| parse_image(image) }
       end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -90,12 +90,12 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :orchestration_stack_parameter => 138,
       :orchestration_stack_output    => 7,
       :orchestration_stack_resource  => 42,
-      :security_group                => 6,
-      :network_port                  => 9,
-      :cloud_network                 => 4,
-      :floating_ip                   => 9,
+      :security_group                => 8,
+      :network_port                  => 10,
+      :cloud_network                 => 6,
+      :floating_ip                   => 11,
       :network_router                => 0,
-      :cloud_subnet                  => 4,
+      :cloud_subnet                  => 6,
     }
   end
 

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 02cc105f-a0d7-4ac6-ad5f-88199b4692e0
+      - 2e44dcfd-d274-4a1f-a600-952706c9dd02
       Client-Request-Id:
-      - 31d37268-743b-4201-9752-66b74e57cbb2
+      - 13018be8-6bf1-4a17-8bfb-18db46b932bc
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_200
+      - ESTSFE_IN_185
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -45,7 +45,7 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AAABAAAAiL9Kn2Z27UubvWFPbm0gLcILpvvjxVSoZXkWgb1sKe0lY73vUZ1zwiTiPblNbhej6eoN9qVUWDSEZNFJNzoXop9jFyjHWnUuOvUfOLyaxlnRHX9IZ1eb1oVzIWg6TLrEKNLXhJhqA7LgkUvSMjDK6h7CvWPwClBZzwj71CFHN7aThyc9csyZBYkxw5pThnLjIAA;
+      - esctx=AAABAAAAiL9Kn2Z27UubvWFPbm0gLYVOpXRYFsGmrDBdNIbJENQYOgthAKKMtR1D5H4_s2z5JDr3SIOrUq7dPbW3i80UXrI_pLRRXd__Ls8TB9uA4OAqKGnecFSKIZWlMZnL5puf-wWSdKsFxENQcZyzFgM9ZhlMn-45zVBgI7mBzeVMNoV7eS37wXWk6fF2H0H1j445IAA;
         domain=.login.windows.net; path=/; secure; HttpOnly
       - flight-uxoptin=true; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
@@ -53,14 +53,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 18 May 2016 16:43:38 GMT
+      - Fri, 20 May 2016 19:35:24 GMT
       Content-Length:
       - '1247'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1463593419","not_before":"1463589519","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw"}'
+      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1463776525","not_before":"1463772625","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg"}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:39 GMT
+  recorded_at: Fri, 20 May 2016 19:35:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -77,7 +77,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -98,21 +98,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - a3867411-fefb-4b96-89a1-46b90ea09b3e
+      - 50add8f2-de8a-4412-b27e-03daf6d9e640
       X-Ms-Correlation-Request-Id:
-      - a3867411-fefb-4b96-89a1-46b90ea09b3e
+      - 50add8f2-de8a-4412-b27e-03daf6d9e640
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164339Z:a3867411-fefb-4b96-89a1-46b90ea09b3e
+      - NORTHCENTRALUS:20160520T193525Z:50add8f2-de8a-4412-b27e-03daf6d9e640
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:38 GMT
+      - Fri, 20 May 2016 19:35:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01"}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:40 GMT
+  recorded_at: Fri, 20 May 2016 19:35:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames?api-version=2015-01-01
@@ -129,7 +129,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -146,24 +146,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14919'
+      - '14994'
       X-Ms-Request-Id:
-      - 61c2d269-8cdf-4c58-a06a-3e129ff130bb
+      - c353b6d6-1819-4a30-ae16-6a9a0b4ee9f2
       X-Ms-Correlation-Request-Id:
-      - 61c2d269-8cdf-4c58-a06a-3e129ff130bb
+      - c353b6d6-1819-4a30-ae16-6a9a0b4ee9f2
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164340Z:61c2d269-8cdf-4c58-a06a-3e129ff130bb
+      - NORTHCENTRALUS:20160520T193526Z:c353b6d6-1819-4a30-ae16-6a9a0b4ee9f2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:40 GMT
+      - Fri, 20 May 2016 19:35:25 GMT
       Content-Length:
       - '3190'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat","tagName":"redhat","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat/tagValues/True","tagValue":"True","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName","tagName":"displayName","count":{"type":"Total","value":19},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterVirtualMachine","tagValue":"OpenShiftMasterVirtualMachine","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/DeployOpenShift","tagValue":"DeployOpenShift","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodes","tagValue":"OpenShiftNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/PrepNodes","tagValue":"PrepNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/KeyVault","tagValue":"KeyVault","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLB","tagValue":"OpenShiftNodeLB","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterNetworkInterface","tagValue":"OpenShiftMasterNetworkInterface","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeNetworkInterfaces","tagValue":"OpenShiftNodeNetworkInterfaces","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLBPublicIP","tagValue":"OpenShiftNodeLBPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterPublicIP","tagValue":"OpenShiftMasterPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualNetwork","tagValue":"VirtualNetwork","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/StorageAccounts","tagValue":"StorageAccounts","count":{"type":"Total","value":2}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand","tagName":"on-demand","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand/tagValues/true","tagValue":"true","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test","tagName":"rlt_test","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test/tagValues/b","tagValue":"b","count":{"type":"Total","value":1}}]}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:40 GMT
+  recorded_at: Fri, 20 May 2016 19:35:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -180,7 +180,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -199,17 +199,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cc31dd15-b7ac-4db2-82dc-c946ea9c15ba
+      - 1afdcca9-6264-416f-817c-164e564f2aad
       X-Ms-Correlation-Request-Id:
-      - cc31dd15-b7ac-4db2-82dc-c946ea9c15ba
+      - 1afdcca9-6264-416f-817c-164e564f2aad
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164341Z:cc31dd15-b7ac-4db2-82dc-c946ea9c15ba
+      - NORTHCENTRALUS:20160520T193527Z:1afdcca9-6264-416f-817c-164e564f2aad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:41 GMT
+      - Fri, 20 May 2016 19:35:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
@@ -271,19 +271,19 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","Canada Central","Canada East","South India"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        India","Canada Central","Canada East","UK North","UK South 2","South India"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","South India","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        India","South India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
-        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Central
+        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
         South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Central
@@ -472,7 +472,10 @@ http_interactions:
         US"],"apiVersions":["2015-08-01-preview"]}]},{"namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
-        Europe","East US","West US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}]},{"namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Europe","East US","West US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}]},{"namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -556,7 +559,11 @@ http_interactions:
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Canada
         East","Canada Central","Central US","Australia East","Australia Southeast","Brazil
-        South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]}]},{"namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe"],"apiVersions":["2016-06-01"]}]},{"namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -1189,7 +1196,7 @@ http_interactions:
         US","Australia Southeast","Australia East","South Central US"],"apiVersions":["2014-04-01"]}]},{"namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["West
         US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:41 GMT
+  recorded_at: Fri, 20 May 2016 19:35:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
@@ -1206,7 +1213,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -1223,22 +1230,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5eff6f0d-39fc-434c-a6fd-a2aa40565b23
+      - 60d98a2d-183c-4a81-894f-c0fd9bc17a97
       X-Ms-Correlation-Request-Id:
-      - 5eff6f0d-39fc-434c-a6fd-a2aa40565b23
+      - 60d98a2d-183c-4a81-894f-c0fd9bc17a97
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164342Z:5eff6f0d-39fc-434c-a6fd-a2aa40565b23
+      - NORTHCENTRALUS:20160520T193528Z:60d98a2d-183c-4a81-894f-c0fd9bc17a97
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:41 GMT
+      - Fri, 20 May 2016 19:35:27 GMT
       Content-Length:
       - '750'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:42 GMT
+  recorded_at: Fri, 20 May 2016 19:35:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2016-03-30
@@ -1255,7 +1262,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -1278,18 +1285,18 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - fbe11119-be0d-4b3f-865b-a19aa0f9e4f4
+      - fa118e05-3942-4d00-b538-80dfcff75ada
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14954'
+      - '14961'
       X-Ms-Correlation-Request-Id:
-      - 48865e3e-b6d9-473e-a788-94a8e4c5719a
+      - f8537400-ae76-4e43-887a-7c97cbeb3c4d
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164342Z:48865e3e-b6d9-473e-a788-94a8e4c5719a
+      - NORTHCENTRALUS:20160520T193529Z:f8537400-ae76-4e43-887a-7c97cbeb3c4d
       Date:
-      - Wed, 18 May 2016 16:43:41 GMT
+      - Fri, 20 May 2016 19:35:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n
@@ -1453,7 +1460,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 16\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:43 GMT
+  recorded_at: Fri, 20 May 2016 19:35:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments?api-version=2016-02-01
@@ -1470,7 +1477,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -1487,17 +1494,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14956'
+      - '14989'
       X-Ms-Request-Id:
-      - 2bde0b0e-5c6d-4ad0-a1ea-35fd33004cb2
+      - 96d242a7-3f73-447d-8136-42c3b96a01b6
       X-Ms-Correlation-Request-Id:
-      - 2bde0b0e-5c6d-4ad0-a1ea-35fd33004cb2
+      - 96d242a7-3f73-447d-8136-42c3b96a01b6
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164343Z:2bde0b0e-5c6d-4ad0-a1ea-35fd33004cb2
+      - NORTHCENTRALUS:20160520T193531Z:96d242a7-3f73-447d-8136-42c3b96a01b6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:43 GMT
+      - Fri, 20 May 2016 19:35:30 GMT
       Content-Length:
       - '44143'
     body:
@@ -1512,7 +1519,7 @@ http_interactions:
         Contains a numeric digit\\r\\n4) Contains a special character.\"\r\n  }\r\n}"}]}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010","name":"Microsoft.WindowsServer2012R2Datacenter-20160222104010","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A1"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg241"},"networkSecurityGroupName":{"type":"String","value":"miqtestwinimg3696"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqtestwinimg6202"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.5830069Z","duration":"PT10M55.2480986S","correlationId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg241"},{"id":"Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},{"id":"Microsoft.Network/publicIpAddresses/miqtestwinimg6202"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646","name":"Microsoft.WindowsServer2012R2Datacenter-20160222101646","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg724"},"networkSecurityGroupName":{"type":"String","value":"miq-test-winimg"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miq-test-winimg"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.8666296Z","duration":"PT10M47.5658692S","correlationId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg724"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-winimg"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-winimg"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019","name":"Microsoft.WindowsServer2012R2Datacenter-20160218113019","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-win12"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miqazuretest19881"},"networkInterfaceName":{"type":"String","value":"miq-test-win12610"},"networkSecurityGroupName":{"type":"String","value":"miq-test-win12"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest14047"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.18.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.18.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-win12"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.8337856Z","duration":"PT11M9.8080785S","correlationId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-win12"},{"id":"Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-win12610"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-win12"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-win12"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest19881"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest14047"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651","name":"Canonical.UbuntuServer1510-20160218112651","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-ubuntu1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest16487"},"virtualNetworkName":{"type":"String","value":"miqazuretest18687"},"networkInterfaceName":{"type":"String","value":"miq-test-ubuntu1989"},"networkSecurityGroupName":{"type":"String","value":"miq-test-ubuntu1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest16487"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.17.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.17.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-ubuntu1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.2528115Z","duration":"PT4M10.3614981S","correlationId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-ubuntu1"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest18687"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest16487"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:44 GMT
+  recorded_at: Fri, 20 May 2016 19:35:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments?api-version=2016-02-01
@@ -1529,7 +1536,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -1546,24 +1553,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14958'
+      - '14972'
       X-Ms-Request-Id:
-      - caeb5e65-e617-4849-8bdf-d5307a7120c1
+      - 1c1500b0-7d79-4674-aad2-acc96242f91a
       X-Ms-Correlation-Request-Id:
-      - caeb5e65-e617-4849-8bdf-d5307a7120c1
+      - 1c1500b0-7d79-4674-aad2-acc96242f91a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164344Z:caeb5e65-e617-4849-8bdf-d5307a7120c1
+      - NORTHCENTRALUS:20160520T193531Z:1c1500b0-7d79-4674-aad2-acc96242f91a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:44 GMT
+      - Fri, 20 May 2016 19:35:30 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:44 GMT
+  recorded_at: Fri, 20 May 2016 19:35:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations?api-version=2016-02-01
@@ -1580,7 +1587,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -1597,24 +1604,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14957'
+      - '14991'
       X-Ms-Request-Id:
-      - c7112d4e-77d9-46ef-b643-ace2ac045353
+      - a30e8366-1807-4225-b641-ada5ce97e5fa
       X-Ms-Correlation-Request-Id:
-      - c7112d4e-77d9-46ef-b643-ace2ac045353
+      - a30e8366-1807-4225-b641-ada5ce97e5fa
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164345Z:c7112d4e-77d9-46ef-b643-ace2ac045353
+      - NORTHCENTRALUS:20160520T193532Z:a30e8366-1807-4225-b641-ada5ce97e5fa
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:44 GMT
+      - Fri, 20 May 2016 19:35:31 GMT
       Content-Length:
       - '1284'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations/9F5B589CD174DDD3","operationId":"9F5B589CD174DDD3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-05-17T16:27:37.3271271Z","duration":"PT2.0080487S","trackingId":"f712a792-6f75-4bf1-b01a-fefd65afc50e","serviceRequestId":"da737f57-474c-454c-a750-884421e3f2f8","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqmismatch1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations/08587381044319043881","operationId":"08587381044319043881","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-05-17T16:27:37.6273566Z","duration":"PT0.1814503S","trackingId":"710ac6bf-c100-4a10-a51c-21fd87fc0138","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:45 GMT
+  recorded_at: Fri, 20 May 2016 19:35:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations?api-version=2016-02-01
@@ -1631,7 +1638,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -1648,17 +1655,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14932'
+      - '14990'
       X-Ms-Request-Id:
-      - 0d42a786-b581-4e63-a076-1fde86bc0085
+      - 5148ab6b-4c54-4b94-8346-87b5ef22b01b
       X-Ms-Correlation-Request-Id:
-      - 0d42a786-b581-4e63-a076-1fde86bc0085
+      - 5148ab6b-4c54-4b94-8346-87b5ef22b01b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164346Z:0d42a786-b581-4e63-a076-1fde86bc0085
+      - NORTHCENTRALUS:20160520T193533Z:5148ab6b-4c54-4b94-8346-87b5ef22b01b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:45 GMT
+      - Fri, 20 May 2016 19:35:33 GMT
       Content-Length:
       - '2551'
     body:
@@ -1669,7 +1676,7 @@ http_interactions:
         an uppercase character\r\n2) Contains a lowercase character\r\n3) Contains
         a numeric digit\r\n4) Contains a special character."}},"targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/anym","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"anym"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/F9F20A47A97EE080","operationId":"F9F20A47A97EE080","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:22.487592Z","duration":"PT0.9167668S","trackingId":"61348482-004f-46c0-88b3-65e3154b74ee","serviceRequestId":"170c3cfe-fffa-47ab-8e8b-815ece2e94e1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/3DCCD9CF9359AFF8","operationId":"3DCCD9CF9359AFF8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:21.4774538Z","duration":"PT12.4116622S","trackingId":"f38c5a77-b7dc-456d-811b-344f369b4484","serviceRequestId":"5205ab85-5f20-4302-bace-181cfd212c3e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/myVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myVNET"}}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:46 GMT
+  recorded_at: Fri, 20 May 2016 19:35:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2016-02-01
@@ -1686,7 +1693,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -1703,24 +1710,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14965'
+      - '14987'
       X-Ms-Request-Id:
-      - d3ea5b36-b985-46fc-857a-a7d2071bfb59
+      - a1de127f-8b64-48a1-bb8d-8b1f626b3864
       X-Ms-Correlation-Request-Id:
-      - d3ea5b36-b985-46fc-857a-a7d2071bfb59
+      - a1de127f-8b64-48a1-bb8d-8b1f626b3864
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164347Z:d3ea5b36-b985-46fc-857a-a7d2071bfb59
+      - NORTHCENTRALUS:20160520T193533Z:a1de127f-8b64-48a1-bb8d-8b1f626b3864
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:46 GMT
+      - Fri, 20 May 2016 19:35:33 GMT
       Content-Length:
       - '6866'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:47 GMT
+  recorded_at: Fri, 20 May 2016 19:35:34 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json
@@ -1756,33 +1763,33 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2C22:651A:D5A9BC:573C9BC3
+      - 17EB2C22:68C7:FA632:573F6623
       Content-Length:
       - '10366'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 18 May 2016 16:43:48 GMT
+      - Fri, 20 May 2016 19:35:34 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1835-DFW
+      - cache-dfw1837-DFW
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 6fe618ccde1946c2c812d934959443751a4a7caf
+      - d7ec315da0371643b4a97ea17ad444aaff142e04
       Expires:
-      - Wed, 18 May 2016 16:48:48 GMT
+      - Fri, 20 May 2016 19:40:34 GMT
       Source-Age:
-      - '0'
+      - '227'
     body:
       encoding: UTF-8
       string: |
@@ -2130,7 +2137,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:48 GMT
+  recorded_at: Fri, 20 May 2016 19:35:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2016-02-01
@@ -2147,7 +2154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -2164,24 +2171,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14948'
+      - '14989'
       X-Ms-Request-Id:
-      - a911766b-a8c0-46a8-8b45-d92eda2fe39c
+      - ab3aebbf-15c8-4ff6-959b-fd2216847c13
       X-Ms-Correlation-Request-Id:
-      - a911766b-a8c0-46a8-8b45-d92eda2fe39c
+      - ab3aebbf-15c8-4ff6-959b-fd2216847c13
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164348Z:a911766b-a8c0-46a8-8b45-d92eda2fe39c
+      - NORTHCENTRALUS:20160520T193535Z:ab3aebbf-15c8-4ff6-959b-fd2216847c13
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:48 GMT
+      - Fri, 20 May 2016 19:35:34 GMT
       Content-Length:
       - '801'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:48 GMT
+  recorded_at: Fri, 20 May 2016 19:35:35 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json
@@ -2217,33 +2224,33 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2C1F:23BB:8C3644:573C9BC5
+      - 17EB2C1F:452F:A57F6:573F6623
       Content-Length:
       - '3830'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 18 May 2016 16:43:49 GMT
+      - Fri, 20 May 2016 19:35:35 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1823-DFW
+      - cache-dfw1844-DFW
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 1f1e00c940cee7d324d1fb2b4f27d41fa1976fa1
+      - b3ea39b9a2a74a171ea45083ea2f6df19ccf6c72
       Expires:
-      - Wed, 18 May 2016 16:48:49 GMT
+      - Fri, 20 May 2016 19:40:35 GMT
       Source-Age:
-      - '0'
+      - '227'
     body:
       encoding: UTF-8
       string: |
@@ -2382,7 +2389,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:49 GMT
+  recorded_at: Fri, 20 May 2016 19:35:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations?api-version=2016-02-01
@@ -2399,7 +2406,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -2416,24 +2423,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14954'
+      - '14998'
       X-Ms-Request-Id:
-      - e59bdc0a-580f-4c63-a55b-790a4c1e9a0d
+      - a7adc5a6-d0b6-48ad-80cd-78304174252b
       X-Ms-Correlation-Request-Id:
-      - e59bdc0a-580f-4c63-a55b-790a4c1e9a0d
+      - a7adc5a6-d0b6-48ad-80cd-78304174252b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164349Z:e59bdc0a-580f-4c63-a55b-790a4c1e9a0d
+      - NORTHCENTRALUS:20160520T193536Z:a7adc5a6-d0b6-48ad-80cd-78304174252b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:49 GMT
+      - Fri, 20 May 2016 19:35:35 GMT
       Content-Length:
       - '6166'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:06.7915034Z","duration":"PT3M1.4329712S","trackingId":"b747ec27-f04a-4dc5-a097-03b78d06b4f3","serviceRequestId":"0b164261-eee1-422e-b558-7cb959e795eb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:48:05.2174686Z","duration":"PT7M35.1627165S","trackingId":"dc765fff-be2e-485c-b812-26cbaf08492c","serviceRequestId":"b4e8ecc8-2e94-4423-b928-2c29900ed123","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/3FD73BA3A618D357","operationId":"3FD73BA3A618D357","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:29.9601151Z","duration":"PT2.604551S","trackingId":"280b442e-2010-45a6-b9b2-ac761d5dee7d","serviceRequestId":"ebbe21b7-a988-4950-9675-0d063e84b60e","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:18.3026417Z","duration":"PT4.8364985S","trackingId":"7d2f970a-57fc-40b4-9152-2c3c883d58c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/6CCA0B3A82197571","operationId":"6CCA0B3A82197571","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.0300385Z","duration":"PT13.4143548S","trackingId":"0830ff7f-fb77-44f0-a393-6003873380e8","serviceRequestId":"ea9c728c-70ba-4de3-a55c-8cf6cd310ca0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/291C0AC5D4F88BDB","operationId":"291C0AC5D4F88BDB","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.2645854Z","duration":"PT13.7950357S","trackingId":"bfd21915-f13e-4ece-a48c-19a5a9a58fcd","serviceRequestId":"60371f22-c3c6-4256-b204-0efc36c51aae","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:14.3483638Z","duration":"PT0.8769498S","trackingId":"54ee2082-f487-4f98-b5da-08f4fb8450ac","serviceRequestId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/08587429420731427531","operationId":"08587429420731427531","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.53375Z","duration":"PT0.5447355S","trackingId":"d4fae0de-498c-4177-8239-46a0f58e2ebf","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:50 GMT
+  recorded_at: Fri, 20 May 2016 19:35:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations?api-version=2016-02-01
@@ -2450,7 +2457,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -2467,24 +2474,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14916'
+      - '14998'
       X-Ms-Request-Id:
-      - 45def59a-e479-4863-a388-b21042a9a170
+      - 1c1f81fb-8dce-4592-9436-9d9c66068c22
       X-Ms-Correlation-Request-Id:
-      - 45def59a-e479-4863-a388-b21042a9a170
+      - 1c1f81fb-8dce-4592-9436-9d9c66068c22
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164350Z:45def59a-e479-4863-a388-b21042a9a170
+      - NORTHCENTRALUS:20160520T193537Z:1c1f81fb-8dce-4592-9436-9d9c66068c22
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:50 GMT
+      - Fri, 20 May 2016 19:35:37 GMT
       Content-Length:
       - '6161'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.1806556Z","duration":"PT3M14.7317782S","trackingId":"2e8bc5df-290e-4427-9d7e-b07dc8b56157","serviceRequestId":"e6051ebe-75e3-4280-ad61-5c4928614ad2","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:24:20.3730557Z","duration":"PT7M15.3472227S","trackingId":"b15735ed-1f9c-4235-8554-0359a94d8021","serviceRequestId":"b90d407e-ca03-4efe-ac8c-a40133c4521a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/FAC43E00E60F40D6","operationId":"FAC43E00E60F40D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:04.9686575Z","duration":"PT1.7424043S","trackingId":"9cd93d46-01d3-4fcb-9d33-32d362efad6b","serviceRequestId":"5b900931-b60d-4e18-8e0e-ea23472a6911","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/4A34D86BCACDE87A","operationId":"4A34D86BCACDE87A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.172193Z","duration":"PT13.1694927S","trackingId":"f1189e74-dc7c-4a8e-9f87-f125c87fac6e","serviceRequestId":"f4510097-ff5e-4476-9d16-ef1b3233a77d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/857E6EBF700A64F8","operationId":"857E6EBF700A64F8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.1483554Z","duration":"PT13.0919048S","trackingId":"ca1bda1a-fda1-4270-8442-a3145bfbe1f2","serviceRequestId":"7f2145f1-40af-4b08-addc-8356a4ddc063","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:51.1217903Z","duration":"PT1.1217779S","trackingId":"76e77bc0-53a4-4df3-a941-4c5e007b6a66","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:50.9535836Z","duration":"PT0.9351894S","trackingId":"de79265b-c4a2-457b-807a-9e98060a82f6","serviceRequestId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/08587429434771769170","operationId":"08587429434771769170","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.7888649Z","duration":"PT0.5055897S","trackingId":"d03c7b95-d9d8-48bb-a526-41e9651ad971","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:50 GMT
+  recorded_at: Fri, 20 May 2016 19:35:37 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2016-02-01
@@ -2501,7 +2508,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -2518,24 +2525,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14927'
+      - '14958'
       X-Ms-Request-Id:
-      - a10ad2e8-8f68-4d6b-a0ff-d6b1460a2cd4
+      - 0f6789fa-eed0-4b2e-8c89-b30a9326a0fa
       X-Ms-Correlation-Request-Id:
-      - a10ad2e8-8f68-4d6b-a0ff-d6b1460a2cd4
+      - 0f6789fa-eed0-4b2e-8c89-b30a9326a0fa
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164351Z:a10ad2e8-8f68-4d6b-a0ff-d6b1460a2cd4
+      - NORTHCENTRALUS:20160520T193537Z:0f6789fa-eed0-4b2e-8c89-b30a9326a0fa
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:50 GMT
+      - Fri, 20 May 2016 19:35:37 GMT
       Content-Length:
       - '6818'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","serviceRequestId":"57d6085f-2656-460f-9fdc-391f3813ba9b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","serviceRequestId":"9e20cfcf-cf82-4053-8a96-ba1a60126341","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","serviceRequestId":"fac0cc26-0839-4302-9536-69cff4273fb9","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","serviceRequestId":"82cddf5c-1792-4498-9ed5-ccdfaf52d93c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","serviceRequestId":"f082fd2f-3170-4f36-b9ff-a635e33f5fcf","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","serviceRequestId":"7df6e0cb-b78b-47ff-b479-90a1aee5a885","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","serviceRequestId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:51 GMT
+  recorded_at: Fri, 20 May 2016 19:35:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations?api-version=2016-02-01
@@ -2552,7 +2559,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -2569,24 +2576,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14925'
+      - '14962'
       X-Ms-Request-Id:
-      - 8879cf32-9b72-472d-a8ad-5ea4433da5c0
+      - c9009d63-a408-4aba-a324-efe206760fb7
       X-Ms-Correlation-Request-Id:
-      - 8879cf32-9b72-472d-a8ad-5ea4433da5c0
+      - c9009d63-a408-4aba-a324-efe206760fb7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164352Z:8879cf32-9b72-472d-a8ad-5ea4433da5c0
+      - NORTHCENTRALUS:20160520T193538Z:c9009d63-a408-4aba-a324-efe206760fb7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:51 GMT
+      - Fri, 20 May 2016 19:35:37 GMT
       Content-Length:
       - '7718'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/15838BCFE46760A1","operationId":"15838BCFE46760A1","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:28.6222483Z","duration":"PT3M20.660116S","trackingId":"a6653508-59b3-4e4a-b796-f1cf431a9162","serviceRequestId":"9df73a78-c24e-444a-82cb-ec8632cb8775","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/DDBEEC376EA09F7E","operationId":"DDBEEC376EA09F7E","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:38:07.8075094Z","duration":"PT7M9.35647S","trackingId":"943dac3c-a98b-465d-b759-06506e599546","serviceRequestId":"21e68a17-9e60-4b90-b988-c524ac8db616","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.5055633Z","duration":"PT0.6114738S","trackingId":"1b754371-18ec-4517-bd38-46c9d2ef975d","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.3710882Z","duration":"PT0.4790524S","trackingId":"9dfcf1d7-6e4a-4a73-b17e-13b2afdf9d6b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/7F5153152761DD05","operationId":"7F5153152761DD05","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:38.3445066Z","duration":"PT1.6145978S","trackingId":"861a701b-3964-4754-954c-cb21d5e93db8","serviceRequestId":"2d4bd016-1a2d-4e33-ac21-27105e650564","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/F97EC162743B5FF4","operationId":"F97EC162743B5FF4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:57.7800754Z","duration":"PT34.9812759S","trackingId":"92865cda-40cb-41c9-9317-d864b2b3c309","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/EA21060B6C976C52","operationId":"EA21060B6C976C52","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.6308058Z","duration":"PT13.8442357S","trackingId":"e950697d-0ec6-40f5-8d14-7bfae0ecabf5","serviceRequestId":"edf1e84f-f9ac-4254-85fa-93f2dd649032","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/61B1466BCE99F9D3","operationId":"61B1466BCE99F9D3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.4233646Z","duration":"PT13.6985797S","trackingId":"fd76215f-8c01-4e2a-8068-636237270be4","serviceRequestId":"5803f928-b459-4872-b035-ae900c9c3eee","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/58705CE1AC7417FE","operationId":"58705CE1AC7417FE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.5145163Z","duration":"PT13.7848628S","trackingId":"31027583-c7fb-4302-9bbe-9d1f79502a4c","serviceRequestId":"cd05b456-afab-41a8-8952-43c02b657253","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/08587432846644519702","operationId":"08587432846644519702","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.7434262Z","duration":"PT2.0330234S","trackingId":"1bf25585-8cf8-4c99-9078-aa6f5c036128","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:52 GMT
+  recorded_at: Fri, 20 May 2016 19:35:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations?api-version=2016-02-01
@@ -2603,7 +2610,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -2620,24 +2627,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14918'
+      - '14976'
       X-Ms-Request-Id:
-      - d38a433b-51fc-49e7-b51a-79f34acb998a
+      - a332a181-5471-4d95-a2cd-8aa9ed6d3c3f
       X-Ms-Correlation-Request-Id:
-      - d38a433b-51fc-49e7-b51a-79f34acb998a
+      - a332a181-5471-4d95-a2cd-8aa9ed6d3c3f
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164353Z:d38a433b-51fc-49e7-b51a-79f34acb998a
+      - NORTHCENTRALUS:20160520T193539Z:a332a181-5471-4d95-a2cd-8aa9ed6d3c3f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:52 GMT
+      - Fri, 20 May 2016 19:35:38 GMT
       Content-Length:
       - '7609'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/056F4B33F11A3099","operationId":"056F4B33F11A3099","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:01.4236054Z","duration":"PT1M23.6187466S","trackingId":"70c620a7-2c3c-4743-ae6f-e3836270f2f1","serviceRequestId":"b592f413-95b5-42cb-84a1-817ab3f09275","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/62E621EEEC5E62EE","operationId":"62E621EEEC5E62EE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:29:37.7414996Z","duration":"PT2M9.3834226S","trackingId":"48044c61-7a07-4aff-be71-aeacc2471e7b","serviceRequestId":"e29ef1dc-4e0b-4a92-84f2-a3a746643bcd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.2125225Z","duration":"PT0.642269S","trackingId":"51ea1626-1a59-4e23-8590-445c4ca176d0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/34A4347ECF2A45BE","operationId":"34A4347ECF2A45BE","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.1112967Z","duration":"PT0.5497549S","trackingId":"ce1e6b19-7951-4c73-9005-20fe16d36036","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8F3051FDE964A700","operationId":"8F3051FDE964A700","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:09.9030716Z","duration":"PT2.0210551S","trackingId":"ed583a8c-7b18-4b99-a285-f09a67c14a3b","serviceRequestId":"c065af43-94f0-421b-a773-737f6584f645","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/9D251C6DB1BEEA3B","operationId":"9D251C6DB1BEEA3B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:27.4794736Z","duration":"PT33.3813549S","trackingId":"f9366eee-29f7-42e3-b0fe-1f577c8ae55c","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/7CE1E6C413F108AC","operationId":"7CE1E6C413F108AC","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.7755462Z","duration":"PT13.6793163S","trackingId":"ca83e042-a8c6-4ffb-9f2c-2e4a9f1bbd7c","serviceRequestId":"12a02fc5-02a7-4d40-a4b5-903a8dc79922","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/76F60549C9B601F7","operationId":"76F60549C9B601F7","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.0295771Z","duration":"PT12.9355177S","trackingId":"7fb0a493-ee8a-4d59-86f3-f435a2e1deba","serviceRequestId":"cd42e571-c085-4c3e-b89a-d86568b2e289","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/E142660DAD24486A","operationId":"E142660DAD24486A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.101236Z","duration":"PT12.9593617S","trackingId":"68e1b6fa-040c-450f-bd16-0426d5af0f9f","serviceRequestId":"57c68449-35f3-409e-8f51-f4cd9b65a3ab","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/08587432848725863745","operationId":"08587432848725863745","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.1079152Z","duration":"PT1.6252469S","trackingId":"229c4e55-24ce-4126-b6ff-de2aba268ff3","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:53 GMT
+  recorded_at: Fri, 20 May 2016 19:35:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2016-02-01
@@ -2654,7 +2661,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -2671,27 +2678,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14958'
+      - '14976'
       X-Ms-Request-Id:
-      - 12d66550-12bc-4228-9a28-90491c3408c6
+      - d8bd661d-fd26-439f-9f51-fa9c7107edf0
       X-Ms-Correlation-Request-Id:
-      - 12d66550-12bc-4228-9a28-90491c3408c6
+      - d8bd661d-fd26-439f-9f51-fa9c7107edf0
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164353Z:12d66550-12bc-4228-9a28-90491c3408c6
+      - NORTHCENTRALUS:20160520T193539Z:d8bd661d-fd26-439f-9f51-fa9c7107edf0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:53 GMT
+      - Fri, 20 May 2016 19:35:39 GMT
       Content-Length:
       - '7624'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:54 GMT
+  recorded_at: Fri, 20 May 2016 19:35:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2705,285 +2712,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
-      X-Ms-Request-Id:
-      - b72bd4fe-2ba1-4463-a9e4-c8edccbf6b16
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
-      X-Ms-Correlation-Request-Id:
-      - 531994a3-7ff8-4434-82fd-fc50b899ff8c
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164354Z:531994a3-7ff8-4434-82fd-fc50b899ff8c
-      Date:
-      - Wed, 18 May 2016 16:43:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\":
-        \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A0\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"RedHat\",\r\n
-        \           \"offer\": \"RHEL\",\r\n            \"sku\": \"7.2\",\r\n            \"version\":
-        \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\":
-        \"Linux\",\r\n            \"name\": \"miq-test-rhel1\",\r\n            \"createOption\":
-        \"FromImage\",\r\n            \"vhd\": {\r\n              \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-rhel1\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
-        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
-        \     \"name\": \"miq-test-rhel1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"c4d577ae-4be8-41c1-84f8-642320910a5e\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A0\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n
-        \           \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"15.10\",\r\n
-        \           \"version\": \"latest\"\r\n          },\r\n          \"osDisk\":
-        {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"miq-test-ubuntu1\",\r\n
-        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
-        \             \"uri\": \"https://miqazuretest16487.blob.core.windows.net/vhds/miq-test-ubuntu12016218112647.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-ubuntu1\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
-        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\",\r\n
-        \     \"name\": \"miq-test-ubuntu1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"6e555b88-3fd4-4b72-a404-4bba5d11de93\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A0\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n
-        \           \"offer\": \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n
-        \           \"version\": \"latest\"\r\n          },\r\n          \"osDisk\":
-        {\r\n            \"osType\": \"Windows\",\r\n            \"name\": \"miq-test-win12\",\r\n
-        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
-        \             \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-win122016218113014.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-win12\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\",\r\n
-        \     \"name\": \"miq-test-win12\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"e17a95b0-f4fb-4196-93c5-0c8be7d5c536\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Basic_A1\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n
-        \           \"offer\": \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n
-        \           \"version\": \"latest\"\r\n          },\r\n          \"osDisk\":
-        {\r\n            \"osType\": \"Windows\",\r\n            \"name\": \"miq-test-winimg\",\r\n
-        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
-        \             \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg201622210407.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miq-test-winimg\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg\",\r\n
-        \     \"name\": \"miq-test-winimg\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n        \"availabilitySet\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
-        \       },\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Basic_A0\"\r\n
-        \       },\r\n        \"storageProfile\": {\r\n          \"imageReference\":
-        {\r\n            \"publisher\": \"OpenLogic\",\r\n            \"offer\": \"CentOS\",\r\n
-        \           \"sku\": \"7.1\",\r\n            \"version\": \"latest\"\r\n          },\r\n
-        \         \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\":
-        \"miqazure-centos1\",\r\n            \"createOption\": \"FromImage\",\r\n
-        \           \"vhd\": {\r\n              \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miqazure-centos1\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
-        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"resources\": [\r\n        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \       }\r\n      ],\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
-        \     \"name\": \"miqazure-centos1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n        \"availabilitySet\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \       },\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_D1\"\r\n
-        \       },\r\n        \"storageProfile\": {\r\n          \"imageReference\":
-        {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n            \"offer\":
-        \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n            \"version\":
-        \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\":
-        \"Windows\",\r\n            \"name\": \"osdisk\",\r\n            \"createOption\":
-        \"FromImage\",\r\n            \"vhd\": {\r\n              \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"spec0deply1vm0\",\r\n          \"adminUsername\":
-        \"deploy1admin\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
-        \     \"name\": \"spec0deply1vm0\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    },\r\n    {\r\n      \"properties\":
-        {\r\n        \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n        \"availabilitySet\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \       },\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_D1\"\r\n
-        \       },\r\n        \"storageProfile\": {\r\n          \"imageReference\":
-        {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n            \"offer\":
-        \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n            \"version\":
-        \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\":
-        \"Windows\",\r\n            \"name\": \"osdisk\",\r\n            \"createOption\":
-        \"FromImage\",\r\n            \"vhd\": {\r\n              \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"spec0deply1vm1\",\r\n          \"adminUsername\":
-        \"deploy1admin\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n
-        \         \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\"}]},\r\n
-        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
-        \           \"enabled\": true,\r\n            \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
-        \     },\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
-        \     \"name\": \"spec0deply1vm1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
-      X-Ms-Request-Id:
-      - 0feb61e2-de79-43b0-be29-5544781fd53c
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14961'
-      X-Ms-Correlation-Request-Id:
-      - 590f3fcb-7471-43e4-96d9-6b527cd66010
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164355Z:590f3fcb-7471-43e4-96d9-6b527cd66010
-      Date:
-      - Wed, 18 May 2016 16:43:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\":
-        \"9b746cf3-2e11-4c65-8bd5-4c83b7d9a5a4\",\r\n        \"hardwareProfile\":
-        {\r\n          \"vmSize\": \"Standard_A1\"\r\n        },\r\n        \"storageProfile\":
-        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"canonical\",\r\n
-        \           \"offer\": \"ubuntuserver\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n
-        \           \"version\": \"16.04.201604203\"\r\n          },\r\n          \"osDisk\":
-        {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"miqazuretest26611\",\r\n
-        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
-        \             \"uri\": \"https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_8021743a-5957-4dc1-a645-ca210d5d7fc5.vhd\"\r\n
-        \           },\r\n            \"caching\": \"ReadWrite\"\r\n          },\r\n
-        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n
-        \         \"computerName\": \"miqmismatch1\",\r\n          \"adminUsername\":
-        \"dberger\",\r\n          \"customData\": \"CiNjbG91ZC1jb25maWcKICB3cml0ZV9maWxlczoKICAgIC0gcGF0aDogL3Rlc3QudHh0CiAgICAgIHBlcm1pc3Npb25zOiAiMDY0NCIKICAgICAgb3duZXI6ICJkYmVyZ2VyIgogICAgICBjb250ZW50OiB8CiAgICAgICAgSGVsbG8gV29ybGQK\",\r\n
-        \         \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
-        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1\"}]},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1\",\r\n
-        \     \"name\": \"miqmismatch1\",\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \     \"location\": \"eastus\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3000,276 +2729,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4d1c70ec-79b0-452e-b5a3-ffe742f191ce
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14960'
+      - 1b45db4a-5de8-4e36-ae7b-2fcc7ba0a742
       X-Ms-Correlation-Request-Id:
-      - 5b9b9cbe-200d-402f-b6f3-173b08670f7f
+      - 1b45db4a-5de8-4e36-ae7b-2fcc7ba0a742
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164355Z:5b9b9cbe-200d-402f-b6f3-173b08670f7f
-      Date:
-      - Wed, 18 May 2016 16:43:55 GMT
-      Connection:
-      - close
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1390\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \     \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-12-CE-C0\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1989\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\",\r\n
-        \     \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"134a6669-ac4a-4d08-a0db-387bc4c49537\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.17.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12610\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\",\r\n
-        \     \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"5c2eef2c-0b36-4277-a940-957ed4d13be0\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.18.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg241\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\",\r\n
-        \     \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.7\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg724\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724\",\r\n
-        \     \"etag\": \"W/\\\"890c589e-07f2-4c8e-8524-268e24646fef\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"bef7b677-30b7-460b-a6e3-3004f093da99\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"890c589e-07f2-4c8e-8524-268e24646fef\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.6\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1611\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \     \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.5\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1\",\r\n
-        \     \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"23d804a8-b623-49e7-9c8d-1d64245bef1e\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"miqmismatch1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\",\r\n
-        \           \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.8\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-10-6F-F4\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic0\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \     \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.0.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n
-        \                 \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \               }\r\n              ],\r\n              \"loadBalancerInboundNatRules\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n
-        \       \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\":
-        [],\r\n          \"internalDomainNameSuffix\": \"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"virtualMachine\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
-        \     \"etag\": \"W/\\\"92bde856-e663-4de1-8ca7-068103585381\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"92bde856-e663-4de1-8ca7-068103585381\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.0.0.5\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n
-        \                 \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \               }\r\n              ],\r\n              \"loadBalancerInboundNatRules\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n
-        \       \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\":
-        [],\r\n          \"internalDomainNameSuffix\": \"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"virtualMachine\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14808'
-      X-Ms-Request-Id:
-      - fd85c99b-e484-4223-8a47-1ac979b58609
-      X-Ms-Correlation-Request-Id:
-      - fd85c99b-e484-4223-8a47-1ac979b58609
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164356Z:fd85c99b-e484-4223-8a47-1ac979b58609
+      - NORTHCENTRALUS:20160520T193541Z:1b45db4a-5de8-4e36-ae7b-2fcc7ba0a742
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:43:55 GMT
+      - Fri, 20 May 2016 19:35:40 GMT
       Content-Length:
-      - '12'
+      - '18305'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[]}'
+      string: '{"value":[{"properties":{"vmId":"796c5bcc-338a-448d-b61c-165279a7fb3e","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"OpenLogic","offer":"CentOS","sku":"7.1","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-centos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-centos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"03e8467b-baab-4867-9cc4-157336b7e2e4","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-rhel1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-rhel1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest18686.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"c4d577ae-4be8-41c1-84f8-642320910a5e","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"15.10","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-ubuntu1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest16487.blob.core.windows.net/vhds/miq-test-ubuntu12016218112647.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-ubuntu1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest16487.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"6e555b88-3fd4-4b72-a404-4bba5d11de93","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-win12","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-win122016218113014.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-win12","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"e17a95b0-f4fb-4196-93c5-0c8be7d5c536","hardwareProfile":{"vmSize":"Basic_A1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-winimg","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg201622210407.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-winimg","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"d7022008-f6b1-4f4c-8be8-e2d677ef3261","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm0","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"4d1502d5-351a-42f4-8569-22284f906d68","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm1","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"9b746cf3-2e11-4c65-8bd5-4c83b7d9a5a4","hardwareProfile":{"vmSize":"Standard_A1"},"storageProfile":{"imageReference":{"publisher":"canonical","offer":"ubuntuserver","sku":"16.04.0-LTS","version":"16.04.201604203"},"osDisk":{"osType":"Linux","name":"miqazuretest26611","createOption":"FromImage","vhd":{"uri":"https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_8021743a-5957-4dc1-a645-ca210d5d7fc5.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqmismatch1","adminUsername":"dberger","customData":"CiNjbG91ZC1jb25maWcKICB3cml0ZV9maWxlczoKICAgIC0gcGF0aDogL3Rlc3QudHh0CiAgICAgIHBlcm1pc3Npb25zOiAiMDY0NCIKICAgICAgb3duZXI6ICJkYmVyZ2VyIgogICAgICBjb250ZW50OiB8CiAgICAgICAgSGVsbG8gV29ybGQK","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1"}]},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/miqmismatch1","name":"miqmismatch1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"440f18d3-d4a7-4660-a7fa-ec955e248c9c","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET1"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"CoreOS","offer":"CoreOS","sku":"Alpha","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-coreos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest32946.blob.core.windows.net/vhds/miqazure-coreos12016218151822.vhd"},"caching":"ReadWrite"},"dataDisks":[{"lun":0,"name":"Test-DataDisk1","createOption":"Attach","vhd":{"uri":"https://miqazuretest32946.blob.core.windows.net/vhds/miqazure-coreos12016218151822.vhd"},"caching":"ReadOnly"}]},"osProfile":{"computerName":"miqazure-coreos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"properties":{},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235"}]},"provisioningState":"Failed"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{}},{"properties":{"vmId":"dacd39ce-d7f9-4acd-8b78-49cac347d6e0","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"jf-metrics-2","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/jf-metrics-220164216051.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"jf-metrics-2","adminUsername":"jfrey","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus"},{"properties":{"vmId":"046acf8d-a861-4ec8-99ee-d14d63da19ca","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"osType":"Linux","name":"jf-metrics-3","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/jf-metrics-32016410105739.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"jf-metrics-3","adminUsername":"jfrey","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus"},{"properties":{"vmId":"26b70d9d-1022-41b0-aa94-75c2dd526e4a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux1","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux1201621814595.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus"},{"properties":{"vmId":"4ed26e6d-edf8-4868-a174-4daf1ec8713a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux2","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux2201621815529.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux2","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus"}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:56 GMT
+  recorded_at: Fri, 20 May 2016 19:35:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3283,7 +2761,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3293,8 +2771,6 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -3302,95 +2778,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a9b03ced-7c0d-4f5b-be82-d4f5a53b1dd8
+      - 047eaa0f-e472-4f9b-8744-9004d0533f37
+      X-Ms-Correlation-Request-Id:
+      - 047eaa0f-e472-4f9b-8744-9004d0533f37
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160520T193543Z:047eaa0f-e472-4f9b-8744-9004d0533f37
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14918'
-      X-Ms-Correlation-Request-Id:
-      - ac699fad-7b00-4f47-86cc-b78ef43e9af4
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164357Z:ac699fad-7b00-4f47-86cc-b78ef43e9af4
       Date:
-      - Wed, 18 May 2016 16:43:56 GMT
+      - Fri, 20 May 2016 19:35:42 GMT
+      Content-Length:
+      - '27684'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
-        \     \"etag\": \"W/\\\"e68a3d66-4215-4cf1-8f0f-65364da57c65\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n        \"ipAddress\":
-        \"13.92.253.245\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipConfiguration\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\",\r\n
-        \     \"etag\": \"W/\\\"8c14171e-afdb-469f-be79-e3c1c006be91\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\",\r\n
-        \     \"etag\": \"W/\\\"e28a3b72-79ab-428e-9bd3-85a775af8e03\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg\",\r\n
-        \     \"etag\": \"W/\\\"a091b576-4b02-4f33-81e8-6161b046fee5\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"410a657e-4107-4cf0-9447-1efd44e2363a\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \     \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqtestwinimg6202\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\",\r\n
-        \     \"etag\": \"W/\\\"b656279a-26ff-4021-94bb-263420cf494e\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"fb942169-855b-44f8-b12f-fd63e961b140\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1ip\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
-        \     \"etag\": \"W/\\\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"dnsSettings\": {\r\n          \"domainNameLabel\": \"spec0deply1dns\",\r\n
-        \         \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n        },\r\n
-        \       \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"v-publicIp\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp\",\r\n
-        \     \"etag\": \"W/\\\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"b2dff9bd-173c-4e3e-b531-3e0e340bc07d\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
+      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"}}},{"name":"rhel--westu-3742715939-nic","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"07a6cbb0-6f40-4cc0-8b59-c6e373022308","ipConfigurations":[{"name":"ipconfig1463067665324","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false}},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-12-CE-C0","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"}}},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"}}},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"}}},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"}}},{"name":"miq-test-winimg724","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"bef7b677-30b7-460b-a6e3-3004f093da99","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg"}}},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"}}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-6F-F4","enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"}}},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"}}},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"}}},{"name":"jf-metrics-1130","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c8e67ef0-66f4-46b2-9341-f9c885b63950","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1"}}},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"}}},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-77-CE","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"}}},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"}}},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-11-C3","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"}}},{"name":"miqazure-sharednic1-dyn","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e1344ec7-08bf-487b-84d5-51b9c70e7ddc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"}}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:57 GMT
+  recorded_at: Fri, 20 May 2016 19:35:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3404,7 +2810,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3414,8 +2820,6 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -3423,39 +2827,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9cf2d2d4-1464-4c21-a88c-1958027d2685
+      - e15ce54f-de2e-4ed3-8145-c6d7fe90b2c3
+      X-Ms-Correlation-Request-Id:
+      - e15ce54f-de2e-4ed3-8145-c6d7fe90b2c3
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160520T193545Z:e15ce54f-de2e-4ed3-8145-c6d7fe90b2c3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14956'
-      X-Ms-Correlation-Request-Id:
-      - fa5a7714-e4dd-4788-a6ad-7e9369679f57
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164357Z:fa5a7714-e4dd-4788-a6ad-7e9369679f57
       Date:
-      - Wed, 18 May 2016 16:43:56 GMT
+      - Fri, 20 May 2016 19:35:44 GMT
+      Content-Length:
+      - '12056'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\",\r\n
-        \     \"etag\": \"W/\\\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c\",\r\n        \"ipAddress\":
-        \"40.76.5.200\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"dnsSettings\":
-        {\r\n          \"domainNameLabel\": \"miqmismatch1\",\r\n          \"fqdn\":
-        \"miqmismatch1.eastus.cloudapp.azure.com\"\r\n        },\r\n        \"ipConfiguration\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
+      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}}},{"name":"rhel--westu-3742715939-pip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip","etag":"W/\"b4539336-af86-4417-a6b5-0c3936f3272d\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ea971f95-f711-48c1-8876-859bc3c1543a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"rhel--westu-3742715939-pip","fqdn":"rhel--westu-3742715939-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"e68a3d66-4215-4cf1-8f0f-65364da57c65\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"13.92.253.245","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"8c14171e-afdb-469f-be79-e3c1c006be91\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"e28a3b72-79ab-428e-9bd3-85a775af8e03\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg","etag":"W/\"a091b576-4b02-4f33-81e8-6161b046fee5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"410a657e-4107-4cf0-9447-1efd44e2363a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"}}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"v-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp","etag":"W/\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b2dff9bd-173c-4e3e-b531-3e0e340bc07d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1","etag":"W/\"be35748a-21e4-426c-bc81-fd064427e2bc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d2e64d4-f867-49da-9c32-a566b2d35968","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}}},{"name":"miq-delete-me","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miq-delete-me","etag":"W/\"5171fcd1-f597-45d4-9f8e-59eac23f6f99\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fc52242e-2505-4f33-ad3e-0042acc24b12","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","ipAddress":"40.76.5.200","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"4d0cbf71-c0d1-415d-a467-bb05ca49c343\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","ipAddress":"40.86.82.249","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"2e9bb8e1-94a8-4472-9407-3b9236cad91b\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"d13a8a44-f2c2-457a-a3e3-12dad359d25f\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","ipAddress":"13.67.185.16","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:57 GMT
+  recorded_at: Fri, 20 May 2016 19:35:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3469,7 +2859,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3492,25 +2882,98 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 1a317ab6-2f9b-4a62-aa5e-0926f140adef
+      - 321fedfa-39ec-449f-aeb5-6cee2ed0012d
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14958'
+      - '14976'
       X-Ms-Correlation-Request-Id:
-      - d3a7cbf0-6a23-4496-a02d-dd679c7b63f6
+      - e41c6f54-bc7b-4192-a9f0-0c65e5219db6
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164358Z:d3a7cbf0-6a23-4496-a02d-dd679c7b63f6
+      - NORTHCENTRALUS:20160520T193546Z:e41c6f54-bc7b-4192-a9f0-0c65e5219db6
       Date:
-      - Wed, 18 May 2016 16:43:57 GMT
+      - Fri, 20 May 2016 19:35:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-20T19:35:47+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-04-22T19:08:11.7898141+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-04-22T19:08:11.8523162+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Fri, 20 May 2016 19:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      X-Ms-Request-Id:
+      - e7651015-b73c-4bff-9836-40477a76e2f0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14971'
+      X-Ms-Correlation-Request-Id:
+      - 4ab42341-7838-4272-a637-420c0ce780ed
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160520T193546Z:4ab42341-7838-4272-a637-420c0ce780ed
+      Date:
+      - Fri, 20 May 2016 19:35:46 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
         \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2016-05-18T16:43:40+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        \       \"time\": \"2016-05-20T19:35:42+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
         [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
         \       \"typeHandlerVersion\": \"2.3.7\",\r\n        \"status\": {\r\n          \"code\":
         \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
@@ -3533,10 +2996,10 @@ http_interactions:
         \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:58 GMT
+  recorded_at: Fri, 20 May 2016 19:35:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3550,7 +3013,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3573,24 +3036,24 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - d76728b4-3a31-469a-816d-8212f5696be2
+      - 48c0d1fb-753f-4beb-80bc-d303f830d000
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14953'
+      - '14958'
       X-Ms-Correlation-Request-Id:
-      - a66b92b8-6f66-4b10-a98e-526b8c175ffc
+      - a87d1085-fd21-4b32-a5fb-d079c461ea7b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164359Z:a66b92b8-6f66-4b10-a98e-526b8c175ffc
+      - NORTHCENTRALUS:20160520T193547Z:a87d1085-fd21-4b32-a5fb-d079c461ea7b
       Date:
-      - Wed, 18 May 2016 16:43:58 GMT
+      - Fri, 20 May 2016 19:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-18T16:43:59+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-20T19:35:48+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3605,10 +3068,10 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:59 GMT
+  recorded_at: Fri, 20 May 2016 19:35:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3622,7 +3085,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3645,24 +3108,24 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 98bad9aa-7fdb-4b65-b95c-892f7b401bd2
+      - a798792f-754f-4a42-8267-833b45c5880e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14955'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - a7633adc-5f5f-407c-8c62-87bd91c2a147
+      - f45a083b-cbde-4135-9c2d-991a6be2f4ce
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164359Z:a7633adc-5f5f-407c-8c62-87bd91c2a147
+      - NORTHCENTRALUS:20160520T193548Z:f45a083b-cbde-4135-9c2d-991a6be2f4ce
       Date:
-      - Wed, 18 May 2016 16:43:59 GMT
+      - Fri, 20 May 2016 19:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-18T16:44:00+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-20T19:35:49+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3676,10 +3139,10 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:43:59 GMT
+  recorded_at: Fri, 20 May 2016 19:35:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3693,7 +3156,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3716,24 +3179,24 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 7ed707fb-90ac-4288-a218-710b09840c23
+      - 06fcc372-70f4-4c0c-a134-f4bcde5ee61c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14957'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - 34d6bdaf-65f8-4c53-b812-e60757a60c75
+      - ca0464bf-8242-476b-9d10-dcbbbd5a97b3
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164400Z:34d6bdaf-65f8-4c53-b812-e60757a60c75
+      - NORTHCENTRALUS:20160520T193548Z:ca0464bf-8242-476b-9d10-dcbbbd5a97b3
       Date:
-      - Wed, 18 May 2016 16:44:00 GMT
+      - Fri, 20 May 2016 19:35:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-18T16:44:01+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-20T19:35:49+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3749,10 +3212,10 @@ http_interactions:
         \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:00 GMT
+  recorded_at: Fri, 20 May 2016 19:35:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3766,7 +3229,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3789,98 +3252,25 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - e0e25744-52f7-4537-af75-90ad5fec368b
+      - f8d4a1be-3b02-4fde-9c8a-720a3420243f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14956'
+      - '14962'
       X-Ms-Correlation-Request-Id:
-      - 92e59ee1-a862-4547-ae1f-a31539193742
+      - 324f4474-586b-476d-9ec0-77b14ae17cec
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164401Z:92e59ee1-a862-4547-ae1f-a31539193742
+      - NORTHCENTRALUS:20160520T193549Z:324f4474-586b-476d-9ec0-77b14ae17cec
       Date:
-      - Wed, 18 May 2016 16:44:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-18T16:44:02+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-04-22T19:08:11.7898141+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-04-22T19:08:11.8523162+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
-      X-Ms-Request-Id:
-      - 6025d510-bf95-425c-b9f0-1afaa0309d56
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14928'
-      X-Ms-Correlation-Request-Id:
-      - f4ffe344-248f-455f-9226-27682e37235c
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164401Z:f4ffe344-248f-455f-9226-27682e37235c
-      Date:
-      - Wed, 18 May 2016 16:44:01 GMT
+      - Fri, 20 May 2016 19:35:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-18T16:44:02+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-20T19:35:50+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3893,10 +3283,10 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:02 GMT
+  recorded_at: Fri, 20 May 2016 19:35:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3910,7 +3300,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -3933,25 +3323,25 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 321d3031-d3af-44b9-8602-192dabf8f338
+      - 1d164423-017b-4c73-a3d7-6c6ef217a067
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14964'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 312af207-f94d-4287-b73a-8782928d7e0b
+      - 2d505472-f52d-4ede-b7e4-41f2c5945243
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164403Z:312af207-f94d-4287-b73a-8782928d7e0b
+      - NORTHCENTRALUS:20160520T193549Z:2d505472-f52d-4ede-b7e4-41f2c5945243
       Date:
-      - Wed, 18 May 2016 16:44:03 GMT
+      - Fri, 20 May 2016 19:35:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-18T16:44:03+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-20T19:35:50+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3964,10 +3354,10 @@ http_interactions:
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:03 GMT
+  recorded_at: Fri, 20 May 2016 19:35:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1/instanceView?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/miqmismatch1/instanceView?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3981,7 +3371,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -4004,24 +3394,24 @@ http_interactions:
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
       X-Ms-Request-Id:
-      - 4b7de528-715c-4dfb-a6b9-e53f4bf526df
+      - e64b95e3-3cff-48a8-91b9-526a5eacdbbf
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14946'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - eb7af77d-e2da-41ed-b592-36a9b8a58517
+      - 8218019e-2544-4f67-b49b-e7f1a608788a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164403Z:eb7af77d-e2da-41ed-b592-36a9b8a58517
+      - NORTHCENTRALUS:20160520T193550Z:8218019e-2544-4f67-b49b-e7f1a608788a
       Date:
-      - Wed, 18 May 2016 16:44:02 GMT
+      - Fri, 20 May 2016 19:35:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.1.3\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2016-05-18T16:43:54+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2016-05-20T19:35:41+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": []\r\n  },\r\n  \"disks\":
         [\r\n    {\r\n      \"name\": \"miqazuretest26611\",\r\n      \"statuses\":
         [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
@@ -4033,7 +3423,7 @@ http_interactions:
         \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:04 GMT
+  recorded_at: Fri, 20 May 2016 19:35:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
@@ -4050,7 +3440,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -4069,27 +3459,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 07540ec4-49c7-4dbe-90c0-420997782477
+      - dc7895f5-83a6-4e36-8cc5-3f263ff3fce0
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14947'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 07540ec4-49c7-4dbe-90c0-420997782477
+      - dc7895f5-83a6-4e36-8cc5-3f263ff3fce0
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164404Z:07540ec4-49c7-4dbe-90c0-420997782477
+      - NORTHCENTRALUS:20160520T193551Z:dc7895f5-83a6-4e36-8cc5-3f263ff3fce0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:04 GMT
+      - Fri, 20 May 2016 19:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","kind":"Storage","location":"eastus","name":"miqazuretest14047","properties":{"creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","kind":"Storage","location":"eastus","name":"miqazuretest16487","properties":{"creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","kind":"Storage","location":"eastus","name":"miqazuretest18686","properties":{"creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","kind":"Storage","location":"eastus","name":"spec0deply1stor","properties":{"creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
 
 '
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:04 GMT
+  recorded_at: Fri, 20 May 2016 19:35:51 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2016-01-01
@@ -4106,7 +3496,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
       Content-Length:
       - '0'
   response:
@@ -4127,27 +3517,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1cd2b80b-b248-4912-bffa-543d602db114
+      - 77af0eb0-32b9-4879-8280-3cc0a8e4a13d
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 1cd2b80b-b248-4912-bffa-543d602db114
+      - 77af0eb0-32b9-4879-8280-3cc0a8e4a13d
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164404Z:1cd2b80b-b248-4912-bffa-543d602db114
+      - NORTHCENTRALUS:20160520T193551Z:77af0eb0-32b9-4879-8280-3cc0a8e4a13d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:04 GMT
+      - Fri, 20 May 2016 19:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w=="},{"keyName":"key2","permissions":"Full","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg=="}]}
 
 '
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:04 GMT
+  recorded_at: Fri, 20 May 2016 19:35:51 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
@@ -4164,11 +3554,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:04 GMT
+      - Fri, 20 May 2016 19:35:51 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:KXUDJMIcELnY83AT9VkNDRfM9v0XrndJ2rxEzX2GI6w=
+      - SharedKey miqazuretest14047:k6ehWpq0cJ/rSYN+j7k+PATerv3bUvVT0ejJCqVsIxE=
   response:
     status:
       code: 200
@@ -4181,11 +3571,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8d1ffc0c-0001-0051-6224-b1388a000000
+      - a1753477-0001-0013-4dce-b2139e000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:04 GMT
+      - Fri, 20 May 2016 19:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4236,7 +3626,7 @@ http_interactions:
         cz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0Vu
         dW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:05 GMT
+  recorded_at: Fri, 20 May 2016 19:35:52 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e?comp=list&restype=container
@@ -4253,11 +3643,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:05 GMT
+      - Fri, 20 May 2016 19:35:52 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:X4iHRmXhxIdzIkUxi2PNt9brKi4j7KyJ25o5Qs76Myg=
+      - SharedKey miqazuretest14047:30K8zhCfZuuf62ZrgQ8zCzZAT6rcXtGXSzVMmeytgcA=
   response:
     status:
       code: 200
@@ -4270,11 +3660,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ae3cc8a5-0001-001d-4a24-b1ff95000000
+      - 693028b0-0001-00a7-02ce-b21f9c000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:05 GMT
+      - Fri, 20 May 2016 19:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4309,7 +3699,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:05 GMT
+  recorded_at: Fri, 20 May 2016 19:35:52 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-6e555b88-3fd4-4b72-a404-4bba5d11de93?comp=list&restype=container
@@ -4326,11 +3716,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:05 GMT
+      - Fri, 20 May 2016 19:35:52 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:iTlrIhpWLwF70GoP1D/C2detGaRW7yOb29uEVNfZf/g=
+      - SharedKey miqazuretest14047:p3Z5G6OVjT6K/bas8EZ1QDjkTtCK89ch12ou4+SiWdc=
   response:
     status:
       code: 200
@@ -4343,11 +3733,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 227ff7ab-0001-00e2-0624-b1c20d000000
+      - 6f3e40c8-0001-005e-28ce-b2d57c000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:05 GMT
+      - Fri, 20 May 2016 19:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4370,7 +3760,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:06 GMT
+  recorded_at: Fri, 20 May 2016 19:35:53 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-b97ff488-e114-40ed-8d7a-f4500d73eec0?comp=list&restype=container
@@ -4387,11 +3777,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:06 GMT
+      - Fri, 20 May 2016 19:35:53 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:O+Pr8SKtD8XOLKKB5LB9KesSWLL+gFfUwdrTRkHhgto=
+      - SharedKey miqazuretest14047:p9Azuu1U9TcjD5lXTS1Uvca5SmnuBulC93hnMcXvVDA=
   response:
     status:
       code: 200
@@ -4404,11 +3794,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 07c4aba1-0001-0073-7624-b156bc000000
+      - 3519fc37-0001-0096-30ce-b2444b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:06 GMT
+      - Fri, 20 May 2016 19:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4431,7 +3821,7 @@ http_interactions:
         c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:06 GMT
+  recorded_at: Fri, 20 May 2016 19:35:53 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-e17a95b0-f4fb-4196-93c5-0c8be7d5c536?comp=list&restype=container
@@ -4448,11 +3838,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:06 GMT
+      - Fri, 20 May 2016 19:35:53 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:4xwErAvTFz0OlA626pJhYaGfDjqyMnZyPfKwBqFr8PM=
+      - SharedKey miqazuretest14047:6SX1V1xkO2h6p56dGvNooHEi5ddu3BDi4WP2r+0ceMM=
   response:
     status:
       code: 200
@@ -4465,11 +3855,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d62dc109-0001-0053-6724-b13a70000000
+      - bdb540af-0001-0056-6cce-b2ce0f000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:06 GMT
+      - Fri, 20 May 2016 19:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4480,7 +3870,7 @@ http_interactions:
         ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNiI+PEJsb2JzIC8+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:07 GMT
+  recorded_at: Fri, 20 May 2016 19:35:54 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -4497,11 +3887,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:07 GMT
+      - Fri, 20 May 2016 19:35:54 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:BQQ5izJ/d7mWC93qwqZDjGMct7ObxZ8XvJru63cCz0E=
+      - SharedKey miqazuretest14047:hxFSGLGYIrn3xMLVHUhECzHRJyB1CccXyKT516HQ3eg=
   response:
     status:
       code: 200
@@ -4514,11 +3904,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 04e4b2a1-0001-0123-6224-b10fe1000000
+      - d2850a18-0001-0035-46ce-b2882a000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:06 GMT
+      - Fri, 20 May 2016 19:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4579,7 +3969,7 @@ http_interactions:
         YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+
         PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:07 GMT
+  recorded_at: Fri, 20 May 2016 19:35:54 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
@@ -4596,11 +3986,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:07 GMT
+      - Fri, 20 May 2016 19:35:54 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:lxMgeImlXrGzESHYjFdMIMCuz40J91sR5Wbxu57s4XE=
+      - SharedKey miqazuretest14047:LeJMB8JpBKk42n+eryqjmtqN8eaqYOCh8mow/J187U8=
   response:
     status:
       code: 200
@@ -4613,11 +4003,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c39eee02-0001-0014-5024-b1e51b000000
+      - 8267137d-0001-004d-44ce-b2e09d000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:06 GMT
+      - Fri, 20 May 2016 19:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4654,7 +4044,7 @@ http_interactions:
         L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1
         bHRzPg==
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:08 GMT
+  recorded_at: Fri, 20 May 2016 19:35:54 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4671,11 +4061,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:08 GMT
+      - Fri, 20 May 2016 19:35:54 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:p1P8OKnDNBoHZms8ruD/NLleg7YX+GAg/lzGqtd10AA=
+      - SharedKey miqazuretest14047:d3mmuEoeCf+NEtmzjKwnxj5pv8n1qsvwAVzDPzhJjb4=
   response:
     status:
       code: 200
@@ -4688,11 +4078,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 006314bd-0001-001c-6524-b1fe68000000
+      - c643ac59-0001-0044-59ce-b2fa13000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:08 GMT
+      - Fri, 20 May 2016 19:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4800,7 +4190,7 @@ http_interactions:
         ZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:08 GMT
+  recorded_at: Fri, 20 May 2016 19:35:55 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghrspec3_034c938b-eaa9-4399-8ed2-cb7216fabf0b.vhd
@@ -4817,11 +4207,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:08 GMT
+      - Fri, 20 May 2016 19:35:55 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:vU0lPp6WRw+DZ+ZXsUgWjg6GenQ5wib6r5duA9TU6qA=
+      - SharedKey miqazuretest14047:RN5nvI1Dm5lOM6V3zAM9naRHdYirgvRHJT4hRVquWt4=
   response:
     status:
       code: 200
@@ -4842,7 +4232,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 28571b15-0001-009d-7024-b15c3f000000
+      - 4e3a9645-0001-004c-55ce-b2e160000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4866,12 +4256,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 27 Apr 2016 19:35:14 GMT
       Date:
-      - Wed, 18 May 2016 16:44:08 GMT
+      - Fri, 20 May 2016 19:35:54 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:08 GMT
+  recorded_at: Fri, 20 May 2016 19:35:55 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghtest23_e23609fb-9c7c-413c-9be6-9a0e1c9cdbd7.vhd
@@ -4888,11 +4278,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:08 GMT
+      - Fri, 20 May 2016 19:35:55 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:2y52hZsT+7t+FVcmm7w+Ru7TpWJW0VUAQRzbNe899/o=
+      - SharedKey miqazuretest14047:yeFMB4D3lCbmwSkXUpuUVR46wi315miOz5OuygYuymA=
   response:
     status:
       code: 200
@@ -4913,7 +4303,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 443c61ae-0001-0055-2a24-b1cd08000000
+      - 5026d3b3-0001-0108-78ce-b27b59000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4937,12 +4327,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 13 May 2016 21:02:19 GMT
       Date:
-      - Wed, 18 May 2016 16:44:08 GMT
+      - Fri, 20 May 2016 19:35:55 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:09 GMT
+  recorded_at: Fri, 20 May 2016 19:35:56 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghwiths_73b9a95a-dde1-43b5-8139-2bb0465d391a.vhd
@@ -4959,11 +4349,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:09 GMT
+      - Fri, 20 May 2016 19:35:56 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:RE/gPxPtVKThC1BmsMb6z3ymgnS+Iu/iJYCYrFRDE64=
+      - SharedKey miqazuretest14047:+0BAXCLjzTeEqgZDpU+JOIGczHZb4Iu0wXTTFJX141k=
   response:
     status:
       code: 200
@@ -4984,7 +4374,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e355c7dc-0001-00d6-7c24-b16da5000000
+      - f45e539c-0001-010f-74ce-b28ddc000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -5008,12 +4398,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Thu, 28 Apr 2016 14:17:59 GMT
       Date:
-      - Wed, 18 May 2016 16:44:09 GMT
+      - Fri, 20 May 2016 19:35:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:09 GMT
+  recorded_at: Fri, 20 May 2016 19:35:56 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/sectest2_84ad7b2b-9100-40db-8997-a31912cf27c1.vhd
@@ -5030,11 +4420,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:09 GMT
+      - Fri, 20 May 2016 19:35:56 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:iIHtofEONqil8zgPAXZxPmrrBHE0NHQUbfRC1LT6PkM=
+      - SharedKey miqazuretest14047:6aZBskr6X9bEAqaD5WeoHwpQRjBTkM/4CHvOYJssenI=
   response:
     status:
       code: 200
@@ -5055,7 +4445,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b9996683-0001-012e-0224-b1e0ed000000
+      - 432ca935-0001-008b-6bce-b29da1000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -5079,12 +4469,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 20 Apr 2016 16:04:56 GMT
       Date:
-      - Wed, 18 May 2016 16:44:09 GMT
+      - Fri, 20 May 2016 19:35:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:10 GMT
+  recorded_at: Fri, 20 May 2016 19:35:57 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
@@ -5101,11 +4491,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:10 GMT
+      - Fri, 20 May 2016 19:35:57 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:TYPPS2FFMRQ+aNl5YUx6cFYc/Qi1bh+UCvcT+zAMWLo=
+      - SharedKey miqazuretest14047:3QzQJ6Mx49C58R0dW/vjyPqsnegd1y06y0X3AkothRY=
   response:
     status:
       code: 200
@@ -5126,7 +4516,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f991768a-0001-00d2-0d24-b19827000000
+      - ea1c21ec-0001-002f-6dce-b2a745000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5158,12 +4548,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 17:08:02 GMT
       Date:
-      - Wed, 18 May 2016 16:44:10 GMT
+      - Fri, 20 May 2016 19:35:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:10 GMT
+  recorded_at: Fri, 20 May 2016 19:35:58 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
@@ -5180,11 +4570,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:10 GMT
+      - Fri, 20 May 2016 19:35:58 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest14047:nQFidvqxaV8yYxNEAxa3d1+gX1bePBsGuvfTIN+vYFg=
+      - SharedKey miqazuretest14047:YeD9pnFjyK/gbbCyUHYUhWbUkf9LOlOqohw1rHvjvv4=
   response:
     status:
       code: 200
@@ -5205,7 +4595,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 81642200-0001-00c7-3024-b15abe000000
+      - 9ad72bf1-0001-0113-15ce-b255cb000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -5229,12 +4619,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 16:17:06 GMT
       Date:
-      - Wed, 18 May 2016 16:44:09 GMT
+      - Fri, 20 May 2016 19:35:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:10 GMT
+  recorded_at: Fri, 20 May 2016 19:35:58 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2016-01-01
@@ -5251,7 +4641,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
       Content-Length:
       - '0'
   response:
@@ -5272,27 +4662,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3230f015-5ab7-4a34-bb2e-bc437e0c083d
+      - d71b4c9d-8ec2-4524-ae1b-4845de838eb8
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 3230f015-5ab7-4a34-bb2e-bc437e0c083d
+      - d71b4c9d-8ec2-4524-ae1b-4845de838eb8
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164411Z:3230f015-5ab7-4a34-bb2e-bc437e0c083d
+      - NORTHCENTRALUS:20160520T193558Z:d71b4c9d-8ec2-4524-ae1b-4845de838eb8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:10 GMT
+      - Fri, 20 May 2016 19:35:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ=="},{"keyName":"key2","permissions":"Full","value":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA=="}]}
 
 '
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:11 GMT
+  recorded_at: Fri, 20 May 2016 19:35:59 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
@@ -5309,11 +4699,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:11 GMT
+      - Fri, 20 May 2016 19:35:59 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:xox2t6e1gsca5fdYJxZYuIAbn+sNBB5eAoygLxcnB4s=
+      - SharedKey miqazuretest16487:mRIvu/6aRaCRj0RkXUZk0rYeXZtIZJIr8/SGDF4UCp4=
   response:
     status:
       code: 200
@@ -5326,11 +4716,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9333f4c5-0001-00b0-6224-b1dfff000000
+      - ea5e526d-0001-00bf-3fce-b23209000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:10 GMT
+      - Fri, 20 May 2016 19:35:58 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5352,7 +4742,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:11 GMT
+  recorded_at: Fri, 20 May 2016 19:35:59 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e?comp=list&restype=container
@@ -5369,11 +4759,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:11 GMT
+      - Fri, 20 May 2016 19:35:59 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:o+ZXaXH5uKIaOD36euUCngXqeYf4tbls83oqjCYB5f4=
+      - SharedKey miqazuretest16487:fdGvUtemCDjwctkForOjP5O6MOxql+ek97FUs7Lg7XE=
   response:
     status:
       code: 200
@@ -5386,11 +4776,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7476e78e-0001-007c-0f24-b1bb4a000000
+      - 22163aa6-0001-00b2-64ce-b2dd05000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:11 GMT
+      - Fri, 20 May 2016 19:35:59 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5425,7 +4815,7 @@ http_interactions:
         c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:12 GMT
+  recorded_at: Fri, 20 May 2016 19:36:00 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5442,11 +4832,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:12 GMT
+      - Fri, 20 May 2016 19:36:00 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest16487:Z9roId4DOuSg3GOmGYo1X3aunlDLJDZu/0bD+0VT57k=
+      - SharedKey miqazuretest16487:u1qKdnaSL9xjTgoVI4EubsoytLbAUGcdyhG0Ra2lUJg=
   response:
     status:
       code: 200
@@ -5459,11 +4849,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8f8e9a01-0001-0125-5024-b1f899000000
+      - 9ae6743e-0001-0092-60ce-b2b1c9000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:11 GMT
+      - Fri, 20 May 2016 19:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5498,7 +4888,7 @@ http_interactions:
         PjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJl
         c3VsdHM+
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:12 GMT
+  recorded_at: Fri, 20 May 2016 19:36:00 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2016-01-01
@@ -5515,7 +4905,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
       Content-Length:
       - '0'
   response:
@@ -5536,27 +4926,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5f6d402b-97b2-406a-b67b-2055d393880c
+      - dfabb73a-5a1c-4323-b674-5ccce543cbde
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 5f6d402b-97b2-406a-b67b-2055d393880c
+      - dfabb73a-5a1c-4323-b674-5ccce543cbde
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164412Z:5f6d402b-97b2-406a-b67b-2055d393880c
+      - NORTHCENTRALUS:20160520T193601Z:dfabb73a-5a1c-4323-b674-5ccce543cbde
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:12 GMT
+      - Fri, 20 May 2016 19:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw=="},{"keyName":"key2","permissions":"Full","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w=="}]}
 
 '
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:13 GMT
+  recorded_at: Fri, 20 May 2016 19:36:01 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
@@ -5573,11 +4963,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:13 GMT
+      - Fri, 20 May 2016 19:36:01 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:b+yrRIyGG1AmG6zXG7bjGjRZvU/Mn5w0Q/z0wCxDMEs=
+      - SharedKey miqazuretest18686:hdOspVNSZ46YCZnZEWhJ2vaIjvv/PWT7PVuKmwZzKLo=
   response:
     status:
       code: 200
@@ -5590,11 +4980,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 08e87f81-0001-00d1-1724-b19b20000000
+      - 0004f97f-0001-00de-65ce-b276d6000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:13 GMT
+      - Fri, 20 May 2016 19:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5616,7 +5006,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:13 GMT
+  recorded_at: Fri, 20 May 2016 19:36:01 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4?comp=list&restype=container
@@ -5633,11 +5023,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:13 GMT
+      - Fri, 20 May 2016 19:36:01 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:3KoXT1Vx0YOyIdTjPe72QePTavE3Fuqvunl69bK1kzM=
+      - SharedKey miqazuretest18686:9qZBxacU//fhOdJ68AkfW81EqPj0mLBo9cEpSM7eslA=
   response:
     status:
       code: 200
@@ -5650,11 +5040,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 630a7a07-0001-009e-5224-b15f38000000
+      - b3a669f2-0001-006e-61ce-b28f56000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:13 GMT
+      - Fri, 20 May 2016 19:36:01 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5665,8 +5055,8 @@ http_interactions:
         YWItNDg2Ny05Y2M0LTE1NzMzNmI3ZTJlNCI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXJoZWwxLjAzZTg0NjdiLWJhYWItNDg2Ny05Y2M0LTE1NzMz
         NmI3ZTJlNC5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5XZWQsIDE4IE1heSAyMDE2IDE2OjQzOjI1IEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzdGM0I4ODI0QzExRTwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5GcmksIDIwIE1heSAyMDE2IDE5OjM1OjUyIEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzgwRTVGNDNDQ0MwMTwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -5677,9 +5067,9 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRl
         c3QtcmhlbDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0
         LnNlcmlhbGNvbnNvbGUubG9nPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPldlZCwgMTggTWF5IDIwMTYgMTI6MDM6MjIgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQzN0YxNDY4RERDRjk5PC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD42OTEyMDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
+        ZGlmaWVkPkZyaSwgMjAgTWF5IDIwMTYgMTM6MTk6NDkgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzODBCMTZCQkQ3NzQ3PC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD43NjgwMDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
         ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
         Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNoZS1Db250
         cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVl
@@ -5689,7 +5079,7 @@ http_interactions:
         dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:13 GMT
+  recorded_at: Fri, 20 May 2016 19:36:02 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5706,11 +5096,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:13 GMT
+      - Fri, 20 May 2016 19:36:02 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazuretest18686:acCHWFL3pHVcC2RbQT+X0ch9pZe/tfku1uuFYf/83Bs=
+      - SharedKey miqazuretest18686:Yc6cYOiUHagaBj4xaaBImPTyDvQMfEgSORPD6PwzxCA=
   response:
     status:
       code: 200
@@ -5723,11 +5113,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 94472a81-0001-0092-4e24-b1b1c9000000
+      - d0fbe56f-0001-0011-51ce-b21164000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:14 GMT
+      - Fri, 20 May 2016 19:36:01 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5736,33 +5126,33 @@ http_interactions:
         enVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtcmhl
         bDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0LnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDE4IE1h
-        eSAyMDE2IDE2OjQ0OjA1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzdGM0JBMDU0M0EyNjwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIwIE1h
+        eSAyMDE2IDE5OjM1OjQyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzgwRTVFRTIyNDgzQTwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250
         ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
         cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MTVMeTlvWXAyNXhnVGVEYmlw
-        Rlc4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VWQ3cThZSzFXZGV4cHRZcVk5
+        ckRhdz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
         LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
         PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
         ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
         QmxvYj48TmFtZT5taXEtdGVzdC1yaGVsMTIwMTYyMTgxMTIyNDMudmhkPC9O
-        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMTggTWF5IDIw
-        MTYgMTY6NDQ6MTAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0Yz
-        QkEzNTM0NEQ4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjAgTWF5IDIw
+        MTYgMTk6MzU6MjEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzODBF
+        NUUyMThBMTgzPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
         Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
         dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
         b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmRRTCtYSGpGTlBkb01F
         d2VJNjNmd1E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
         dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        PjE1NzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        PjE2MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
         ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
         dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
         dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9C
         bG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0
         cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:14 GMT
+  recorded_at: Fri, 20 May 2016 19:36:02 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2016-01-01
@@ -5779,7 +5169,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
       Content-Length:
       - '0'
   response:
@@ -5800,27 +5190,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1f266d27-7ad7-4a70-867c-df779cabe018
+      - 1d66ab8a-4082-477c-addc-021b2979c3ad
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 1f266d27-7ad7-4a70-867c-df779cabe018
+      - 1d66ab8a-4082-477c-addc-021b2979c3ad
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164414Z:1f266d27-7ad7-4a70-867c-df779cabe018
+      - NORTHCENTRALUS:20160520T193602Z:1d66ab8a-4082-477c-addc-021b2979c3ad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:14 GMT
+      - Fri, 20 May 2016 19:36:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ=="},{"keyName":"key2","permissions":"Full","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw=="}]}
 
 '
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:14 GMT
+  recorded_at: Fri, 20 May 2016 19:36:02 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
@@ -5837,11 +5227,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:14 GMT
+      - Fri, 20 May 2016 19:36:02 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:4KSdWDoD/xqRTKoiiUBegtTnqLc/WM+CJcxO3ShSK9Q=
+      - SharedKey spec0deply1stor:VX65r0l7X9m2wCKFswcQQRm1fuDLdrLueZRBk0CNaRQ=
   response:
     status:
       code: 200
@@ -5854,11 +5244,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 44cc0c9a-0001-012f-1324-b1e110000000
+      - 8f217357-0001-00ec-43ce-b22e06000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:14 GMT
+      - Fri, 20 May 2016 19:36:02 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5886,7 +5276,7 @@ http_interactions:
         b3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2Vy
         IC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:15 GMT
+  recorded_at: Fri, 20 May 2016 19:36:03 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68?comp=list&restype=container
@@ -5903,11 +5293,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:15 GMT
+      - Fri, 20 May 2016 19:36:03 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:MOvxSpyCZdGI93dB9vndGc0pjlH9fmKDD+Qm72forWc=
+      - SharedKey spec0deply1stor:PjZVKDETyPKQIk+A4HCKwLu9DHFjWfpjgbjyDs2fD5s=
   response:
     status:
       code: 200
@@ -5920,11 +5310,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - eeba862b-0001-010f-5224-b18ddc000000
+      - 681e042e-0001-000c-5ace-b2c88e000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:15 GMT
+      - Fri, 20 May 2016 19:36:02 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5947,7 +5337,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:15 GMT
+  recorded_at: Fri, 20 May 2016 19:36:03 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261?comp=list&restype=container
@@ -5964,11 +5354,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:15 GMT
+      - Fri, 20 May 2016 19:36:03 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:hnO+a4Xi2ydIY2w8KHg2h7FvFL09eqHRTFUOpvFXoTo=
+      - SharedKey spec0deply1stor:UTM3FbevdGuu2WnwH39hOf/wxJgBZKRBDLH3XwsjEDg=
   response:
     status:
       code: 200
@@ -5981,11 +5371,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 38f3a437-0001-00a0-5724-b1e919000000
+      - c9ac684c-0001-0014-5cce-b2e51b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:14 GMT
+      - Fri, 20 May 2016 19:36:03 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6008,7 +5398,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:16 GMT
+  recorded_at: Fri, 20 May 2016 19:36:04 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6025,11 +5415,11 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 18 May 2016 16:44:16 GMT
+      - Fri, 20 May 2016 19:36:04 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec0deply1stor:ITeOBYrY2pCrjbQ2DxVnQpGwyl5RRc5bHE/zgp0N/nU=
+      - SharedKey spec0deply1stor:Xsi71rDSdvaeiT7amU3rte/JWoHoCVcb5TyFbXLasTs=
   response:
     status:
       code: 200
@@ -6042,11 +5432,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6f26200c-0001-00d9-4f24-b18053000000
+      - a0c265a3-0001-00e4-02ce-b23575000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Wed, 18 May 2016 16:44:15 GMT
+      - Fri, 20 May 2016 19:36:03 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6104,7 +5494,7 @@ http_interactions:
         PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4
         dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:16 GMT
+  recorded_at: Fri, 20 May 2016 19:36:04 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
@@ -6121,7 +5511,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -6140,30 +5530,30 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5e40838c-f58c-411e-8b64-3b0d90dcbd5d
+      - fb61f4dc-fda5-4a84-ab0e-3ed36db3110c
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14917'
+      - '14970'
       X-Ms-Correlation-Request-Id:
-      - 5e40838c-f58c-411e-8b64-3b0d90dcbd5d
+      - fb61f4dc-fda5-4a84-ab0e-3ed36db3110c
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164417Z:5e40838c-f58c-411e-8b64-3b0d90dcbd5d
+      - NORTHCENTRALUS:20160520T193605Z:fb61f4dc-fda5-4a84-ab0e-3ed36db3110c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:16 GMT
+      - Fri, 20 May 2016 19:36:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}
 
 '
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:17 GMT
+  recorded_at: Fri, 20 May 2016 19:36:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -6177,7 +5567,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -6194,25 +5584,97 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 96ce7645-4fd9-4a20-a047-5279ab353a3b
+      - 3a14f3bf-1e5d-4930-8deb-c55a54638eed
       X-Ms-Correlation-Request-Id:
-      - 96ce7645-4fd9-4a20-a047-5279ab353a3b
+      - 3a14f3bf-1e5d-4930-8deb-c55a54638eed
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164420Z:96ce7645-4fd9-4a20-a047-5279ab353a3b
+      - NORTHCENTRALUS:20160520T193610Z:3a14f3bf-1e5d-4930-8deb-c55a54638eed
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:20 GMT
+      - Fri, 20 May 2016 19:36:09 GMT
       Content-Length:
-      - '750'
+      - '55827'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}]}'
+      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"1b43094e-d28d-46b6-af3a-f2701904f448","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/securityRules/default-allow-ssh","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/DenyAllInBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"1bcf8a44-79f6-402b-93fc-117cb3a427fd\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235"}]}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}},{"name":"rhel1-inbound1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"80","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}},{"name":"rhel1-inbound2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"443","destinationPortRange":"443","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":200,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"}]}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"71d7bf65-e381-4a93-947e-d9d3d1e8184f","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/securityRules/default-allow-ssh","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllInBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"}]}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b0ec472f-5934-4415-9bfe-e3d3fb679e66","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/securityRules/default-allow-rdp","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetInBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllInBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllOutBound","etag":"W/\"db8d8a40-4494-4379-bbf2-aa01e5085de9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610"}]}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"2946a0a6-cb60-42b0-9083-bfff52256da6","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/securityRules/default-allow-rdp","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetInBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllInBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllOutBound","etag":"W/\"a6f49791-d273-460b-a910-19cbf429b429\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724"}]}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"9ca49a93-6f7d-464c-b23d-e61e847ce2d6","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"f1907e14-fcad-4f75-8faa-ab325bf879d9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"}]}},{"name":"miqtestwinimg3696","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e3c9f688-d2e9-4fba-9f3a-4cac2e9dcdb7","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/securityRules/default-allow-rdp","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetInBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllInBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllOutBound","etag":"W/\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241"}]}},{"name":"jf-metrics-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2e7a59c-3ee5-4024-a59a-3026670be09b","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1/securityRules/default-allow-rdp","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1/defaultSecurityRules/DenyAllInBound","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"12a49e27-4121-4c4b-bbbb-acc384011204\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130"}]}},{"name":"miq-delete-me","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"7b3ea011-4dba-443c-9641-c230a445a8b9","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me/securityRules/default-allow-ssh","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me/defaultSecurityRules/AllowVnetInBound","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me/defaultSecurityRules/DenyAllInBound","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miq-delete-me/defaultSecurityRules/DenyAllOutBound","etag":"W/\"a2ea417d-8f0b-4417-8759-a64b30057ba0\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","type":"Microsoft.Network/networkSecurityGroups","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6c9b701-ab36-4e91-adfc-e284a8db85ee","securityRules":[{"name":"default-allow-rdp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2/securityRules/default-allow-rdp","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2/defaultSecurityRules/AllowVnetInBound","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2/defaultSecurityRules/DenyAllInBound","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2/defaultSecurityRules/DenyAllOutBound","etag":"W/\"7584f0b4-43b5-4aae-9534-06f9b2bfa2de\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751"}]}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","type":"Microsoft.Network/networkSecurityGroups","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"c4b821b0-d894-452e-88b2-c4e51da2a4d1","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3/securityRules/default-allow-ssh","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3/defaultSecurityRules/AllowVnetInBound","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3/defaultSecurityRules/DenyAllInBound","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3/defaultSecurityRules/DenyAllOutBound","etag":"W/\"c6633e35-543d-43ee-a89d-f88843b9f919\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421"}]}},{"name":"miqazure-sharednsg1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","type":"Microsoft.Network/networkSecurityGroups","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f6baaa43-dacf-4e3f-8643-f4445a3f8209","securityRules":[{"name":"miqazure-inbound1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/securityRules/miqazure-inbound1","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","protocol":"*","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993"}]}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:20 GMT
+  recorded_at: Fri, 20 May 2016 19:36:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -6226,521 +5688,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a9eaaa92-15b1-4529-b2fc-7a0efa8260b3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14965'
-      X-Ms-Correlation-Request-Id:
-      - e633cea1-a666-4e7b-a2f0-96d56ddd71f5
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164421Z:e633cea1-a666-4e7b-a2f0-96d56ddd71f5
-      Date:
-      - Wed, 18 May 2016 16:44:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
-        \     \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n
-        \       \"securityRules\": [\r\n          {\r\n            \"name\": \"default-allow-ssh\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"rhel1-inbound1\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"80\",\r\n              \"destinationPortRange\": \"80\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 100,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"rhel1-inbound2\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"443\",\r\n              \"destinationPortRange\": \"443\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 200,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miq-test-ubuntu1\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\",\r\n
-        \     \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"71d7bf65-e381-4a93-947e-d9d3d1e8184f\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-ssh\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/securityRules/default-allow-ssh\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"dfc7a2b6-7724-48a0-8cf5-9cb2938aee56\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miq-test-win12\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\",\r\n
-        \     \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"b0ec472f-5934-4415-9bfe-e3d3fb679e66\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-rdp\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/securityRules/default-allow-rdp\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"3389\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"db8d8a40-4494-4379-bbf2-aa01e5085de9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miq-test-winimg\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg\",\r\n
-        \     \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"2946a0a6-cb60-42b0-9083-bfff52256da6\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-rdp\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/securityRules/default-allow-rdp\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"3389\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"a6f49791-d273-460b-a910-19cbf429b429\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miqazure-centos1\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
-        \     \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-ssh\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"22\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"name\":
-        \"miqtestwinimg3696\",\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696\",\r\n
-        \     \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"e3c9f688-d2e9-4fba-9f3a-4cac2e9dcdb7\",\r\n        \"securityRules\":
-        [\r\n          {\r\n            \"name\": \"default-allow-rdp\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/securityRules/default-allow-rdp\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"protocol\": \"Tcp\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"3389\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 1000,\r\n              \"direction\":
-        \"Inbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"defaultSecurityRules\":
-        [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \           \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n
-        \             \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllInBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to all
-        VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\":
-        \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \             \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n
-        \             \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n
-        \         {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \             \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n
-        \             \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\":
-        \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\":
-        \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\":
-        \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\":
-        \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \           \"etag\": \"W/\\\"2dffc47b-f552-4a5f-adaf-db6cf268a4d1\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\":
-        \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\":
-        \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\":
-        \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\":
-        65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n
-        \       ],\r\n        \"networkInterfaces\": [\r\n          {\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -6756,28 +5704,26 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14958'
       X-Ms-Request-Id:
-      - 61b98aa5-0db4-4fe1-a6b3-d3dd738d4abf
+      - af203342-410e-4013-80fd-a64079269f1a
       X-Ms-Correlation-Request-Id:
-      - 61b98aa5-0db4-4fe1-a6b3-d3dd738d4abf
+      - af203342-410e-4013-80fd-a64079269f1a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164421Z:61b98aa5-0db4-4fe1-a6b3-d3dd738d4abf
+      - NORTHCENTRALUS:20160520T193612Z:af203342-410e-4013-80fd-a64079269f1a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:21 GMT
+      - Fri, 20 May 2016 19:36:12 GMT
       Content-Length:
-      - '12'
+      - '10413'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[]}'
+      string: '{"value":[{"name":"miq-azure-test3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","type":"Microsoft.Network/virtualNetworks","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8b01d08a-ea11-45f6-85b2-b7a200de06dd","addressSpace":{"addressPrefixes":["10.20.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.20.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}]}}]}},{"name":"rhel--westu-3742715939-vnet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet","etag":"W/\"179be2fb-a232-43fb-9a33-d75a5062a066\"","type":"Microsoft.Network/virtualNetworks","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"5abc00cb-33e5-4879-b2c4-3bb32e466ab5","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"rhel--westu-3742715939-snet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet","etag":"W/\"179be2fb-a232-43fb-9a33-d75a5062a066\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.1.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}]}}]}},{"name":"miq-azure-test1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","etag":"W/\"0f86710b-e306-406d-9ae6-932fcd17e9dc\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915","addressSpace":{"addressPrefixes":["10.16.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default","etag":"W/\"0f86710b-e306-406d-9ae6-932fcd17e9dc\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.16.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}]}}]}},{"name":"miqazuretest18687","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","etag":"W/\"90e05db2-0da6-4768-a07a-da2e928f143d\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"87a78829-3e13-4a97-9b81-486d93ce6439","addressSpace":{"addressPrefixes":["10.17.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default","etag":"W/\"90e05db2-0da6-4768-a07a-da2e928f143d\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.17.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}]}}]}},{"name":"miqazuretest19881","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","etag":"W/\"ade5c8a7-0552-4003-b771-998e0aa8b49e\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"9787e570-7ff0-4152-a0ab-da6fa10ba46e","addressSpace":{"addressPrefixes":["10.18.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default","etag":"W/\"ade5c8a7-0552-4003-b771-998e0aa8b49e\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.18.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}]}}]}},{"name":"spec0deply1vnet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"0bb1f005-1af2-4d4b-966a-89aaf6daefca","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"Subnet-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1"}]}}]}},{"name":"miq-azure-test2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2","etag":"W/\"56d2f57d-5269-4414-97a0-df2887aefd88\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f950a3cf-749a-49d5-a7fb-33a400b0e93c","addressSpace":{"addressPrefixes":["172.25.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default","etag":"W/\"56d2f57d-5269-4414-97a0-df2887aefd88\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.25.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}]}}]}},{"name":"miqazuretest33606","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606","etag":"W/\"5364e401-4c75-4693-81c3-3a44e6cb5475\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"865401e7-9dcb-43f0-b9f0-48a20c2bf5f2","addressSpace":{"addressPrefixes":["172.23.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default","etag":"W/\"5364e401-4c75-4693-81c3-3a44e6cb5475\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.23.0.0/24"}}]}},{"name":"miqazure-sharedvn1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1","etag":"W/\"0c54641c-6be9-400a-bf10-3822f04902b9\"","type":"Microsoft.Network/virtualNetworks","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f83aa7be-47d0-485b-a614-0c1432fbe518","addressSpace":{"addressPrefixes":["10.19.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default","etag":"W/\"0c54641c-6be9-400a-bf10-3822f04902b9\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.19.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}]}}]}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:21 GMT
+  recorded_at: Fri, 20 May 2016 19:36:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -6791,122 +5737,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - dd206a46-adae-4484-b25e-1fca7c6c8491
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14959'
-      X-Ms-Correlation-Request-Id:
-      - bf4bda56-0122-41f5-b5de-83cb1323db10
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164422Z:bf4bda56-0122-41f5-b5de-83cb1323db10
-      Date:
-      - Wed, 18 May 2016 16:44:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-azure-test1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \     \"etag\": \"W/\\\"0f86710b-e306-406d-9ae6-932fcd17e9dc\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.16.0.0/16\"\r\n
-        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"0f86710b-e306-406d-9ae6-932fcd17e9dc\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.16.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    },\r\n    {\r\n      \"name\": \"miqazuretest18687\",\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687\",\r\n
-        \     \"etag\": \"W/\\\"90e05db2-0da6-4768-a07a-da2e928f143d\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"87a78829-3e13-4a97-9b81-486d93ce6439\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.17.0.0/16\"\r\n
-        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"90e05db2-0da6-4768-a07a-da2e928f143d\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.17.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    },\r\n    {\r\n      \"name\": \"miqazuretest19881\",\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881\",\r\n
-        \     \"etag\": \"W/\\\"ade5c8a7-0552-4003-b771-998e0aa8b49e\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"9787e570-7ff0-4152-a0ab-da6fa10ba46e\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.18.0.0/16\"\r\n
-        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"default\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\",\r\n
-        \           \"etag\": \"W/\\\"ade5c8a7-0552-4003-b771-998e0aa8b49e\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.18.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1vnet\",\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
-        \     \"etag\": \"W/\\\"faeb44c8-b1d7-4efb-9551-a713405cde5a\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"0bb1f005-1af2-4d4b-966a-89aaf6daefca\",\r\n        \"addressSpace\":
-        {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n          ]\r\n
-        \       },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
-        \"Subnet-1\",\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\",\r\n
-        \           \"etag\": \"W/\\\"faeb44c8-b1d7-4efb-9551-a713405cde5a\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n
-        \     }\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -6922,28 +5753,26 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14807'
       X-Ms-Request-Id:
-      - 87919dda-6715-4f73-89e0-d290da44ee04
+      - 672d2c1b-0849-4545-9880-0fb4ed7afee4
       X-Ms-Correlation-Request-Id:
-      - 87919dda-6715-4f73-89e0-d290da44ee04
+      - 672d2c1b-0849-4545-9880-0fb4ed7afee4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164422Z:87919dda-6715-4f73-89e0-d290da44ee04
+      - NORTHCENTRALUS:20160520T193613Z:672d2c1b-0849-4545-9880-0fb4ed7afee4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:22 GMT
+      - Fri, 20 May 2016 19:36:13 GMT
       Content-Length:
-      - '12'
+      - '27684'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[]}'
+      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"}}},{"name":"rhel--westu-3742715939-nic","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"07a6cbb0-6f40-4cc0-8b59-c6e373022308","ipConfigurations":[{"name":"ipconfig1463067665324","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false}},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-12-CE-C0","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"}}},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"}}},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"}}},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"}}},{"name":"miq-test-winimg724","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"bef7b677-30b7-460b-a6e3-3004f093da99","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg"}}},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"}}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-6F-F4","enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"}}},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"}}},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"}}},{"name":"jf-metrics-1130","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c8e67ef0-66f4-46b2-9341-f9c885b63950","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1"}}},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"}}},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-77-CE","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"}}},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"}}},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-11-C3","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"}}},{"name":"miqazure-sharednic1-dyn","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e1344ec7-08bf-487b-84d5-51b9c70e7ddc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"}}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:22 GMT
+  recorded_at: Fri, 20 May 2016 19:36:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -6957,256 +5786,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 41e3f2e4-66da-402d-9ada-d7ec3157b3a5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14917'
-      X-Ms-Correlation-Request-Id:
-      - 599dbaf9-bc89-4ddf-9dac-9add57ef80d3
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164423Z:599dbaf9-bc89-4ddf-9dac-9add57ef80d3
-      Date:
-      - Wed, 18 May 2016 16:44:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1390\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \     \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"41938171-1b02-4bd5-b4c4-92a25b399c5a\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-12-CE-C0\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"networkSecurityGroup\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
-        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1989\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989\",\r\n
-        \     \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"134a6669-ac4a-4d08-a0db-387bc4c49537\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.17.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12610\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610\",\r\n
-        \     \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"5c2eef2c-0b36-4277-a940-957ed4d13be0\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.18.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg241\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241\",\r\n
-        \     \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"4a17a745-16a9-42d9-88c9-17a518959525\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.7\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg724\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724\",\r\n
-        \     \"etag\": \"W/\\\"890c589e-07f2-4c8e-8524-268e24646fef\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"bef7b677-30b7-460b-a6e3-3004f093da99\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"890c589e-07f2-4c8e-8524-268e24646fef\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.6\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1611\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \     \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"983f6d15-3374-4515-80e7-d6fad785d109\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.5\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": []\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
-        \       },\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1\",\r\n
-        \     \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"23d804a8-b623-49e7-9c8d-1d64245bef1e\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"miqmismatch1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\",\r\n
-        \           \"etag\": \"W/\\\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.16.0.8\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"publicIPAddress\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\"\r\n
-        \             },\r\n              \"subnet\": {\r\n                \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
-        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
-        \         \"internalDomainNameSuffix\": \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"macAddress\": \"00-0D-3A-10-6F-F4\",\r\n        \"enableIPForwarding\":
-        false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
-        \         \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic0\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \     \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"298826cf-4629-466b-aacf-f752015c101c\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.0.0.4\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n
-        \                 \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \               }\r\n              ],\r\n              \"loadBalancerInboundNatRules\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n
-        \       \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\":
-        [],\r\n          \"internalDomainNameSuffix\": \"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"virtualMachine\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1nic1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
-        \     \"etag\": \"W/\\\"92bde856-e663-4de1-8ca7-068103585381\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/networkInterfaces\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n        \"ipConfigurations\":
-        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
-        \           \"etag\": \"W/\\\"92bde856-e663-4de1-8ca7-068103585381\\\"\",\r\n
-        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"privateIPAddress\": \"10.0.0.5\",\r\n              \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
-        \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n
-        \                 \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \               }\r\n              ],\r\n              \"loadBalancerInboundNatRules\":
-        [\r\n                {\r\n                  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \               }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n
-        \       \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\":
-        [],\r\n          \"internalDomainNameSuffix\": \"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net\"\r\n
-        \       },\r\n        \"enableIPForwarding\": false,\r\n        \"virtualMachine\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
   response:
     status:
       code: 200
@@ -7222,209 +5802,21 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14955'
       X-Ms-Request-Id:
-      - 973f68de-a742-4032-82a6-549e769ee8a9
+      - a2cd8568-dff3-404b-8be0-4a48051ca95a
       X-Ms-Correlation-Request-Id:
-      - 973f68de-a742-4032-82a6-549e769ee8a9
+      - a2cd8568-dff3-404b-8be0-4a48051ca95a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164423Z:973f68de-a742-4032-82a6-549e769ee8a9
+      - NORTHCENTRALUS:20160520T193615Z:a2cd8568-dff3-404b-8be0-4a48051ca95a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 18 May 2016 16:44:22 GMT
+      - Fri, 20 May 2016 19:36:14 GMT
       Content-Length:
-      - '12'
+      - '12056'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[]}'
+      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}}},{"name":"rhel--westu-3742715939-pip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip","etag":"W/\"b4539336-af86-4417-a6b5-0c3936f3272d\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ea971f95-f711-48c1-8876-859bc3c1543a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"rhel--westu-3742715939-pip","fqdn":"rhel--westu-3742715939-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"e68a3d66-4215-4cf1-8f0f-65364da57c65\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"13.92.253.245","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"8c14171e-afdb-469f-be79-e3c1c006be91\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"e28a3b72-79ab-428e-9bd3-85a775af8e03\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg","etag":"W/\"a091b576-4b02-4f33-81e8-6161b046fee5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"410a657e-4107-4cf0-9447-1efd44e2363a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"}}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"v-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp","etag":"W/\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b2dff9bd-173c-4e3e-b531-3e0e340bc07d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1","etag":"W/\"be35748a-21e4-426c-bc81-fd064427e2bc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d2e64d4-f867-49da-9c32-a566b2d35968","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}}},{"name":"miq-delete-me","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miq-delete-me","etag":"W/\"5171fcd1-f597-45d4-9f8e-59eac23f6f99\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fc52242e-2505-4f33-ad3e-0042acc24b12","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","ipAddress":"40.76.5.200","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"4d0cbf71-c0d1-415d-a467-bb05ca49c343\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","ipAddress":"40.86.82.249","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"2e9bb8e1-94a8-4472-9407-3b9236cad91b\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"d13a8a44-f2c2-457a-a3e3-12dad359d25f\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","ipAddress":"13.67.185.16","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}}}]}'
     http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e890b167-7fe5-4746-8fe9-5783a4d00daf
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14957'
-      X-Ms-Correlation-Request-Id:
-      - 95546a34-1e1f-4b99-aad3-a85cdcfc48f2
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164423Z:95546a34-1e1f-4b99-aad3-a85cdcfc48f2
-      Date:
-      - Wed, 18 May 2016 16:44:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
-        \     \"etag\": \"W/\\\"e68a3d66-4215-4cf1-8f0f-65364da57c65\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n        \"ipAddress\":
-        \"13.92.253.245\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"ipConfiguration\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1\",\r\n
-        \     \"etag\": \"W/\\\"8c14171e-afdb-469f-be79-e3c1c006be91\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"e272bd74-f661-484f-b223-88dd128a4049\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12\",\r\n
-        \     \"etag\": \"W/\\\"e28a3b72-79ab-428e-9bd3-85a775af8e03\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"b9200977-8147-40a5-83c2-d5892d5ddedc\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg\",\r\n
-        \     \"etag\": \"W/\\\"a091b576-4b02-4f33-81e8-6161b046fee5\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"410a657e-4107-4cf0-9447-1efd44e2363a\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \     \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"miqtestwinimg6202\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202\",\r\n
-        \     \"etag\": \"W/\\\"b656279a-26ff-4021-94bb-263420cf494e\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"fb942169-855b-44f8-b12f-fd63e961b140\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"spec0deply1ip\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
-        \     \"etag\": \"W/\\\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"dnsSettings\": {\r\n          \"domainNameLabel\": \"spec0deply1dns\",\r\n
-        \         \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n        },\r\n
-        \       \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \       }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"v-publicIp\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp\",\r\n
-        \     \"etag\": \"W/\\\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"b2dff9bd-173c-4e3e-b531-3e0e340bc07d\",\r\n        \"publicIPAddressVersion\":
-        \"IPv4\",\r\n        \"publicIPAllocationMethod\": \"Dynamic\",\r\n        \"idleTimeoutInMinutes\":
-        4,\r\n        \"ipConfiguration\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM1ODk1MTksIm5iZiI6MTQ2MzU4OTUxOSwiZXhwIjoxNDYzNTkzNDE5LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Y2MLkOO1z6YJByLaS8jMxzM1IB2AYrG3WFZRP-jPZms4nGPgWxecRrCNvJXly4rgB9TyuPrFid4iMzXQ-pAce7Mv-2IoTnDkCfUtjwrCoNzvOVWYEJbJCa4vO8i-7ol_yFoB-XExEVXrdd11y1xgHGOJpbRSPuVQkidmOxTwoB3e3MFZwy5nSRioT9sCTpagp-SrOCZp2d09RZvRWKgCgeWUMCsssCt0r3XVcwRUHtOGmKF_aESBmtW_GdhG-3p5QJIZJsIwHn7M3q48iraihcVVaGZ6ZDvRR-kGg2RgPamkWP7ZFh7QRKsu7Ej9epfY9oBmPJP_KSUX3oOuXP6Zqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b0d543e6-b4f0-4f0a-96a9-af220dc84272
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14951'
-      X-Ms-Correlation-Request-Id:
-      - de5d0dfe-68b4-4c63-b0d9-398247ad7d32
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160518T164424Z:de5d0dfe-68b4-4c63-b0d9-398247ad7d32
-      Date:
-      - Wed, 18 May 2016 16:44:23 GMT
-      Connection:
-      - close
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"miqmismatch1\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1\",\r\n
-        \     \"etag\": \"W/\\\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\\\"\",\r\n      \"type\":
-        \"Microsoft.Network/publicIPAddresses\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"resourceGuid\": \"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c\",\r\n        \"ipAddress\":
-        \"40.76.5.200\",\r\n        \"publicIPAddressVersion\": \"IPv4\",\r\n        \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n        \"idleTimeoutInMinutes\": 4,\r\n        \"dnsSettings\":
-        {\r\n          \"domainNameLabel\": \"miqmismatch1\",\r\n          \"fqdn\":
-        \"miqmismatch1.eastus.cloudapp.azure.com\"\r\n        },\r\n        \"ipConfiguration\":
-        {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
-        \       }\r\n      }\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 18 May 2016 16:44:24 GMT
+  recorded_at: Fri, 20 May 2016 19:36:16 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This addresses the issue I brought up at https://github.com/ManageIQ/manageiq/issues/8779.

First, with `gather_data_for_this_region` the default method has been switched to :list_all instead of :list. The armrest gem will either use a single call to fetch all resources if the REST API allows it, or a threaded call that collects all the data if the API doesn't. In practice, benchmarking experiments showed this to be a faster approach.

Whatever method is used, the data gathered is now filtered by the location of the resource itself, rather than the location of the resource group that it belongs to. Only for those few resource types (e.g. templates) that don't have a location property do we fall back to the location of its resource group.