### PR TITLE
miq expression field supports virtual arel columns

### DIFF
--- a/lib/extensions/arel_groups.rb
+++ b/lib/extensions/arel_groups.rb
@@ -1,0 +1,14 @@
+# this is from https://github.com/rails/arel/pull/435
+# this allows sorting and where clauses to work with virtual_attribute columns
+if defined?(Arel::Nodes::Grouping)
+  module Arel
+    module Nodes
+      class Grouping
+        include Arel::Expressions
+        include Arel::AliasPredication
+        include Arel::OrderPredications
+        include Arel::Math
+      end
+    end
+  end
+end


### PR DESCRIPTION
**before:**
If `arel_attribute` returns something other than an attribute,
methods like `eq` would blow up.

**after:**
All virtual attributes wrapped in `Arel::Nodes::Grouping` can be used for sort and where clauses since they will implement the helper methods that are required throughout rails framework.

This is temporary until https://github.com/rails/arel/pull/435 is merged

/cc @imtayadeway ~~I wish we could do it closer to `arel_attribute` but it is proving difficult.~~ Can't get any closer to `arel_attribute`