### PR TITLE
Remove VMDB::Config caching from MiqQueue

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -124,8 +124,6 @@ class MiqQueue < ApplicationRecord
     msg
   end
 
-  cache_with_timeout(:vmdb_config) { VMDB::Config.new("vmdb") }
-
   MIQ_QUEUE_GET = <<-EOL
     state = 'ready'
     AND (zone IS NULL OR zone = ?)
@@ -155,7 +153,7 @@ class MiqQueue < ApplicationRecord
       options[:priority] || MIN_PRIORITY,
     ]
 
-    prefetch_max_per_worker = vmdb_config.config[:server][:prefetch_max_per_worker] || 10
+    prefetch_max_per_worker = Settings.server.prefetch_max_per_worker || 10
     msgs = MiqQueue.where(cond).order("priority, id").limit(prefetch_max_per_worker)
     return nil if msgs.empty? # Nothing available in the queue
 


### PR DESCRIPTION
Fixes #8885 

I'm not really sure what causes #8885, but we don't need the caching of VMDB::Config at all now that we can access Settings directly.  This code can probably be changed to not even use the setting, since I'm not sure what it's purpose is (and doesn't have a default), but I decided to handle separately.