### PR TITLE
Support for MiddlewareServer performance reports

### DIFF
--- a/app/models/middleware_server_performance.rb
+++ b/app/models/middleware_server_performance.rb
@@ -1,0 +1,69 @@
+class MiddlewareServerPerformance < ActsAsArModel
+  set_columns_hash(
+    :id            => :string,
+    :name          => :string,
+    :resource_type => :string,
+    :feed          => :string,
+    :ems_ref       => :string,
+    :start_time    => :datetime,
+    :end_time      => :datetime
+  )
+
+  alias resource_id id
+  alias resource_name name
+
+  def self.build_results_for_report_middleware(options)
+    start_time, end_time, interval = parse_time_interval(options)
+    results = []
+    MiddlewareServer.find_each do |ms|
+      raw_stats = fetch_raw_stats(ms, start_time, end_time, interval)
+      if raw_stats.values[0]
+        columns = raw_stats.values[0].keys
+        columns.each { |column| set_columns_hash(column => :float) }
+        raw_stats.each { |timestamp, stats| results.push(parse_row(ms, timestamp, interval, stats)) }
+      end
+    end
+    [results, {}]
+  end
+
+  def self.parse_time_interval(options)
+    now = Time.now.utc
+    start_time = now - options[:start_offset]
+    end_time = now - options[:end_offset]
+    interval = case options[:interval]
+               when 'daily'   then 1.day.seconds
+               when 'hourly'  then 1.hour.seconds
+               else end_time - start_time
+               end
+    [start_time, end_time, interval]
+  end
+
+  def self.fetch_raw_stats(middleware_server, start_time, end_time, interval)
+    raw_stats = {}
+    middleware_server.metrics_available.each do |metric|
+      middleware_server.collect_stats_metric(metric, start_time, end_time, interval).each do |stat|
+        timestamp = stat['start']
+        raw_stats[timestamp] = {} if raw_stats[timestamp].nil?
+        %w(min avg median max samples).each do |w|
+          raw_stats[timestamp]["#{metric[:name]}_#{w}"] = stat[w]
+        end
+      end unless metric[:type] == "AVAILABILITY"
+    end
+    raw_stats
+  end
+
+  def self.parse_row(middleware_server, timestamp, interval, stats)
+    start_time = Time.at(timestamp / 1000).utc
+    row = MiddlewareServerPerformance.new
+    %w(id name feed ems_ref).each { |field| row[field] = middleware_server[field] }
+    row[:resource_type] = middleware_server.class.name
+    row[:start_time] = start_time
+    row[:end_time] = start_time + interval
+    stats.each { |metric_name, value| row[metric_name] = value }
+    row
+  end
+
+  def to_a
+    [self]
+  end
+end

--- a/app/models/mixins/live_metrics_mixin.rb
+++ b/app/models/mixins/live_metrics_mixin.rb
@@ -7,6 +7,7 @@ module LiveMetricsMixin
 
   delegate :fetch_metrics_available, :to => :metrics_capture
   delegate :collect_live_metric, :to => :metrics_capture
+  delegate :collect_stats_metric, :to => :metrics_capture
 
   included do
     def collect_live_metrics(metrics, start_time, end_time, interval)

--- a/product/reports/670_Performance by Asset Type - Middleware Servers/110_JVM Heap Usage - daily over last week.yaml
+++ b/product/reports/670_Performance by Asset Type - Middleware Servers/110_JVM Heap Usage - daily over last week.yaml
@@ -1,0 +1,71 @@
+--- 
+where_clause: 
+dims: 
+created_on: 2016-05-23 14:53:10.822035 Z
+reserved: 
+title: "JVM Heap Usage - daily averages for last week"
+conditions: 
+updated_on: 2016-05-23 00:35:33.732482 Z
+order: Descending
+graph: 
+menu_name: "JVM Heap Usage - daily over last week"
+rpt_group: Custom
+priority: 
+col_order: 
+- id
+- name
+- start_time
+- mw_heap_used_min
+- mw_heap_used_avg
+- mw_heap_used_max
+- mw_heap_committed_min
+- mw_heap_committed_avg
+- mw_heap_committed_max
+- mw_heap_max_min
+- mw_heap_max_avg
+- mw_heap_max_max
+timeline: 
+id: 670
+file_mtime: 
+categories: 
+rpt_type: Custom
+filename: 
+db_options:
+  :rpt_type: middleware
+  :options:
+    :interval: daily
+    :start_offset: 604800
+    :end_offset: 0
+include: {}
+
+db: MiddlewareServerPerformance
+cols: 
+- id
+- name
+- start_time
+- mw_heap_used_min
+- mw_heap_used_avg
+- mw_heap_used_max
+- mw_heap_committed_min
+- mw_heap_committed_avg
+- mw_heap_committed_max
+- mw_heap_max_min
+- mw_heap_max_avg
+- mw_heap_max_max
+template_type: report
+group: n
+sortby:
+- id
+headers: 
+- Id
+- Name
+- Start
+- Used - min (bytes)
+- Used - avg (bytes)
+- Used - max (bytes)
+- Committed - min (bytes)
+- Committed - avg (bytes)
+- Committed - max (bytes)
+- Maximum - min (bytes)
+- Maximum - avg (bytes)
+- Maximum - max (bytes)

--- a/product/reports/670_Performance by Asset Type - Middleware Servers/120_JVM Non Heap Usage - daily over last week.yaml
+++ b/product/reports/670_Performance by Asset Type - Middleware Servers/120_JVM Non Heap Usage - daily over last week.yaml
@@ -1,0 +1,63 @@
+--- 
+where_clause: 
+dims: 
+created_on: 2016-05-23 14:53:10.822035 Z
+reserved: 
+title: "JVM Non Heap Usage - daily averages for last week"
+conditions: 
+updated_on: 2016-05-23 00:35:33.732482 Z
+order: Descending
+graph: 
+menu_name: "JVM Non Heap Usage - daily over last week"
+rpt_group: Custom
+priority: 
+col_order: 
+- id
+- name
+- start_time
+- mw_non_heap_used_min
+- mw_non_heap_used_avg
+- mw_non_heap_used_max
+- mw_non_heap_committed_min
+- mw_non_heap_committed_avg
+- mw_non_heap_committed_max
+timeline: 
+id: 671
+file_mtime: 
+categories: 
+rpt_type: Custom
+filename: 
+db_options:
+  :rpt_type: middleware
+  :options:
+    :interval: daily
+    :start_offset: 604800
+    :end_offset: 0
+include: {}
+
+db: MiddlewareServerPerformance
+cols: 
+- id
+- name
+- start_time
+- mw_non_heap_used_min
+- mw_non_heap_used_avg
+- mw_non_heap_used_max
+- mw_non_heap_committed_min
+- mw_non_heap_committed_avg
+- mw_non_heap_committed_max
+template_type: report
+group: n
+sortby:
+- id
+headers: 
+- Id
+- Name
+- Start
+- Used - min (bytes)
+- Used - avg (bytes)
+- Used - max (bytes)
+- Committed - min (bytes)
+- Committed - avg (bytes)
+- Committed - max (bytes)
+

--- a/product/reports/670_Performance by Asset Type - Middleware Servers/130_JVM Garbage Collection - daily over last week.yaml
+++ b/product/reports/670_Performance by Asset Type - Middleware Servers/130_JVM Garbage Collection - daily over last week.yaml
@@ -1,0 +1,53 @@
+--- 
+where_clause: 
+dims: 
+created_on: 2016-05-23 14:53:10.822035 Z
+reserved: 
+title: "JVM Garbage Collection - daily averages for last week"
+conditions: 
+updated_on: 2016-05-23 00:35:33.732482 Z
+order: Descending
+graph: 
+menu_name: "JVM Garbage Collection - daily over last week"
+rpt_group: Custom
+priority: 
+col_order: 
+- id
+- name
+- start_time
+- mw_accumulated_gc_duration_min
+- mw_accumulated_gc_duration_avg
+- mw_accumulated_gc_duration_max
+timeline: 
+id: 672
+file_mtime: 
+categories: 
+rpt_type: Custom
+filename: 
+db_options:
+  :rpt_type: middleware
+  :options:
+    :interval: daily
+    :start_offset: 604800
+    :end_offset: 0
+include: {}
+
+db: MiddlewareServerPerformance
+cols: 
+- id
+- name
+- start_time
+- mw_accumulated_gc_duration_min
+- mw_accumulated_gc_duration_avg
+- mw_accumulated_gc_duration_max
+template_type: report
+group: n
+sortby:
+- id
+headers: 
+- Id
+- Name
+- Start
+- Duration - min (milliseconds)
+- Duration - avg (milliseconds)
+- Duration - max (milliseconds)

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
   context "Seeding" do
-    include_examples(".seed called multiple times", 132)
+    include_examples(".seed called multiple times", 135)
   end
 end


### PR DESCRIPTION
This is just a preliminar start for reports based on performance in Middleware provider.
![image](https://cloud.githubusercontent.com/assets/1662329/15613800/adf1a344-2435-11e6-9920-168cd627c96f.png)
Added some equivalent reports to the graphs used at MiddlewareServer level.
This work is still on WIP status.
The goal of this branch was to get familiar with the reports feature and validate that LiveMetrics can work with the current engine without drawbacks.
@miq-bot add_label providers/hawkular
@miq-bot add_label wip