### PR TITLE
Refactored the remote console cleanup strategy

### DIFF
--- a/spec/lib/websocket_server_spec.rb
+++ b/spec/lib/websocket_server_spec.rb
@@ -37,7 +37,7 @@ describe WebsocketServer do
   end
 
   describe '#cleanup' do
-    subject { @server.send(:cleanup, errors) }
+    subject { @server.send(:cleanup, error) }
 
     before(:each) do
       pairing.merge!(
@@ -47,27 +47,13 @@ describe WebsocketServer do
       sockets.push(left, right)
     end
 
-    context 'without errors' do
-      let(:errors) { [] }
+    let(:error) { right }
 
-      it 'removes a closed socket' do
-        left.close
-        expect(proxy).to receive(:cleanup)
-        subject
-        expect(sockets).to_not include(left)
-        expect(pairing.keys).to_not include(left)
-      end
-    end
-
-    context 'with errors' do
-      let(:errors) { [right] }
-
-      it 'removes the failed socket' do
-        expect(proxy).to receive(:cleanup)
-        subject
-        expect(sockets).to_not include(right)
-        expect(pairing.keys).to_not include(right)
-      end
+    it 'removes the failed socket' do
+      expect(proxy).to receive(:cleanup)
+      subject
+      expect(sockets).to_not include(right)
+      expect(pairing.keys).to_not include(right)
     end
   end
 end


### PR DESCRIPTION
This will ease the implementation of the remote console proxy logging.
https://github.com/ManageIQ/manageiq/pull/8777

This also allows to move the body of the thread loop into a method for easier testing.