### PR TITLE
Fixes to DOM ids

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -378,9 +378,9 @@ function miqUpdateAllCheckboxes(button_div, override) {
       state = override;
     }
     if (typeof ManageIQ.grids.gtl_list_grid == 'undefined' &&
-        ($("input[id^='listcheckbox']").length)) {
+        ($("input.listcheckbox").length)) {
       // No list_grid on the screen
-      var cbs = $("input[id^='listcheckbox']")
+      var cbs = $("input.listcheckbox")
       cbs.prop('checked', state);
       miqUpdateButtons(cbs[0], button_div);
     } else if (typeof ManageIQ.grids.gtl_list_grid == 'undefined' &&

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -59,10 +59,10 @@ nobr { white-space: nowrap;}
 
 /************ Tabs ************/
 
-ul#searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px;}
-#searchtoolbar li { margin-right: 7px;padding: 0 4px 1px 4px; height:22px; width: 30px;float: left;display: inline;border: 1px solid #7e7e7e;}
-#searchtoolbar li:hover { background: #aeaeae;}
-#searchtoolbar li img.dimmed { background: none;}
+ul.searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px;}
+.searchtoolbar li { margin-right: 7px;padding: 0 4px 1px 4px; height:22px; width: 30px;float: left;display: inline;border: 1px solid #7e7e7e;}
+.searchtoolbar li:hover { background: #aeaeae;}
+.searchtoolbar li img.dimmed { background: none;}
 
 /* Automate Specific */
 .checkall { padding: 0 0 7px 7px;} /*styling for automate (Check All) */

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -96,8 +96,8 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 /*************************** Class for html buttons in explorer views *********************************/
 /************ Quad Icons ************/
 
-#quadicon { position:relative;float:left;padding: 0 1px 1px 0;width: 72px; height: 80px;color: #e3e4e4;text-transform: none;}
-#quadicon:hover{ padding: 1px 0 0 1px;}
+.quadicon { position:relative;float:left;padding: 0 1px 1px 0;width: 72px; height: 80px;color: #e3e4e4;text-transform: none;}
+.quadicon:hover{ padding: 1px 0 0 1px;}
 
 div.panecontent .flobj { margin-left: 40px;}
 

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -13,16 +13,17 @@ module QuadiconHelper
     options.reverse_merge! :size => 72
     options[:db] ||= db_from_item(item)
 
+    id = "quadicon_#{item.id}"
     if options[:typ] == :listnav
-      id = ""
       options[:height] ||= 80
       style = "margin-left: auto; margin-right: auto; width: 75px; height: #{options[:height]}px; z-index: 0;"
+      cls   = ""
     else
       style = ""
-      id = "quadicon"
+      cls   = "quadicon"
     end
 
-    content_tag(:div, :style => style, :id => id) do
+    content_tag(:div, :style => style, :id => id, :class => cls) do
       partial_name = partial_name_from_item(item)
       # List of removed partials with two lines
       norender = %w(cim_base_storage_extent cim_storage_extent ontap_file_share ontap_logical_disk ontap_storage_system ontap_storage_volume snia_local_file_system)

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -194,6 +194,7 @@ module ToolbarHelper
   def prepare_tag_keys(props)
     h = data_hash_keys(props)
     h.update('title'      => _(props[:title]),
+             'id'         => props[:id],
              'data-click' => props[:id])
     h['name'] = props[:name] if props.key?(:name)
     h['data-confirm-tb'] = _(props[:confirm]) if props.key?(:confirm)

--- a/app/views/configuration/_ui_4.html.haml
+++ b/app/views/configuration/_ui_4.html.haml
@@ -15,7 +15,7 @@
           - @timeprofiles.each do |row|
             %tr
               %td.narrow
-                = check_box_tag("check_#{row['id']}", "1", false, :id => "listcheckbox", :onclick => "miqUpdateButtons(this, 'center_tb');")
+                = check_box_tag("check_#{row['id']}", "1", false, :class => "listcheckbox", :onclick => "miqUpdateButtons(this, 'center_tb');")
               - title = row["description"] == "UTC" ? _("Click to view Time Profile") : _("Click to view/edit Time Profile")
               - [row["description"], row["profile_type"], row["profile_key"],
                   @timeprofile_details[row.description][:days].join(", "),

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -1,14 +1,15 @@
 -# Parameters:
 -# widget MiqWidget object
+- button_id = "btn_#{presenter.widget.id}"
 %div{:id => "w_#{presenter.widget.id}"}
   .card-pf
     .card-pf-heading
       %h2.card-pf-title.sortable-handle{:style => "cursor:move"}
         = h(presenter.widget.title)
         .dropdown.dropdown-kebab-pf.pull-right
-          %button.btn.btn-link.dropdown-toggle{:type => "button", :id => "dropdownKebab", "data-toggle" => "dropdown"}
+          %button.btn.btn-link.dropdown-toggle{:type => "button", :id => button_id, "data-toggle" => "dropdown"}
             %span.fa.fa-ellipsis-v
-          %ul.dropdown-menu{"aria-labelledby" => "dropdownKebab"}
+          %ul.dropdown-menu{"aria-labelledby" => button_id}
             - if role_allows(:feature => "dashboard_add")
               %li
                 = presenter.button_close

--- a/app/views/layouts/_adv_search.html.haml
+++ b/app/views/layouts/_adv_search.html.haml
@@ -3,7 +3,7 @@
 
   .modal.fade#advsearchModal{"tabindex"        => "-1",
                              "role"            => "dialog",
-                             "aria-labelledby" => "exampleModalLabel",
+                             "aria-labelledby" => "adv_search_label",
                              "aria-describedby" => "modal",
                              "aria-hidden"     => "true",
                              "data-keyboard"   => "false",
@@ -18,7 +18,7 @@
               &times;
             %span.sr-only
               Close
-          %h4.modal-title#exampleModalLabel
+          %h4.modal-title#adv_search_label
             = _("Advanced Search")
         .modal-body
           %div{:id => "searching_spinner_center", :style => "position: absolute;display: block;top: 50%;left: 50%;"}

--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -1,7 +1,7 @@
 - entry_point ||= "Instance"
 .modal.fade#automate_tree_div{"tabindex"        => "-1",
                               "role"            => "dialog",
-                              "aria-labelledby" => "exampleModalLabel",
+                              "aria-labelledby" => "ep_modal_label",
                               "aria-describedby" => "modal",
                               "aria-hidden"     => "true",
                               "data-keyboard"   => "false",
@@ -15,7 +15,7 @@
             &times;
           %span.sr-only
             Close
-        %h4.modal-title#exampleModalLabel
+        %h4.modal-title#ep_modal_label
           = hidden_field_tag(:ignore_form_changes)
           = _("Select Entry Point %s") % entry_point
 

--- a/app/views/layouts/_drift_history.html.haml
+++ b/app/views/layouts/_drift_history.html.haml
@@ -17,7 +17,7 @@
       - @timestamps.reverse.each_with_index do |ts, idx|
         %tr
           %td
-            = check_box_tag("check_#{(@timestamps.length - 1 - idx)}", 1, false, :id => "listcheckbox", :onclick => "miqUpdateButtons(this,'center_tb');")
+            = check_box_tag("check_#{(@timestamps.length - 1 - idx)}", 1, false, :class => "listcheckbox", :onclick => "miqUpdateButtons(this,'center_tb');")
           %td
             = h(format_timezone(ts, Time.zone, "view"))
             (#{h(time_ago_in_words(ts.in_time_zone(Time.zone)))} ago)

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -8,7 +8,7 @@
 
 #exp_editor_div
   %fieldset{:style => "width: auto; padding-left: 6px; padding-top: 6px"}
-    %ul#searchtoolbar
+    %ul.searchtoolbar
       - if @edit[@expkey][:exp_idx] > 0
         %li
           = link_to(image_tag(image_path('toolbars/undo.png'),

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,15 +1,4 @@
 = render :partial => "layouts/adv_search"
-:javascript
-  $('#exampleModal').on('show.bs.modal', function (event) {
-  var button = $(event.relatedTarget) // Button that triggered the modal
-  var recipient = button.data('whatever') // Extract info from data-* attributes
-  // If necessary, you could initiate an AJAX request here (and then do the updating in a callback).
-  // Update the modal's content. We'll use jQuery here, but you could use a data binding library or other methods instead.
-  var modal = $(this)
-  modal.find('.modal-title').text('New message to ' + recipient)
-  modal.find('.modal-body input').val(recipient)
-  })
-
 - if is_browser_ie?
   %script{:defer => "defer", :type => "text/javascript"}
     miqOnLoad();

--- a/app/views/layouts/_quick_search.html.haml
+++ b/app/views/layouts/_quick_search.html.haml
@@ -1,6 +1,6 @@
 .modal.fade#quicksearchbox{"tabindex"        => "-1",
                            "role"            => "dialog",
-                           "aria-labelledby" => "exampleModalLabel",
+                           "aria-labelledby" => "qs_label",
                            "aria-describedby" => "modal",
                            "aria-hidden"     => "true",
                            "data-keyboard"   => "false",

--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -9,7 +9,7 @@
               &times;
             %span.sr-only
               Close
-          %h4.modal-title#exampleModalLabel
+          %h4.modal-title#qs_label
             = @edit.fetch_path(@expkey, :selected, :description)
         .modal-body
           - if @qs_exp_table

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -21,7 +21,7 @@
       - exptypes -= [EXP_FIND_TYPE]
   #exp_atom_editor_div
     %fieldset{:style => "width:auto; padding-left: 6px; padding-top: 6px;"}
-      %ul#searchtoolbar
+      %ul.searchtoolbar
         %li
           - t = _('Commit expression element changes')
           = link_to(image_tag(image_path('toolbars/commit.png'), :alt => t),

--- a/app/views/layouts/gtl/_grid.html.haml
+++ b/app/views/layouts/gtl/_grid.html.haml
@@ -12,10 +12,9 @@
               %td{:valign => "bottom", :width => "8", :align => "left"}
                 - unless @embedded || @no_checkboxes
                   = check_box_tag("check_#{to_cid(@id)}", 1, false,
-                  :id      => "listcheckbox",
-                  :style   => "padding-bottom: 0px; margin-bottom: 0px",
-                  :class   => "list-grid-checkbox",
-                  :onclick => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
+                                  :style   => "padding-bottom: 0px; margin-bottom: 0px",
+                                  :class   => "listcheckbox list-grid-checkbox",
+                                  :onclick => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
               %td
                 = render_quadicon(item, :mode => :icon)
             %tr

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -83,9 +83,8 @@
           - unless @embedded || @no_checkboxes
             %td.narrow
               = check_box_tag("check_#{@id}", 1, false,
-                :id      => "listcheckbox",
-                :class   => "list-grid-checkbox",
-                :onclick => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
+                              :class   => "listcheckbox list-grid-checkbox",
+                              :onclick => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
           - title = ""
           - click = ""
           - unless (@embedded || @no_checkboxes) && ! @showlinks

--- a/app/views/layouts/gtl/_tile.html.haml
+++ b/app/views/layouts/gtl/_tile.html.haml
@@ -18,9 +18,8 @@
                   %td{:valign => "bottom", :width => "5", :style => "padding-top: #{@gtl_small_tiles ? 80 : 0}px;"}
                     - unless @embedded || @no_checkboxes
                       = check_box_tag("check_#{to_cid(@id)}", 1, false,
-                        :id      => "listcheckbox",
-                        :class   => "list-grid-checkbox",
-                        :onclick => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
+                                      :class   => "listcheckbox list-grid-checkbox",
+                                      :onclick => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
                   %td
                     = render_quadicon(item, :mode => :icon)
                 %tr

--- a/app/views/ops/rhn/_server_table.html.haml
+++ b/app/views/ops/rhn/_server_table.html.haml
@@ -60,7 +60,7 @@
           %td.narrow
             = check_box_tag("check_server_#{update.id}", 1,
                             update.checked,
-                            :id => 'listcheckbox',
+                            :class => 'listcheckbox',
                             :onclick => "miqUpdateButtons(this,'rhn_buttons');")
           %td= update.name
           %td= update.zone

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -9,8 +9,8 @@ describe QuadiconHelper do
     end
 
     it "renders quadicon for a vmware vm" do
-      expect(subject).to have_selector('div#quadicon')
-      expect(subject).to have_selector('div#quadicon div.flobj')
+      expect(subject).to have_selector('div.quadicon')
+      expect(subject).to have_selector('div.quadicon div.flobj')
     end
   end
 


### PR DESCRIPTION
* fix duplicated DOM ids in quadicons, checkboxes and other places
* add DOM ids to toolbar buttons and quadicons and dashboard widgets - ping @mfalesni, @psav , @jkrocil 
* replace/remove cut-n-paste ids
* remove some dead code referencing non-existent DOM ids

Ping @AparnaKarve, @h-kataria, @skateman, @dclarizio, @himdel, @mzazrivec  : please, review and help me look for these issues in code review

Ping @epwinchell : please, check my id ==> class fixes and related style.