### PR TITLE
Fix #9039 - add feed field in middleware server summary page

### DIFF
--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module MiddlewareServerHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name hostname bind_addr product version)
+    %i(name hostname feed bind_addr product version)
   end
 
   def textual_group_relationships
@@ -26,6 +26,10 @@ module MiddlewareServerHelper::TextualSummary
 
   def textual_hostname
     @record.hostname
+  end
+
+  def textual_feed
+    @record.feed
   end
 
   def textual_bind_addr


### PR DESCRIPTION

![withfeed](https://cloud.githubusercontent.com/assets/6277245/15672841/c1fcc266-273b-11e6-9241-28d4a2c47152.png)



@miq-bot add_label enhancement, ui, providers/hawkular
@miq-bot assign @pilhuhn 