### PR TITLE
Fix Container Provider default view

### DIFF
--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -16,6 +16,10 @@ class EmsContainerController < ApplicationController
     @table_name ||= "ems_container"
   end
 
+  def show_list
+    process_show_list(:gtl_dbname => 'emscontainer')
+  end
+
   def ems_path(*args)
     ems_container_path(*args)
   end


### PR DESCRIPTION
Fixes: Cannot change the default view for Container Providers. 
Bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1338803
cc @simon3z 

![prov](https://cloud.githubusercontent.com/assets/11769555/15502223/4d673df8-21bb-11e6-85c9-1a9d60aaeb03.png)

