### PR TITLE
[Darga] Rollback arel_spec_helper change

### DIFF
--- a/spec/support/arel_spec_helper.rb
+++ b/spec/support/arel_spec_helper.rb
@@ -8,8 +8,10 @@ module ArelSpecHelper
 
   # run the sql for a virtual column. making sure it works in select and order
   def virtual_column_sql_value(klass, v_col_name)
-    query = klass.select(:id, klass.arel_attribute(v_col_name.to_sym).as("extra"))
-                 .order(v_col_name.to_sym)
+    query = klass.select(klass.arel_attribute("id"),
+                         Arel::Nodes::As.new(klass.arel_attribute(v_col_name),
+                                             Arel::Nodes::SqlLiteral.new("extra")))
+                 .order(klass.arel_attribute(v_col_name))
     query.first["extra"]
   end
 end


### PR DESCRIPTION
This change depended upon an arel grouping patch that is not
applied to darga.

rolling back part of 3030b57a944b4b928c849778ae7eabf710672906