### PR TITLE
Use .where() instead of .find() in a query

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -348,7 +348,7 @@ module ApplicationController::Tags
     @edit[:cat] ||= cats.min_by(&:description)
 
     unless @object_ids.blank?
-      @tagitems = @tagging.constantize.find(@object_ids).sort_by { |t| t.name.try(:downcase).to_s }
+      @tagitems = @tagging.constantize.where(:id => @object_ids).sort_by { |t| t.name.try(:downcase).to_s }
     end
 
     @view = get_db_view(@tagging)               # Instantiate the MIQ Report view object


### PR DESCRIPTION
As suggested in

https://github.com/ManageIQ/manageiq/pull/8932/files/ac929e015b9025accbecc30cad6d5cdc86fa9a6c#r64424012