### PR TITLE
Update diagnostics tree whenever we update settings in settings tree

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -473,7 +473,7 @@ module OpsController::Settings::Common
         session[:changed] = @changed = false
         get_node_info(x_node)
         if @sb[:active_tab] == "settings_server"
-          replace_right_cell(@nodetype, [:settings])
+          replace_right_cell(@nodetype, [:diagnostics, :settings])
         elsif @sb[:active_tab] == "settings_custom_logos"
           render :update do |page|
             page << javascript_prologue


### PR DESCRIPTION
Some information (such as server's zone info) is displayed in both trees and therefore both trees
need to be updated when we change something in the settings tree.

https://bugzilla.redhat.com/show_bug.cgi?id=1328201