### PR TITLE
PatternFly updated to 3.4.0 with tertiary-nav

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ gem "jquery-hotkeys-rails"
 gem "jquery-rails",                   "~>4.0.4"
 gem "jquery-rjs",                     "=0.1.1",                       :git => "git://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"
 gem "lodash-rails",                   "~>3.10.0"
-# gem "patternfly-sass",                "~>3.3.5"
-gem 'patternfly-sass', :github => 'manageiq/patternfly-sass', :branch => '3.3.5-tertiary'
+# gem "patternfly-sass",                "~>3.4.0"
+gem 'patternfly-sass', :github => 'manageiq/patternfly-sass', :branch => 'tertiary-nav'
 gem "sass-rails"
 gem "sprockets-es6",                  "~>0.9.0",  :require => "sprockets/es6"
 

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "angular": "^1.5.3",
     "angular-animate": "^1.5.3",
     "angular-mocks": "^1.5.3",
-    "angular-patternfly-sass": "3.3.5",
+    "angular-patternfly-sass": "3.4.0",
     "angular-sanitize": "^1.5.3",
     "bootstrap-filestyle": "^1.2.1",
     "bootstrap-hover-dropdown": "^2.0.11",


### PR DESCRIPTION
This version contains the new timing settings for tertiary navigation and it needs to be backported to darga!