### PR TITLE
Vim performance group by tag

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -214,11 +214,10 @@ module MiqReport::Generator
         results, self.extras[:interval]  = db_class.vms_by_category(performance)
         build_table(results, db, options)
       else
-        results, self.extras[:group_by_tag_cols], self.extras[:group_by_tags] = db_class.find_and_group_by_tags(
-          :where_clause => where_clause,
+        results, self.extras[:group_by_tag_cols], self.extras[:group_by_tags] = db_class.group_by_tags(
+          db_class.find_entries(ext_options).where(where_clause),
           :category     => performance[:group_by_category],
           :cat_model    => options[:cat_model],
-          :ext_options  => ext_options,
           :include      => includes
         )
         build_correlate_tag_cols

--- a/app/models/vim_performance_tag.rb
+++ b/app/models/vim_performance_tag.rb
@@ -4,11 +4,11 @@ class VimPerformanceTag < MetricRollup
   end
 
   def self.find_and_group_by_tags(options)
-    raise _("no category provided") if options[:category].blank?
     group_by_tags(where(options[:where_clause]), options)
   end
 
   def self.group_by_tags(recs, options)
+    raise _("no category provided") if options[:category].blank?
     raise _("option :cat_model must have a value") unless options[:cat_model]
     cat_assoc = Object.const_get(options[:cat_model].to_s).table_name.to_sym
     tp = options.fetch_path(:ext_options, :time_profile)

--- a/app/models/vim_performance_tag.rb
+++ b/app/models/vim_performance_tag.rb
@@ -3,8 +3,13 @@ class VimPerformanceTag < MetricRollup
     true
   end
 
+  def self.find_entries(_ext_options = {})
+    # noop - just return default scope (will be chained from here)
+    self
+  end
+
   def self.find_and_group_by_tags(options)
-    group_by_tags(where(options[:where_clause]), options)
+    group_by_tags(find_entries(options[:ext_options]).where(options[:where_clause]), options)
   end
 
   def self.group_by_tags(recs, options)

--- a/app/models/vim_performance_tag_daily.rb
+++ b/app/models/vim_performance_tag_daily.rb
@@ -3,11 +3,11 @@ class VimPerformanceTagDaily < VimPerformanceTag
     true
   end
 
-  def self.find_and_group_by_tags(options)
-    ext_options = options[:ext_options] || {}
-    entries = Metric::Helper.find_for_interval_name("daily", ext_options[:time_profile] || ext_options[:tz],
-                                                    ext_options[:class])
-                            .where(options[:where_clause])
-    group_by_tags(entries, options)
+  # @options ext_options :time_profile
+  # @options ext_options :tz
+  # @options ext_options :class
+  def self.find_entries(ext_options)
+    ext_options ||= {}
+    Metric::Helper.find_for_interval_name("daily", ext_options[:time_profile] || ext_options[:tz], ext_options[:class])
   end
 end

--- a/app/models/vim_performance_tag_daily.rb
+++ b/app/models/vim_performance_tag_daily.rb
@@ -4,7 +4,6 @@ class VimPerformanceTagDaily < VimPerformanceTag
   end
 
   def self.find_and_group_by_tags(options)
-    raise _("no catagory provided") if options[:category].blank?
     ext_options = options[:ext_options] || {}
     entries = Metric::Helper.find_for_interval_name("daily", ext_options[:time_profile] || ext_options[:tz],
                                                     ext_options[:class])


### PR DESCRIPTION
1. `MiqExpression.merge_where_clause` is munging sql when active record will do this for us. This PR chips away at that method. (part of the "remove sql munging" theme)
2. To remove the munging, the primary data query is extracted from `group_by_tags`. This will help us move the `GROUP BY` from ruby into sql. (part of the "Rbac scopes" theme)


**after:**

location|count|target for the results
---         |---     |----
`VmCommon#get_node_info`|3|`get_view(:where_clause)`
`Rbac#find_targets_with_rbac`|4|`ActsAsActiveRecord#all(:conditions)`
`MiqReport::Generator#_generate_table`|1|`Rbac.search`

