### PR TITLE
Validate preview tab without filters in chargeback report

### DIFF
--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -312,12 +312,12 @@ module ReportController::Reports
   def valid_chargeback_fields
     is_valid = false
     # There are valid show typ fields
-    if %w(owner tenant tag).include?(@edit[:new][:cb_show_typ])
+    if %w(owner tenant tag entity).include?(@edit[:new][:cb_show_typ])
       is_valid = case @edit[:new][:cb_show_typ]
                  when "owner" then @edit[:new][:cb_owner_id]
                  when "tenant" then @edit[:new][:cb_tenant_id]
                  when "tag" then @edit[:new][:cb_tag_cat] && @edit[:new][:cb_tag_value]
-                 when "entity" then @edit[:new][:cb_entity_id]
+                 when "entity" then @edit[:new][:cb_entity_id] && @edit[:new][:cb_provider_id]
                  end
     end
     is_valid

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -391,7 +391,7 @@ module ReportController::Reports
       else
         if @edit[:new][:fields].length == 0
           add_flash(_("Preview tab is not available until at least 1 field has been selected"), :error)
-        elsif @edit[:new][:model] == "Chargeback" && !valid_chargeback_fields
+        elsif Chargeback.db_is_chargeback?(@edit[:new][:model]) && !valid_chargeback_fields
           add_flash(_("Preview tab is not available until Chargeback Filters has been configured"), :error)
           active_tab = "edit_3"
         end

--- a/spec/controllers/miq_report_controller/reports_spec.rb
+++ b/spec/controllers/miq_report_controller/reports_spec.rb
@@ -50,6 +50,18 @@ describe ReportController, "::Reports" do
         expect(assigns(:flash_array)).to be_nil
       end
     end
+
+    it "check existence of flash message when tab is changed to preview without selecting filters(chargeback report)" do
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@edit, :new => {:fields => [["Date Created"]], :model => "ChargebackVm"})
+      controller.instance_variable_set(:@_params, :tab => "new_7") # preview
+      controller.send(:check_tabs)
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages).not_to be_nil
+      flash_str = "Preview tab is not available until Chargeback Filters has been configured"
+      expect(flash_messages.first[:message]).to eq(flash_str)
+      expect(flash_messages.first[:level]).to eq(:error)
+    end
   end
 
   describe "#miq_report_delete" do


### PR DESCRIPTION
no bz or issue for this fix

https://github.com/ManageIQ/manageiq/pull/8818 this needs be merged first beucase there is Chargeback.subclasses is used 

Fixes:
- when entering preview tab and there is no filter selected in filter tab it should display validation message
- report based on container chargeback - when entering preview tab and there is no provider selected in filter tab it should display validation message

cc @gtanzillo 

