### PR TITLE
Sleep for a while when pubsub topic does not exist

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb
@@ -2,6 +2,14 @@
 # event type messages. Parsing of the message is deferred to the caller of
 # #poll.
 class ManageIQ::Providers::Google::CloudManager::EventCatcher::Stream
+  # Generic exception if we are unable to reach GCP
+  class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
+  end
+
+  # Topic wasn't found (event catcher likely not set up)
+  class TopicNotFound < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
+  end
+
   def initialize(ems)
     @ems = ems
     @collecting_events = true
@@ -35,12 +43,22 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Stream
         subscription.acknowledge(msgs)
       end
     end
+  rescue Fog::Errors::Error
+    raise ProviderUnreachable, "Error when contacting Google Pubsub for events; this may be a temporary failure."
   end
 
   def get_or_create_subscription(google)
+    # If event catcher is not yet setup, then we'll get a fog error
     google.subscriptions.get(subscription_name) ||
       google.subscriptions.create(:name  => subscription_name,
                                   :topic => topic_name)
+  rescue Fog::Errors::NotFound
+    # Rather than expose the notfound error, we expose our own exception
+    # indicating that the worker thread should back off
+    msg = "Unable to find topic #{topic_name}; this likely is because event"\
+        " support for the Google Cloud Platform is not yet setup. Please see"\
+        " the documentation for instructions."
+    raise TopicNotFound, msg
   end
 
   def subscription_name

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -332,7 +332,10 @@ class MiqWorker::Runner
       begin
         heartbeat
         do_work
-      rescue TemporaryFailure
+      rescue TemporaryFailure => error
+        msg = "#{log_prefix} Temporary failure (message: '#{error}') caught"\
+            " during #do_work. Sleeping for a while before resuming."
+        _log.warn(msg)
         recover_from_temporary_failure
       rescue SystemExit
         do_exit("SystemExit signal received.  ")


### PR DESCRIPTION
This prevents the log from getting spammed full of error messages when the
event catcher has not yet been set up on GCP.

Closes #9016