### PR TITLE
pluggable providers: refactored ems_cloud_discovery

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1129,7 +1129,7 @@ module ApplicationController::CiProcessing
       if request.parameters[:controller] == 'ems_infra'
         @discover_type = ExtManagementSystem.ems_infra_discovery_types
       else
-        @discover_type = ExtManagementSystem.cloud_discovery_managers.map do |cloud_manager|
+        @discover_type = ManageIQ::Providers::CloudManager.subclasses.select(&:supports_discovery?).map do |cloud_manager|
           [cloud_manager.description, cloud_manager.ems_type]
         end
         @discover_type_selected = @discover_type.first.try!(:last)
@@ -1219,8 +1219,8 @@ module ApplicationController::CiProcessing
             end
             Host.discoverByIpRange(from_ip, to_ip, options)
           else
-            cloud_manager = ExtManagementSystem.cloud_discovery_managers.find do |ems|
-              ems.ems_type == params[:discover_type_selected]
+            cloud_manager = ManageIQ::Providers::CloudManager.subclasses.detect do |ems|
+              ems.supports_discovery? && ems.ems_type == params[:discover_type_selected]
             end
             if cloud_manager.ems_type == 'azure'
               cloud_manager.discover_queue(@client_id, @client_key, @azure_tenant_id)

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1129,8 +1129,8 @@ module ApplicationController::CiProcessing
       if request.parameters[:controller] == 'ems_infra'
         @discover_type = ExtManagementSystem.ems_infra_discovery_types
       else
-        @discover_type = ExtManagementSystem.ems_cloud_discovery_types.invert.collect do |type|
-          [discover_type(type[0]), type[1]]
+        @discover_type = ExtManagementSystem.cloud_discovery_managers.map do |cloud_manager|
+          [cloud_manager.description, cloud_manager.ems_type]
         end
         @discover_type_selected = @discover_type.first.try!(:last)
       end
@@ -1175,7 +1175,7 @@ module ApplicationController::CiProcessing
       drop_breadcrumb(:name => _("%{title} Discovery") % {:title => title}, :url => "/host/discover")
       @discover_type_selected = params[:discover_type_selected]
 
-      if request.parameters[:controller] == "ems_cloud" && params[:discover_type_selected] == ExtManagementSystem.ems_cloud_discovery_types['azure']
+      if request.parameters[:controller] == "ems_cloud" && params[:discover_type_selected] == 'azure'
         @client_id = params[:client_id] if params[:client_id]
         @client_key = params[:client_key] if params[:client_key]
         @azure_tenant_id = params[:azure_tenant_id] if params[:azure_tenant_id]
@@ -1219,10 +1219,13 @@ module ApplicationController::CiProcessing
             end
             Host.discoverByIpRange(from_ip, to_ip, options)
           else
-            if params[:discover_type_selected] == ExtManagementSystem.ems_cloud_discovery_types['azure']
-              ManageIQ::Providers::Azure::CloudManager.discover_queue(@client_id, @client_key, @azure_tenant_id)
+            cloud_manager = ExtManagementSystem.cloud_discovery_managers.find do |ems|
+              ems.ems_type == params[:discover_type_selected]
+            end
+            if cloud_manager.ems_type == 'azure'
+              cloud_manager.discover_queue(@client_id, @client_key, @azure_tenant_id)
             else
-              ManageIQ::Providers::Amazon::CloudManager.discover_queue(@userid, @password)
+              cloud_manager.discover_queue(@userid, @password)
             end
           end
         rescue => err
@@ -1297,7 +1300,7 @@ module ApplicationController::CiProcessing
         if params[:discover_type_selected] && params[:discover_type_selected] == 'azure'
           page << javascript_hide("discover_credentials")
           page << javascript_show("discover_azure_credentials")
-        elsif params[:discover_type_selected] && params[:discover_type_selected] == 'amazon'
+        elsif params[:discover_type_selected] && params[:discover_type_selected] == 'ec2'
           page << javascript_hide("discover_azure_credentials")
           page << javascript_show("discover_credentials")
         else

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -389,10 +389,6 @@ class ExtManagementSystem < ApplicationRecord
     @ems_infra_discovery_types ||= %w(virtualcenter scvmm rhevm)
   end
 
-  def self.cloud_discovery_managers
-    ManageIQ::Providers::CloudManager.subclasses.find_all(&:supports_discovery?)
-  end
-
   def disconnect_inv
     hosts.each { |h| h.disconnect_ems(self) }
     vms.each   { |v| v.disconnect_ems(self) }

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -389,12 +389,8 @@ class ExtManagementSystem < ApplicationRecord
     @ems_infra_discovery_types ||= %w(virtualcenter scvmm rhevm)
   end
 
-  def self.register_cloud_discovery_type(type_hash)
-    ems_cloud_discovery_types.merge!(type_hash)
-  end
-
-  def self.ems_cloud_discovery_types
-    @ems_cloud_discovery_types ||= {}
+  def self.cloud_discovery_managers
+    ManageIQ::Providers::CloudManager.subclasses.find_all(&:supports_discovery?)
   end
 
   def disconnect_inv

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -41,14 +41,14 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
   before_validation :ensure_managers
 
+  supports :discovery
+
   def ensure_managers
     build_network_manager unless network_manager
     network_manager.name            = "#{name} Network Manager"
     network_manager.zone_id         = zone_id
     network_manager.provider_region = provider_region
   end
-
-  ExtManagementSystem.register_cloud_discovery_type('azure' => 'azure')
 
   def self.ems_type
     @ems_type ||= "azure".freeze

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -40,6 +40,8 @@ module ManageIQ::Providers
 
     alias_method :all_cloud_networks, :cloud_networks
 
+    supports_not :discovery
+
     # Development helper method for Rails console for opening a browser to the EMS.
     #
     # This method is NOT meant to be called from production code.

--- a/app/views/ems_cloud/discover.html.haml
+++ b/app/views/ems_cloud/discover.html.haml
@@ -21,7 +21,7 @@
   #discover_azure_credentials{:style => display}
     = render :partial => "layouts/discover_azure_credentials",
           :locals  => {:label => _("Credentials")}
-  - display = (@discover_type_selected && @discover_type_selected == 'amazon') ? "" : "display:none;"
+  - display = (@discover_type_selected && @discover_type_selected == 'ec2') ? "" : "display:none;"
   #discover_credentials{:style => display}
     = render :partial => "layouts/discover_credentials",
           :locals  => {:label => _("Credentials")}

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -120,9 +120,14 @@ describe ApplicationController do
                                         :controller             => "ems_cloud"
                                       )
       allow(controller).to receive(:drop_breadcrumb)
+      cloud_manager_stub = double('CloudManager',
+                                  :supports_discovery? => true,
+                                  :ems_type            => 'example',
+                                  :description         => 'Example Manager')
+      allow(ManageIQ::Providers::CloudManager).to receive(:subclasses).and_return([cloud_manager_stub])
       controller.send(:discover)
       expect(response.status).to eq(200)
-      expect(controller.instance_variable_get(:@discover_type)).to include(["Azure", "azure"], ["Amazon", "amazon"])
+      expect(controller.instance_variable_get(:@discover_type)).to include(["Example Manager", "example"])
     end
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -79,17 +79,6 @@ describe ExtManagementSystem do
     expect(described_class.ems_infra_discovery_types).to match_array(expected_types)
   end
 
-  it ".cloud_discovery_managers" do
-    module ManageIQ::Providers::Example
-      class CloudManager < ManageIQ::Providers::CloudManager
-        def self.supports_discovery?
-          true
-        end
-      end
-    end
-    expect(described_class.cloud_discovery_managers).to include(ManageIQ::Providers::Example::CloudManager)
-  end
-
   context "#ipaddress / #ipaddress=" do
     it "will delegate to the default endpoint" do
       ems = FactoryGirl.build(:ems_vmware, :ipaddress => "1.2.3.4")

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -79,10 +79,15 @@ describe ExtManagementSystem do
     expect(described_class.ems_infra_discovery_types).to match_array(expected_types)
   end
 
-  it ".ems_cloud_discovery_types" do
-    discovery_type = {'amazon' => 'ec2'}
-    described_class.register_cloud_discovery_type(discovery_type)
-    expect(described_class.ems_cloud_discovery_types).to include(discovery_type)
+  it ".cloud_discovery_managers" do
+    module ManageIQ::Providers::Example
+      class CloudManager < ManageIQ::Providers::CloudManager
+        def self.supports_discovery?
+          true
+        end
+      end
+    end
+    expect(described_class.cloud_discovery_managers).to include(ManageIQ::Providers::Example::CloudManager)
   end
 
   context "#ipaddress / #ipaddress=" do


### PR DESCRIPTION
This removes the constants `Amazon::CloudManager` and `Azure::CloudManager` from the UI part.

It also introduces a possible use of the proposed [SupportsFeatureMixin](https://github.com/ManageIQ/manageiq/pull/8886) (but with explicit `supports_discovery?` definitions)
Now a provider does not actively register as a one that supports discovery, but it is being asked by the UI.

I might even remove `ExtManagementSystem.cloud_discovery_managers` and inline it 

@Fryguy or anybody else?

@miq-bot add_labels refactoring, ui, providers