### PR TITLE
Fix error when tagging objects with null / nil name attribute

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -347,7 +347,9 @@ module ApplicationController::Tags
     # Set to first category, if not already set
     @edit[:cat] ||= cats.min_by(&:description)
 
-    @tagitems = @tagging.constantize.find(@object_ids).sort_by { |t| t.name.try(:downcase) } unless @object_ids.blank?
+    unless @object_ids.blank?
+      @tagitems = @tagging.constantize.find(@object_ids).sort_by { |t| t.name.try(:downcase).to_s }
+    end
 
     @view = get_db_view(@tagging)               # Instantiate the MIQ Report view object
     @view.table = MiqFilter.records2table(@tagitems, @view.cols + ['id'])


### PR DESCRIPTION
This is to fix the following error:

```
FATAL -- : Error caught: [ArgumentError] comparison of NilClass with String failed
app/controllers/application_controller/tags.rb:350:in `sort_by' app/controllers/application_controller/tags.rb:350:in `tag_edit_build_screen'
app/controllers/application_controller/tags.rb:172:in `tagging_tags_set_form_vars'
app/controllers/application_controller/tags.rb:152:in `tagging_edit_tags_reset'
app/controllers/application_controller/tags.rb:15:in `tagging_edit'
...
```

https://bugzilla.redhat.com/show_bug.cgi?id=1339170