### PR TITLE
[Darga] Display unique names in containers explorer

### DIFF
--- a/app/presenters/tree_builder_containers.rb
+++ b/app/presenters/tree_builder_containers.rb
@@ -4,6 +4,7 @@ class TreeBuilderContainers < TreeBuilder
   def tree_init_options(_)
     {
       :leaf     => "Container",
+      :open_all => true,
       :full_ids => true
     }
   end
@@ -16,8 +17,24 @@ class TreeBuilderContainers < TreeBuilder
     )
   end
 
-  # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, rbac_filtered_objects(Container.where(:deleted_on => nil)), "name")
+    objects = ContainerGroup.where(:deleted_on => nil).order(:name)
+    list = objects.compact.map do |c|
+      {
+        :id          => c.id,
+        :text        => c.name,
+        :tip         => c.ems_ref,
+        :image       => "folder",
+        :cfmeNoClick => true
+      }
+    end
+    count_only_or_objects(count_only, list, nil)
+  end
+
+  # level 2 - containers
+  def x_get_tree_custom_kids(object, count_only, _options)
+    container_group = ContainerGroup.find(object[:id])
+    objects = rbac_filtered_objects(container_group.containers.where(:deleted_on => nil)) if container_group
+    count_only_or_objects(count_only, objects, 'name')
   end
 end

--- a/spec/presenters/tree_builder_containers_spec.rb
+++ b/spec/presenters/tree_builder_containers_spec.rb
@@ -8,15 +8,20 @@ describe TreeBuilderContainers do
     MiqRegion.seed
     EvmSpecHelper.local_miq_server
 
-    @tagged_container = FactoryGirl.create(:container, :name => "Tagged Container", :tags => [tag])
-    @untagged_container = FactoryGirl.create(:container, :name => "Untagged Container")
-
+    @container_group = FactoryGirl.create(:container_group, :name => "Container group", :id => 42)
+    @tagged_container = FactoryGirl.create(:container,
+                                           :name            => "Tagged Container",
+                                           :tags            => [tag],
+                                           :container_group => @container_group)
+    @untagged_container = FactoryGirl.create(:container,
+                                             :name            => "Untagged Container",
+                                             :container_group => @container_group)
     login_as user
   end
 
   describe ".new" do
     def get_tree_results(tree)
-      JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+      tree.x_get_child_nodes("xx-42").map { |c| c[:title] }
     end
 
     it "returns all containers" do


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq/pull/8889

Display unique container names in containers explorer tree view.

Bugzilla reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1333520