### PR TITLE
MiqAeCustomization#explorer - reset state

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -129,18 +129,6 @@ module ApplicationController::Buttons
     end
   end
 
-  # AJAX routine for user selected
-  def button_select
-    render :update do |page|
-      page << javascript_prologue
-      if params[:id] == "new"
-        page.redirect_to :action => 'button_new'    # redirect to new
-      else
-        page.redirect_to :action => 'button_edit', :id => params[:id], :field => params[:field]   # redirect to edit
-      end
-    end
-  end
-
   # AJAX driven routine to delete a user
   def ab_button_delete
     assert_privileges("ab_button_delete")

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -107,7 +107,11 @@ class MiqAeCustomizationController < ApplicationController
     @trees = []
     @flash_array = @sb[:flash_msg] unless @sb[:flash_msg].blank?
     @explorer = true
+
     build_resolve_screen
+
+    # service dialog edit abandoned
+    self.x_active_tree = :dialogs_tree if x_active_tree == :dialog_edit_tree
 
     build_accordions_and_trees
 

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -1,22 +1,7 @@
 module MiqAeCustomizationController::CustomButtons
   extend ActiveSupport::Concern
 
-  def automate_button
-    @in_a_form = true
-    @resolve = {} if params[:button] == "reset"
-    if params[:button] == "cancel_simulate"
-      # resetting changed, when coming back from simulate screen.
-      @changed = session[:changed]
-      session[:changed] =~ session[:changed]
-      @edit = session[:edit] = nil
-      @custom_button = @edit[:custom_button] if @edit && @edit[:custom_button]
-    else
-      @edit = nil
-    end
-    explorer
-  end
-
-  private ###########
+  private
 
   def buttons_node_image(node)
     case node

--- a/app/views/miq_ae_customization/button_edit.html.haml
+++ b/app/views/miq_ae_customization/button_edit.html.haml
@@ -1,1 +1,0 @@
-= render :partial => 'automate_button'

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -233,6 +233,38 @@ describe MiqAeCustomizationController do
         expect(assigns(:flash_array)).not_to include("the flash messages")
       end
     end
+
+    context "when in dialog edit state" do
+      render_views
+
+      before do
+        FactoryGirl.create(:miq_server, :guid => MiqServer.my_guid)
+        MiqServer.my_server_clear_cache
+      end
+
+      it "still renders the main_div" do
+        session[:sandboxes] = {
+          "miq_ae_customization" => {
+            :trees         => {:dialog_edit_tree => {:active_node => "root"},
+                               :dialogs_tree     => {:active_node => "root"}},
+            :active_tree   => :dialog_edit_tree,
+            :active_accord => :dialogs,
+          },
+        }
+        session[:edit] = {
+          :new => {},
+          :current => {},
+        }
+
+        get :explorer
+
+        expect(assigns(:sb)[:active_tree]).to eq(:dialogs_tree)
+        expect(response).to render_template('miq_ae_customization/explorer')
+
+        # empty main_div
+        expect(response.body).not_to match(/<div id=['"]main_div['"]>\s*<\/div>/)
+      end
+    end
   end
 
   describe "#upload_import_file" do


### PR DESCRIPTION
We're only ever calling `explorer` by accessing the main screen, so it makes sense to clear the state in there - and we never show `dialog_edit_tree` in explorer state.. So changing it to `:dialogs_tree` in such a case.

+ Added a spec checking that `#main_div` is not empty, and the right tree is set.

https://bugzilla.redhat.com/show_bug.cgi?id=1338023