### PR TITLE
Add support for substring in topology search

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -23,7 +23,7 @@ ManageIQ.angular.app.service('topologyService', function() {
     var nodes = svg.selectAll("g");
     if (query != "") {
       var selected = nodes.filter(function (d) {
-        return d.item.name != query;
+        return d.item.name.indexOf(query) == -1;
       });
       selected.style("opacity", "0.2");
       var links = svg.selectAll("line");


### PR DESCRIPTION
Allow search for substrings and not only exact string match in the topology search.
Please note this is case sensitive.

![substringsearchtopology](https://cloud.githubusercontent.com/assets/6277245/15454527/a21ed6c2-2043-11e6-8373-6f46cb45d908.png)

@miq-bot add_label enhancement, ui, topology