### PR TITLE
Don't allow objects into MiqQueue.

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -116,6 +116,11 @@ class MiqQueue < ApplicationRecord
 
     options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
 
+    if !Rails.env.production? && options[:args] &&
+       (arg = options[:args].detect { |a| a.kind_of?(ActiveRecord::Base) && !a.new_record? })
+      raise ArgumentError, "MiqQueue.put(:class_name => #{options[:class_name]}, :method => #{options[:method_name]}) does not support args with #{arg.class.name} objects"
+    end
+
     msg = MiqQueue.create!(options)
     _log.info("#{MiqQueue.format_full_log_msg(msg)}")
     msg

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -460,6 +460,12 @@ describe MiqQueue do
       expect(MiqQueue.get).to have_attributes(:args => [3, 4], :task_id => 'fun_task')
       expect(MiqQueue.get).to eq(nil)
     end
+
+    it "does not allow objects on the queue" do
+      expect do
+        MiqQueue.put(:class_name => 'MyClass', :method_name => 'method1', :args => [MiqServer.first])
+      end.to raise_error(ArgumentError)
+    end
   end
 
   describe ".unqueue" do


### PR DESCRIPTION
For tests and development only, ensure no ar objects are inserted into the queue.

Currently, a Vm is being inserted into the Queue for refresh and it is very large. This puts some protective measure for developers to catch these errors early on in the development process

code to be fixed:

- [x] Spec only [ref](https://travis-ci.org/ManageIQ/manageiq/jobs/132967566#L1056) ==> #9116
- [x] MiqReport on [async.rb](https://github.com/ManageIq/manageiq/blob/master/app/models/miq_report/generator/async.rb#L74)