### PR TITLE
Delay load azure-armrest

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -22,6 +22,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
     def raw_connect(client_id, client_key, azure_tenant_id, subscription = nil, proxy_uri = nil)
       proxy_uri ||= VMDB::Util.http_proxy_uri
 
+      require 'azure-armrest'
       ::Azure::Armrest::ArmrestService.configure(
         :client_id       => client_id,
         :client_key      => client_key,

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -16,7 +16,7 @@ gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails
 # Not locally modified and not required
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.3",            :require => false
-gem "azure-armrest",           "=0.2.6"
+gem "azure-armrest",           "=0.2.6",            :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false


### PR DESCRIPTION
@blomquisg @djberg96 Please review.

It is common for providers to require their necessary gem in the raw_connect method, but azure-armrest doesn't follow that pattern and loads itself in the gemfile.  If you don't have an azure provider you pay a time and memory penalty.  This PR is trying to remove that.  We noticed that it costs 0.1s and 770Kb memory during boot, but most of that penalty is loading rest-client.

I grepped the code and there are a couple places that aren't going through raw_connect for some reason.  I'm not sure this PR will break those cases, so can you help me out to find out?  Specifically, https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb#L65

In addition, I've noticed that azure-armrest has "infected" a bunch of files, and I don't understand why. [[1]](https://github.com/ManageIQ/manageiq/blob/master/gems/pending/spec/spec_helper.rb#L2) [[2]](https://github.com/ManageIQ/manageiq/blob/master/gems/pending/spec/spec_helper.rb#L40-L50) [[3]](https://github.com/ManageIQ/manageiq/blob/master/gems/pending/spec/miq_vm/miq_azure_vm_image_spec.rb#L3) (amongst others)