### PR TITLE
Use Chargeback.subclasses instead of enumeration of subclasses

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -97,7 +97,7 @@ module MiqReport::Formatting
     options[:column] = col
 
     # Chargeback Reports: Add the selected currency in the assigned rate to options
-    if db.to_s == "ChargebackVm" || db.to_s == "ChargebackContainerProject"
+    if Chargeback.db_is_chargeback?(db)
       compute_selected_rate = ChargebackRate.get_assignments(:compute)[0]
       storage_selected_rate = ChargebackRate.get_assignments(:storage)[0]
       selected_rate = compute_selected_rate.nil? ? storage_selected_rate : compute_selected_rate


### PR DESCRIPTION
just small change as we can do Chargeback.subclasses
0> Chargeback.subclasses
=> [ChargebackContainerProject, ChargebackVm]

it was done in https://github.com/ManageIQ/manageiq/pull/9013
fyi @tledesma 