### PR TITLE
Replace conditional #to_arel with polymorphic expressions

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -566,8 +566,8 @@ class MiqExpression
 
   def to_sql(tz = nil)
     tz ||= "UTC"
-    @pexp, attrs = preprocess_for_sql(@exp.deep_clone)
-    sql = Component.build(@pexp, tz).to_sql(tz) if @pexp.present?
+    sqlable_expression_data, attrs = preprocess_for_sql(@exp.deep_clone)
+    sql = Component.build(sqlable_expression_data).to_sql(tz) if sqlable_expression_data.present?
     incl = includes_for_sql unless sql.blank?
     [sql, incl, attrs]
   end

--- a/lib/miq_expression/component.rb
+++ b/lib/miq_expression/component.rb
@@ -1,0 +1,38 @@
+module MiqExpression::Component
+  TYPES = {
+    "!"            => Not,
+    "!="           => NotEqual,
+    "<"            => LessThan,
+    "<="           => LessThanOrEqual,
+    "="            => Equal,
+    ">"            => GreaterThan,
+    ">="           => GreaterThanOrEqual,
+    "after"        => After,
+    "and"          => And,
+    "before"       => Before,
+    "contains"     => Contains,
+    "ends with"    => EndsWith,
+    "equal"        => Equal,
+    "from"         => From,
+    "includes"     => Like,
+    "is empty"     => IsEmpty,
+    "is not empty" => IsNotEmpty,
+    "is not null"  => IsNotNull,
+    "is null"      => IsNull,
+    "is"           => Is,
+    "like"         => Like,
+    "not like"     => NotLike,
+    "not"          => Not,
+    "or"           => Or,
+    "starts with"  => StartsWith
+  }.freeze
+
+  def self.for_operator(operator)
+    TYPES[operator.downcase] or raise _("operator '%{operator_name}' is not supported") % {:operator_name => operator}
+  end
+
+  def self.build(expression)
+    operator = expression.keys.first
+    for_operator(operator).build(expression[operator])
+  end
+end

--- a/lib/miq_expression/component/after.rb
+++ b/lib/miq_expression/component/after.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::After < MiqExpression::Component::Leaf
+  def to_arel(timezone)
+    target.gt(MiqExpression::RelativeDatetime.normalize(value, timezone, "end", target.date?))
+  end
+end

--- a/lib/miq_expression/component/and.rb
+++ b/lib/miq_expression/component/and.rb
@@ -1,0 +1,6 @@
+class MiqExpression::Component::And < MiqExpression::Component::Composite
+  def to_arel(timezone)
+    first, *rest = sub_expressions
+    rest.inject(first.to_arel(timezone)) { |arel, sub_expression| arel.and(sub_expression.to_arel(timezone)) }
+  end
+end

--- a/lib/miq_expression/component/base.rb
+++ b/lib/miq_expression/component/base.rb
@@ -1,0 +1,13 @@
+class MiqExpression::Component::Base
+  def self.build
+    raise "Called abtract method: .build"
+  end
+
+  def to_sql(timezone)
+    to_arel(timezone).to_sql
+  end
+
+  def to_arel(_timezone)
+    raise "Called abstract method: #to_arel"
+  end
+end

--- a/lib/miq_expression/component/before.rb
+++ b/lib/miq_expression/component/before.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::Before < MiqExpression::Component::Leaf
+  def to_arel(timezone)
+    target.lt(MiqExpression::RelativeDatetime.normalize(value, timezone, "beginning", target.date?))
+  end
+end

--- a/lib/miq_expression/component/composite.rb
+++ b/lib/miq_expression/component/composite.rb
@@ -1,0 +1,11 @@
+class MiqExpression::Component::Composite < MiqExpression::Component::Base
+  def self.build(sub_expressions)
+    new(sub_expressions.map { |e| MiqExpression::Component.build(e) })
+  end
+
+  attr_reader :sub_expressions
+
+  def initialize(sub_expressions)
+    @sub_expressions = sub_expressions
+  end
+end

--- a/lib/miq_expression/component/contains.rb
+++ b/lib/miq_expression/component/contains.rb
@@ -1,0 +1,14 @@
+class MiqExpression::Component::Contains < MiqExpression::Component::Leaf
+  def self.build(options)
+    target = if options["tag"]
+               MiqExpression::Tag.parse(options["tag"])
+             else
+               MiqExpression::Field.parse(options["field"])
+             end
+    new(target, options["value"])
+  end
+
+  def to_arel(_timezone)
+    target.contains(value)
+  end
+end

--- a/lib/miq_expression/component/ends_with.rb
+++ b/lib/miq_expression/component/ends_with.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::EndsWith < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.matches("%#{value}")
+  end
+end

--- a/lib/miq_expression/component/equal.rb
+++ b/lib/miq_expression/component/equal.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::Equal < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.eq(value)
+  end
+end

--- a/lib/miq_expression/component/from.rb
+++ b/lib/miq_expression/component/from.rb
@@ -1,0 +1,7 @@
+class MiqExpression::Component::From < MiqExpression::Component::Leaf
+  def to_arel(timezone)
+    start_value = MiqExpression::RelativeDatetime.normalize(value[0], timezone, "beginning", target.date?)
+    end_value   = MiqExpression::RelativeDatetime.normalize(value[1], timezone, "end", target.date?)
+    target.between(start_value..end_value)
+  end
+end

--- a/lib/miq_expression/component/greater_than.rb
+++ b/lib/miq_expression/component/greater_than.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::GreaterThan < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.gt(value)
+  end
+end

--- a/lib/miq_expression/component/greater_than_or_equal.rb
+++ b/lib/miq_expression/component/greater_than_or_equal.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::GreaterThanOrEqual < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.gteq(value)
+  end
+end

--- a/lib/miq_expression/component/is.rb
+++ b/lib/miq_expression/component/is.rb
@@ -1,0 +1,12 @@
+class MiqExpression::Component::Is < MiqExpression::Component::Leaf
+  def to_arel(timezone)
+    start_val = MiqExpression::RelativeDatetime.normalize(value, timezone, "beginning", target.date?)
+    end_val = MiqExpression::RelativeDatetime.normalize(value, timezone, "end", target.date?)
+
+    if !target.date? || MiqExpressionRelativeDatetime.relative?(value)
+      target.between(start_val..end_val)
+    else
+      target.eq(start_val)
+    end
+  end
+end

--- a/lib/miq_expression/component/is_empty.rb
+++ b/lib/miq_expression/component/is_empty.rb
@@ -1,0 +1,7 @@
+class MiqExpression::Component::IsEmpty < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    arel = target.eq(nil)
+    arel = arel.or(target.eq("")) if target.string?
+    arel
+  end
+end

--- a/lib/miq_expression/component/is_not_empty.rb
+++ b/lib/miq_expression/component/is_not_empty.rb
@@ -1,0 +1,7 @@
+class MiqExpression::Component::IsNotEmpty < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    arel = target.not_eq(nil)
+    arel = arel.and(target.not_eq("")) if target.string?
+    arel
+  end
+end

--- a/lib/miq_expression/component/is_not_null.rb
+++ b/lib/miq_expression/component/is_not_null.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::IsNotNull < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.not_eq(nil)
+  end
+end

--- a/lib/miq_expression/component/is_null.rb
+++ b/lib/miq_expression/component/is_null.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::IsNull < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.eq(nil)
+  end
+end

--- a/lib/miq_expression/component/leaf.rb
+++ b/lib/miq_expression/component/leaf.rb
@@ -1,0 +1,17 @@
+class MiqExpression::Component::Leaf < MiqExpression::Component::Base
+  def self.build(options)
+    value = if MiqExpression::Field.is_field?(options["value"])
+              MiqExpression::Field.parse(options["value"]).arel_attribute
+            else
+              options["value"]
+            end
+    new(MiqExpression::Field.parse(options["field"]), value)
+  end
+
+  attr_reader :target, :value
+
+  def initialize(target, value)
+    @target = target
+    @value = value
+  end
+end

--- a/lib/miq_expression/component/less_than.rb
+++ b/lib/miq_expression/component/less_than.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::LessThan < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.lt(value)
+  end
+end

--- a/lib/miq_expression/component/less_than_or_equal.rb
+++ b/lib/miq_expression/component/less_than_or_equal.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::LessThanOrEqual < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.lteq(value)
+  end
+end

--- a/lib/miq_expression/component/like.rb
+++ b/lib/miq_expression/component/like.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::Like < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.matches("%#{value}%")
+  end
+end

--- a/lib/miq_expression/component/not.rb
+++ b/lib/miq_expression/component/not.rb
@@ -1,0 +1,15 @@
+class MiqExpression::Component::Not < MiqExpression::Component::Base
+  def self.build(sub_expression)
+    new(MiqExpression::Component.build(sub_expression))
+  end
+
+  attr_reader :sub_expression
+
+  def initialize(sub_expression)
+    @sub_expression = sub_expression
+  end
+
+  def to_arel(timezone)
+    Arel::Nodes::Not.new(sub_expression.to_arel(timezone))
+  end
+end

--- a/lib/miq_expression/component/not_equal.rb
+++ b/lib/miq_expression/component/not_equal.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::NotEqual < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.not_eq(value)
+  end
+end

--- a/lib/miq_expression/component/not_like.rb
+++ b/lib/miq_expression/component/not_like.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::NotLike < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.does_not_match("%#{value}%")
+  end
+end

--- a/lib/miq_expression/component/or.rb
+++ b/lib/miq_expression/component/or.rb
@@ -1,0 +1,6 @@
+class MiqExpression::Component::Or < MiqExpression::Component::Composite
+  def to_arel(timezone)
+    first, *rest = sub_expressions
+    rest.inject(first.to_arel(timezone)) { |arel, sub_expression| arel.or(sub_expression.to_arel(timezone)) }
+  end
+end

--- a/lib/miq_expression/component/starts_with.rb
+++ b/lib/miq_expression/component/starts_with.rb
@@ -1,0 +1,5 @@
+class MiqExpression::Component::StartsWith < MiqExpression::Component::Leaf
+  def to_arel(_timezone)
+    target.matches("#{value}%")
+  end
+end


### PR DESCRIPTION
~~Blocked by https://github.com/ManageIQ/manageiq/pull/8946~~

Drawbacks:
- \> LOC. To be fair, most of which are class/module/method declarations
- \> Indirection

Benefits:

- Opens the possibility to refactor `to_ruby`, `to_human`, the complex
  `preprocess_for_sql` and `sql_supports_atom?`, pretty much anywhere
  there's a (giant) case statement on operator. Preprocessing could just
  go away
- I think this will help in optimizing MiqExpression in discrete chunks,
  with more confidence

@miq-bot assign @gtanzillo 
@miq-bot add-label core, refactoring
/cc @yrudman 
