### PR TITLE
Remove toplevel constant warnings from the specs.

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -563,8 +563,8 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
                "/#{ip_group}/providers/Microsoft.Network"\
                "/publicIPAddresses/miqmismatch1"
 
-    @network_port = ManageIQ::Providers::Azure::CloudManager::NetworkPort.where(:name => nic_name).first
-    @floating_ip  = ManageIQ::Providers::Azure::CloudManager::FloatingIp.where(:ems_ref => ems_ref).first
+    @network_port = ManageIQ::Providers::Azure::NetworkManager::NetworkPort.where(:name => nic_name).first
+    @floating_ip  = ManageIQ::Providers::Azure::NetworkManager::FloatingIp.where(:ems_ref => ems_ref).first
 
     expect(@network_port).to have_attributes(
       :status  => 'Succeeded',


### PR DESCRIPTION
The warnings were:
/Users/jfrey/dev/manageiq/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb:566: warning: toplevel constant NetworkPort referenced by ManageIQ::Providers::Azure::CloudManager::NetworkPort
/Users/jfrey/dev/manageiq/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb:567: warning: toplevel constant FloatingIp referenced by ManageIQ::Providers::Azure::CloudManager::FloatingIp

@blomquisg @djberg96 Please review.