### PR TITLE
Add built in policy to prevent retired vm from starting.

### DIFF
--- a/product/policy/built_in_policies.yml
+++ b/product/policy/built_in_policies.yml
@@ -29,6 +29,19 @@
   :modifier: deny
   :mode: control
   :action: prevent
+- :name: Prevent Retired Instance from Starting
+  :description: Prevent Retired Instance from starting
+  :towhat: Vm
+  :event: vm_resume
+  :applies_to?: true
+  :active: true
+  :condition:
+    "=":
+      field: Vm-retired
+      value: true
+  :modifier: deny
+  :mode: control
+  :action: vm_suspend
 - :name: Stop Retired VM
   :description: Stop Retired VM
   :towhat: Vm
@@ -42,3 +55,4 @@
   :modifier: deny
   :mode: control
   :action: vm_stop
+


### PR DESCRIPTION
Retired instances may be left in suspended state on Openstack server.
The build in policy will keep the retired instance remained in powered off state if it is powered on from the Openstack server.

https://bugzilla.redhat.com/show_bug.cgi?id=1325167