### PR TITLE
Ensure virtual column arel supports basic interface

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -42,7 +42,8 @@ module VirtualArel
     private
 
     def define_virtual_arel(name, arel)
-      self._virtual_arel = _virtual_arel.merge(name => arel)
+      arel = Arel::Nodes::Grouping.new(arel) unless arel.respond_to?(:eq)
+      self._virtual_arel[name] = arel
     end
   end
 end


### PR DESCRIPTION
Many areas of active record use arel helper methods.
Unfortunately, the helper methods are not consistent.
Adding Grouping gets the node closer to attribute

alternate to #8882 - required by #8870

/cc @imtayadeway 