### PR TITLE
Expose the associations of ManageIQ::Providers::Openstack::NetworkManager::NetworkPort to automate.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-network_port.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-network_port.rb
@@ -1,5 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Openstack_NetworkManager_NetworkPort < MiqAeServiceNetworkPort
-    expose :cloud_network, :association => true
+    expose :cloud_subnets,   :association => true
+    expose :network_routers, :association => true
+    expose :public_networks, :association => true
   end
 end


### PR DESCRIPTION
Expose the associations of ManageIQ::Providers::Openstack::NetworkManager::NetworkPort to automate service model.

https://bugzilla.redhat.com/show_bug.cgi?id=1338628