### PR TITLE
Fixed condition that sets value of ldap_role variable

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -732,11 +732,11 @@ module OpsController::Settings::Common
       if params[:authentication_mode] && params[:authentication_mode] != auth[:mode]
         if params[:authentication_mode] == "ldap"
           params[:authentication_ldapport] = "389"
-          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:get_direct_groups]
+          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:ldap_role]
           @authldapport_reset = true
         elsif params[:authentication_mode] == "ldaps"
           params[:authentication_ldapport] = "636"
-          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:get_direct_groups]
+          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:ldap_role]
           @authldapport_reset = true
         else
           @sb[:newrole] = auth[:ldap_role] = false    # setting it to false if database was selected to hide user_proxies box

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -75,7 +75,13 @@ module OpsController::Settings::Common
           if ["ldap", "ldaps"].include?(@edit[:new][:authentication][:mode])
             page << javascript_show("ldap_div")
             page << javascript_show("ldap_role_div")
-            page << javascript_show("user_proxies_div") if @edit[:new][:authentication][:ldap_role]
+            page << javascript_show("ldap_role_div")
+
+            page << set_element_visible("user_proxies_div",        @edit[:new][:authentication][:ldap_role])
+            page << set_element_visible("ldap_role_details_div",   @edit[:new][:authentication][:ldap_role])
+            page << set_element_visible("ldap_default_group_div", !@edit[:new][:authentication][:ldap_role])
+
+            page << (@edit[:new][:authentication][:ldap_role] ? javascript_checked('ldap_role') : javascript_unchecked('ldap_role'))
           else
             page << javascript_hide("ldap_div")
             page << javascript_hide("ldap_role_div")

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -284,12 +284,11 @@ describe OpsController do
       before do
         miq_server = FactoryGirl.create(:miq_server)
         current = VMDB::Config.new("vmdb")
-        current.config[:authentication] = {:ldap_role         => true,
-                                           :get_direct_groups => true,
-                                           :mode              => 'ldap'
+        current.config[:authentication] = {:ldap_role => true,
+                                           :mode      => 'ldap'
         }
         edit = {:current => current,
-                :new     => current.config,
+                :new     => copy_hash(current.config),
                 :key     => "settings_authentication_edit__#{miq_server.id}"
         }
         controller.instance_variable_set(:@edit, edit)


### PR DESCRIPTION
Fixed condition that sets value of ldap_role variable that is being used to show/hide certain fields on the form.

https://bugzilla.redhat.com/show_bug.cgi?id=1339732

@martinpovolny please review.

before
![before1](https://cloud.githubusercontent.com/assets/3450808/15581023/d2206d7a-2338-11e6-8a66-74625fe80cee.png)

![before2](https://cloud.githubusercontent.com/assets/3450808/15581027/d605883a-2338-11e6-8257-aac5ca8dcd4a.png)

then uncheck & check "Get User Groups from LDAP" checkbox again to see all fields
![before3](https://cloud.githubusercontent.com/assets/3450808/15581075/f55ae6d0-2338-11e6-9a98-adee52c9a8d8.png)

after
![after1](https://cloud.githubusercontent.com/assets/3450808/15581079/fb4dcb20-2338-11e6-8f41-299111f2c6e1.png)

![after2](https://cloud.githubusercontent.com/assets/3450808/15581086/ff74fd68-2338-11e6-9661-2d0d88b66535.png)
