### PR TITLE
Treat absent instances as terminated in GCP

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -5,6 +5,6 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
     with_provider_object(&:destroy)
-    self.update_attributes!(:raw_power_state => "DELETED")
+    update_attributes!(:raw_power_state => "TERMINATED")
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -5,6 +5,6 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
 
   def raw_reboot_guest
     with_provider_object(&:reboot)
-    self.update_attributes!(:raw_power_state => "reboot") # show state as suspended
+    # Other providers update the power state, but we don't have a "reboot" state
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
@@ -25,11 +25,15 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Power
 
   def raw_start
     with_provider_object(&:start)
-    self.update_attributes!(:raw_power_state => "starting")
+    # it's a better user experience if we update the state here, but should we
+    # be making a service call instead?
+    update_attributes!(:raw_power_state => "PROVISIONING")
   end
 
   def raw_stop
     with_provider_object(&:stop)
-    self.update_attributes!(:raw_power_state => "stopping")
+    # it's a better user experience if we update the state here, but should we
+    # be making a service call instead?
+    update_attributes!(:raw_power_state => "STOPPING")
   end
 end


### PR DESCRIPTION
After terminating an instance, it will no longer be listed in
EmsRefresh#refresh calls. Ensure that a missing instance in Google Cloud
Platform is treated as 'terminated' rather than 'unknown'.

https://bugzilla.redhat.com/show_bug.cgi?id=1335881