### PR TITLE
Deprecate MiqQueue.put(:args => Object) vs Array

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -116,7 +116,6 @@ class MiqQueue < ApplicationRecord
     options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
     options[:role]         = options[:role].to_s unless options[:role].nil?
 
-    # Let's deprecate supplying non-array args soon
     options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
 
     msg = MiqQueue.create!(options)


### PR DESCRIPTION
removing the TODO to deprecate `MiqQueue.put(:args => Object)` vs `:args => [Object]`

/cc @Fryguy @jrafanie you probably have an opinion here.