### PR TITLE
Reset the Settings after we seed MiqServer

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -179,6 +179,7 @@ class MiqServer < ApplicationRecord
       _log.info("Creating Default MiqServer with guid=[#{my_guid}], zone=[#{Zone.default_zone.name}]")
       create!(:guid => my_guid, :zone => Zone.default_zone)
       my_server_clear_cache
+      Vmdb::Settings.init # Re-initialize the Settings now that we have a server record
       _log.info("Creating Default MiqServer... Complete")
     end
     my_server


### PR DESCRIPTION
Upon boot on a fresh database, the Settings object contains a
DatabaseSource that refers to a nil MiqServer.  This is intentional as
it allows accessing the Settings before a MiqServer has been created, in
particular during intializers and in some rake tasks that need the Rails
environment.

However, when the server starts and creates the MiqServer record during
.seed, the Settings is still pointing to the nil MiqServer record.
This creates an inconsistency where the server (and thus all workers
forked from it) do not know about changes to the MiqServer object.
Changing settings in the UI will write the SettingsChange records to the
database attached to the correct MiqServer object, but since the
Settings object can't see them, it doesn't know to update.

This commit fixes all problems where config changes are made on the very
first server boot.  One particular problem that is strange is if an
MiqServer is moved into another Zone.  The zone value is normally
written into the settings.  However, since the server doesn't see the
change reflected in the Settings, it thinks the user modified the
Advanced Settings to put the original server back, so after about 20
seconds, the server moves back to the original zone.  This problem is
fixed by this commit

https://bugzilla.redhat.com/show_bug.cgi?id=1339702
https://bugzilla.redhat.com/show_bug.cgi?id=1328201

@gtanzillo @jrafanie Please review.
cc @carbonin 