### PR TITLE
Return back Service Template to direct RBAC

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -29,6 +29,7 @@ module Rbac
     ResourcePool
     SecurityGroup
     Service
+    ServiceTemplate
     Storage
     VmOrTemplate
   )

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,30 +5,6 @@ describe ApplicationController do
     expect(CimBaseStorageExtentController.model).to eq CimBaseStorageExtent
   end
 
-  context "Service Templates" do
-    before :each do
-      EvmSpecHelper.local_miq_server
-      child_tenant = FactoryGirl.create(:tenant)
-      tenant_role = FactoryGirl.create(:miq_user_role, :settings => {:restrictions => {:vms => :user_or_group}})
-      user_with_child_tenant = FactoryGirl.create(:user_with_group)
-      user_with_child_tenant.current_group.miq_user_role = tenant_role
-      user_with_child_tenant.current_group.tenant = child_tenant
-      user_with_child_tenant.current_group.save
-      FactoryGirl.create(:user_admin)
-
-      FactoryGirl.create(:service_template) # created with root tenant
-      @service_template_with_child_tenant = FactoryGirl.create(:service_template, :tenant => child_tenant)
-      login_as user_with_child_tenant
-    end
-
-    it "returns all catalog items related to current tenant and root tenant" do
-      controller.instance_variable_set(:@settings, {})
-      allow_any_instance_of(ApplicationController).to receive(:fetch_path)
-      view, _pages = controller.send(:get_view, ServiceTemplate, {})
-      expect(view.table.data.count).to eq(2)
-    end
-  end
-
   context "#find_by_id_filtered" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION

https://bugzilla.redhat.com/show_bug.cgi?id=1296671
it was added here https://github.com/ManageIQ/manageiq/pull/6347 but after research with @gtanzillo we determine that is works as expected:
So I reverted (https://github.com/ManageIQ/manageiq/pull/6347) and added specs.

so for service templates (catalog items)

-  for non-self-service-users
there is used descendant tenant strategy
tags are supported

-  for self-service-users (user or groups)
service templates(catalog items ) are visible to user's groups
tags *are supported*: if some catalog item (service template) is tagged - and user has assigned the tag - then the user can see the catalog item even there is no ownership relation between him and the catalog item.


cc @gtanzillo 

