### PR TITLE
[WIP] Reload settings after any save under ops.

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -536,6 +536,7 @@ module OpsController::Settings::Common
       get_node_info(x_node)
       replace_right_cell(@nodetype)
     end
+    Vmdb::Settings.reload!
   end
 
   def settings_update_reset


### PR DESCRIPTION
Reload settings after any save under ops using
Vmdb::Settings.reload!

The settings need to be reloaded after some of the changes. This fix
reloads each time, so it introduces some undeeded reloads. This is to be
safe for now that we reload enough.

https://bugzilla.redhat.com/show_bug.cgi?id=1339702

The problem DOES NOT happen in development mode, please review with that on mind.

The method that is being changed needs refactoring, splitting into more methods at least and only some of the branches will need the reload. But this is not a simple fix and I prefer that to be done in a separate PR.