### PR TITLE
Smartstate scan does not run from a datastore summary screen.

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1958,8 +1958,8 @@ module ApplicationController::CiProcessing
         process_storage(storages, method)
       end
 
-      if @lastaction == "show_list" || @lastaction == "explorer" # In storage controller, refresh show_list, else let the other controller handle it
-        show_list
+      if @lastaction == "show_list"
+        show_list unless @explorer
         @refresh_partial = "layouts/gtl"
       end
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2011,7 +2011,7 @@ module ApplicationController::CiProcessing
   def deletestorages
     assert_privileges("storage_delete")
     datastores = []
-    if @lastaction == "show_list" || @lastaction == "storage_list" || (@lastaction == "show" && @layout != "storage")  # showing a list, scan all selected hosts
+    if %w(show_list storage_list storage_pod_list).include?(@lastaction) || (@lastaction == "show" && @layout != "storage") # showing a list, scan all selected hosts
       datastores = find_checked_items
       if datastores.empty?
         add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "storage"), :task => display_name}, :error)

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1945,7 +1945,7 @@ module ApplicationController::CiProcessing
     storages = []
 
     # Either a list or coming from a different controller (eg from host screen, go to its storages)
-    if @lastaction == "show_list" || @lastaction == 'storage_list'|| @layout != "storage"
+    if %w(show_list storage_list storage_pod_list).include?(@lastaction) || @layout != "storage"
       storages = find_checked_items
 
       if method == 'scan' && !Storage.batch_operation_supported?('smartstate_analysis', storages)

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -341,6 +341,7 @@ class StorageController < ApplicationController
   end
 
   def tree_select
+    @lastaction = "explorer"
     self.x_active_tree = params[:tree] if params[:tree]
     self.x_node        = params[:id]
 

--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -3,6 +3,7 @@ module StorageController::StorageD
   extend ActiveSupport::Concern
 
   def storage_tree_select
+    @lastaction = "explorer"
     _typ, id = params[:id].split("_")
     @record = Storage.find(from_cid(id))
   end

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -3,6 +3,7 @@ module StorageController::StoragePod
   extend ActiveSupport::Concern
 
   def storage_pod_tree_select
+    @lastaction = "explorer"
     _typ, id = params[:id].split("_")
     @record = Storage.find(from_cid(id))
   end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -198,6 +198,24 @@ describe StorageController do
         flash_messages = assigns(:flash_array)
         expect(flash_messages.first[:message]).to_not include("Datastores no longer exists")
       end
+
+      it 'can Perform a remove datastore from the datastore cluster list' do
+        allow(controller).to receive(:x_active_tree).and_return(:storage_pod_tree)
+        allow(controller).to receive(:x_active_accord).and_return(:storage_pod_accord)
+        allow(controller).to receive(:x_node).and_return("xx-#{to_cid(storage_cluster.id)}")
+        storage
+        storage_cluster
+        session[:sb] = {:active_accord => :storage_pod_accord}
+        seed_session_trees('storage', :storage_pod_tree, 'root')
+        post :tree_select, :params => {:id => "xx-#{to_cid(storage_cluster.id)}", :format => :js}
+        expect(response.status).to eq(200)
+        post :x_button, :params => {:pressed         => 'storage_delete',
+                                    :miq_grid_checks => to_cid(storage.id),
+                                    :format          => :js}
+        expect(response.status).to eq(200)
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first[:message]).to_not include("Datastores no longer exists")
+      end
     end
 
     context "#tree_select" do

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -100,6 +100,7 @@ describe StorageController do
       before do
         session[:settings] = {:views => {}, :perpage => {:list => 5}}
         EvmSpecHelper.create_guid_miq_server_zone
+        @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
       end
 
       it 'can render the explorer' do
@@ -159,6 +160,12 @@ describe StorageController do
         expect(response.status).to eq(200)
         expect(response.body).to include('<h3>\n1 Datastore Being Tagged\n<\/h3>')
         expect(response.body).to include("Name: #{datastore.name} | Datastores Type: ")
+      end
+
+      it 'can Perform a datastore Smart State Analysis from the datastore summary page' do
+        allow(controller).to receive(:x_node).and_return("ds-#{@datastore.compressed_id}")
+        post :x_button, :params => { :pressed => 'storage_scan', :id => @datastore.id }
+        expect(response.status).to eq(200)
       end
     end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1339195

Fixes running the scan from the list of datastores in a cluster: 

https://bugzilla.redhat.com/show_bug.cgi?id=1329599

Also fixes the deleteion of a datastore from the list of datastores in a cluster.