### PR TITLE
Do not average the sum of pod and image created per one day

### DIFF
--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -137,6 +137,11 @@ module Metric::Rollup
     :cpu_usage_rate_average
   ]
 
+  DAILY_SUM_COLUMNS = [
+    :stat_container_group_create_rate,
+    :stat_container_group_delete_rate,
+    :stat_container_image_registration_rate
+  ].freeze
   BURST_COLS = [
     :cpu_usage_rate_average,
     :disk_usage_rate_average,

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -109,8 +109,13 @@ class VimPerformanceDaily < MetricRollup
       _int, rtype, rid = key
 
       if rollup_day
-        (Metric::Rollup::ROLLUP_COLS & (only_cols || Metric::Rollup::ROLLUP_COLS)).each do |c|
+        rollup_columns = (Metric::Rollup::ROLLUP_COLS & (only_cols || Metric::Rollup::ROLLUP_COLS))
+        average_columns = rollup_columns - Metric::Rollup::DAILY_SUM_COLUMNS
+
+        average_columns.each do |c|
           Metric::Aggregation::Process.average(c, nil, result[key], counts[key])
+        end
+        rollup_columns.each do |c|
           result[key][c] = result[key][c].round if columns_hash[c.to_s].type == :integer && !result[key][c].nil?
         end
       else


### PR DESCRIPTION
Do not average the sum of pod and image created per one day. 

Fix: https://github.com/ManageIQ/manageiq/issues/8842

_Description of issue:_
what happen:
when less then 24 pods are created per day we get an average of 0 pods created per hour per day.
what should happen:
when less then 24 pods are created per day we get the number of pods created per day.

what we are doing:
we average all columns hourly values per one day.
why this fix the problem:
we do not average the columns that we want to sum over the hourly values per one day.