### PR TITLE
HACK: Add columns to the select needed later for an update call

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -57,7 +57,11 @@ class Job < ApplicationRecord
   end
 
   def self.agent_state_update_queue(jobid, state, message = nil)
-    job = Job.where("guid = ?", jobid).select("id, state, guid").first
+    # HACK: add agent_state, agent_message, and updated_on to select as a
+    # workaround for: https://github.com/rails/rails/issues/25228
+    warn_message = "Verify we need to specify agent_state, agent_message, and updated_on in the select at: #{__FILE__}:#{__LINE__ + 2}"
+    warn(warn_message) if Rails.version == "5.0.0"
+    job = Job.where("guid = ?", jobid).select("id, state, guid, agent_state, agent_message, updated_on").first
     unless job.nil?
       job.agent_state_update(state, message)
     else

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -16,6 +16,13 @@ describe Job do
       @job      = @vm.scan
     end
 
+    it "agent_state_update_queue updates agent_state and agent_message" do
+      Job.agent_state_update_queue(@job.guid, "finished", "failed!")
+      @job.reload
+      expect(@job.agent_state).to eq "finished"
+      expect(@job.agent_message).to eq "failed!"
+    end
+
     context "where job is dispatched but never started" do
       before(:each) do
         @job.update_attribute(:dispatch_status, "active")


### PR DESCRIPTION
Currently, the following code raises an NotImplementedError on rails 5.0.0.rc1:

```ruby
p = Person.where(...).select(:name).first
p.update(:color => 'blue')
```

This fails because we're providing a list of columns to select and Rails' dirty
tracking is checking for column changes on columns we didn't select.  The list of
attributes it checks includes the column(s) passed to update along with the
updated_on column.  To get around this bug in Rails, let's select the columns we
want to update and also updated_on.  We could have also worked around this issue
by NOT specifying a `.select`.

Workaround for: https://github.com/rails/rails/issues/25228

Fixes #8687