### PR TITLE
Add a new default format to cpu_used metrics

### DIFF
--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -301,7 +301,7 @@
     :megabytes: :megabytes_human
     :gigabytes: :gigabytes_human
     :kbps:      :kbps
-    :mhz:       :mhz
+    :mhz:       :mhz_precision_2
     :mhz_avg:   :mhz_avg
     :percent: :percent_precision_1
     :elapsed_time: :elapsed_time_human
@@ -421,11 +421,23 @@
     :description: Megahertz Avg (12.1 Mhz)
     :columns:
     :sub_types:
+      - :mhz
       - :mhz_avg
     :function:
       :name: mhz_to_human_size
       :delimiter: ","
     :precision: 1
+
+  :mhz_precision_2:
+    :description: Megahertz Avg (12.11 Mhz)
+    :columns:
+    :sub_types:
+      - :mhz
+      - :mhz_avg
+    :function:
+      :name: mhz_to_human_size
+      :delimiter: ","
+    :precision: 2
 
   :percent_precision_0:
     :description: Percentage (99%)


### PR DESCRIPTION
Fix the BZ [1337293](https://bugzilla.redhat.com/show_bug.cgi?id=1337293) with @amaurygonzalez 

The option by default to display the CPU Total column was Megahertz (12MHz) so its value was being rounded off. 
We have added the possibility to express this value with one or two decimal places. 
The new default option will be Megahertz Avg (12.11MHz)

![captura de pantalla de 2016-05-25 13-53-25](https://cloud.githubusercontent.com/assets/13876427/15539518/4e3e5414-2283-11e6-85fb-a241317610cd.png)

cc @gtanzillo @lpichler 

