### PR TITLE
Fix report type when rendering instances under availability zone

### DIFF
--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -11,7 +11,9 @@ class VmController < ApplicationController
   end
 
   def show_list
-    process_show_list(:association => session[:vm_type])
+    options = {:association => session[:vm_type]}
+    options[:model] = "ManageIQ::Providers::CloudManager::Vm" if params['sb_controller'] == 'availability_zone'
+    process_show_list(options)
   end
 
   private ####


### PR DESCRIPTION
When navigating to Cloud -> Availability Zone -> Utilization -> Instances running / Instances stopped,
we were using general VM report, which we normally use to render both instances and vms
(all in one view).

It's better fit to render view we use when we render cloud instances.

https://bugzilla.redhat.com/show_bug.cgi?id=1334522

Before:
![az-after](https://cloud.githubusercontent.com/assets/6648365/15609885/bff2f39e-2422-11e6-94f0-137eb5aab929.jpg)

After:
![az-before](https://cloud.githubusercontent.com/assets/6648365/15609880/b955b2ba-2422-11e6-90a8-469d5044dfab.jpg)