### PR TITLE
SSA: Add missing controller_unit information for RHEV VM at the end of scanning

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -63,8 +63,14 @@ class Hardware < ApplicationRecord
                    .select(:id, :device_type, :location, :address)
                    .collect { |rec| [rec.id, [rec.device_type, rec.location, rec.address]] }
 
-    deletes[:disk] = parent.hardware.disks.select(:id, :device_type, :location)
+    if (parent.vendor == "redhat")
+      deletes[:disk] = parent.hardware.disks.select(:id, :device_type, :location)
+                     .collect { |rec| [rec.id, [rec.device_type, "0:#{rec.location}"]] }
+    else
+      deletes[:disk] = parent.hardware.disks.select(:id, :device_type, :location)
                      .collect { |rec| [rec.id, [rec.device_type, rec.location]] }
+    end
+
 
     xmlNode.root.each_recursive do |e|
       begin

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -63,7 +63,7 @@ class Hardware < ApplicationRecord
                    .select(:id, :device_type, :location, :address)
                    .collect { |rec| [rec.id, [rec.device_type, rec.location, rec.address]] }
 
-    if (parent.vendor == "redhat")
+    if parent.vendor == "redhat"
       deletes[:disk] = parent.hardware.disks.select(:id, :device_type, :location)
                      .collect { |rec| [rec.id, [rec.device_type, "0:#{rec.location}"]] }
     else


### PR DESCRIPTION
After smart state analysis, in the vm detail page, two datastore summary tables become empty. The reason is RHEV doesn't have the concept of disk controller.  Hard code disk location as "0:#{disk_index}" to keep location in sync with other kind of providers.

https://github.com/ManageIQ/manageiq/issues/8617