### PR TITLE
Use the ClassMethods module for class methods we want to include

### DIFF
--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -58,4 +58,16 @@ describe MiqWebServerWorkerMixin do
       :app         => Rails.application
     )
   end
+
+  it "overloading and calling super on a class method" do
+    before = test_class.binding_address
+
+    test_class.class_eval do
+      def self.binding_address
+        super + "JUNK"
+      end
+    end
+
+    expect(test_class.binding_address).to eq (before + "JUNK")
+  end
 end


### PR DESCRIPTION
Fixes a bug if you try to call super in a class that includes this module:
  ```super: no superclass method `binding_address' for #<Class:0x007fb83fdee398>```

cc @fryguy (this is what we saw when we tried to overload the class method in the UiWorker)

cc @skateman (I'm not sure if you ran into this trying to overload any class methods on the WebsocketWorker.

Note, most of this is whitespace changes.  I moved the former class methods into the ClassMethods module and moved the instance methods that were mixed in with the class methods.

This is probably ok to backport to darga but I'm fine with darga/no and waiting to see if it's needed since I don't know that anyone else has hit this bug.