### PR TITLE
pluggable providers: textual summary for vm architecture

### DIFF
--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -116,9 +116,9 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_architecture
-    return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
-    bitness = @record.hardware.try(:bitness)
-    {:label => _("Architecture"), :value => bitness.nil? ? "" : "#{bitness} bit"}
+    bitness = @record.hardware.try!(:bitness)
+    return nil if bitness.blank?
+    {:label => _("Architecture"), :value => "#{bitness} bit"}
   end
 
   def textual_advanced_settings


### PR DESCRIPTION
always display architecture if the records hardware has bitness

I'm not sure if this is really wanted from the UI perspective,
but we scan amazon and azure for hardware bitness too, so my
guess is, that was never displayed?

Another approach would be to explicitly say in the providers vm,
that it supports hardware bitness. But imho thats too much.
If it's there, then display it.