### PR TITLE
Extract class MiqExpression::Tag

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1,4 +1,5 @@
 class MiqExpression
+  require_nested :Tag
   include Vmdb::Logging
   attr_accessor :exp, :context_type, :preprocess_options
 
@@ -1242,7 +1243,7 @@ class MiqExpression
       field = [prefix, name].join("-")
       result.push([value2human(field, opts.merge(:classification => cat)), field])
     end
-    if opts[:include_my_tags] && opts[:userid] && Tag.exists?(["name like ?", "/user/#{opts[:userid]}/%"])
+    if opts[:include_my_tags] && opts[:userid] && ::Tag.exists?(["name like ?", "/user/#{opts[:userid]}/%"])
       prefix = path.nil? ? "user_tag" : [path, "user_tag"].join(".")
       field = [prefix, opts[:userid]].join("_")
       result.push([value2human(field, opts), field])
@@ -1478,7 +1479,7 @@ class MiqExpression
       return catobj ? catobj.entries.collect { |e| [e.description, e.name] } : []
     elsif ns == "user_tag" || ns == "user"
       cat = field.split("-").last
-      return Tag.where("name like ?", "/user/#{cat}%").select(:name).collect do |t|
+      return ::Tag.where("name like ?", "/user/#{cat}%").select(:name).collect do |t|
         tag_name = t.name.split("/").last
         [tag_name, tag_name]
       end
@@ -1769,13 +1770,8 @@ class MiqExpression
     when "contains"
       # Only support for tags of the main model
       if exp[operator].key?("tag")
-        klass, ns = exp[operator]["tag"].split(".")
-        ns  = "/" + ns.split("-").join("/")
-        ns = ns.sub(/(\/user_tag\/)/, "/user/") # replace with correct namespace for user tags
-        tag = exp[operator]["value"]
-        klass = klass.constantize
-        ids = klass.find_tagged_with(:any => tag, :ns => ns).pluck(:id)
-        klass.arel_attribute(:id).in(ids)
+        tag = Tag.parse(exp[operator]["tag"])
+        tag.contains(exp[operator]["value"])
       else
         field = Field.parse(exp[operator]["field"])
         field.contains(exp[operator]["value"])

--- a/app/models/miq_expression/tag.rb
+++ b/app/models/miq_expression/tag.rb
@@ -1,0 +1,20 @@
+class MiqExpression::Tag
+  def self.parse(tag)
+    klass, ns = tag.split(".")
+    ns = "/" + ns.split("-").join("/")
+    ns = ns.sub(/(\/user_tag\/)/, "/user/") # replace with correct namespace for user tags
+    new(klass.constantize, ns)
+  end
+
+  attr_reader :model, :namespace
+
+  def initialize(model, namespace)
+    @model = model
+    @namespace = namespace
+  end
+
+  def contains(value)
+    ids = model.find_tagged_with(:any => value, :ns => namespace).pluck(:id)
+    model.arel_attribute(:id).in(ids)
+  end
+end


### PR DESCRIPTION
This aims to:

* put the knowledge of parsing tags into one definitive place
* provide this class with a small interface in common with
  Field (currently just `#contains`)

The name conflicts with the top-level `Tag` which is unfortunate. Some
additional changes were required here to be explicit which one is being
referred to.

@miq-bot add-label core, refactoring
@miq-bot assign @gtanzillo