### PR TITLE
Refactor get_error_message_from_fog to convert exceptions to string

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2460,11 +2460,6 @@ class ApplicationController < ActionController::Base
     set_active_elements(allowed_features.first)
   end
 
-  def get_error_message_from_fog(ex)
-    matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
-    matched_message ? matched_message[1] : ex
-  end
-
   def start_url_for_user(start_url)
     return url_for(start_url) unless start_url.nil?
     return url_for(:controller => "dashboard", :action => "show") unless self.helpers.settings(:display, :startpage)

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -535,7 +535,7 @@ module ApplicationController::CiProcessing
           add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
             :instance => ui_lookup(:table => 'vm_cloud'),
             :name     => @record.name,
-            :details  => get_error_message_from_fog(ex.to_s)}, :error)
+            :details  => get_error_message_from_fog(ex)}, :error)
         end
       else
         add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
@@ -627,7 +627,7 @@ module ApplicationController::CiProcessing
           add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
             :instance => ui_lookup(:table => 'vm_cloud'),
             :name     => @record.name,
-            :details  => get_error_message_from_fog(ex.to_s)}, :error)
+            :details  => get_error_message_from_fog(ex)}, :error)
         end
       else
         add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
@@ -1337,9 +1337,10 @@ module ApplicationController::CiProcessing
     end
   end
 
-  def get_error_message_from_fog(ex)
-    matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
-    matched_message ? matched_message[1] : ex
+  def get_error_message_from_fog(exception)
+    exception_string = exception.to_s
+    matched_message = exception_string.match(/message\\\": \\\"(.*)\\\", /)
+    matched_message ? matched_message[1] : exception_string
   end
 
   private ############################

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -134,7 +134,7 @@ class AuthKeyPairCloudController < ApplicationController
           add_flash(_("Unable to create %{model} %{name}. %{error}") % {
             :model => ui_lookup(:table => 'auth_key_pair_cloud'),
             :name  => options[:name],
-            :error => get_error_message_from_fog(ex.to_s)}, :error)
+            :error => get_error_message_from_fog(ex)}, :error)
         end
         @breadcrumbs.pop if @breadcrumbs
         session[:edit] = nil
@@ -300,10 +300,5 @@ class AuthKeyPairCloudController < ApplicationController
     session[:auth_key_pair_cloud_display]    = @display unless @display.nil?
     session[:auth_key_pair_cloud_filters]    = @filters
     session[:auth_key_pair_cloud_catinfo]    = @catinfo
-  end
-
-  def get_error_message_from_fog(ex)
-    matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
-    matched_message ? matched_message[1] : ex
   end
 end

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -212,9 +212,4 @@ class VmCloudController < ApplicationController
   def skip_breadcrumb?
     breadcrumb_prohibited_for_action?
   end
-
-  def get_error_message_from_fog(ex)
-    matched_message = ex.match(/message\\\": \\\"(.*)\\\", /)
-    matched_message ? matched_message[1] : ex
-  end
 end


### PR DESCRIPTION
* Refactor `get_error_message_from_fog` to convert the exception into a string rather than requiring
  the stringified exception to be passed in.
* Remove redundant copies of `get_error_message_from_fog` since it's in the ApplicationController now.

This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1339173