### PR TITLE
Add units to C&U charts

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -47,7 +47,7 @@ module MiqReport::Formatting
     function_name = format[:function][:name]
 
     options = format.merge(format[:function]).slice(
-      %i(delimiter separator precision length tz column format prefix suffix description unit))
+      *%i(delimiter separator precision length tz column format prefix suffix description unit))
 
     [function_name, options]
   end

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -74,6 +74,15 @@ module ReportFormatter
       if chart_is_stacked?
         mri.chart[:data][:groups] = [[]]
       end
+
+      # C&U chart
+      if graph_options[:chart_type] == :performance
+        format, options = javascript_format(mri.graph[:columns][0], nil)
+        return unless format
+
+        axis_formatter = {:function => format, :options => options}
+        mri.chart[:axis][:y] = {:tick => {:format => axis_formatter}}
+      end
     end
 
     def c3_convert_type(type)

--- a/spec/lib/report_formater/jqplot_formater_spec.rb
+++ b/spec/lib/report_formater/jqplot_formater_spec.rb
@@ -69,12 +69,12 @@ describe ReportFormatter::JqplotFormatter do
     it "uses correct formating function for axis with given column format" do
       report.col_formats = [nil, :general_number_precision_0]
       render_report(report)
-      expect(report.chart[:options][:axes][:xaxis][:tickOptions][:formatter]).to eq("ManageIQ.charts.formatters.number_with_delimiter.jqplot({})")
+      expect(report.chart[:options][:axes][:xaxis][:tickOptions][:formatter]).to eq("ManageIQ.charts.formatters.number_with_delimiter.jqplot({\"delimiter\":\",\",\"precision\":0,\"description\":\"Number (1,234)\"})")
     end
 
     it "uses correct formating function for axis with implicit column format" do
       render_report(report)
-      expect(report.chart[:options][:axes][:xaxis][:tickOptions][:formatter]).to eq("ManageIQ.charts.formatters.mbytes_to_human_size.jqplot({})")
+      expect(report.chart[:options][:axes][:xaxis][:tickOptions][:formatter]).to eq("ManageIQ.charts.formatters.mbytes_to_human_size.jqplot({\"precision\":1,\"description\":\"Suffixed Megabytes (MB, GB)\"})")
     end
   end
 end


### PR DESCRIPTION
Add units to Y axis of C&U charts.
![screenshot from 2016-05-27 15-56-23](https://cloud.githubusercontent.com/assets/9535558/15610051/9bbd569e-2423-11e6-8434-aba9442cbd53.png)
