### PR TITLE
SupportsFeatureMixin

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -1,0 +1,96 @@
+module SupportsFeatureMixin
+  #
+  # Including this in a model gives you a DSL to make features supported or not
+  #
+  #   class Post
+  #     include SupportsFeatureMixin
+  #     supports :publish
+  #     supports_not :fake, "We keep it real"
+  #     supports :archive do |post|
+  #       post.unsupported[:archive] = "Its too good" if post.featured?
+  #     end
+  #   end
+  #
+  # To make a feature conditionally supported, pass a block to the +supports+ method.
+  # The block receives the instance as an argument.
+  # If you set a key with the name of the feature to +instance.unsupported+ with a reason
+  # then the feature will be unsupported and the reason will be accessible through
+  #
+  #   instance.unsupported[:feature]
+  #
+  # The above allows you to call +support_feature?+ methods on the Class and Instance:
+  #
+  #   Post.supports_publish?                       # => true
+  #   Post.new.supports_publish?                   # => true
+  #   Post.supports_fake?                          # => false
+  #   Post.supports_archive?                       # => true
+  #   Post.new(featured: true).supports_archive?   # => false
+  #
+  # To get a reason why a feature is unsupported use the +unsupported+ method
+  #
+  #   Post.unsupported[:publish]                   # => nil
+  #   Post.unsupported[:fake]                      # => "We keep it real"
+  #   Post.new(featured).unsupported[:archive]     # => "Its too good"
+  #
+  # If you include this concern in a Module that gets included by the Model
+  # you have to extend that model with +ActiveSupport::Concern+ and wrap the
+  # +supports+ calls in an +included+ block. This is also true for modules in between!
+  #
+  #   module Operations
+  #     extend ActiveSupport::Concern
+  #     module Power
+  #       extend ActiveSupport::Concern
+  #       included do
+  #         supports :operation
+  #       end
+  #     end
+  #   end
+  #
+  extend ActiveSupport::Concern
+
+  def unsupported
+    @unsupported ||= Hash.new do |_hash, feature|
+      unsupported[feature] unless public_send("supports_#{feature}?")
+    end
+  end
+
+  class_methods do
+    def unsupported
+      # TODO: durandom - is Thread.current needed here?
+      Thread.current["unsupported_#{object_id}"] ||= Hash.new do |_hash, feature|
+        unsupported[feature] unless public_send("supports_#{feature}?")
+      end
+    end
+
+    def supports(feature, &block)
+      send(:define_supports_methods, feature, true, &block)
+    end
+
+    def supports_not(feature, reason)
+      send(:define_supports_methods, feature, false, reason)
+    end
+
+    private
+
+    def define_supports_methods(feature, is_supported, reason = nil)
+      method_name = "supports_#{feature}?"
+
+      define_method(method_name) do
+        unsupported.delete(feature)
+        if block_given?
+          yield(self)
+        else
+          unsupported[feature] = reason unless is_supported
+        end
+        !unsupported.key?(feature)
+      end
+
+      define_singleton_method(method_name) do
+        unsupported.delete(feature)
+        # TODO: durandom - make reason evaluate in class context, to e.g. include the name of a subclass (.to_proc?)
+        unsupported[feature] = reason unless is_supported
+        !unsupported.key?(feature)
+      end
+    end
+  end
+end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -6,19 +6,20 @@ module SupportsFeatureMixin
   #     include SupportsFeatureMixin
   #     supports :publish
   #     supports_not :fake, "We keep it real"
-  #     supports :archive do |post|
-  #       post.unsupported[:archive] = "Its too good" if post.featured?
+  #     supports :archive do
+  #       unsupported_reason_add(:archive) = "Its too good" if featured?
   #     end
   #   end
   #
   # To make a feature conditionally supported, pass a block to the +supports+ method.
-  # The block receives the instance as an argument.
-  # If you set a key with the name of the feature to +instance.unsupported+ with a reason
-  # then the feature will be unsupported and the reason will be accessible through
+  # The block is evaluated in the context of the instance.
+  # If you call the private method +unsupported_reason_add+ whith the feature
+  # and a reason, then the feature will be unsupported and the reason will be
+  # accessible through
   #
-  #   instance.unsupported[:feature]
+  #   instance.unsupported_reason(:feature)
   #
-  # The above allows you to call +support_feature?+ methods on the Class and Instance:
+  # The above allows you to call +supports_feature?+ methods on the Class and Instance:
   #
   #   Post.supports_publish?                       # => true
   #   Post.new.supports_publish?                   # => true
@@ -28,9 +29,9 @@ module SupportsFeatureMixin
   #
   # To get a reason why a feature is unsupported use the +unsupported+ method
   #
-  #   Post.unsupported[:publish]                   # => nil
-  #   Post.unsupported[:fake]                      # => "We keep it real"
-  #   Post.new(featured).unsupported[:archive]     # => "Its too good"
+  #   Post.unsupported_reason(:publish)                     # => nil
+  #   Post.unsupported_reason(:fake)                        # => "We keep it real"
+  #   Post.new(featured: true).unsupported_reason(:archive) # => "Its too good"
   #
   # If you include this concern in a Module that gets included by the Model
   # you have to extend that model with +ActiveSupport::Concern+ and wrap the
@@ -48,18 +49,25 @@ module SupportsFeatureMixin
   #
   extend ActiveSupport::Concern
 
+  def unsupported_reason(feature)
+    public_send("supports_#{feature}?") unless unsupported.key?(feature)
+    unsupported[feature]
+  end
+
+  private
+
+  def unsupported_reason_add(feature, reason)
+    unsupported[feature] = reason
+  end
+
   def unsupported
-    @unsupported ||= Hash.new do |_hash, feature|
-      unsupported[feature] unless public_send("supports_#{feature}?")
-    end
+    @unsupported ||= {}
   end
 
   class_methods do
-    def unsupported
-      # TODO: durandom - is Thread.current needed here?
-      Thread.current["unsupported_#{object_id}"] ||= Hash.new do |_hash, feature|
-        unsupported[feature] unless public_send("supports_#{feature}?")
-      end
+    def unsupported_reason(feature)
+      public_send("supports_#{feature}?") unless unsupported.key?(feature)
+      unsupported[feature]
     end
 
     def supports(feature, &block)
@@ -72,13 +80,23 @@ module SupportsFeatureMixin
 
     private
 
-    def define_supports_methods(feature, is_supported, reason = nil)
+    def unsupported
+      # This is a class variable and it might be modified during runtime
+      # because we dont eager load all classes at boot time, so it needs to be thread safe
+      @unsupported ||= Concurrent::Hash.new
+    end
+
+    def unsupported_reason_add(feature, reason)
+      unsupported[feature] = reason
+    end
+
+    def define_supports_methods(feature, is_supported, reason = nil, &block)
       method_name = "supports_#{feature}?"
 
       define_method(method_name) do
         unsupported.delete(feature)
         if block_given?
-          yield(self)
+          instance_eval(&block)
         else
           unsupported[feature] = reason unless is_supported
         end

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -27,8 +27,8 @@ describe SupportsFeatureMixin do
       extend ActiveSupport::Concern
 
       included do
-        supports :fake do |post|
-          post.unsupported[:fake] = "Need more money" unless post.bribe
+        supports :fake do
+          unsupported_reason_add(:fake, "Need more money") unless bribe
         end
       end
     end)
@@ -54,12 +54,12 @@ describe SupportsFeatureMixin do
       expect(Post.new.respond_to?(:supports_publish?)).to be true
     end
 
-    it "unsupported on the class" do
-      expect(Post.respond_to?(:unsupported)).to be true
+    it "unsupported_reason on the class" do
+      expect(Post.respond_to?(:unsupported_reason)).to be true
     end
 
-    it "unsupported on the instance" do
-      expect(Post.new.respond_to?(:unsupported)).to be true
+    it "unsupported_reason on the instance" do
+      expect(Post.new.respond_to?(:unsupported_reason)).to be true
     end
   end
 
@@ -72,12 +72,12 @@ describe SupportsFeatureMixin do
       expect(Post.new.supports_publish?).to be true
     end
 
-    it "#unsupported[:feature] is nil" do
-      expect(Post.new.unsupported[:publish]).to be nil
+    it "#unsupported_reason(:feature) is nil" do
+      expect(Post.new.unsupported_reason(:publish)).to be nil
     end
 
-    it ".unsupported[:feature] is nil" do
-      expect(Post.unsupported[:publish]).to be nil
+    it ".unsupported_reason(:feature) is nil" do
+      expect(Post.unsupported_reason(:publish)).to be nil
     end
   end
 
@@ -90,12 +90,12 @@ describe SupportsFeatureMixin do
       expect(Post.new.supports_fake?).to be false
     end
 
-    it "#unsupported[:feature] returns a reason" do
-      expect(Post.new.unsupported[:fake]).to eq "We keep it real!"
+    it "#unsupported_reason(:feature) returns a reason" do
+      expect(Post.new.unsupported_reason(:fake)).to eq "We keep it real!"
     end
 
-    it ".unsupported[:feature] returns a reason" do
-      expect(Post.unsupported[:fake]).to eq "We keep it real!"
+    it ".unsupported_reason(:feature) returns a reason" do
+      expect(Post.unsupported_reason(:fake)).to eq "We keep it real!"
     end
   end
 
@@ -134,11 +134,11 @@ describe SupportsFeatureMixin do
       end
 
       it "gives no reason on the class" do
-        expect(SpecialPost.unsupported[:fake]).to be nil
+        expect(SpecialPost.unsupported_reason(:fake)).to be nil
       end
 
       it "gives no reason on the instance" do
-        expect(SpecialPost.new(:bribe => true).unsupported[:fake]).to be nil
+        expect(SpecialPost.new(:bribe => true).unsupported_reason(:fake)).to be nil
       end
     end
 
@@ -146,11 +146,11 @@ describe SupportsFeatureMixin do
       it "gives a reason on the instance" do
         special_post = SpecialPost.new
         expect(special_post.supports_fake?).to be false
-        expect(special_post.unsupported[:fake]).to eq "Need more money"
+        expect(special_post.unsupported_reason(:fake)).to eq "Need more money"
       end
 
       it "gives a reason without calling supports_feature? first" do
-        expect(SpecialPost.new.unsupported[:fake]).to eq "Need more money"
+        expect(SpecialPost.new.unsupported_reason(:fake)).to eq "Need more money"
       end
     end
 
@@ -158,10 +158,10 @@ describe SupportsFeatureMixin do
       it "is checks the current condition" do
         special_post = SpecialPost.new
         expect(special_post.supports_fake?).to be false
-        expect(special_post.unsupported[:fake]).to eq "Need more money"
+        expect(special_post.unsupported_reason(:fake)).to eq "Need more money"
         special_post.bribe = true
         expect(special_post.supports_fake?).to be true
-        expect(special_post.unsupported[:fake]).to be nil
+        expect(special_post.unsupported_reason(:fake)).to be nil
       end
     end
   end

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -1,0 +1,168 @@
+describe SupportsFeatureMixin do
+  before do
+    stub_const('Post::Operations::Publishing', Module.new do
+      extend ActiveSupport::Concern
+
+      included do
+        supports :publish
+      end
+    end)
+
+    stub_const('Post::Operations', Module.new do
+      extend ActiveSupport::Concern
+      include Post::Operations::Publishing
+
+      included do
+        supports :archive
+        supports_not :fake, "We keep it real!"
+      end
+    end)
+
+    stub_const('Post', Class.new do
+      include SupportsFeatureMixin
+      include Post::Operations
+    end)
+
+    stub_const('SpecialPost::Operations', Module.new do
+      extend ActiveSupport::Concern
+
+      included do
+        supports :fake do |post|
+          post.unsupported[:fake] = "Need more money" unless post.bribe
+        end
+      end
+    end)
+
+    stub_const('SpecialPost', Class.new(Post) do
+      include SupportsFeatureMixin
+      include SpecialPost::Operations
+
+      attr_accessor :bribe
+
+      def initialize(options = {})
+        self.bribe = options[:bribe]
+      end
+    end)
+  end
+
+  context "defines method" do
+    it "supports_feature? on the class" do
+      expect(Post.respond_to?(:supports_publish?)).to be true
+    end
+
+    it "supports_feature? on the instance" do
+      expect(Post.new.respond_to?(:supports_publish?)).to be true
+    end
+
+    it "unsupported on the class" do
+      expect(Post.respond_to?(:unsupported)).to be true
+    end
+
+    it "unsupported on the instance" do
+      expect(Post.new.respond_to?(:unsupported)).to be true
+    end
+  end
+
+  context "for a supported feature" do
+    it ".supports_feature? is true" do
+      expect(Post.supports_publish?).to be true
+    end
+
+    it "#supports_feature? is true" do
+      expect(Post.new.supports_publish?).to be true
+    end
+
+    it "#unsupported[:feature] is nil" do
+      expect(Post.new.unsupported[:publish]).to be nil
+    end
+
+    it ".unsupported[:feature] is nil" do
+      expect(Post.unsupported[:publish]).to be nil
+    end
+  end
+
+  context "for an unsupported feature" do
+    it ".supports_feature? is false" do
+      expect(Post.supports_fake?).to be false
+    end
+
+    it "#supports_feature? is true" do
+      expect(Post.new.supports_fake?).to be false
+    end
+
+    it "#unsupported[:feature] returns a reason" do
+      expect(Post.new.unsupported[:fake]).to eq "We keep it real!"
+    end
+
+    it ".unsupported[:feature] returns a reason" do
+      expect(Post.unsupported[:fake]).to eq "We keep it real!"
+    end
+  end
+
+  context "definition in nested modules" do
+    it "defines a class method on the model" do
+      expect(Post.respond_to?(:supports_archive?)).to be true
+    end
+
+    it "defines an instance method" do
+      expect(Post.new.respond_to?(:supports_archive?)).to be true
+    end
+  end
+
+  context "a feature defined on the base class" do
+    it "defines supports_feature? on the subclass" do
+      expect(SpecialPost.respond_to?(:supports_publish?)).to be true
+    end
+
+    it "defines supports_feature? on an instance of the subclass" do
+      expect(SpecialPost.new.respond_to?(:supports_publish?)).to be true
+    end
+
+    it "can be overriden on the subclass" do
+      expect(SpecialPost.supports_fake?).to be true
+    end
+  end
+
+  context "conditionally supported feature" do
+    context "when the condition is met" do
+      it "is supported on the class" do
+        expect(SpecialPost.supports_fake?).to be true
+      end
+
+      it "is supported on the instance" do
+        expect(SpecialPost.new(:bribe => true).supports_fake?).to be true
+      end
+
+      it "gives no reason on the class" do
+        expect(SpecialPost.unsupported[:fake]).to be nil
+      end
+
+      it "gives no reason on the instance" do
+        expect(SpecialPost.new(:bribe => true).unsupported[:fake]).to be nil
+      end
+    end
+
+    context "when the condition is not met" do
+      it "gives a reason on the instance" do
+        special_post = SpecialPost.new
+        expect(special_post.supports_fake?).to be false
+        expect(special_post.unsupported[:fake]).to eq "Need more money"
+      end
+
+      it "gives a reason without calling supports_feature? first" do
+        expect(SpecialPost.new.unsupported[:fake]).to eq "Need more money"
+      end
+    end
+
+    context "when the condition changes on the instance" do
+      it "is checks the current condition" do
+        special_post = SpecialPost.new
+        expect(special_post.supports_fake?).to be false
+        expect(special_post.unsupported[:fake]).to eq "Need more money"
+        special_post.bribe = true
+        expect(special_post.supports_fake?).to be true
+        expect(special_post.unsupported[:fake]).to be nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first stab at refactoring `is_available?` and `validate_` calls.

Before this a `validate_<feature>` call had to be implemented as an instance method and had to return a hash or nil. `{ available: true, message: 'Not available' }`
In case nil is returned, the feature is not available. 
In case a Hash is returned and available is false, then the feature is basically available, but for the reason in :message its currently not. 
If :available is true, the feature is available right now.
My concern with this is 
* wording: validate_ sounds like rails validation, but we are not validating the object itself
* return value: either a nil value could be returned or a hash
* an object/record needs to be present to check the general validity of a feature

The `validate_` method would generally be used by the UI to test the availability of an operation/feature. 
This would be done by a pair of methods: `is_available?(operation)` and `is_available_now_error_message(operation)`
My concern with this is:
* wording: `is_available?` does not communicate what is available and the side effect that it depends on internal state of the object
* input is keyword which cannot be introspected like a method without any arguments (what can I query for?)
* an object/record needs to be present to check the general validity of a feature

A first refactor was the extraction into a [AvailabilityMixin](https://github.com/ManageIQ/manageiq/pull/7062) and a rename of those `available` method names: https://github.com/ManageIQ/manageiq/pull/3596

I propose a more DSL like approach that adds a `supports` class method, which defines 3 methods
* A class level method that returns the general support of a feature
* An instance level method that answers if the feature is supported by this instance
* Another instance level method that returns the reason for being not supported by the instance

```ruby
class Animal
  supports :die
  supports :fly, false
end

class Bird < Animal
  supports :fly do |bird|
    if bird.penguin? 
      "Penguins can't fly"
    else
      true
    end
  end
end

Animal.supports_die? # true
Animal.new.supports_die? # true
Animal.supports_fly? # false
Bird.supports_fly? # true
Bird.new(penguin: true).support_fly? # false
Bird.new(penguin: true).unsupported_fly_reason # 'Penguins can't fly
```

As an example I refactored `live_migrate`

@Fryguy @martinpovolny @mfalesni what do you think of this?

@miq-bot add_label refactoring