### PR TITLE
Fix redirect path after Cancel is clicked in VM Migrate

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -581,10 +581,7 @@ module ApplicationController::MiqRequestMethods
         if @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
           page.redirect_to :action => "show_list", :controller => "vm"
         else
-          # had to get id from breadcrumbs url,
-          # because there is no params[:id] when cancel is pressed on copy Request screen.
-          url = @breadcrumbs.last[:url].split('/')
-          page.redirect_to :controller => url[1], :action => url[2], :id => url[3]
+          page.redirect_to @breadcrumbs.last[:url]
         end
       end
     end

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -32,4 +32,21 @@ describe MiqRequestController do
       expect(partial).to eq('prov_configured_system_foreman_dialog')
     end
   end
+
+  describe '#prov_edit' do
+    it 'redirects to the last link in breadcrumbs' do
+      allow_any_instance_of(described_class).to receive(:set_user_time_zone)
+      session[:edit] = {}
+      controller.instance_variable_set(:@breadcrumbs, [{:url => "/ems_infra/show_list?page=1&refresh=y"},
+                                                       {:url => "/ems_infra/1000000000001?display=vms"},
+                                                       {}])
+      controller.instance_variable_set(:@_params, :id => "new", :button => "cancel")
+      allow(controller).to receive(:role_allows).and_return(true)
+      page = double('page')
+      allow(page).to receive(:<<).with(any_args)
+      expect(page).to receive(:redirect_to).with("/ems_infra/1000000000001?display=vms")
+      expect(controller).to receive(:render).with(:update).and_yield(page)
+      controller.send(:prov_edit)
+    end
+  end
 end


### PR DESCRIPTION
Use the URL available in breadcrumbs for redirect instead of constructing a new URL.

https://bugzilla.redhat.com/show_bug.cgi?id=1339924