### PR TITLE
SampleFileUpdater to update configurations

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'pathname'
 require 'optparse'
+require_relative '../lib/task_helpers/sample_file_updater.rb'
 
 
 options = {:do_tests => true, :do_db => true}
@@ -29,12 +30,7 @@ Dir.chdir APP_ROOT do
   system "bower install --allow-root -F --config.analytics=false"
 
   puts "\n== Copying sample files =="
-  unless File.exist?("config/database.yml")
-    system "cp config/database.pg.yml config/database.yml"
-  end
-  unless File.exist?("certs/v2_key")
-    system "cp certs/v2_key.dev certs/v2_key"
-  end
+  TaskHelpers::SampleFileUpdater.run
 
   if options[:do_db]
     puts "\n== Preparing database =="

--- a/bin/update
+++ b/bin/update
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'pathname'
+require_relative '../lib/task_helpers/sample_file_updater.rb'
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
@@ -8,6 +9,9 @@ Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system "bundle update"
   system "bower update --allow-root -F --config.analytics=false"
+
+  puts "\n== Updating sample files (if needed) =="
+  TaskHelpers::SampleFileUpdater.run
 
   puts "\n== Migrating database =="
   system "bin/rake db:migrate db:seed"

--- a/lib/task_helpers/sample_file_updater.rb
+++ b/lib/task_helpers/sample_file_updater.rb
@@ -1,0 +1,85 @@
+require 'fileutils'
+require 'io/console'
+
+module TaskHelpers
+  class SampleFileUpdater
+    PROMPT_TO_OVERWRITE = {"config/database.pg.yml" => "config/database.yml"}
+    COPY_IF_NONEXISTENT = {"certs/v2_key.dev"       => "certs/v2_key"}
+
+    def self.run
+      new.run
+    end
+
+    def run
+      run_nonexistents
+      run_prompts unless ENV['MIQ_DISABLE_SAMPLES_PROMPT']
+      nil
+    end
+
+    private
+
+    def run_prompts
+      PROMPT_TO_OVERWRITE.each do |example_path, actual_path|
+        example = full_pathname_for(example_path)
+        actual  = full_pathname_for(actual_path)
+
+        if File.exist?(actual)
+          unless FileUtils.identical?(example, actual)
+            puts "Your local copy of '#{actual.basename}' differs from the example ('#{example.basename}')"
+            case prompt_overwrite
+            when :overwrite
+              cp(example, actual, overwrite: true)
+            when :skip
+              puts "Ok, skipping..."
+            when :skip_all
+              puts "Ok, skipping this and all remaining checks..."
+              break
+            end
+          end
+        else
+          cp(example, actual)
+        end
+      end
+    end
+
+    def prompt_overwrite
+      puts "Do you wish to overwrite your copy with the example? (Y)es, (n)o, (S)kip all "
+      prompt = STDIN.getch
+      puts prompt
+      case prompt
+      when 'Y'
+        :overwrite
+      when 'n'
+        :skip
+      when 'S'
+        :skip_all
+      else
+        puts "Invalid option, try again?"
+        prompt_overwrite
+      end
+    end
+
+    def run_nonexistents
+      COPY_IF_NONEXISTENT.each do |example_path, actual_path|
+        example = full_pathname_for(example_path)
+        actual  = full_pathname_for(actual_path)
+
+        cp(example, actual) unless File.exist?(actual)
+      end
+    end
+
+    def full_pathname_for(relative_path_from_root)
+      Pathname.new(__dir__).expand_path + "../../#{relative_path_from_root}"
+    end
+
+    def cp(source, destination, overwrite: false)
+      msg = if overwrite
+              "Overwriting #{source} with #{destination}..."
+            else
+              "Copying #{source} to #{destination}..."
+            end
+      puts msg
+      FileUtils.cp(source, destination)
+    end
+  end
+end

--- a/lib/task_helpers/sample_file_updater.rb
+++ b/lib/task_helpers/sample_file_updater.rb
@@ -3,8 +3,8 @@ require 'io/console'
 
 module TaskHelpers
   class SampleFileUpdater
-    PROMPT_TO_OVERWRITE = {"config/database.pg.yml" => "config/database.yml"}
-    COPY_IF_NONEXISTENT = {"certs/v2_key.dev"       => "certs/v2_key"}
+    PROMPT_TO_OVERWRITE = {"config/database.pg.yml" => "config/database.yml"}.freeze
+    COPY_IF_NONEXISTENT = {"certs/v2_key.dev"       => "certs/v2_key"}.freeze
 
     def self.run
       new.run
@@ -28,7 +28,7 @@ module TaskHelpers
             puts "Your local copy of '#{actual.basename}' differs from the example ('#{example.basename}')"
             case prompt_overwrite
             when :overwrite
-              cp(example, actual, overwrite: true)
+              cp(example, actual, :overwrite => true)
             when :skip
               puts "Ok, skipping..."
             when :skip_all

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -1,5 +1,6 @@
 $:.push("#{File.dirname(__FILE__)}")
 require 'evm_application'
+require 'task_helpers/sample_file_updater'
 
 namespace :evm do
   desc "Start the ManageIQ EVM Application"
@@ -53,5 +54,9 @@ namespace :evm do
       Rake::Task["environment"].invoke
       DescendantLoader.instance.class_inheritance_relationships
     end
+  end
+
+  task :update_sample_files do
+    TaskHelpers::SampleFileUpdater.run
   end
 end


### PR DESCRIPTION
This allows us to make breaking changes to configuration files (such as https://github.com/ManageIQ/manageiq/pull/8868), providing a helpful rake task to prompt developers to update their configurations if they differ from the checked-in sample. The helper class is also run on bin/setup and bin/update.

![](http://screenshots.chrisarcand.com/perm74ifx.jpg)

For people that maintain their own custom configurations and don't want to be pestered every time they run the bins, there is a convenient environment variable (`MIQ_DISABLE_SAMPLES_PROMPT`) that you can set to ignore the checks and deal with whatever horrid errors you get from changes we [hopefully infrequently] make on your own.

@miq-bot add_labels core, developer