### PR TITLE
Remove ruby-graphviz gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,6 @@ unless ENV['APPLIANCE']
   group :development do
     gem "haml_lint",        "~>0.16.1", :require => false
     gem "rubocop",          "~>0.37.2", :require => false
-    gem "ruby-graphviz",                :require => false  # Used by state_machine:draw Rake Task
   end
 
   group :test do


### PR DESCRIPTION
We don't use this gem, so :wave: