### PR TITLE
Support for winrm-elevated version 0.4.0

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -49,7 +49,7 @@ gem "sys-uname",               "~>1.0.1",           :require => false
 gem "trollop",                 "~>2.0",             :require => false
 gem "uuidtools",               "~>2.1.3",           :require => false
 gem "winrm",                   "~>1.7.2",           :require => false
-gem "winrm-elevated",          "~>0.3.0",           :require => false
+gem "winrm-elevated",          "~>0.4.0",           :require => false
 gem 'sys-proctable',           "~> 1.0",            :require => false
 
 # Linux-only section

--- a/gems/pending/spec/util/miq_winrm_spec.rb
+++ b/gems/pending/spec/util/miq_winrm_spec.rb
@@ -40,15 +40,4 @@ describe MiqWinRM do
       expect(@winrm.port).to eq(5985)
     end
   end
-
-  context "New Elevated Runner" do
-    before(:each) do
-      @connection = @winrm.connect(:user => @user, :pass => @password, :hostname => @host)
-    end
-
-    it "Creates an Elevated Runner successfully" do
-      expect { @winrm.elevate }.to_not raise_error
-      expect(@winrm.elevate).to be_a(WinRM::Elevated::Runner)
-    end
-  end
 end

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -26,7 +26,8 @@ class MiqWinRM
   end
 
   def elevate
-    @elevated_runner = WinRM::Elevated::Runner.new(@connection)
+    execute if @executor.nil?
+    @elevated_runner = WinRM::Elevated::Runner.new(@executor)
   end
 
   def run_powershell_script(script)


### PR DESCRIPTION
winrm-elevated version 0.4.0 changes the initializer argument from
the previous winrm service object to the newer executor object.
Change miq_winrm to pass the executor.

@roliveri @djberg96 please review. 