### PR TITLE
[WIP] Add a button for re-checking authentication status for providers

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -437,6 +437,18 @@ module EmsCommon
         end
         return
       end
+      if params[:pressed] == "ems_cloud_recheck_auth_status"
+        @record = find_by_id_filtered(model, params[:id])
+        result, details = @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype),
+                                                                   :save => true)
+        if result
+          add_flash(_("Re-checking Authentication status initiated for this #{ui_lookup(:table => "ems_cloud")}"))
+        else
+          add_flash(_("Re-checking Authentication status for this #{ui_lookup(:table => "ems_cloud")} was not successful: %{details}") % {:details => details}, :error)
+        end
+        render_flash
+        return
+      end
 
       custom_buttons if params[:pressed] == "custom_button"
 

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -438,7 +438,8 @@ module EmsCommon
         return
       end
       if params[:pressed] == "ems_cloud_recheck_auth_status" ||
-         params[:pressed] == "ems_infra_recheck_auth_status"
+         params[:pressed] == "ems_infra_recheck_auth_status" ||
+         params[:pressed] == "ems_container_recheck_auth_status"
         @record = find_by_id_filtered(model, params[:id])
         result, details = @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype),
                                                                    :save => true)

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -437,12 +437,13 @@ module EmsCommon
         end
         return
       end
-      if params[:pressed] == "ems_cloud_recheck_auth_status"
+      if params[:pressed] == "ems_cloud_recheck_auth_status" ||
+         params[:pressed] == "ems_infra_recheck_auth_status"
         @record = find_by_id_filtered(model, params[:id])
         result, details = @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype),
                                                                    :save => true)
         if result
-          add_flash(_("Re-checking Authentication status initiated for this #{ui_lookup(:table => "ems_cloud")}"))
+          add_flash(_("Re-checking Authentication status initiated for this #{ui_lookup(:table => controller_name)}"))
         else
           add_flash(_("Re-checking Authentication status for this #{ui_lookup(:table => "ems_cloud")} was not successful: %{details}") % {:details => details}, :error)
         end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -443,7 +443,7 @@ module EmsCommon
         result, details = @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype),
                                                                    :save => true)
         if result
-          add_flash(_("Re-checking Authentication status initiated for this #{ui_lookup(:table => controller_name)}"))
+          add_flash(_("Authentication status will be saved and workers will be restarted for this #{ui_lookup(:table => controller_name)}"))
         else
           add_flash(_("Re-checking Authentication status for this #{ui_lookup(:table => "ems_cloud")} was not successful: %{details}") % {:details => details}, :error)
         end

--- a/app/helpers/application_helper/button/ems_cloud_recheck_auth_status.rb
+++ b/app/helpers/application_helper/button/ems_cloud_recheck_auth_status.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::EmsCloudRecheckAuthStatus < ApplicationHelper::Button::Basic
+  def skip?
+    !@record.is_available?(:authentication_status)
+  end
+end

--- a/app/helpers/application_helper/button/ems_container_recheck_auth_status.rb
+++ b/app/helpers/application_helper/button/ems_container_recheck_auth_status.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::EmsContainerRecheckAuthStatus < ApplicationHelper::Button::Basic
+  def skip?
+    !@record.is_available?(:authentication_status)
+  end
+end

--- a/app/helpers/application_helper/button/ems_infra_recheck_auth_status.rb
+++ b/app/helpers/application_helper/button/ems_infra_recheck_auth_status.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::EmsInfraRecheckAuthStatus < ApplicationHelper::Button::Basic
+  def skip?
+    !@record.is_available?(:authentication_status)
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -74,13 +74,13 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
   button_group('ems_cloud_authentication', [
     select(
       :ems_cloud_authentication_choice,
-      'product fa-lg',
+      'fa fa-lock fa-lg',
       t = N_('Authentication'),
       t,
       :items => [
         button(
           :ems_cloud_recheck_auth_status,
-          'product fa-lg',
+          'fa fa-search fa-lg',
           N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
           N_('Re-check Authentication Status'),
           :klass => ApplicationHelper::Button::EmsCloudRecheckAuthStatus),

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -71,4 +71,20 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
       ]
     ),
   ])
+  button_group('ems_cloud_authentication', [
+    select(
+      :ems_cloud_authentication_choice,
+      'product fa-lg',
+      t = N_('Authentication'),
+      t,
+      :items => [
+        button(
+          :ems_cloud_recheck_auth_status,
+          'product fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status'),
+          :klass => ApplicationHelper::Button::EmsCloudRecheckAuthStatus),
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -77,4 +77,20 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
       ]
     ),
   ])
+  button_group('ems_container_authentication', [
+    select(
+      :ems_container_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :items => [
+        button(
+          :ems_container_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_container")}'),
+          N_('Re-check Authentication Status'),
+          :klass => ApplicationHelper::Button::EmsContainerRecheckAuthStatus),
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -82,4 +82,20 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
       ]
     ),
   ])
+  button_group('ems_infra_authentication', [
+    select(
+      :ems_infra_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :items => [
+        button(
+          :ems_infra_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_infra")}'),
+          N_('Re-check Authentication Status'),
+          :klass => ApplicationHelper::Button::EmsInfraRecheckAuthStatus),
+      ]
+    ),
+  ])
 end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -61,6 +61,10 @@ module ManageIQ::Providers
       end
     end
 
+    def validate_authentication_status
+      {:available => true, :message => nil}
+    end
+
     def stop_event_monitor_queue_on_credential_change
       if event_monitor_class && !self.new_record? && self.credentials_changed?
         _log.info("EMS: [#{name}], Credentials have changed, stopping Event Monitor.  It will be restarted by the WorkerMonitor.")

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -58,5 +58,9 @@ module ManageIQ::Providers
     def validate_performance
       {:available => true, :message => nil}
     end
+
+    def validate_authentication_status
+      {:available => true, :message => nil}
+    end
   end
 end

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -46,5 +46,9 @@ module ManageIQ::Providers
     def validate_timeline
       {:available => true, :message => nil}
     end
+
+    def validate_authentication_status
+      {:available => true, :message => nil}
+    end
   end
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -716,6 +716,10 @@
       :description: Refresh Infrastructure Providers
       :feature_type: control
       :identifier: ems_infra_refresh
+    - :name: Re-check Authentication Status
+      :description: Re-check Authentication Status of Infrastructure Providers
+      :feature_type: control
+      :identifier: ems_infra_recheck_auth_status
   - :name: Modify
     :description: Modify Infrastructure Providers
     :feature_type: admin

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3230,6 +3230,10 @@
       :description: Manage Policies of Containers Providers
       :feature_type: control
       :identifier: ems_container_protect
+    - :name: Re-check Authentication Status
+      :description: Re-check Authentication Status of Containers Providers
+      :feature_type: control
+      :identifier: ems_container_recheck_auth_status
   - :name: Modify
     :description: Modify Containers Providers
     :feature_type: admin

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -364,6 +364,10 @@
       :description: Refresh Cloud Providers
       :feature_type: control
       :identifier: ems_cloud_refresh
+    - :name: Re-check Authentication Status 
+      :description: Re-check Authentication Status of Cloud Providers
+      :feature_type: control
+      :identifier: ems_cloud_recheck_auth_status 
   - :name: Modify
     :description: Modify Cloud Providers
     :feature_type: admin

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1040 }
+  let(:expected_feature_count) { 1043 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
Addresses <a href=https://github.com/ManageIQ/manageiq/issues/8643#issuecomment-219093632>a part</a> of https://github.com/ManageIQ/manageiq/issues/8643.

While the other major UI changes mentioned in https://github.com/ManageIQ/manageiq/issues/8643 for the ems editors are still underway, we can move forward with this particular change which basically adds a `Re-check Authentication` button in the EMS Summary screen to update the Authentication status.

<img width="1209" alt="screen shot 2016-06-01 at 7 06 53 am" src="https://cloud.githubusercontent.com/assets/1538216/15712539/809ce17a-27c7-11e6-998e-170513680f31.png">


