### PR TITLE
Fix containers tree view titles

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -184,12 +184,12 @@ class ContainerController < ApplicationController
     [{:role     => "container_accord",
       :role_any => true,
       :name     => :containers,
-      :title    => _("Relationships")},
+      :title    => ui_lookup(:tables => "container")},
 
      {:role     => "container_filter_accord",
       :role_any => true,
       :name     => :containers_filter,
-      :title    => _("All Containers")},
+      :title    => _("Filters")},
     ].map do |hsh|
       ApplicationController::Feature.new_with_hash(hsh)
     end


### PR DESCRIPTION
In containers tree view the titles are mixed up.

The tab labeled "Relationships" does not show relationships, it show the container list.
The tab labeled "All containers" does not shoe *All* containers, it show subsections filtered from the containers list.

before:
![relationships](https://cloud.githubusercontent.com/assets/2181522/15503492/e006769a-21c2-11e6-87b4-7c009259ff2f.png)

after:
![relationships-after](https://cloud.githubusercontent.com/assets/2181522/15503502/e7f3d000-21c2-11e6-8762-5c6c33b24782.png)

