### PR TITLE
Improve the validation check for Hawkular endpoints

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -221,7 +221,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       return true;
     } else if(($scope.currentTab == "hawkular" && $scope.emsCommonModel.ems_controller == "ems_container") &&
       ($scope.emsCommonModel.emstype) &&
-      ($scope.emsCommonModel.hawkular_hostname != '' && $scope.emsCommonModel.hawkular_api_port)) {
+      ($scope.emsCommonModel.hawkular_hostname != '' && $scope.emsCommonModel.hawkular_api_port) &&
+      ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid) &&
+      ($scope.emsCommonModel.default_verify != '' && $scope.angularForm.default_verify.$valid)) {
       return true;
     } else if($scope.emsCommonModel.emstype == "gce" && $scope.emsCommonModel.project != '' &&
       ($scope.currentTab == "default" ||

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
@@ -25,7 +25,13 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawkul
      :verify_ssl => @ext_management_system.verify_ssl_mode}
   end
 
-  def status
-    @client.http_get('/status')
+  def hawkular_try_connect
+    # check the connection and the credentials by trying
+    # to access hawkular's availability private data, and fetch one line of data.
+    # this will check the connection and the credentials
+    # because only if the connection is ok, and the token is valid,
+    # we will get an OK response, with an array of data, or an empty array
+    # if no data availabel.
+    @client.avail.get_data('all', :limit => 1).kind_of?(Array)
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -41,9 +41,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   PERF_ROLLUP_CHILDREN = :container_nodes
 
-  def hawkular_status
-    client = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularClient.new(self)
-    client.status
+  def verify_hawkular_credentials
+    ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularClient.new(self).hawkular_try_connect
   end
 
   # UI methods for determining availability of fields
@@ -72,7 +71,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   def verify_credentials(auth_type = nil, options = {})
     options = options.merge(:auth_type => auth_type)
     if options[:auth_type] == "hawkular"
-      hawkular_status['MetricsService'] == 'STARTED'
+      verify_hawkular_credentials
     else
       with_provider_connection(options, &:api_valid?)
     end


### PR DESCRIPTION
Currently on provider addition we only check the Hawkular endpoint presence (and status). This doesn't actually validate that the provided token can access and collect the metrics.
We should improve the validation check including also the token correctness.

This commit checks the private metric path (and not the public status path) that requires valid authentication.

Fixes: https://github.com/ManageIQ/manageiq/issues/9022