### PR TITLE
session[:start_url] - save the actual path, instead of controller & action & id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1049,7 +1049,7 @@ class ApplicationController < ActionController::Base
     timed_out = PrivilegeCheckerService.new.user_session_timed_out?(session, current_user) if timed_out.nil?
     reset_session
 
-    session[:start_url] = url_for(:controller => controller_name, :action => action_name, :id => params[:id])
+    session[:start_url] = request.url
 
     respond_to do |format|
       format.html do

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -20,6 +20,12 @@ describe "Login process" do
       expect(session[:start_url]).to eq('http://www.example.com/host/show/10')
     end
 
+    it "redirects to 'login' and sets start_url for main menu click" do
+      get '/dashboard/maintab/?tab=svc'
+      expect(response).to redirect_to(:controller => 'dashboard', :action => 'login', :timeout => false)
+      expect(session[:start_url]).to eq('http://www.example.com/dashboard/maintab?tab=svc')
+    end
+
     it "allows login with correct password" do
       post '/dashboard/authenticate', :params => { :user_name => user.userid, :user_password => 'smartvm' }
       expect(response.status).to eq(200)


### PR DESCRIPTION
Because sometimes you also need the actual params..

When clicking the main menu (1st level), if the session has already timed out, only `/dashboard/maintab` would be saved, instead of eg. `/dashbard/maintab?tab=svc`..

https://bugzilla.redhat.com/show_bug.cgi?id=1329009

@martinpovolny can you please verify this shouldn't break anything? Since we're no longer doing the whilelist...

Cc @bmclaughlin 