### PR TITLE
Improve adding multiple disks to VMware VMs

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -76,7 +76,19 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
   end
 
   def add_disks(vim_obj, vmcs, disks)
-    controller_key, unit_number = vim_obj.send(:getScsiCandU)
+    available_units      = vim_obj.send(:available_scsi_units)
+
+    disks.each do |d|
+      controller_key, unit_number = available_units.pop
+      if controller_key.nil?
+        # TODO
+      end
+
+      d[:controller_key] = controller_key
+      d[:unit_number]    = unit_number
+
+      add_disk_config_spec(vmcs, d)
+    end
 
     # if there is no scsi controller
     if controller_key.blank?

--- a/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -738,7 +738,7 @@ class MiqVimVm
     # - persistent is set to true to be backward compatible
     # - thin_provisioned is set to false explicitly since we call to_s on it further, so nil will not work for us
     options = {:persistent => true, :thin_provisioned => false}.merge(options)
-    ck, un = getScsiCandU
+    ck, un = available_scsi_units.first
     raise "addDisk: no SCSI controller found" unless ck
 
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") do |vmcs|
@@ -899,10 +899,6 @@ class MiqVimVm
 
     scsi_controller_bus_numbers
   end
-
-  def getScsiCandU
-    available_scsi_units.first
-  end # def getScsiCandU
 
   #
   # Returns the [controllerKey, key] pair for the virtul device

--- a/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -22,6 +22,7 @@ class MiqVimVm
                                   ParaVirtualSCSIController
                                 ).freeze
   MAX_SCSI_DEVICES          = 15
+  MAX_SCSI_CONTROLLERS      = 4
 
   attr_reader :name, :localPath, :dsPath, :hostSystem, :uuid, :vmh, :devices, :invObj, :annotation, :customValues, :vmMor
 
@@ -885,6 +886,19 @@ class MiqVimVm
 
     scsi_units
   end # def available_scsi_units
+
+  def available_scsi_controller_buses
+    scsi_controller_bus_numbers = [*0..MAX_SCSI_CONTROLLERS - 1]
+
+    devices = getProp("config.hardware")["config"]["hardware"]["device"]
+
+    scsi_controllers = devices.select { |dev| VIRTUAL_SCSI_CONTROLLERS.include?(dev.xsiType) }
+    scsi_controllers.each do |controller|
+      scsi_controller_bus_numbers -= [controller["busNumber"].to_i]
+    end
+
+    scsi_controller_bus_numbers
+  end
 
   def getScsiCandU
     available_scsi_units.first

--- a/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -853,8 +853,9 @@ class MiqVimVm
   # Find a SCSI controller and
   # return its key and next available unit number.
   #
-  def getScsiCandU
-    controller_key = unit_number = nil
+  def available_scsi_units
+    scsi_units       = []
+    all_unit_numbers = [*0..MAX_SCSI_DEVICES]
 
     devices = getProp("config.hardware")["config"]["hardware"]["device"]
     scsi_controllers = devices.select { |dev| VIRTUAL_SCSI_CONTROLLERS.include?(dev.xsiType) }
@@ -875,14 +876,18 @@ class MiqVimVm
       populated_units << scsi_controller["scsiCtlrUnitNumber"].to_i
 
       # Pick the lowest available unit number
-      all_unit_numbers = [*0..MAX_SCSI_DEVICES]
       available_units  = all_unit_numbers - populated_units
 
-      unit_number = available_units.sort.first
-      break
+      available_units.each do |unit|
+        scsi_units << [controller_key, unit]
+      end
     end
 
-    return controller_key, unit_number
+    scsi_units
+  end # def available_scsi_units
+
+  def getScsiCandU
+    available_scsi_units.first
   end # def getScsiCandU
 
   #

--- a/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -887,7 +887,7 @@ class MiqVimVm
     scsi_units
   end # def available_scsi_units
 
-  def available_scsi_controller_buses
+  def available_scsi_buses
     scsi_controller_bus_numbers = [*0..MAX_SCSI_CONTROLLERS - 1]
 
     devices = getProp("config.hardware")["config"]["hardware"]["device"]

--- a/gems/pending/spec/VMwareWebService/MiqVimVm_spec.rb
+++ b/gems/pending/spec/VMwareWebService/MiqVimVm_spec.rb
@@ -133,7 +133,7 @@ describe MiqVimVm do
       end
     end
 
-    context "#getScsiCandU" do
+    context "#available_scsi_units" do
       let(:miq_vim_vm) do
         {
           "config" => {
@@ -155,7 +155,7 @@ describe MiqVimVm do
 
       context "with 0 scsi controllers" do
         it "returns nil, nil" do
-          controller_key, unit_number = @vim_vm.getScsiCandU
+          controller_key, unit_number = @vim_vm.available_scsi_units.first
           expect(controller_key).to be_nil
           expect(unit_number).to    be_nil
         end
@@ -180,7 +180,7 @@ describe MiqVimVm do
 
         context "with 0 disks" do
           it "returns the first unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(0)
           end
@@ -206,7 +206,7 @@ describe MiqVimVm do
 
         context "with 0 disks" do
           it "returns the first unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(0)
           end
@@ -232,7 +232,7 @@ describe MiqVimVm do
 
         context "with 0 disks" do
           it "returns the first unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(0)
           end
@@ -262,7 +262,7 @@ describe MiqVimVm do
 
         context "with 0 disks" do
           it "returns the first unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(0)
           end
@@ -284,7 +284,7 @@ describe MiqVimVm do
           end
 
           it "returns the first available unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(1)
           end
@@ -308,7 +308,7 @@ describe MiqVimVm do
           end
 
           it "returns the first available unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(2)
           end
@@ -332,7 +332,7 @@ describe MiqVimVm do
           end
 
           it "returns the lowest available unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(1)
           end
@@ -356,7 +356,7 @@ describe MiqVimVm do
           end
 
           it "skips the scsi controller unit number" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(8)
           end
@@ -380,7 +380,7 @@ describe MiqVimVm do
           end
 
           it "returns nil, nil" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to be_nil
             expect(unit_number).to    be_nil
           end
@@ -428,7 +428,7 @@ describe MiqVimVm do
           end
 
           it "picks the free unit on the first controller" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1000")
             expect(unit_number).to    eq(8)
           end
@@ -452,7 +452,7 @@ describe MiqVimVm do
           end
 
           it "picks the first unit on the second controller" do
-            controller_key, unit_number = @vim_vm.getScsiCandU
+            controller_key, unit_number = @vim_vm.available_scsi_units.first
             expect(controller_key).to eq("1001")
             expect(unit_number).to    eq(0)
           end


### PR DESCRIPTION
This fixes two issues when adding multiple disks to a VMware VM:

1. If you need to add an additional SCSI controller to be able to add a new disk it would fail (e.g.: adding the 16th disk).  This is because the open scsi bus was always assumed to be `0`
2. If you had non-consecutive free SCSI units it would try to add a disk to a populated location (e.g.: SCSI 0:0 and SCSI 0:2 are populated, adding two disks would try to put them at 0:1 and 0:2).  This was because `getScsiCandU` was only returning the first free disk position, and subsequent unit_numbers were `+1` from the first one.

The fix is to return all free disk and scsi bus positions so that `add_disks` can iterate through known free unit_numbers and scsi buses.

This change allows you to add up to the maximum 60 disks in one reconfigure task, adding all 4 scsi adapters in the same request.  You can also add disks when e.g. every other disk position is free.

https://bugzilla.redhat.com/show_bug.cgi?id=1337310