### PR TITLE
Use fully qualified field name in report's yaml

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -371,7 +371,7 @@ module MiqReport::Generator
 
     data = build_includes(objs)
     result = data.collect do|entry|
-      build_reportable_data(entry, :only => only_cols, "include" => include)
+      build_reportable_data(entry, {:only => only_cols, "include" => include}, nil)
     end.flatten
 
     if rpt_options && rpt_options[:pivot]
@@ -604,11 +604,12 @@ module MiqReport::Generator
     end
   end
 
-  def build_cols_from_include(hash)
+  def build_cols_from_include(hash, parent_association = nil)
     return [] if hash.blank?
     hash.inject([]) do |a, (k, v)|
-      v["columns"].each { |c| a << "#{k}.#{c}" }              if v.key?("columns")
-      a += (build_cols_from_include(v["include"]) || []) if v.key?("include")
+      full_path = get_full_path(parent_association, k)
+      v["columns"].each { |c| a << get_full_path(full_path, c) } if v.key?("columns")
+      a += (build_cols_from_include(v["include"], full_path) || []) if v.key?("include")
       a
     end
   end
@@ -639,10 +640,10 @@ module MiqReport::Generator
     end
   end
 
-  def build_reportable_data(entry, options = {})
+  def build_reportable_data(entry, options, parent_association)
     rec = entry[:obj]
     data_records = [build_get_attributes_with_options(rec, options)]
-    data_records = build_add_includes(data_records, entry, options["include"]) if options["include"]
+    data_records = build_add_includes(data_records, entry, options["include"], parent_association) if options["include"]
     data_records
   end
 
@@ -666,18 +667,19 @@ module MiqReport::Generator
     attrs
   end
 
-  def build_add_includes(data_records, entry, includes)
+  def build_add_includes(data_records, entry, includes, parent_association)
     include_has_options = includes.kind_of?(Hash)
     associations = include_has_options ? includes.keys : Array(includes)
 
     associations.each do |association|
       existing_records = data_records.dup
       data_records = []
-
+      full_path = get_full_path(parent_association, association)
       if include_has_options
-        assoc_options = includes[association].merge(:qualify_attribute_names => association, :only =>  includes[association]["columns"])
+        assoc_options = includes[association].merge(:qualify_attribute_names => full_path, 
+                                                    :only                    => includes[association]["columns"])
       else
-        assoc_options = {:qualify_attribute_names => association, :only =>  includes[association]["columns"]}
+        assoc_options = {:qualify_attribute_names => full_path, :only => includes[association]["columns"]}
       end
 
       if association == "categories" || association == "managed"
@@ -694,7 +696,7 @@ module MiqReport::Generator
             next unless @descriptions_by_tag_id.key?(t.id)
             entarr << @descriptions_by_tag_id[t.id]
           end
-          assochash[association + "." + c] = entarr unless entarr.empty?
+          assochash[full_path + "." + c] = entarr unless entarr.empty?
         end
         # join the the category data together
         longest = 0
@@ -716,7 +718,7 @@ module MiqReport::Generator
         else
           association_objects.each do |obj|
             unless association == "categories" || association == "managed"
-              association_records = build_reportable_data(obj, assoc_options)
+              association_records = build_reportable_data(obj, assoc_options, full_path)
             else
               association_records = [obj]
             end
@@ -821,5 +823,15 @@ module MiqReport::Generator
 
   def get_time_zone(default_tz = nil)
     time_profile ? time_profile.tz || tz || default_tz : tz || default_tz
+  end
+
+  private
+
+  def get_full_path(parent, child)
+    if parent
+      "#{parent}.#{child}"
+    else
+      child.to_s
+    end
   end
 end

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -676,7 +676,7 @@ module MiqReport::Generator
       data_records = []
       full_path = get_full_path(parent_association, association)
       if include_has_options
-        assoc_options = includes[association].merge(:qualify_attribute_names => full_path, 
+        assoc_options = includes[association].merge(:qualify_attribute_names => full_path,
                                                     :only                    => includes[association]["columns"])
       else
         assoc_options = {:qualify_attribute_names => full_path, :only => includes[association]["columns"]}

--- a/product/reports/100_Configuration Management - Virtual Machines/005_VMs with Free Space _ 50% by Department.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/005_VMs with Free Space _ 50% by Department.yaml
@@ -28,13 +28,13 @@ col_order:
 - name
 - v_owning_cluster
 - storage.name
-- volumes.name
-- volumes.free_space_percent
-- volumes.free_space
-- volumes.size
-- volumes.used_space_percent
-- volumes.used_space
-- volumes.filesystem
+- hardware.volumes.name
+- hardware.volumes.free_space_percent
+- hardware.volumes.free_space
+- hardware.volumes.size
+- hardware.volumes.used_space_percent
+- hardware.volumes.used_space
+- hardware.volumes.filesystem
 timeline: 
 id: 103
 file_mtime: 
@@ -69,7 +69,7 @@ template_type: report
 group: c
 sortby: 
 - managed.department
-- volumes.free_space_percent
+- hardware.volumes.free_space_percent
 headers: 
 - Department Classification
 - Name

--- a/product/reports/100_Configuration Management - Virtual Machines/006_VMs w_Free Space _ 75% by Function.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/006_VMs w_Free Space _ 75% by Function.yaml
@@ -28,13 +28,13 @@ col_order:
 - name
 - v_owning_cluster
 - storage.name
-- volumes.name
-- volumes.free_space_percent
-- volumes.free_space
-- volumes.size
-- volumes.used_space_percent
-- volumes.used_space
-- volumes.filesystem
+- hardware.volumes.name
+- hardware.volumes.free_space_percent
+- hardware.volumes.free_space
+- hardware.volumes.size
+- hardware.volumes.used_space_percent
+- hardware.volumes.used_space
+- hardware.volumes.filesystem
 timeline: 
 id: 104
 file_mtime: 
@@ -69,7 +69,7 @@ template_type: report
 group: c
 sortby: 
 - managed.function
-- volumes.free_space_percent
+- hardware.volumes.free_space_percent
 headers: 
 - Function
 - Name

--- a/product/reports/100_Configuration Management - Virtual Machines/007_VMs w_Free Space _ 75% by LOB.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/007_VMs w_Free Space _ 75% by LOB.yaml
@@ -28,13 +28,13 @@ col_order:
 - name
 - v_owning_cluster
 - storage.name
-- volumes.name
-- volumes.free_space_percent
-- volumes.free_space
-- volumes.size
-- volumes.used_space_percent
-- volumes.used_space
-- volumes.filesystem
+- hardware.volumes.name
+- hardware.volumes.free_space_percent
+- hardware.volumes.free_space
+- hardware.volumes.size
+- hardware.volumes.used_space_percent
+- hardware.volumes.used_space
+- hardware.volumes.filesystem
 timeline: 
 id: 102
 file_mtime: 
@@ -69,7 +69,7 @@ template_type: report
 group: c
 sortby: 
 - managed.lob
-- volumes.free_space_percent
+- hardware.volumes.free_space_percent
 headers: 
 - Line of Business
 - Name

--- a/product/reports/100_Configuration Management - Virtual Machines/010_VMs_ Hardware.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/010_VMs_ Hardware.yaml
@@ -13,11 +13,11 @@ col_order:
 - name
 - hardware.memory_mb
 - hardware.cpu_total_cores
-- disks.controller_type
-- disks.device_type
-- disks.mode
-- disks.start_connected
-- disks.size
+- hardware.disks.controller_type
+- hardware.disks.device_type
+- hardware.disks.mode
+- hardware.disks.start_connected
+- hardware.disks.size
 timeline:
 id: 89
 file_mtime:

--- a/product/reports/100_Configuration Management - Virtual Machines/028_VMs with Volume Free Space -= 20%.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/028_VMs with Volume Free Space -= 20%.yaml
@@ -23,13 +23,13 @@ col_order:
 - name
 - v_owning_cluster
 - storage.name
-- volumes.name
-- volumes.free_space_percent
-- volumes.free_space
-- volumes.size
-- volumes.used_space_percent
-- volumes.used_space
-- volumes.filesystem
+- hardware.volumes.name
+- hardware.volumes.free_space_percent
+- hardware.volumes.free_space
+- hardware.volumes.size
+- hardware.volumes.used_space_percent
+- hardware.volumes.used_space
+- hardware.volumes.filesystem
 timeline: 
 id: 139
 file_mtime: 
@@ -59,7 +59,7 @@ template_type: report
 group: c
 sortby: 
 - v_owning_cluster
-- volumes.free_space_percent
+- hardware.volumes.free_space_percent
 headers: 
 - Name
 - Parent Cluster

--- a/product/reports/100_Configuration Management - Virtual Machines/029_VMs with Volume Free Space -= 80%.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/029_VMs with Volume Free Space -= 80%.yaml
@@ -23,13 +23,13 @@ col_order:
 - name
 - v_owning_cluster
 - storage.name
-- volumes.name
-- volumes.free_space_percent
-- volumes.free_space
-- volumes.size
-- volumes.used_space_percent
-- volumes.used_space
-- volumes.filesystem
+- hardware.volumes.name
+- hardware.volumes.free_space_percent
+- hardware.volumes.free_space
+- hardware.volumes.size
+- hardware.volumes.used_space_percent
+- hardware.volumes.used_space
+- hardware.volumes.filesystem
 timeline: 
 id: 141
 file_mtime: 
@@ -59,7 +59,7 @@ template_type: report
 group: c
 sortby: 
 - v_owning_cluster
-- volumes.free_space_percent
+- hardware.volumes.free_space_percent
 headers: 
 - Name
 - Parent Cluster

--- a/product/reports/100_Configuration Management - Virtual Machines/030_by MAC Address.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/030_by MAC Address.yaml
@@ -10,8 +10,8 @@ menu_name: "VMs by MAC Address"
 rpt_group: Custom
 priority: 10
 col_order: 
-- nics.address
-- nics.location
+- hardware.nics.address
+- hardware.nics.location
 - name
 - host.name
 - storage.name
@@ -42,7 +42,7 @@ cols:
 template_type: report
 group: 
 sortby: 
-- nics.address
+- hardware.nics.address
 - name
 headers: 
 - MAC Address

--- a/product/reports/110_Configuration Management - Hosts/040_Summary for VMs.yaml
+++ b/product/reports/110_Configuration Management - Hosts/040_Summary for VMs.yaml
@@ -14,7 +14,7 @@ col_order:
 - ipaddress
 - vms.name
 - vms.os_image_name
-- managed.power_state
+- vms.managed.power_state
 - vms.v_owning_datacenter
 - vms.v_owning_folder
 - vms.v_owning_resource_pool

--- a/product/reports/110_Configuration Management - Hosts/070_Storage Adapters.yaml
+++ b/product/reports/110_Configuration Management - Hosts/070_Storage Adapters.yaml
@@ -12,15 +12,15 @@ priority: 10
 col_order: 
 - name
 - ipaddress
-- storage_adapters.model
-- storage_adapters.controller_type
-- storage_adapters.device_name
-- storage_adapters.device_type
-- storage_adapters.location
-- storage_adapters.iscsi_alias
-- storage_adapters.iscsi_name
-- storage_adapters.present
-- storage_adapters.start_connected
+- hardware.storage_adapters.model
+- hardware.storage_adapters.controller_type
+- hardware.storage_adapters.device_name
+- hardware.storage_adapters.device_type
+- hardware.storage_adapters.location
+- hardware.storage_adapters.iscsi_alias
+- hardware.storage_adapters.iscsi_name
+- hardware.storage_adapters.present
+- hardware.storage_adapters.start_connected
 timeline: 
 id: 71
 file_mtime: 
@@ -49,7 +49,7 @@ template_type: report
 group: c
 sortby: 
 - name
-- storage_adapters.device_name
+- hardware.storage_adapters.device_name
 headers: 
 - Host Name
 - IP Address

--- a/product/reports/110_Configuration Management - Hosts/080_Network information.yaml
+++ b/product/reports/110_Configuration Management - Hosts/080_Network information.yaml
@@ -11,16 +11,16 @@ rpt_group: Custom
 priority: 
 col_order: 
 - name
-- networks.ipaddress
-- networks.subnet_mask
-- networks.dhcp_enabled
-- networks.dhcp_server
-- networks.dns_server
-- networks.default_gateway
-- networks.description
-- networks.domain
-- networks.lease_expires
-- networks.lease_obtained
+- hardware.networks.ipaddress
+- hardware.networks.subnet_mask
+- hardware.networks.dhcp_enabled
+- hardware.networks.dhcp_server
+- hardware.networks.dns_server
+- hardware.networks.default_gateway
+- hardware.networks.description
+- hardware.networks.domain
+- hardware.networks.lease_expires
+- hardware.networks.lease_obtained
 timeline: 
 id: 111
 file_mtime: 
@@ -49,7 +49,7 @@ template_type: report
 group: 
 sortby: 
 - name
-- networks.ipaddress
+- hardware.networks.ipaddress
 headers: 
 - Name
 - Network IP Address

--- a/product/reports/120_Configuration Management - Providers/030_VM Relationships.yaml
+++ b/product/reports/120_Configuration Management - Providers/030_VM Relationships.yaml
@@ -16,7 +16,7 @@ col_order:
 - ext_management_system.name
 - ext_management_system.ipaddress
 - name
-- networks.ipaddress
+- hardware.networks.ipaddress
 timeline: 
 id: 115
 file_mtime: 

--- a/product/reports/130_Configuration Management - Clusters/030_VM Affinity with Power State.yaml
+++ b/product/reports/130_Configuration Management - Clusters/030_VM Affinity with Power State.yaml
@@ -33,7 +33,7 @@ template_type: report
 group: c
 sortby: 
 - v_owning_cluster
-- power_state
+- vms.power_state
 headers: 
 - Cluster
 - Host Name

--- a/product/reports/170_Configuration Management - Containers/010_Nodes by Capacity.yaml
+++ b/product/reports/170_Configuration Management - Containers/010_Nodes by Capacity.yaml
@@ -15,8 +15,8 @@ include:
         - memory_mb
 col_order:
 - name
-- hardware.cpu_total_cores
-- hardware.memory_mb
+- computer_system.hardware.cpu_total_cores
+- computer_system.hardware.memory_mb
 headers:
 - Name
 - CPU Cores
@@ -24,8 +24,8 @@ headers:
 conditions:
 order: Descending
 sortby:
-- hardware.cpu_total_cores
-- hardware.memory_mb
+- computer_system.hardware.cpu_total_cores
+- computer_system.hardware.memory_mb
 group:
 graph:
 dims:

--- a/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
+++ b/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
@@ -14,14 +14,14 @@ include:
         - cpu_total_cores
 col_order:
 - name
-- hardware.cpu_total_cores
+- computer_system.hardware.cpu_total_cores
 headers:
 - Number of Nodes per CPU Cores
 - Hardware Number of CPU Cores
 conditions:
 order: Descending
 sortby:
-- hardware.cpu_total_cores
+- computer_system.hardware.cpu_total_cores
 group:
 graph:
   :type: ColumnThreed

--- a/product/reports/300_Migration Readiness - Virtual Machines/020_Detailed - VMs migration ready.yaml
+++ b/product/reports/300_Migration Readiness - Virtual Machines/020_Detailed - VMs migration ready.yaml
@@ -38,8 +38,8 @@ col_order:
 - host.name
 - storage.name
 - v_datastore_path
-- disks.start_connected
-- disks.device_type
+- hardware.disks.start_connected
+- hardware.disks.device_type
 timeline: 
 id: 145
 file_mtime: 

--- a/product/reports/300_Migration Readiness - Virtual Machines/021_Detailed - VMs NOT migration ready.yaml
+++ b/product/reports/300_Migration Readiness - Virtual Machines/021_Detailed - VMs NOT migration ready.yaml
@@ -36,8 +36,8 @@ col_order:
 - host.name
 - storage.name
 - v_datastore_path
-- disks.start_connected
-- disks.device_type
+- hardware.disks.start_connected
+- hardware.disks.device_type
 timeline: 
 id: 144
 file_mtime: 

--- a/product/reports/425_VM Sprawl - Candidates/052_VMs with Volume Free Space -= 75%.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/052_VMs with Volume Free Space -= 75%.yaml
@@ -29,13 +29,13 @@ col_order:
 - name
 - storage.name
 - v_owning_cluster
-- volumes.name
-- volumes.free_space_percent
-- volumes.used_space_percent
-- volumes.free_space
-- volumes.used_space
-- volumes.size
-- volumes.filesystem
+- hardware.volumes.name
+- hardware.volumes.free_space_percent
+- hardware.volumes.used_space_percent
+- hardware.volumes.free_space
+- hardware.volumes.used_space
+- hardware.volumes.size
+- hardware.volumes.filesystem
 timeline: 
 id: 180
 file_mtime: 
@@ -68,7 +68,7 @@ template_type: report
 group: c
 sortby: 
 - storage.name
-- volumes.free_space_percent
+- hardware.volumes.free_space_percent
 headers: 
 - VM
 - Datastore

--- a/product/reports/425_VM Sprawl - Candidates/054_VM Uptime - longest running.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/054_VM Uptime - longest running.yaml
@@ -26,10 +26,10 @@ col_order:
 - vm.boot_time
 - vm.last_scan_on
 - vm.power_state
-- managed.environment
-- managed.function
-- managed.lob
-- managed.location
+- vm.managed.environment
+- vm.managed.function
+- vm.managed.lob
+- vm.managed.location
 - timestamp
 timeline: 
 id: 186

--- a/product/reports/425_VM Sprawl - Candidates/059_Summary of VM Create and Deletes.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/059_Summary of VM Create and Deletes.yaml
@@ -29,8 +29,8 @@ col_order:
 - vm_name
 - vm.v_owning_cluster
 - host_name
-- managed.environment
-- managed.location
+- vm.managed.environment
+- vm.managed.location
 - timestamp
 - event_type
 - message

--- a/product/reports/500_Events - Operations/130_Reconfigure_Events_by_Department.yaml
+++ b/product/reports/500_Events - Operations/130_Reconfigure_Events_by_Department.yaml
@@ -12,7 +12,7 @@ menu_name: "Reconfigure Events by Department"
 rpt_group: Custom
 priority: 
 col_order: 
-- managed.department
+- vm.managed.department
 - vm_name
 - timestamp
 - username
@@ -38,7 +38,7 @@ cols:
 template_type: report
 group: c
 sortby: 
-- managed.department
+- vm.managed.department
 - vm_name
 headers: 
 - ManageIQ Tag Department

--- a/product/reports/650_Performance by Asset Type - Virtual Machines/150_All Departments with Performance.yaml
+++ b/product/reports/650_Performance by Asset Type - Virtual Machines/150_All Departments with Performance.yaml
@@ -110,7 +110,7 @@ rpt_group: Custom
 priority: 
 col_order: 
 - ems_cluster.name
-- managed.folder_path_yellow
+- vm.managed.folder_path_yellow
 - resource_name
 - vm.v_annotation
 - vm.cpu_total_cores
@@ -157,7 +157,7 @@ col_order:
 - vm.disk_6_size
 - vm.disk_6_size_on_disk
 - vm.disk_6_used_percent_of_provisioned
-- managed.department
+- vm.managed.department
 - host.name
 timeline: 
 file_mtime:
@@ -285,12 +285,12 @@ cols:
 template_type: report
 group: c
 sortby: 
-- managed.department
+- vm.managed.department
 - resource_name
 rpt_options: 
   :pivot: 
     :group_cols: 
-    - managed.department
+    - vm.managed.department
     - resource_name
 headers: 
 - Cluster

--- a/product/reports/700_Running Processes - Virtual Machines/110_Processes_for_prod_ VMs_sort_by_CPU_Time.yaml
+++ b/product/reports/700_Running Processes - Virtual Machines/110_Processes_for_prod_ VMs_sort_by_CPU_Time.yaml
@@ -17,16 +17,16 @@ rpt_group: Custom
 priority: 
 col_order: 
 - name
-- processes.cpu_time
-- processes.percent_cpu
-- processes.created_on
-- processes.updated_on
-- processes.memory_size
-- processes.memory_usage
-- processes.name
-- processes.percent_memory
-- processes.pid
-- processes.priority
+- operating_system.processes.cpu_time
+- operating_system.processes.percent_cpu
+- operating_system.processes.created_on
+- operating_system.processes.updated_on
+- operating_system.processes.memory_size
+- operating_system.processes.memory_usage
+- operating_system.processes.name
+- operating_system.processes.percent_memory
+- operating_system.processes.pid
+- operating_system.processes.priority
 timeline: 
 id: 100
 file_mtime: 
@@ -57,7 +57,7 @@ template_type: report
 group: c
 sortby: 
 - name
-- processes.cpu_time
+- operating_system.processes.cpu_time
 headers: 
 - Name
 - Process Cpu Time

--- a/product/reports/900_Provisioning - Activity Reports/110_Provisioning Activity - by Approver.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/110_Provisioning Activity - by Approver.yaml
@@ -18,16 +18,16 @@ menu_name: "Provisioning Activity - by Approver"
 rpt_group: Custom
 priority: 
 col_order: 
-- miq_request.v_approved_by
-- miq_request.v_approved_by_email
-- miq_request.fulfilled_on
+- miq_provision.miq_request.v_approved_by
+- miq_provision.miq_request.v_approved_by_email
+- miq_provision.miq_request.fulfilled_on
 - name
 - v_annotation
 - miq_provision_template.name
 - evm_owner.name
 - evm_owner.email
-- miq_request.requester_name
-- miq_request.created_on
+- miq_provision.miq_request.requester_name
+- miq_provision.miq_request.created_on
 - miq_provision.description
 - miq_provision.message
 - retires_on
@@ -130,7 +130,7 @@ cols:
 template_type: report
 group: c
 sortby: 
-- miq_request.v_approved_by
+- miq_provision.miq_request.v_approved_by
 - name
 rpt_options: {}
 

--- a/product/reports/900_Provisioning - Activity Reports/120_Provisioning Activity - by Datastore.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/120_Provisioning Activity - by Datastore.yaml
@@ -19,16 +19,16 @@ rpt_group: Custom
 priority: 
 col_order: 
 - storage.name
-- miq_request.requester_name
-- miq_request.created_on
+- miq_provision.miq_request.requester_name
+- miq_provision.miq_request.created_on
 - name
 - v_annotation
 - miq_provision_template.name
 - evm_owner.name
 - evm_owner.email
-- miq_request.v_approved_by
-- miq_request.v_approved_by_email
-- miq_request.fulfilled_on
+- miq_provision.miq_request.v_approved_by
+- miq_provision.miq_request.v_approved_by_email
+- miq_provision.miq_request.fulfilled_on
 - miq_provision.description
 - miq_provision.message
 - retires_on
@@ -131,7 +131,7 @@ template_type: report
 group: c
 sortby: 
 - storage.name
-- miq_request.requester_name
+- miq_provision.miq_request.requester_name
 rpt_options: {}
 
 headers: 

--- a/product/reports/900_Provisioning - Activity Reports/130_Provisioning Activity - by Requester.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/130_Provisioning Activity - by Requester.yaml
@@ -18,16 +18,16 @@ menu_name: "Provisioning Activity - by Requester"
 rpt_group: Custom
 priority: 
 col_order: 
-- miq_request.requester_name
-- miq_request.created_on
+- miq_provision.miq_request.requester_name
+- miq_provision.miq_request.created_on
 - name
 - v_annotation
 - miq_provision_template.name
 - evm_owner.name
 - evm_owner.email
-- miq_request.v_approved_by
-- miq_request.v_approved_by_email
-- miq_request.fulfilled_on
+- miq_provision.miq_request.v_approved_by
+- miq_provision.miq_request.v_approved_by_email
+- miq_provision.miq_request.fulfilled_on
 - miq_provision.description
 - miq_provision.message
 - retires_on
@@ -130,8 +130,8 @@ cols:
 template_type: report
 group: c
 sortby: 
-- miq_request.requester_name
-- miq_request.created_on
+- miq_provision.miq_request.requester_name
+- miq_provision.miq_request.created_on
 rpt_options: {}
 
 headers: 

--- a/product/reports/900_Provisioning - Activity Reports/140_Provisioning Activity - by VM.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/140_Provisioning Activity - by VM.yaml
@@ -23,11 +23,11 @@ col_order:
 - miq_provision_template.name
 - evm_owner.name
 - evm_owner.email
-- miq_request.requester_name
-- miq_request.created_on
-- miq_request.v_approved_by
-- miq_request.v_approved_by_email
-- miq_request.fulfilled_on
+- miq_provision.miq_request.requester_name
+- miq_provision.miq_request.created_on
+- miq_provision.miq_request.v_approved_by
+- miq_provision.miq_request.v_approved_by_email
+- miq_provision.miq_request.fulfilled_on
 - miq_provision.description
 - miq_provision.message
 - retires_on
@@ -130,7 +130,7 @@ cols:
 template_type: report
 group: 
 sortby: 
-- miq_request.fulfilled_on
+- miq_provision.miq_request.fulfilled_on
 rpt_options: {}
 
 headers: 

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -59,8 +59,6 @@ describe 'YAML reports' do
   end
 
   it "defines fields for reporting by fully qualified name" do
-    #report_yamls = ["/Users/yrudman/work/rh/manageiq/product/reports/650_Performance by Asset Type - Virtual Machines/150_All Departments with Performance.yaml"]
-
     report_yamls.each do |yaml|
       report_yaml = YAML.load(File.open(yaml))
       report_yaml.delete('menu_name')
@@ -68,11 +66,7 @@ describe 'YAML reports' do
       report.generate_table(:userid => @user.userid)
       cols_from_data = report.table.column_names.to_set
       cols_from_yaml = report_yaml['col_order'].to_set
-      
       expect(cols_from_yaml).to be_subset(cols_from_data)
-      
-      sortby_cols = report_yaml['sortby'].to_set
-      expect(sortby_cols).to be_subset(cols_from_data)
     end
   end
 end

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -48,11 +48,11 @@ describe 'YAML reports' do
   def collect_columns(include_hash, parent = nil)
     return [] if include_hash.nil?
     include_hash.inject([]) do |cols, (table_name, data)|
-      if parent
-        full_path = "#{parent}.#{table_name}"
-      else
-        full_path = "#{table_name}"
-      end
+      full_path = if parent
+                    "#{parent}.#{table_name}"
+                  else
+                    table_name.to_s
+                  end
       cols += data["columns"].collect { |col_name| "#{full_path}.#{col_name}" } if data['columns']
       cols + collect_columns(data['include'], full_path)
     end


### PR DESCRIPTION
Reports on nested associations do not bring data after copy to Custom folder:  #8835

Issues: 
1. New custom reports (created from UI) define columns for reporting (in report's yaml) by fully qualified name.  Data collected for report using only last association to create field=>data mapping. 
Any column in custom report which use nested association will be empty.
2. Copy of  standard reports generating fully qualified field name (it is not yaml copy) and reports looking fine as standard would seems broken after copy.

Changes:
1. Modified yaml for standard reports with nested associations to use fully qualified filed name.
2. Change processing in generator.rb to use fully qualified name.
3. Added test to compare field names in yaml and generated.

fixed report (from #8835) after been copied:
![screen shot 2016-05-26 at 5 35 09 pm](https://cloud.githubusercontent.com/assets/6556758/15590935/461fc200-2368-11e6-8f7e-f21d19f30295.png)


