### PR TITLE
Attributes as service model objects in class schema

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -30,10 +30,6 @@ module MiqAeEngine
     # Default conversion for Service Models
     SM_LOOKUP         = Hash.new { |_, k| k.classify }.merge(
       'ems'                    => 'ExtManagementSystem',
-      'vm'                     => 'Vm',
-      'user'                   => 'User',
-      'storage'                => 'Storage',
-      'host'                   => 'Host',
       'host_provision'         => 'MiqHostProvision',
       'host_provision_request' => 'MiqHostProvisionRequest',
       'policy'                 => 'MiqPolicy',

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -30,6 +30,10 @@ module MiqAeEngine
     # Default conversion for Service Models
     SM_LOOKUP         = Hash.new { |_, k| k.classify }.merge(
       'ems'                    => 'ExtManagementSystem',
+      'vm'                     => 'Vm',
+      'user'                   => 'User',
+      'storage'                => 'Storage',
+      'host'                   => 'Host',
       'host_provision'         => 'MiqHostProvision',
       'host_provision_request' => 'MiqHostProvisionRequest',
       'policy'                 => 'MiqPolicy',

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -19,7 +19,9 @@ class MiqAeField < ApplicationRecord
   validates_inclusion_of  :aetype,     :in => AVAILABLE_AETYPES,   :allow_nil => true  # nil => attribute
   AVAILABLE_DATATYPES_FOR_UI = ["string", "symbol", "integer", "float", "boolean", "time",
                                 "array", "password", NULL_COALESCING_DATATYPE].freeze
-  AVAILABLE_DATATYPES        = AVAILABLE_DATATYPES_FOR_UI + ["host", "vm", "storage", "ems", "policy", "server", "request", "provision"]
+  AVAILABLE_DATATYPES = AVAILABLE_DATATYPES_FOR_UI + ["host", "vm", "storage",
+                                                      "ems", "policy", "server",
+                                                      "request", "provision", "user"]
   validates_inclusion_of  :datatype,   :in => AVAILABLE_DATATYPES, :allow_nil => true  # nil => string
 
   before_save        :set_message_and_default_value
@@ -30,12 +32,12 @@ class MiqAeField < ApplicationRecord
     AVAILABLE_AETYPES
   end
 
-  def self.available_datatypes_for_ui
-    AVAILABLE_DATATYPES_FOR_UI
-  end
-
   def self.available_datatypes
     AVAILABLE_DATATYPES
+  end
+
+  class <<self
+    alias_method :available_datatypes_for_ui, :available_datatypes
   end
 
   def self.defaults

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -19,9 +19,16 @@ class MiqAeField < ApplicationRecord
   validates_inclusion_of  :aetype,     :in => AVAILABLE_AETYPES,   :allow_nil => true  # nil => attribute
   AVAILABLE_DATATYPES_FOR_UI = ["string", "symbol", "integer", "float", "boolean", "time",
                                 "array", "password", NULL_COALESCING_DATATYPE].freeze
-  AVAILABLE_DATATYPES = AVAILABLE_DATATYPES_FOR_UI + ["host", "vm", "storage",
-                                                      "ems", "policy", "server",
-                                                      "request", "provision", "user"]
+  AVAILABLE_DATATYPES        = AVAILABLE_DATATYPES_FOR_UI +
+                               %w(host
+                                  vm
+                                  storage
+                                  ems
+                                  policy
+                                  server
+                                  request
+                                  provision
+                                  user)
   validates_inclusion_of  :datatype,   :in => AVAILABLE_DATATYPES, :allow_nil => true  # nil => string
 
   before_save        :set_message_and_default_value
@@ -37,7 +44,7 @@ class MiqAeField < ApplicationRecord
   end
 
   class <<self
-    alias_method :available_datatypes_for_ui, :available_datatypes
+    alias available_datatypes_for_ui available_datatypes
   end
 
   def self.defaults


### PR DESCRIPTION
The following service model objects are accessible from class schema as data types

- host
- vm
- storage
- ems
- policy
- server
- request
- provision
- user

The value for the field is the ID of the object, which typically would be retrieved by doing a substitution.

![newdatatypes](https://cloud.githubusercontent.com/assets/6452699/15555909/f5b02f78-2298-11e6-8e81-dbde5f68eb4a.png)

