### PR TITLE
Rbac: Don't lookup null users

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -303,8 +303,8 @@ module Rbac
   end
 
   def self.get_user_info(user, userid, miq_group, miq_group_id)
-    user      ||= User.find_by_userid(userid) || User.current_user
-    miq_group ||= MiqGroup.find_by_id(miq_group_id)
+    user      ||= (userid && User.find_by_userid(userid)) || User.current_user
+    miq_group ||= miq_group_id && MiqGroup.find_by_id(miq_group_id)
     miq_group_id ||= miq_group.try!(:id)
     if user && miq_group && user.current_group_id != miq_group_id
       user.current_group = miq_group if user.miq_groups.include?(miq_group)


### PR DESCRIPTION
Followup to #9003

A few rbac calls use the `User.current_user` (and group) instead of passing those values into rbac.

While this is not common, it is getting hit for automate form autocomplete.
This removes 2 more queries. (chipping away at it)

**before:**
The code was looking up users and groups with a null id.

**after:**
It doesn't lookup up a null userid/groupid.
It goes straight to defaulting to the current user and group

https://bugzilla.redhat.com/show_bug.cgi?id=1337967