### PR TITLE
Metrics seems to fail when not defining a Hawkular Endpoint

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -358,6 +358,8 @@ module Mixins
 
       if ems.kind_of?(ManageIQ::Providers::ContainerManager)
         ems.hostname = hostname
+        hawkular_hostname = hostname if hawkular_hostname.blank?
+
         default_endpoint = {:role => :default, :hostname => hostname, :port => port}
         hawkular_endpoint = {:role => :hawkular, :hostname => hawkular_hostname, :port => hawkular_api_port}
       end

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
@@ -7,11 +7,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawkul
 
   def hawkular_entrypoint
     hawkular_endpoint = @ext_management_system.connection_configurations.hawkular.try(:endpoint)
+    hawkular_endpoint_empty = hawkular_endpoint.try(:hostname).blank?
     worker_class = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
 
     URI::HTTPS.build(
-      :host => hawkular_endpoint ? hawkular_endpoint.hostname : @ext_management_system.hostname,
-      :port => hawkular_endpoint ? hawkular_endpoint.port : worker_class.worker_settings[:metrics_port],
+      :host => hawkular_endpoint_empty ? @ext_management_system.hostname : hawkular_endpoint.hostname,
+      :port => hawkular_endpoint_empty ? worker_class.worker_settings[:metrics_port] : hawkular_endpoint.port,
       :path => worker_class.worker_settings[:metrics_path])
   end
 


### PR DESCRIPTION
When not defining a Hawkular Endpoint hostname metric collection fails, it should fallback to the providers hostname.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1340721
Issue: https://github.com/ManageIQ/manageiq/issues/9024