### PR TITLE
Hawkular refactor livemetrics config

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers
       @ems.metrics_resource(resource).collect do |metric|
         {
           :id   => metric.id,
-          :name => @target.class::METRICS_HWK_MIQ[metric.name],
+          :name => @target.class.supported_metrics[metric.name],
           :type => metric.type,
           :unit => metric.unit
         }

--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -7,28 +7,7 @@ class MiddlewareServer < ApplicationRecord
 
   include LiveMetricsMixin
 
-  # Used to describe Hawkular supported metrics for this resource and convert it into MiQ style names
-  METRICS_HWK_MIQ = {
-    "WildFly Memory Metrics~Heap Used"                                  => "mw_heap_used",
-    "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
-    "WildFly Memory Metrics~NonHeap Committed"                          => "mw_non_heap_committed",
-    "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
-    "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
-    "WildFly Memory Metrics~Accumulated GC Duration"                    => "mw_accumulated_gc_duration",
-    "WildFly Memory Metrics~Heap Max"                                   => "mw_heap_max",
-    "WildFly Memory Metrics~Heap Committed"                             => "mw_heap_committed",
-    "WildFly Memory Metrics~NonHeap Used"                               => "mw_non_heap_used",
-    "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
-    "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
-    "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
-    "WildFly Threading Metrics~Thread Count"                            => "mw_thread_count",
-    "Server Availability~App Server"                                    => "mw_availability_app_server"
-  }.freeze
-
   def metrics_capture
     @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)
   end
-
-  delegate :metrics_available, :to => :metrics_capture
-  delegate :collect_live_metric, :to => :metrics_capture
 end

--- a/product/live_metrics/middleware_server.yaml
+++ b/product/live_metrics/middleware_server.yaml
@@ -1,0 +1,25 @@
+#
+# LiveMetrics configuration file
+#
+#   It defines the live metrics supported in a model that includes a LiveMetricsMixin.
+#   It maps the native id used in the provider for a metric with the column where this metric will be available in
+#   a LiveMetric virtual model.
+#
+#   Format:
+#   - Provider native metric id: MiQ metric id
+#
+- WildFly Memory Metrics~Heap Used: mw_heap_used
+- WildFly Memory Metrics~Heap Max: mw_heap_max
+- WildFly Memory Metrics~Heap Committed: mw_heap_committed
+- WildFly Memory Metrics~NonHeap Used: mw_non_heap_used
+- WildFly Memory Metrics~NonHeap Committed: mw_non_heap_committed
+- WildFly Memory Metrics~Accumulated GC Duration: mw_accumulated_gc_duration
+- WildFly Aggregated Web Metrics~Aggregated Servlet Request Time: mw_agregated_servlet_time
+- WildFly Aggregated Web Metrics~Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
+- WildFly Aggregated Web Metrics~Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
+- WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions
+- WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions: mw_aggregated_expired_web_sessions
+- WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions: mw_aggregated_max_active_web_sessions
+- WildFly Threading Metrics~Thread Count: mw_thread_count
+- Server Availability~App Server: mw_availability_app_server
+

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -21,9 +21,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for all metrics available" do
-    start_time = Time.new(2016, 5, 17, 15, 0, 0, "+02:00")    # Fixed time for testing
-    end_time = Time.new(2016, 5, 18, 0, 0, 0, "+02:00")      # Fixed time for testing
-    interval = 3600                                         # Interval in seconds
+    start_time = Time.new(2016, 5, 17, 15, 0, 0, "+02:00")
+    end_time = Time.new(2016, 5, 18, 0, 0, 0, "+02:00")
+    interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
                      :decode_compressed_response     => true) do # , :record => :new_episodes) do
@@ -35,9 +35,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for three metrics" do
-    start_time = Time.new(2016, 5, 17, 15, 0, 0, "+02:00")    # Fixed time for testing
-    end_time = Time.new(2016, 5, 18, 0, 0, 0, "+02:00")      # Fixed time for testing
-    interval = 3600                                         # Interval in seconds
+    start_time = Time.new(2016, 5, 17, 15, 0, 0, "+02:00")
+    end_time = Time.new(2016, 5, 18, 0, 0, 0, "+02:00")
+    interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
                      :decode_compressed_response     => true) do # , :record => :new_episodes) do
@@ -60,5 +60,26 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
       capture = eap.first_and_last_capture
       expect(capture[0]).to be < capture[1]
     end
+  end
+
+  it "#supported_metrics" do
+    expected_metrics = {
+      "WildFly Memory Metrics~Heap Used"                                  => "mw_heap_used",
+      "WildFly Memory Metrics~Heap Max"                                   => "mw_heap_max",
+      "WildFly Memory Metrics~Heap Committed"                             => "mw_heap_committed",
+      "WildFly Memory Metrics~NonHeap Used"                               => "mw_non_heap_used",
+      "WildFly Memory Metrics~NonHeap Committed"                          => "mw_non_heap_committed",
+      "WildFly Memory Metrics~Accumulated GC Duration"                    => "mw_accumulated_gc_duration",
+      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
+      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
+      "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
+      "WildFly Threading Metrics~Thread Count"                            => "mw_thread_count",
+      "Server Availability~App Server"                                    => "mw_availability_app_server"
+    }.freeze
+    supported_metrics = MiddlewareServer.supported_metrics
+    expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
   end
 end


### PR DESCRIPTION
This PR refactors the supported live metrics into a configuration file based on products/live_metrics.
It depends on #8860, so I have included it here. Once is merged I will rebase it.

I am going to prepare in a separate PR how to extend live metrics to other models (datasources) using this new enhancement.

@miq-bot add_label enhancement, providers/hawkular
