### PR TITLE
Use display_range instead of start_date in group label in output of chargeback report

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -177,4 +177,8 @@ class Chargeback < ActsAsArModel
   def self.report_cb_model(model)
     model.gsub(/^Chargeback/, "")
   end
+
+  def self.db_is_chargeback?(db)
+    subclasses.collect(&:to_s).include?(db)
+  end
 end # class Chargeback

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -50,7 +50,8 @@ module MiqReport::Generator::Html
             end
           end
           save_val = d.data[sortby[0]].to_s
-          group_text = d.data["display_range"] if db == "Chargeback" && sortby[0] == "start_date" # Chargeback, sort by date, but show range
+          # Chargeback, sort by date, but show range
+          group_text = d.data["display_range"] if Chargeback.db_is_chargeback?(db) && sortby[0] == "start_date"
         end
 
         # Build click thru if string can be created

--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -77,7 +77,8 @@ module ReportFormatter
               output << group_rows(save_val, mri.col_order.length, group_text)
             end
             save_val = d.data[mri.sortby[0]].to_s
-            group_text = d.data["display_range"] if mri.db == "Chargeback" && mri.sortby[0] == "start_date" # Chargeback, sort by date, but show range
+            # Chargeback, sort by date, but show range
+            group_text = d.data["display_range"] if Chargeback.db_is_chargeback?(db) && mri.sortby[0] == "start_date"
           end
 
           if row == 0


### PR DESCRIPTION
this needs to be merged first https://github.com/ManageIQ/manageiq/pull/8818 because there is used `Chargeback.subclasses`

before 
![screen shot 2016-05-26 at 17 25 52](https://cloud.githubusercontent.com/assets/14937244/15579964/268779ac-2367-11e6-90f7-68d25d020073.png)

after
![screen shot 2016-05-26 at 17 25 01](https://cloud.githubusercontent.com/assets/14937244/15579959/21faa33c-2367-11e6-8af7-1d09a982d5b8.png)

In summary it is formatting group date.

