### PR TITLE
Added decorator to display correct quadicon for key pair record.

### DIFF
--- a/app/decorators/manageiq/providers/amazon/cloud_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/amazon/cloud_manager/auth_key_pair_decorator.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Amazon::CloudManager::AuthKeyPairDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    item_image
+  end
+
+  private
+
+  # Determine the icon
+  def item_image
+    '100/auth_key_pair'
+  end
+end


### PR DESCRIPTION
Fixes #8987 
@epwinchell please review/test

![key_pair_quad_fix](https://cloud.githubusercontent.com/assets/3450808/15688579/af0e8808-2748-11e6-8668-f854b4f005e4.png)
