### PR TITLE
Rbac: skip current_user.group lookup for default

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -305,7 +305,8 @@ module Rbac
   def self.get_user_info(user, userid, miq_group, miq_group_id)
     user      ||= User.find_by_userid(userid) || User.current_user
     miq_group ||= MiqGroup.find_by_id(miq_group_id)
-    if user && miq_group
+    miq_group_id ||= miq_group.try!(:id)
+    if user && miq_group && user.current_group_id != miq_group_id
       user.current_group = miq_group if user.miq_groups.include?(miq_group)
     end
     miq_group ||= user.try(:current_group)


### PR DESCRIPTION
|     ms |  sql | sqlms |  sqlrows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  511.7 |   32 |  10.7 |       25 |`/vm_infra/prov_field_changed/new`
|  445.6 |   25 |   7.4 |       25 |`/vm_infra/prov_field_changed/new`
| 12% | 22% | 30% | - | -

Reduces 1 query per rbac call for 95% use case

In this example, removed 7 queries. Think in general, improvement
should be less

https://bugzilla.redhat.com/show_bug.cgi?id=1337967