### PR TITLE
Display unique names in containers explorer

### DIFF
--- a/spec/presenters/tree_builder_containers_spec.rb
+++ b/spec/presenters/tree_builder_containers_spec.rb
@@ -8,15 +8,20 @@ describe TreeBuilderContainers do
     MiqRegion.seed
     EvmSpecHelper.local_miq_server
 
-    @tagged_container = FactoryGirl.create(:container, :name => "Tagged Container", :tags => [tag])
-    @untagged_container = FactoryGirl.create(:container, :name => "Untagged Container")
-
+    @container_group = FactoryGirl.create(:container_group, :name => "Container group", :id => 42)
+    @tagged_container = FactoryGirl.create(:container,
+                                           :name            => "Tagged Container",
+                                           :tags            => [tag],
+                                           :container_group => @container_group)
+    @untagged_container = FactoryGirl.create(:container,
+                                             :name            => "Untagged Container",
+                                             :container_group => @container_group)
     login_as user
   end
 
   describe ".new" do
     def get_tree_results(tree)
-      JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+      tree.x_get_child_nodes("xx-42").map { |c| c[:title] }
     end
 
     it "returns all containers" do


### PR DESCRIPTION
Display unique container names in containers explorer tree view.

Bugzilla reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1333520

Before:
![containers](https://cloud.githubusercontent.com/assets/2181522/15470145/628a6e54-20f7-11e6-8a32-a7d297cb4e90.png)

After:
![screenshot-2016-05-26-17-22-29](https://cloud.githubusercontent.com/assets/2181522/15577751/813c28c6-2366-11e6-96a2-213ff157597f.png)


