### PR TITLE
Fix compliance history for vms and container images

### DIFF
--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -85,7 +85,7 @@ module ContainersCommonMixin
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
       update_session_for_compliance_history(record, count)
-      drop_breadcrumb_for_compliance_history(record, controller_name)
+      drop_breadcrumb_for_compliance_history(record, controller_name, count)
       @showtype = @display
     elsif @display == "container_groups" || session[:display] == "container_groups" && params[:display].nil?
       show_container_display(record, "container_groups", ContainerGroup)
@@ -119,12 +119,13 @@ module ContainersCommonMixin
   end
 
   def update_session_for_compliance_history(record, count)
-    session[:ch_tree] = compliance_history_tree(record, count).to_json
+    @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, record)
+    session[:ch_tree] = @ch_tree.tree_nodes
     session[:tree_name] = "ch_tree"
     session[:squash_open] = (count == 1)
   end
 
-  def drop_breadcrumb_for_compliance_history(record, controller_name)
+  def drop_breadcrumb_for_compliance_history(record, controller_name, count)
     if count == 1
       drop_breadcrumb(:name => _("%{name} (Latest Compliance Check)") % {:name => record.name},
                       :url  => "/#{controller_name}/show/#{record.id}?display=#{@display}&refresh=n")

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -266,7 +266,8 @@ module VmCommon
       @button_group = "vmtree"
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
-      session[:ch_tree] = compliance_history_tree(@record, count).to_json
+      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, @record)
+      session[:ch_tree] = @ch_tree.tree_nodes
       session[:tree_name] = "ch_tree"
       session[:squash_open] = (count == 1)
       drop_breadcrumb({:name => @record.name, :url => "/#{rec_cls}/show/#{@record.id}"}, true)


### PR DESCRIPTION
Seems to be dropped by #8121

Before: Nothing happens + error in development.log with a stack trace
```
log/development.log:[----] F, [2016-05-23T17:42:16.691340 #9293:19149b0] FATAL -- : Error caught: [NoMethodError] undefined method `compliance_history_tree' for #<VmInfraController:0x000000082a0668>
```

After:

![2](https://cloud.githubusercontent.com/assets/3010449/15505962/57c34c84-21ce-11e6-819d-cfdc3f53f897.png)

![5](https://cloud.githubusercontent.com/assets/3010449/15505994/71d0a40a-21ce-11e6-9b98-8106ba94dff1.png)


Note: support for one (latest) item seems to be dropped too for all entities?