### PR TITLE
net-ssh bump to 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem "inifile",                        "~>3.0",     :require => false
 gem "logging",                        "~>1.8",     :require => false  # Ziya depends on this
 gem "net_app_manageability",          ">=0.1.0",   :require => false
 gem "net-ping",                       "~>1.7.4",   :require => false
-gem "net-ssh",                        "~>3.0.2",   :require => false
+gem "net-ssh",                        "~>3.2.0.rc2",   :require => false
 gem "omniauth",                       "~>1.3.1",   :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",   :require => false

--- a/gems/pending/util/MiqSshUtilV2.rb
+++ b/gems/pending/util/MiqSshUtilV2.rb
@@ -99,6 +99,7 @@ class MiqSshUtil
         $log.debug "MiqSshUtil::exec - Command: #{cmd} started." if $log
         channel.exec(cmd) { |_channel, success| raise "MiqSshUtil::exec - Could not execute command #{cmd}" unless success }
       end
+      ssh.loop
     end
   end # def exec
 
@@ -196,6 +197,7 @@ class MiqSshUtil
           channel.exec(su_command) { |_channel, success| raise "MiqSshUtil::suexec - Could not execute command #{cmd}" unless success }
         end
       end
+      ssh.loop
     end
   end # suexec
 


### PR DESCRIPTION
This version include the new agent_socket_factory option.
Added `ssh.loop` according to the docs (http://net-ssh.github.io/ssh/v1/chapter-3.html) when dealing with channels and placing callbacks -> "In order to allow the events to be processed in a continuous manner, you need to be sure to call the loop method of your session handle, after setting up any callbacks that you want to be executed. If you do not call the loop method, your session will terminate as soon as the block is exited, which means none of your carefully laid callbacks will ever be called.".