### PR TITLE
Fix fetching saved chargeback reports

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -401,8 +401,6 @@ class ChargebackController < ApplicationController
         @report = rr.report_results
         session[:rpt_task_id] = nil
         if @report.blank?
-          add_flash(_("Saved Report \"%{name}\" not found, Schedule may have failed") %
-            {:name => format_timezone(rr.last_run_on, Time.zone, "gtl")}, :error)
           @saved_reports = cb_rpts_get_all_reps(rr.miq_report_id.to_s)
           rep = MiqReport.find_by_id(rr.miq_report_id)
           if x_active_tree == :cb_reports_tree

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -397,7 +397,7 @@ class ChargebackController < ApplicationController
     else
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime]  = rr.last_run_on
-      if rr.status.casecmp("finished") == 0
+      if MiqTask.state_finished(rr.miq_task_id)
         @report = rr.report_results
         session[:rpt_task_id] = nil
         if @report.blank?
@@ -509,10 +509,6 @@ class ChargebackController < ApplicationController
                               .select("id, miq_report_id, name, last_run_on, report_source")
                               .order(:last_run_on)
 
-    @sb[:last_run_on] = {}
-    saved_reports.each do |s|
-      @sb[:last_run_on][s.last_run_on] = format_timezone(s.last_run_on, Time.zone, 'gtl') + "aa" if s.last_run_on
-    end
     @sb[:tree_typ] = "reports"
     @right_cell_text = _("%{model} \"%{name}\"") % {:model => "Reports", :name => miq_report.name}
     saved_reports


### PR DESCRIPTION
addition for https://bugzilla.redhat.com/show_bug.cgi?id=1336978

there was inproper checking of finished state of report's miq_task, the correct name of completed task is
`complete` as we have in general saved reports as we have here https://github.com/ManageIQ/manageiq/blob/master/app/controllers/report_controller/saved_reports.rb#L29
but now I am using MiqTask method for it.

scenario CI-> Chargeback -> and click on any saved chargeback report - before fix there was displayed message there are no  


also removed message when report doesn't have records.
and only one message is used from this place https://github.com/ManageIQ/manageiq/blob/master/app/controllers/chargeback_controller.rb#L470 - the red one was removed

![screen shot 2016-06-01 at 13 36 01](https://cloud.githubusercontent.com/assets/14937244/15708662/13c468aa-2800-11e6-8aca-c53d18ddbdd4.png)


cc @gtanzillo 
