### PR TITLE
Fix DescendantLoader for ActsAsArModel

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -1,6 +1,4 @@
 class Chargeback < ActsAsArModel
-  DescendantLoader.instance.load_subclasses(self)
-
   VIRTUAL_COL_USES = {
     "v_derived_cpu_total_cores_used" => "cpu_usage_rate_average"
   }

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -268,6 +268,7 @@ end
 
 ActiveRecord::Base.singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
 ActiveSupport::Dependencies.send(:prepend, DescendantLoader::AsDependenciesClearWithLoader)
+ActsAsArModel.singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
 
 at_exit do
   DescendantLoader.instance.save_cache!

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,4 +1,3 @@
-Chargeback
 describe ChargebackContainerProject do
   before do
     MiqRegion.seed

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,4 +1,3 @@
-Chargeback
 describe ChargebackVm do
   before do
     MiqRegion.seed


### PR DESCRIPTION
Alternate implementation to #8818

The prior fix failed when calling `ChargebackVm.superclass` because it created a circular dependency...

Before:
```
[1] pry(main)> ChargebackVm.superclass
RuntimeError: Circular dependency detected while autoloading constant ChargebackVm
from /Users/jfrey/.gem/ruby/2.2.4/bundler/gems/rails-3d01d00e348f/activesupport/lib/active_support/dependencies.rb:509:in `load_missing_constant'
```

After:
```
[1] pry(main)> ChargebackVm.superclass
=> Chargeback
```

@lpichler @gtanzillo Please review