### PR TITLE
Remove dialog service textarea limit

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -44,7 +44,6 @@ module ApplicationHelper::Dialogs
   def textarea_tag_options(field, url)
     tag_options = {
       :class     => "dynamic-text-area-#{field.id} form-control",
-      :maxlength => 8192,
       :size      => "50x6"
     }
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -88,7 +88,6 @@ describe ApplicationHelper::Dialogs do
       it "returns the tag options with a disabled true" do
         expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
           :class     => "dynamic-text-area-100 form-control",
-          :maxlength => 8192,
           :size      => "50x6",
           :disabled  => true,
           :title     => "This element is disabled because it is read only"
@@ -105,7 +104,6 @@ describe ApplicationHelper::Dialogs do
         it "returns the tag options with a data-miq-observe" do
           expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
             :class             => "dynamic-text-area-100 form-control",
-            :maxlength         => 8192,
             :size              => "50x6",
             "data-miq_observe" => {
               :interval     => ".5",
@@ -124,7 +122,6 @@ describe ApplicationHelper::Dialogs do
         it "returns the tag options with a data-miq-observe" do
           expect(helper.textarea_tag_options(dialog_field, "url")).to eq(
             :class             => "dynamic-text-area-100 form-control",
-            :maxlength         => 8192,
             :size              => "50x6",
             "data-miq_observe" => '{"interval":".5","url":"url"}'
           )


### PR DESCRIPTION
We are hitting this issue when we want to put a bigger template
into a textarea. Since there is no server check for size (so
just editing html removes the check), it's redundant to have a
html level check.