### PR TITLE
Fix filter tab in old chargeback reports: Don`t store cb_model into MiqReport#db_options

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -651,12 +651,6 @@ module ReportController::Reports::Editor
       @edit[:new][:cb_tenant_id] = params[:cb_tenant_id].blank? ? nil : params[:cb_tenant_id].to_i
     elsif params.key?(:cb_tag_value)
       @edit[:new][:cb_tag_value] = params[:cb_tag_value].blank? ? nil : params[:cb_tag_value]
-    elsif params.key?(:cb_model)
-      @edit[:new][:cb_model] = params[:cb_model].blank? ? nil : params[:cb_model]
-      reset_report_col_fields
-      build_edit_screen
-      @refresh_div = "form_div"
-      @refresh_partial = "form"
     elsif params.key?(:cb_entity_id)
       @edit[:new][:cb_entity_id] = params[:cb_entity_id].blank? ? nil : params[:cb_entity_id]
     elsif params.key?(:cb_provider_id)
@@ -1220,7 +1214,6 @@ module ReportController::Reports::Editor
         options[:entity_id] = @edit[:new][:cb_entity_id]
       end
 
-      options[:cb_model] = @edit[:new][:cb_model]
       rpt.db_options[:options] = options
     end
 
@@ -1512,7 +1505,7 @@ module ReportController::Reports::Editor
       end
 
       @edit[:new][:cb_show_typ] = "entity"
-      @edit[:new][:cb_model] = options[:cb_model]
+      @edit[:new][:cb_model] = Chargeback.report_cb_model(@rpt.db)
       @edit[:new][:cb_entity_id] = options[:entity_id]
       @edit[:new][:cb_provider_id] = options[:provider_id]
       @edit[:new][:cb_interval] = options[:interval]

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1303,8 +1303,9 @@ describe ReportController do
   end
 
   describe "#miq_report_edit" do
-    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
-    let(:tenant)     { FactoryGirl.create(:tenant) }
+    let(:admin_user)   { FactoryGirl.create(:user, :role => "super_administrator") }
+    let(:tenant)       { FactoryGirl.create(:tenant) }
+    let(:chosen_model) { "ChargebackVm" }
 
     before do
       EvmSpecHelper.local_miq_server
@@ -1320,7 +1321,7 @@ describe ReportController do
       count_miq_reports = MiqReport.count
 
       post :x_button, :params => {:pressed => "miq_report_new"}
-      post :form_field_changed, :params => {:id => "new", :chosen_model => "ChargebackVm"}
+      post :form_field_changed, :params => {:id => "new", :chosen_model => chosen_model}
       post :form_field_changed, :params => {:id => "new", :title => "test"}
       post :form_field_changed, :params => {:id => "new", :name => "test"}
       post :form_field_changed, :params => {:button => "right", :available_fields => ["ChargebackVm-cpu_cost"]}
@@ -1330,7 +1331,8 @@ describe ReportController do
       post :miq_report_edit, :params => {:button => "add"}
 
       expect(MiqReport.count).to eq(count_miq_reports + 1)
-      expect(MiqReport.last.db_options[:options][:cb_model]).to eq("Vm")
+      expect(MiqReport.last.db_options[:rpt_type]).to eq(chosen_model)
+      expect(MiqReport.last.db).to eq(chosen_model)
     end
   end
 end


### PR DESCRIPTION
Don`t store cb_model into MiqReport#db_options because we can derive it from MiqReport#db or MiqReport#db_options[:rpt_type]

but also advantage is the we don't need migration for old chargeback reports - **it throws errors when you click on filter tab on old report** - this PR is fixing this error