### PR TITLE
In MiqExpression, leverage virtual columns w/ arel

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -652,9 +652,7 @@ class MiqExpression
   def field_in_sql?(field)
     # => false if operand is from a virtual reflection
     return false if self.field_from_virtual_reflection?(field)
-
-    # => false if operand if a virtual coulmn
-    return false if self.field_is_virtual_column?(field)
+    return false unless attribute_supported_by_sql?(field)
 
     # => false if excluded by special case defined in preprocess options
     return false if self.field_excluded_by_preprocess_options?(field)
@@ -664,6 +662,10 @@ class MiqExpression
 
   def field_from_virtual_reflection?(field)
     col_details[field][:virtual_reflection]
+  end
+
+  def attribute_supported_by_sql?(field)
+    col_details[field][:sql_support]
   end
 
   def field_is_virtual_column?(field)
@@ -689,7 +691,8 @@ class MiqExpression
 
     operator = exp.keys.first
     if exp[operator].kind_of?(Hash) && exp[operator].key?("field")
-      unless exp[operator]["field"] == "<count>" || self.field_from_virtual_reflection?(exp[operator]["field"]) || self.field_is_virtual_column?(exp[operator]["field"])
+      if exp[operator]["field"] != "<count>" &&
+         !field_from_virtual_reflection?(exp[operator]["field"]) && !field_has_arel?(exp[operator]["field"])
         col = exp[operator]["field"]
         if col.include?(".")
           col = col.split(".").last
@@ -759,7 +762,7 @@ class MiqExpression
   end
 
   def self.get_col_info(field, options = {})
-    result ||= {:data_type => nil, :virtual_reflection => false, :virtual_column => false, :excluded_by_preprocess_options => false, :tag => false, :include => {}}
+    result ||= {:data_type => nil, :virtual_reflection => false, :virtual_column => false, :sql_support => true, :excluded_by_preprocess_options => false, :tag => false, :include => {}}
     col = field.split("-").last if field.include?("-")
     parts = field.split("-").first.split(".")
     model = parts.shift
@@ -784,6 +787,7 @@ class MiqExpression
 
       unless ref
         result[:virtual_reflection] = true
+        result[:sql_support] = false
         result[:virtual_column] = true
         return result
       end
@@ -793,7 +797,8 @@ class MiqExpression
     if col
       result[:data_type] = col_type(model, col)
       result[:format_sub_type] = MiqReport::FORMAT_DEFAULTS_AND_OVERRIDES[:sub_types_by_column][col.to_sym] || result[:data_type]
-      result[:virtual_column] = true if model.virtual_attribute?(col.to_s)
+      result[:virtual_column] = model.virtual_attribute?(col.to_s)
+      result[:sql_support] = model.attribute_supported_by_sql?(col.to_s)
       result[:excluded_by_preprocess_options] = self.exclude_col_by_preprocess_options?(col, options)
     end
     result

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -39,6 +39,10 @@ module VirtualArel
       end
     end
 
+    def attribute_supported_by_sql?(name)
+      load_schema
+      !virtual_attribute?(name) || !!_virtual_arel[name.to_s]
+    end
     private
 
     def define_virtual_arel(name, arel)

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -170,7 +170,7 @@ describe MiqExpression do
       context_type:
       exp:
         CONTAINS:
-          field: MiqGroup.vms-disconnected
+          field: MiqGroup.vms-uncommitted_storage
           value: "false"
       '
 
@@ -1972,15 +1972,16 @@ describe MiqExpression do
 
   describe ".get_col_info" do
     it "return column info for model-virtual field" do
-      field = "VmInfra-archived"
+      field = "VmInfra-uncommitted_storage"
       col_info = described_class.get_col_info(field)
       expect(col_info).to match(
-        :data_type                      => :boolean,
+        :data_type                      => :integer,
         :excluded_by_preprocess_options => false,
-        :format_sub_type                => :boolean,
+        :format_sub_type                => :bytes,
         :include                        => {},
         :tag                            => false,
         :virtual_column                 => true,
+        :sql_support                    => false,
         :virtual_reflection             => false
       )
     end
@@ -1994,6 +1995,7 @@ describe MiqExpression do
         :include                        => {},
         :tag                            => true,
         :virtual_column                 => false,
+        :sql_support                    => true,
         :virtual_reflection             => false
       )
     end
@@ -2007,6 +2009,7 @@ describe MiqExpression do
         :include                        => {},
         :tag                            => true,
         :virtual_column                 => false,
+        :sql_support                    => true,
         :virtual_reflection             => false
       )
     end
@@ -2020,6 +2023,7 @@ describe MiqExpression do
         :include                        => {},
         :tag                            => true,
         :virtual_column                 => false,
+        :sql_support                    => true,
         :virtual_reflection             => false
       )
     end
@@ -2034,6 +2038,7 @@ describe MiqExpression do
         :include                        => {},
         :tag                            => false,
         :virtual_column                 => false,
+        :sql_support                    => true,
         :virtual_reflection             => false
       )
     end
@@ -2048,11 +2053,27 @@ describe MiqExpression do
         :include                        => {:guest_applications => {}},
         :tag                            => false,
         :virtual_column                 => false,
+        :sql_support                    => true,
         :virtual_reflection             => false
       )
     end
 
-    it "return column info for model.virtualassociation..virtualassociation-field" do
+    it "return column info for model.virtualassociation..virtualassociation-field (with sql)" do
+      field = "ManageIQ::Providers::InfraManager::Vm.service.user.vms-uncommitted_storage"
+      col_info = described_class.get_col_info(field)
+      expect(col_info).to match(
+        :data_type                      => :integer,
+        :excluded_by_preprocess_options => false,
+        :format_sub_type                => :bytes,
+        :include                        => {},
+        :tag                            => false,
+        :virtual_column                 => true,
+        :sql_support                    => false,
+        :virtual_reflection             => true
+      )
+    end
+
+    it "return column info for model.virtualassociation..virtualassociation-field (with sql)" do
       field = "ManageIQ::Providers::InfraManager::Vm.service.user.vms-active"
       col_info = described_class.get_col_info(field)
       expect(col_info).to match(
@@ -2062,6 +2083,7 @@ describe MiqExpression do
         :include                        => {},
         :tag                            => false,
         :virtual_column                 => true,
+        :sql_support                    => true,
         :virtual_reflection             => true
       )
     end
@@ -2175,8 +2197,14 @@ describe MiqExpression do
       expect(described_class.new(expression).sql_supports_atom?(expression)).to eq(false)
     end
 
-    it "returns false for model.association-virtualfield" do
-      field = "ManageIQ::Providers::InfraManager::Vm.storage-v_used_space_percent_of_total"
+    it "supports sql for model.association-virtualfield (with arel)" do
+      field = "Host.vms.archived"
+      expression = {"=" => {"field" => field, "value" => "true"}}
+      expect(described_class.new(expression).sql_supports_atom?(expression)).to eq(false)
+    end
+
+    it "does not supports sql for model.association-virtualfield (no arel)" do
+      field = "ManageIQ::Providers::InfraManager::Vm.storage-v_used_space"
       expression = {">=" => {"field" => field, "value" => "50"}}
       expect(described_class.new(expression).sql_supports_atom?(expression)).to eq(false)
     end
@@ -2211,8 +2239,14 @@ describe MiqExpression do
   end
 
   describe "#field_in_sql?" do
-    it "returns false for model.virtualfield" do
+    it "returns true for model.virtualfield (with sql)" do
       field = "ManageIQ::Providers::InfraManager::Vm-archived"
+      expression = {"=" => {"field" => field, "value" => "true"}}
+      expect(described_class.new(expression).field_in_sql?(field)).to eq(true)
+    end
+
+    it "returns false for model.virtualfield (with no sql)" do
+      field = "ManageIQ::Providers::InfraManager::Vm-uncommitted_storage"
       expression = {"=" => {"field" => field, "value" => "true"}}
       expect(described_class.new(expression).field_in_sql?(field)).to eq(false)
     end

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -985,7 +985,7 @@ describe Rbac do
                                                 :miq_group      => group,
                                                 :results_format => :objects)
         expect(results.length).to eq(2)
-        expect(attrs[:total_count]).to eq(3)
+        expect(attrs[:total_count]).to eq(2)
       end
     end
 


### PR DESCRIPTION
**BLOCKED ON**  ~~#8882~~ ~~#8883~~ ~~#8934~~

virtual columns can have corresponding sql, use these columns in the
database

~~my only concern is [here] since this will say "it is good" when it is a subquery. @imtayadeway any thoughts here?~~ **UPDATE:** @imtayadeway said not an issue below

>Support includes operator using "LIKE" only if first operand is in main table

[here]: https://github.com/ManageIQ/manageiq/blob/9e3c7f6a83d6fc8650cdfeb300d81617d46fbcfd/app/models/miq_expression.rb#L835

This is a big performance boost, but holding off on applying to darga

/cc @imtayadeway this one should show some good results