### PR TITLE
Fix deprecation warning from OrchestrationStack, remove unnecessary flatten

### DIFF
--- a/app/models/orchestration_stack/retirement_management.rb
+++ b/app/models/orchestration_stack/retirement_management.rb
@@ -5,7 +5,7 @@ class OrchestrationStack
 
     module ClassMethods
       def retirement_check
-        ems_ids = MiqServer.my_server.zone.ext_management_systems(:select => :id).collect(&:id).flatten
+        ems_ids = MiqServer.my_server.zone.ext_management_systems.select(:id).collect(&:id)
         table   = OrchestrationStack.arel_table
         stacks  = OrchestrationStack.where(table[:retires_on].not_eq(nil)
           .or(table[:retired].eq(true))


### PR DESCRIPTION
This fixes a deprecation warning I've been seeing in the dev.log file:
```
WARN -- : DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call `reload` on the result collection proxy instead. (called from retirement_check at /Users/dberger/Repositories/manageiq-djberg96/app/models/orchestration_stack/retirement_management.rb:8)
```

I also removed the `.flatten` call since I can see no way that could be a nested array.