### PR TITLE
mimic vmware when creating disk location attribute

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -495,7 +495,7 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
           :controller_type => interface,
           :present         => true,
           :filename        => device[:id],
-          :location        => index.to_s,
+          :location        => "0:#{index.to_s}",
           :size            => (device[:provisioned_size] || device[:size]).to_i,
           :size_on_disk    => device[:actual_size] ? device[:actual_size].to_i : 0,
           :disk_type       => device[:sparse] == true ? 'thin' : 'thick',


### PR DESCRIPTION
Vmware disks use different format for location attribute which breaks scanning logic. We need to align with Vmware's #{controller['busNumber']}:#{device['unitNumber']}. This structure was created due to vmware's limitation on number of disks per one disk controller. In ovirt there is no such limitation.

Above problem was reported in: https://github.com/ManageIQ/manageiq/issues/8617