### PR TITLE
Disable Volume 'new' form 'Add' button when form is invalid

### DIFF
--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -33,6 +33,7 @@
         = select_tag("cloud_tenant_id",
                       options_for_select(@cloud_tenant_choices.sort),
                       "ng-model"                    => "cloudVolumeModel.cloud_tenant_id",
+                      "required"                    => "",
                       :miqrequired                  => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
@@ -44,7 +45,8 @@
           - if @volume.id.nil?
             = button_tag("Add",
                          :class        => "btn btn-primary",
-                         "ng-class"    => "{'btn-disabled': !angularForm.$valid}",
+                         "ng-class"    => "{'btn-disabled': angularForm.$invalid}",
+                         "ng-disabled" => "angularForm.$invalid",
                          "ng-click"    => "addClicked()")
           - else
             = button_tag("Save",


### PR DESCRIPTION
Fixes a bug where the 'Add' button appeared to be disabled but was not actually disabled, allowing an invalid form submit. Also fixes a bug where the tenant select box was not required for form submission, allowing invalid form submits.

https://bugzilla.redhat.com/show_bug.cgi?id=1339079