### PR TITLE
[WIP] Run each of the queue workers with a query cache

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -339,10 +339,12 @@ class MiqQueue < ApplicationRecord
         status = STATUS_OK
         message = "Message delivered successfully"
         Timeout.timeout(msg_timeout) do
-          if obj.kind_of?(Class) && !target_id.nil?
-            result = obj.send(method_name, target_id, *args)
-          else
-            result = obj.send(method_name, *args)
+          ActiveRecord::Base.connection.cache do
+            if obj.kind_of?(Class) && !target_id.nil?
+              result = obj.send(method_name, target_id, *args)
+            else
+              result = obj.send(method_name, *args)
+            end
           end
         end
       rescue MiqException::MiqQueueRetryLater => err


### PR DESCRIPTION
**PLEASE DO NOT MERGE**
Still trying to get mind around the implications of this.

For each `miq_queue` job, use query caching
This is how the rack middleware performs for all ui work.


For a refresh, I'm seeing:

|         ms |       ms- |  sql |     sqlms |  sqlrows |`comments`
|        ---:|       ---:|  ---:|       ---:|      ---:| ---
|  161,356.2 |           |53,004 |  11,742.5 |   31,869 |`refresh 1,000 no cache`
|  157,100.3 |           |49,208 |   9,635.7 |   24,545 |`refresh 1,000 cache`
|           2.5%|           |7.2%|      17.9%|   23%

/cc @akrzos This one is for you - this should have a very big performance impact right across the board.
/cc @Fryguy this is the code change I'm proposing
Curious about the memory implications here