### PR TITLE
Automate - Clarify method form with regards to builtins

### DIFF
--- a/app/views/miq_ae_class/_method_data.html.haml
+++ b/app/views/miq_ae_class/_method_data.html.haml
@@ -12,6 +12,8 @@
       @edit[:new][:data],
       :maxlength         => MAX_NAME_LEN,
       "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  - if @edit[:new][:location] == 'builtin'
+    %em= _('Optional, if not specified, method name is used.')
   %tr
     %td
       %span#pwd_note{:style => "color: red;"}

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -47,7 +47,7 @@
         .col-md-8
           = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
   %hr
-  %h3= _("Data")
+  %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
   = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
   %hr
   %h3= _("Input Parameters")

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -35,7 +35,7 @@
           %p.form-control-static
             = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
     = render :partial => "domain_overrides", :locals => {:node_prefix => "aem", :model => "Method"}
-    %h3= _('Data')
+    %h3= (@ae_method.location == 'builtin') ? _('Builtin name') : _('Data')
     - if @ae_method.location == "inline"
       = text_area("method1",
         "data",


### PR DESCRIPTION
I was not sure how that is used exactly, because there was just "Data" specified. Now it is obvious what does that field do. I have uploaded my changes to an upstream appliance and here is how does it look.

Before patch:
==========
![builtin3](https://cloud.githubusercontent.com/assets/2163040/15612174/fcdd9fec-242d-11e6-9644-fe7148fda54b.png)
![builtin4](https://cloud.githubusercontent.com/assets/2163040/15612177/ffc4d5c2-242d-11e6-9702-96dfa0c45c35.png)

After patch:
==========
![builtin1](https://cloud.githubusercontent.com/assets/2163040/15612187/0638be50-242e-11e6-8f53-785866b26ef5.png)
![builtin2](https://cloud.githubusercontent.com/assets/2163040/15612189/0921fd52-242e-11e6-9486-688671ce3dc5.png)
