### PR TITLE
Use groups for attributes

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1371,26 +1371,35 @@ class VmOrTemplate < ApplicationRecord
     ems_id.nil? && storage_id.nil?
   end
   alias_method :archived, :archived?
-  virtual_attribute :archived, :boolean, :arel => ->(t) { t[:ems_id].eq(nil).and(t[:storage_id].eq(nil)) }
+  virtual_attribute :archived, :boolean, :arel => (lambda do |t|
+    t.grouping(t[:ems_id].eq(nil).and(t[:storage_id].eq(nil)))
+  end)
 
   def orphaned?
     ems_id.nil? && !storage_id.nil?
   end
   alias_method :orphaned, :orphaned?
-  virtual_attribute :orphaned, :boolean, :arel => ->(t) { t[:ems_id].eq(nil).and(t[:storage_id].not_eq(nil)) }
+  virtual_attribute :orphaned, :boolean, :arel => (lambda do |t|
+    t.grouping(t[:ems_id].eq(nil).and(t[:storage_id].not_eq(nil)))
+  end)
 
   def active?
     !archived? && !orphaned? && !retired? && !template?
   end
   alias_method :active, :active?
-  virtual_attribute :active, :boolean, :arel => (lambda do (t)
-    t[:ems_id].not_eq(nil).and(t[:retired].not_eq(true)).and(t[:template].not_eq(true))
+  # in sql nil != false ==> false
+  virtual_attribute :active, :boolean, :arel => (lambda do |t|
+    t.grouping(t[:ems_id].not_eq(nil)
+     .and(t[:retired].eq(nil).or(t[:retired].eq(t.create_false)))
+     .and(t[:template].eq(nil).or(t[:template].eq(t.create_false))))
   end)
 
   def disconnected?
     connection_state != "connected"
   end
-  virtual_attribute :disconnected, :boolean, :arel => ->(t) { t[:connection_state].not_eq("connected") }
+  virtual_attribute :disconnected, :boolean, :arel => (lambda do |t|
+    t.grouping(t[:connection_state].eq(nil).or(t[:connection_state].not_eq("connected")))
+  end)
   alias_method :disconnected, :disconnected?
 
   def normalized_state
@@ -1500,7 +1509,7 @@ class VmOrTemplate < ApplicationRecord
   # technically it is capitalized, but for sorting, not a concern
   # but we do need nil to become false
   virtual_attribute :v_is_a_template, :string, :arel => (lambda do |t|
-    Arel::Nodes::NamedFunction.new('COALESCE', [t[:template], Arel::Nodes.build_quoted("false")])
+    t.grouping(arel_coalesce([t[:template], t.create_false]))
   end)
 
   def v_datastore_path
@@ -1923,6 +1932,11 @@ class VmOrTemplate < ApplicationRecord
               :message   => "#{message_prefix} cannot be performed on orphaned #{self.class.model_suffix} VM."}
     end
     {:available => true,   :message => nil}
+  end
+
+  # this is verbose, helper for generating arel
+  def self.arel_coalesce(values)
+    Arel::Nodes::NamedFunction.new('COALESCE', values)
   end
 
   include DeprecatedCpuMethodsMixin

--- a/spec/support/arel_spec_helper.rb
+++ b/spec/support/arel_spec_helper.rb
@@ -8,10 +8,8 @@ module ArelSpecHelper
 
   # run the sql for a virtual column. making sure it works in select and order
   def virtual_column_sql_value(klass, v_col_name)
-    query = klass.select(klass.arel_attribute("id"),
-                         Arel::Nodes::As.new(klass.arel_attribute(v_col_name),
-                                             Arel::Nodes::SqlLiteral.new("extra")))
-                 .order(klass.arel_attribute(v_col_name))
+    query = klass.select(:id, klass.arel_attribute(v_col_name.to_sym).as("extra"))
+                 .order(v_col_name.to_sym)
     query.first["extra"]
   end
 end


### PR DESCRIPTION
Life is safer with parenthesis

Also ensures `v_is_a_template` works in a where clause and `active` will compare with false correctly
