### PR TITLE
Fix step measure types

### DIFF
--- a/db/fixtures/chargeback_rates_measures.yml
+++ b/db/fixtures/chargeback_rates_measures.yml
@@ -6,8 +6,8 @@
 - :name: Hz Units
   :units_display: ["Hz","KHz","MHz","GHz","THz"]
   :units: ["hertz","kilohertz","megahertz","gigahertz","teraherts"]
-  :step: '1024'
+  :step: '1000'
 - :name: Bytes per Second Units
   :units_display: ["Bps","KBps","MBps","GBps"]
   :units: ["bps","kbps","mbps","gbps"]
-  :step: '1024'
+  :step: '1000'


### PR DESCRIPTION
The step of the Hz Units and Bytes per Second Units is 1000 and not 1024. For instance:
 3 MHZ = 3 * 1000 HZ (step = 1000)