### PR TITLE
Use the evm_watchdog service for running updates

### DIFF
--- a/app/models/miq_server/update_management.rb
+++ b/app/models/miq_server/update_management.rb
@@ -4,6 +4,8 @@ LinuxAdmin.logger = $log
 module MiqServer::UpdateManagement
   extend ActiveSupport::Concern
 
+  UPDATE_FILE = Rails.root.join("tmp/miq_update").freeze
+
   module ClassMethods
     def queue_update_registration_status(*ids)
       where(:id => ids.flatten).each(&:queue_update_registration_status)
@@ -160,7 +162,7 @@ module MiqServer::UpdateManagement
     # MiqDatabase.cfme_package_name will update only the CFME package tree.  (Won't disturb the database)
     # "" will update everything
     packages_to_update = EvmDatabase.local? ? [MiqDatabase.cfme_package_name] : []
-    LinuxAdmin::Yum.update(*packages_to_update)
+    File.write(UPDATE_FILE, packages_to_update.join(","))
   end
 
   private

--- a/app/models/miq_server/update_management.rb
+++ b/app/models/miq_server/update_management.rb
@@ -162,7 +162,7 @@ module MiqServer::UpdateManagement
     # MiqDatabase.cfme_package_name will update only the CFME package tree.  (Won't disturb the database)
     # "" will update everything
     packages_to_update = EvmDatabase.local? ? [MiqDatabase.cfme_package_name] : []
-    File.write(UPDATE_FILE, packages_to_update.join(","))
+    File.write(UPDATE_FILE, packages_to_update.join(" "))
   end
 
   private

--- a/gems/pending/util/system/evm_watchdog.rb
+++ b/gems/pending/util/system/evm_watchdog.rb
@@ -1,7 +1,11 @@
 require 'time'
+require 'linux_admin'
+require 'fileutils'
 
 module EvmWatchdog
   PID_LOCATION = '/var/www/miq/vmdb/tmp/pids/evm.pid'.freeze
+  UPDATE_FILE  = '/var/www/miq/vmdb/tmp/miq_update'.freeze
+
   def self.check_evm
     pid_file = read_pid_file(PID_LOCATION)
     pid_ps = get_ps_pids('MIQ Server')
@@ -33,6 +37,13 @@ module EvmWatchdog
         log_info("Detected a PID file: [#{pid_file}], but server state should be: [#{db_state}]...")
       end
     end
+  end
+
+  def self.check_for_update
+    return unless File.exist?(UPDATE_FILE)
+    packages = File.read(UPDATE_FILE).split(",")
+    LinuxAdmin::Yum.update(*packages)
+    FileUtils.rm_f(UPDATE_FILE)
   end
 
   def self.read_pid_file(path_or_io)

--- a/gems/pending/util/system/evm_watchdog.rb
+++ b/gems/pending/util/system/evm_watchdog.rb
@@ -41,7 +41,7 @@ module EvmWatchdog
 
   def self.check_for_update
     return unless File.exist?(UPDATE_FILE)
-    packages = File.read(UPDATE_FILE).split(",")
+    packages = File.read(UPDATE_FILE).split
     LinuxAdmin::Yum.update(*packages)
     FileUtils.rm_f(UPDATE_FILE)
   end

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -186,9 +186,10 @@ describe MiqServer do
       expect(LinuxAdmin::Rpm).to receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release").and_return(true)
       expect(LinuxAdmin::Rpm).to receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta").and_return(true)
       expect(EvmDatabase).to receive(:local?).and_return(true)
-      expect(yum).to receive(:update).once.with("cfme-appliance")
 
       @server.apply_updates
+      expect(File.read(described_class::UPDATE_FILE)).to eq("cfme-appliance")
+      FileUtils.rm_f(described_class::UPDATE_FILE)
     end
 
     it "will apply all updates with remote database" do
@@ -197,9 +198,10 @@ describe MiqServer do
       expect(Dir).to receive(:glob).and_return(["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"])
       expect(LinuxAdmin::Rpm).to receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release").and_return(true)
       expect(EvmDatabase).to receive(:local?).and_return(false)
-      expect(yum).to receive(:update).once.with(no_args)
 
       @server.apply_updates
+      expect(File.read(described_class::UPDATE_FILE)).to eq("")
+      FileUtils.rm_f(described_class::UPDATE_FILE)
     end
 
     it "does not have updates to apply" do
@@ -208,6 +210,7 @@ describe MiqServer do
       allow(MiqDatabase).to receive_messages(:postgres_package_name => "postgresql-server")
 
       @server.apply_updates
+      expect(File.exist?(described_class::UPDATE_FILE)).to be false
     end
   end
 


### PR DESCRIPTION
This will eliminate the deadlock caused by a worker running `yum update` which tries to shut down the server which waits for the worker to exit.

This change will allow the server to exit cleanly and be restarted when the update is complete.

Goes with https://github.com/ManageIQ/manageiq-appliance/pull/73

@bdunne @jrafanie please review