### PR TITLE
Changes to improve the migration time for EmsEvent -> EventStream.

### DIFF
--- a/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
+++ b/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
@@ -17,7 +17,7 @@ class FixEventClassForEvmAlertEvent < ActiveRecord::Migration
 
   def up
     say_with_time("Converting event class for EVMAlertEvent to MiqEvent") do
-      EventStream.where(:type => 'EmsEvent', :event_type => 'EVMAlertEvent').each do |event|
+      EventStream.where(:type => 'EmsEvent', :event_type => 'EVMAlertEvent').find_each do |event|
         attrs = {:type => 'MiqEvent'}
 
         if event.ems_cluster_id


### PR DESCRIPTION
This change only reduces the migration time and does not affect the table size after migration.

The testing DB has 6,933,269 records which took 890s for the migration before the fix.
Following is the metrics after the fix with different batch size.
```
batch size       time(seconds)
500,000           442
100,000           411
5,000             367
2,000             344
1,000             325
900               329
500               343
``` 

https://bugzilla.redhat.com/show_bug.cgi?id=1339303