### PR TITLE
Safely check for orchestration_template for stack

### DIFF
--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -67,7 +67,7 @@ module OrchestrationStackHelper::TextualSummary
   end
 
   def textual_orchestration_template
-    template = @record.orchestration_template
+    template = @record.try(:orchestration_template)
     return nil if template.nil?
     label = ui_lookup(:table => "orchestration_template")
     h = {:label => label, :image => "orchestration_template", :value => template.name}

--- a/app/views/layouts/listnav/_orchestration_stack.html.haml
+++ b/app/views/layouts/listnav/_orchestration_stack.html.haml
@@ -19,7 +19,7 @@
               ems_cloud_path(@record.ext_management_system.id),
               :title => _("Show parent %s for this %s") % l)
 
-        - if @record.orchestration_template
+        - if @record.try(:orchestration_template)
           %li.disabled
             = link_to("#{ui_lookup(:table => 'orchestration_template')}: #{@record.orchestration_template.name}", "#")
 


### PR DESCRIPTION
Safely check for orchestration_template for stack

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1337072