### PR TITLE
Delay load iniparse gem

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
 gem "bundler",       ">= 1.8.4"
 gem "rake",          "~>10.1"
-gem "iniparse"
 
 gem "activesupport",           "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
 gem "actionpack",              "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
@@ -26,6 +25,7 @@ gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by
 gem "fog-openstack",           "~>0.1.5",           :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.2",           :require => false
+gem "iniparse",                                     :require => false
 gem "kubeclient",              "=1.1.3",            :require => false
 gem "hawkular-client",         "=0.2.2",            :require => false
 gem "linux_admin",             "~>0.16.0",          :require => false


### PR DESCRIPTION
The only place that uses IniParse [[1]](https://github.com/ManageIQ/manageiq/blob/master/gems/pending/metadata/linux/LinuxSystemd.rb#L52), calls the require at the top of the file anyway [[2]](https://github.com/ManageIQ/manageiq/blob/master/gems/pending/metadata/linux/LinuxSystemd.rb#L3-L4)

@jrafanie Please review.