### PR TITLE
Upgrade to ansible_tower_client v0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem "ruby-dbus"
 
 # Not vendored and not required
 gem "ancestry",                       "~>2.1.0",   :require => false
-gem "ansible_tower_client",           "~>0.2.0",   :require => false
+gem "ansible_tower_client",           "~>0.3.0",   :require => false
 gem "aws-sdk",                        "~>2.2.19",  :require => false
 gem "dalli",                          "~>2.7.4",   :require => false
 gem "elif",                           "=0.1.0",    :require => false

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -240,7 +240,7 @@ FactoryGirl.define do
           :parent  => :configuration_manager
 
   trait(:provider) do
-    after(:create) { |x| x.create_provider }
+    after(:build, &:create_provider)
   end
 
   trait(:configuration_script) do

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
@@ -1,20 +1,11 @@
 require 'ansible_tower_client'
 require 'faraday'
 describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript do
-  let(:faraday_connection) { instance_double("Faraday::Connection", :post => post, :get => get, :patch => '') }
-  let(:post) { instance_double("Faraday::Result", :body => {}.to_json) }
-  let(:get)  { instance_double("Faraday::Result", :body => {'id' => 1}.to_json) }
-
-  let(:connection) do
-    double(:connection,
-           :api => double(:api,
-                          :job_templates => double(:job_templates, :find => job_template)
-                         )
-          )
-  end
+  let(:api)          { double(:api, :job_templates => double(:job_templates)) }
+  let(:connection)   { double(:connection, :api => api) }
+  let(:job)          { AnsibleTowerClient::Job.new(connection.api, "id" => 1) }
+  let(:job_template) { AnsibleTowerClient::JobTemplate.new(connection.api, "limit" => "", "id" => 1, "url" => "api/job_templates/1/", "name" => "template", "description" => "description", "extra_vars" => {:instance_ids => ['i-3434']}) }
   let(:manager)      { FactoryGirl.create(:configuration_manager_ansible_tower, :provider, :configuration_script) }
-  let(:mock_api)     { AnsibleTowerClient::Api.new(faraday_connection) }
-  let(:job_template) { AnsibleTowerClient::JobTemplate.new(mock_api, "limit" => "", "id" => 1, "url" => "url", "name" => "template", "description" => "description", "extra_vars" => {:instance_ids => ['i-3434']}) }
 
   it "belongs_to the Ansible Tower manager" do
     expect(manager.configuration_scripts.size).to eq 1
@@ -23,18 +14,20 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationS
   end
 
   context "#run" do
-    before { allow_any_instance_of(Provider).to receive_messages(:connect => connection) }
+    before do
+      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
+      allow(api.job_templates).to receive(:find) { job_template }
+    end
 
     it "launches the referenced ansible job template" do
-      expect(manager.provider).to be_a Provider
+      expect(job_template).to receive(:launch).with(:extra_vars => "{\"instance_ids\":[\"i-3434\"]}").and_return(job)
       expect(manager.configuration_scripts.first.run).to be_a AnsibleTowerClient::Job
     end
 
     it "accepts different variables to launch a job template against" do
       added_extras = {:extra_vars => {:some_key => :some_value}}
+      expect(job_template).to receive(:launch).with(:extra_vars=>"{\"instance_ids\":[\"i-3434\"],\"some_key\":\"some_value\"}").and_return(job)
       expect(manager.configuration_scripts.first.run(added_extras)).to be_a AnsibleTowerClient::Job
-      expect_any_instance_of(AnsibleTowerClient::JobTemplate).to receive(:launch).with(:extra_vars=>"{\"instance_ids\":[\"i-3434\"],\"some_key\":\"some_value\"}")
-      manager.configuration_scripts.first.run(added_extras)
     end
   end
 

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
@@ -3,7 +3,7 @@ require 'faraday'
 describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript do
   let(:faraday_connection) { instance_double("Faraday::Connection", :post => post, :get => get, :patch => '') }
   let(:post) { instance_double("Faraday::Result", :body => {}.to_json) }
-  let(:get) { instance_double("Faraday::Result", :body => {'id' => 1}.to_json) }
+  let(:get)  { instance_double("Faraday::Result", :body => {'id' => 1}.to_json) }
 
   let(:connection) do
     double(:connection,

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
@@ -23,10 +23,7 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationS
   end
 
   context "#run" do
-    before do
-      allow_any_instance_of(Provider).to receive_messages(:connect => connection)
-      allow_any_instance_of(ManageIQ::Providers::ConfigurationManager).to receive_messages(:provider => manager.provider)
-    end
+    before { allow_any_instance_of(Provider).to receive_messages(:connect => connection) }
 
     it "launches the referenced ansible job template" do
       expect(manager.provider).to be_a Provider

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
@@ -39,7 +39,9 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationS
       expect_any_instance_of(AnsibleTowerClient::JobTemplate).to receive(:launch).with(:extra_vars=>"{\"instance_ids\":[\"i-3434\"],\"some_key\":\"some_value\"}")
       manager.configuration_scripts.first.run(added_extras)
     end
+  end
 
+  context "#merge_extra_vars" do
     it "merges internal and external hashes to send out to the tower gem" do
       config_script = manager.configuration_scripts.first
       external = {:some_key => :some_value}


### PR DESCRIPTION
Changes in v0.3.0:
- Expose Job#extra_vars_hash and Job#stdout
- Expose Inventory#update_all_inventory_sources
- Change collections to be lazy enumerators to reduce up front API calls.