### PR TITLE
container controller: fix breadcrumbs for container containers

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -119,6 +119,7 @@ class ContainerController < ApplicationController
     session.delete(:exp_parms)
     @in_a_form = false
     render :layout => "application"
+    process_show_list
   end
 
   def identify_container(id = nil)


### PR DESCRIPTION
This will add breadcrumb handling to this controller when using the "explorer" path

![fix_container_page_breadcrumb_](https://cloud.githubusercontent.com/assets/3123328/16409694/88f19148-3d27-11e6-8b91-246a737dfbea.png)


BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1341668