### PR TITLE
Send information in hash format to MiqQueue.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_event.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_event.rb
@@ -81,6 +81,12 @@ module MiqAeEvent
       aevent.merge!("#{hash[:class].name}::#{hash[:name]}" => vmdb_object.id, "#{hash[:key]}_id".to_sym  => vmdb_object.id)
     end
 
+    inputs.delete_if do |_k, value|
+      next unless value.kind_of?(ApplicationRecord)
+      klass = value.class.base_class.name
+      aevent.merge!("#{klass}::#{klass.underscore}" => value.id, "#{klass.underscore}_id".to_sym => value.id)
+    end
+
     aevent.merge(inputs)
   end
 


### PR DESCRIPTION
Send information in hash formats to MiqQueue instead of object which may be huge.

cc @gmcculloug @Fryguy @kbrock 