### PR TITLE
Fix AWS orchestration timeout issue

### DIFF
--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -25,6 +25,7 @@ class DialogFieldTextBox < DialogField
   end
 
   def automate_output_value
+    return nil if @value.nil?
     return MiqPassword.encrypt(@value) if self.protected?
     convert_value_to_type
   end

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/orchestration_service_option_converter.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/orchestration_service_option_converter.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationServiceOptionConve
     on_failure = @dialog_options['dialog_stack_onfailure']
     timeout = @dialog_options['dialog_stack_timeout']
     stack_options = {:parameters => stack_parameters, :disable_rollback => on_failure != 'ROLLBACK'}
-    stack_options[:timeout] = timeout.to_i unless timeout.blank?
+    stack_options[:timeout_in_minutes] = timeout.to_i unless timeout.blank?
 
     stack_options
   end

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -208,6 +208,14 @@ describe DialogFieldTextBox do
             expect(dialog_field.value).to eq(0)
           end
         end
+
+        context "when there is no value" do
+          let(:value) { nil }
+
+          it "does not convert nil value to zero" do
+            expect(dialog_field.value).to be_nil
+          end
+        end
       end
 
       context "when the data type is string" do
@@ -403,6 +411,14 @@ describe DialogFieldTextBox do
 
         it "converts the value to an integer" do
           expect(dialog_field.automate_output_value).to eq(12)
+        end
+      end
+
+      context "when there is no value" do
+        let(:nil_dialog_field) { described_class.new(:data_type => data_type) }
+
+        it "does not convert nil value to zero" do
+          expect(nil_dialog_field.automate_output_value).to be_nil
         end
       end
     end

--- a/spec/models/service_orchestration/option_converter_spec.rb
+++ b/spec/models/service_orchestration/option_converter_spec.rb
@@ -17,9 +17,9 @@ describe ServiceOrchestration::OptionConverter do
   it '#stack_create_options' do
     converter = klass.get_converter(dialog_options, ManageIQ::Providers::Amazon::CloudManager)
     expect(converter.stack_create_options).to have_attributes(
-      :timeout          => 100,
-      :disable_rollback => false,
-      :parameters       => {'para1' => 'stack_param1', 'para2' => 'admin'}
+      :timeout_in_minutes => 100,
+      :disable_rollback   => false,
+      :parameters         => {'para1' => 'stack_param1', 'para2' => 'admin'}
     )
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1340570

Fixes two issues:
1. when the timeout has no input, the value should not get converted to 0
2. the argument key should change from `timeout` to `timeout_in_minutes` due to the upgrade of `aws sdk` from 1.0 to 2.0.