### PR TITLE
Add summary to container explorer page title

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -208,8 +208,9 @@ class ContainerController < ApplicationController
       @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => typ)}
     else
       show_record(from_cid(id))
-      @right_cell_text = _("%{model} \"%{name}\"") % {:name  => @record.name,
-                                                      :model => ui_lookup(:model => TreeBuilder.get_model_for_prefix(@nodetype))}
+      @right_cell_text = _("%{model} \"%{name}\" (Summary)") % {
+        :name  => @record.name,
+        :model => ui_lookup(:model => TreeBuilder.get_model_for_prefix(@nodetype))}
     end
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history


### PR DESCRIPTION
Add "Summary" keyword to container explorer page title. 

Bugzilla reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1338801

Before:
![summary-before](https://cloud.githubusercontent.com/assets/2181522/15509998/480a406c-21de-11e6-885f-ed7047597728.png)

After:
![summary-after](https://cloud.githubusercontent.com/assets/2181522/15510002/4bc8a162-21de-11e6-8214-5bb4a7489b6d.png)
