### PR TITLE
Cache the MiqServer#server_timezone

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -625,7 +625,7 @@ class MiqServer < ApplicationRecord
   end
 
   def server_timezone
-    get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
+    @timezone ||= get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
   end
 
   def tenant_identity


### PR DESCRIPTION
reduces 1 config lookup per rbac call (among others)

(in production mode - 10 VM server, admin user)

https://bugzilla.redhat.com/show_bug.cgi?id=1337967

**before:**

|     ms |  sql | sqlms |  sqlrows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  377.4 |   25 |   7.7 |       25 |`/miq_request/prov_field_changed/new`
|  274.1 |   25 |   6.9 |       25 |`/miq_request/prov_field_changed/new`
|  341.2 |   25 |   6.9 |       25 |`/miq_request/prov_field_changed/new`
|  337.2 |   25 |   7.4 |       25 |`/miq_request/prov_field_changed/new`
|    ---:|  ---:|   ---:|      ---:| ---
|  332.5 |      |   7.2 |          |`avg`

**after:**

|     ms |  sql | sqlms |  sqlrows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  128.8 |   25 |   7.3 |       25 |`/vm_infra/prov_field_changed/new`
|  158.9 |   25 |   8.5 |       25 |`/vm_infra/prov_field_changed/new`
|  147.5 |   25 |   7.1 |       25 |`/vm_infra/prov_field_changed/new`
|  112.1 |   25 |   7.0 |       25 |`/vm_infra/prov_field_changed/new`
|    ---:|  ---:|   ---:|      ---:| ---
|  136.8 |      |   7.5 |          |`avg`


**change:**

|     ms |  sql | sqlms |  sqlrows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  -61.0%|      | +0.4% |  n/a     | sql queries are the same