### PR TITLE
Fix compliance: all objects are always marked as compliant

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -165,8 +165,8 @@ class MiqPolicy < ApplicationRecord
     # TODO: If we need this validation on the object, create a real/virtual attribute so ActiveModel doesn't yell
     target.errors.add(:smart, result[:result])
 
-    action = invoke_actions(target, mode, profiles, succeeded, failed, inputs.merge(:event => erec))
-    result[:action] = action if action
+    actions = invoke_actions(target, mode, profiles, succeeded, failed, inputs.merge(:event => erec))
+    result[:actions] = actions if actions
     result
   end
 


### PR DESCRIPTION
Broken in e5f2470 when returned ```actions``` were named ```action```
When ever there is a compliance check, the resulting created compliance is :compliant => true.
Added a test to prevent regression. 