### PR TITLE
Consistent parameters for ansible job

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -6,6 +6,7 @@
 
 class LaunchAnsibleJob
   ANSIBLE_VAR_REGEX = Regexp.new(/(.*)=(.*$)/)
+  ANSIBLE_DIALOG_VAR_REGEX = Regexp.new(/dialog_param_(?<var>.*)/)
   SCRIPT_CLASS = 'ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript'.freeze
   JOB_CLASS = 'ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job'.freeze
 
@@ -36,8 +37,13 @@ class LaunchAnsibleJob
   def object_vars(object, ext_vars)
     key_list = object.attributes.keys.select { |k| k.start_with?('param', 'dialog_param') }
     key_list.each_with_object(ext_vars) do |key, hash|
-      match_data = ANSIBLE_VAR_REGEX.match(object[key])
-      hash[match_data[1].strip] ||= match_data[2] if match_data
+      if key.start_with?('param')
+        match_data = ANSIBLE_VAR_REGEX.match(object[key])
+        hash[match_data[1].strip] ||= match_data[2] if match_data
+      else
+        match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
+        hash[match_data['var']] = object[key] if match_data
+      end
     end
   end
 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -6,7 +6,7 @@
 
 class LaunchAnsibleJob
   ANSIBLE_VAR_REGEX = Regexp.new(/(.*)=(.*$)/)
-  ANSIBLE_DIALOG_VAR_REGEX = Regexp.new(/dialog_param_(?<var>.*)/)
+  ANSIBLE_DIALOG_VAR_REGEX = Regexp.new(/dialog_param_(.*)/)
   SCRIPT_CLASS = 'ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript'.freeze
   JOB_CLASS = 'ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job'.freeze
 
@@ -42,7 +42,7 @@ class LaunchAnsibleJob
         hash[match_data[1].strip] ||= match_data[2] if match_data
       else
         match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
-        hash[match_data['var']] = object[key] if match_data
+        hash[match_data[1]] = object[key] if match_data
       end
     end
   end

--- a/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
+++ b/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
@@ -69,6 +69,20 @@ describe LaunchAnsibleJob do
     expect(service.get_state_var(:ansible_job_id)).to eq(job.id)
   end
 
+  it "extra vars from dialog params" do
+    root_object['vm'] = svc_vm
+    root_object[:job_template_name] = job_template.name
+    ext_vars['x'] = '1'
+    ext_vars['y'] = '2'
+    job_args[:limit] = vm.name
+    current_object = MiqAeMockObject.new('dialog_param_x' => '1', 'dialog_param_y' => '2')
+    current_object.parent = root_object
+    service.object = current_object
+    expect(job_class).to receive(:create_job).once.with(anything, job_args).and_return(svc_job)
+    LaunchAnsibleJob.new(service).main
+    expect(service.get_state_var(:ansible_job_id)).to eq(job.id)
+  end
+
   it "use limit from job template" do
     root_object[:job_template_name] = job_template.name
     ext_vars['x'] = '1'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1339374

Automate method honors the dialog_param_varname format when we
have to pass extra vars to ansible tower.

e.g.

dialog_param_pkg_name = openssl

will get converted to pkg_name = openssl
every dialog parameter that is prefixed with **dialog_param_** will be sent
to the Ansible Tower