### PR TITLE
Delayed translation of ui constants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -923,7 +923,7 @@ class ApplicationController < ActionController::Base
         when 'db'
           celltext = Dictionary.gettext(row[col], :type => :model, :notfound => :titleize)
         when 'approval_state'
-          celltext = PROV_STATES[row[col]]
+          celltext = _(PROV_STATES[row[col]])
         when 'state'
           celltext = row[col].titleize
         when 'hardware.bitness'

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -189,7 +189,7 @@ class MiqCapacityController < ApplicationController
 
     @sb[:planning][:options][:chosen_vm] = params[:chosen_vm] == "<Choose>" ? nil : params[:chosen_vm] if params[:chosen_vm]
     @sb[:planning][:options][:days] = params[:trend_days].to_i if params[:trend_days]
-    @sb[:planning][:options][:vm_mode] = VALID_PLANNING_VM_MODES[params[:vm_mode]] if params[:vm_mode]
+    @sb[:planning][:options][:vm_mode] = _(VALID_PLANNING_VM_MODES[params[:vm_mode]]) if params[:vm_mode]
     @sb[:planning][:options][:trend_cpu] = (params[:trend_cpu] == "1") if params[:trend_cpu]
     @sb[:planning][:options][:trend_vcpus] = (params[:trend_vcpus] == "1") if params[:trend_vcpus]
     @sb[:planning][:options][:trend_memory] = (params[:trend_memory] == "1") if params[:trend_memory]

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -509,7 +509,7 @@ class MiqRequestController < ApplicationController
   def prov_set_default_options
     resource_type = get_request_tab_type
     opts = @sb[:prov_options][resource_type.to_sym] = {}
-    opts[:states] = PROV_STATES
+    opts[:states] = PROV_STATES.map { |k, v| [k, _(v)] }.to_h
     opts[:reason_text] = nil
     opts[:types] = request_types_for_dropdown
 

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -31,7 +31,7 @@ module OpsController::Settings::AnalysisProfiles
       when "category"
         @category = [] if @category.nil?
         for i in 0...a[:definition]["content"].length
-          @category.push(CATEGORY_CHOICES[a[:definition]["content"][i]["target"]]) if a[:definition]["content"][i]["target"] != "vmevents"
+          @category.push(_(CATEGORY_CHOICES[a[:definition]["content"][i]["target"]])) if a[:definition]["content"][i]["target"] != "vmevents"
         end
       when "file"
         @file = [] if @file.nil?

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -38,19 +38,19 @@ module UiConstants
 
   # PDF page sizes
   PDF_PAGE_SIZES = {
-    "a0"            => _("A0 - 841mm x 1189mm"),
-    "a1"            => _("A1 - 594mm x 841mm"),
-    "a2"            => _("A2 - 420mm x 594mm"),
-    "a3"            => _("A3 - 297mm x 420mm"),
-    "a4"            => _("A4 - 210mm x 297mm (default)"),
-    "US-Letter"     => _("US Letter - 8.5in x 11.0in"),
-    "US-Legal"      => _("US Legal - 8.5in x 14.0in"),
-    "US-Executive"  => _("US Executive - 7.25in x 10.5in"),
-    "US-Ledger"     => _("US Ledger - 17.0in x 11.0in"),
-    "US-Tabloid"    => _("US Tabloid - 11.0in x 17.0in"),
-    "US-Government" => _("US Government - 8.0in x 11.0in"),
-    "US-Statement"  => _("US Statement - 5.5in x 8.5in"),
-    "US-Folio"      => _("US Folio - 8.5in x 13.0in")
+    "a0"            => N_("A0 - 841mm x 1189mm"),
+    "a1"            => N_("A1 - 594mm x 841mm"),
+    "a2"            => N_("A2 - 420mm x 594mm"),
+    "a3"            => N_("A3 - 297mm x 420mm"),
+    "a4"            => N_("A4 - 210mm x 297mm (default)"),
+    "US-Letter"     => N_("US Letter - 8.5in x 11.0in"),
+    "US-Legal"      => N_("US Legal - 8.5in x 14.0in"),
+    "US-Executive"  => N_("US Executive - 7.25in x 10.5in"),
+    "US-Ledger"     => N_("US Ledger - 17.0in x 11.0in"),
+    "US-Tabloid"    => N_("US Tabloid - 11.0in x 17.0in"),
+    "US-Government" => N_("US Government - 8.0in x 11.0in"),
+    "US-Statement"  => N_("US Statement - 5.5in x 8.5in"),
+    "US-Folio"      => N_("US Folio - 8.5in x 13.0in")
   }
   DEFAULT_PDF_PAGE_SIZE = "US-Letter"
 
@@ -283,35 +283,35 @@ module UiConstants
   VIEW_RESOURCES = DEFAULT_SETTINGS[:views].keys.each_with_object({}) { |value, acc| acc[value.to_s] = value }.freeze
 
   TIMER_DAYS = [
-    [_("Day"), "1"],
-    [_("2 Days"), "2"],
-    [_("3 Days"), "3"],
-    [_("4 Days"), "4"],
-    [_("5 Days"), "5"],
-    [_("6 Days"), "6"],
+    [N_("Day"), "1"],
+    [N_("2 Days"), "2"],
+    [N_("3 Days"), "3"],
+    [N_("4 Days"), "4"],
+    [N_("5 Days"), "5"],
+    [N_("6 Days"), "6"],
   ]
   TIMER_HOURS = [
-    [_("Hour"), "1"],
-    [_("2 Hours"), "2"],
-    [_("3 Hours"), "3"],
-    [_("4 Hours"), "4"],
-    [_("6 Hours"), "6"],
-    [_("8 Hours"), "8"],
-    [_("12 Hours"), "12"],
+    [N_("Hour"), "1"],
+    [N_("2 Hours"), "2"],
+    [N_("3 Hours"), "3"],
+    [N_("4 Hours"), "4"],
+    [N_("6 Hours"), "6"],
+    [N_("8 Hours"), "8"],
+    [N_("12 Hours"), "12"],
   ]
   TIMER_WEEKS = [
-    [_("Week"), "1"],
-    [_("2 Weeks"), "2"],
-    [_("3 Weeks"), "3"],
-    [_("4 Weeks"), "4"],
+    [N_("Week"), "1"],
+    [N_("2 Weeks"), "2"],
+    [N_("3 Weeks"), "3"],
+    [N_("4 Weeks"), "4"],
   ]
   TIMER_MONTHS = [
-    [_("Month"), "1"],
-    [_("2 Months"), "2"],
-    [_("3 Months"), "3"],
-    [_("4 Months"), "4"],
-    [_("5 Months"), "5"],
-    [_("6 Months"), "6"],
+    [N_("Month"), "1"],
+    [N_("2 Months"), "2"],
+    [N_("3 Months"), "3"],
+    [N_("4 Months"), "4"],
+    [N_("5 Months"), "5"],
+    [N_("6 Months"), "6"],
   ]
 
   # Maximum fields to show for automation engine resolution screens
@@ -331,10 +331,10 @@ module UiConstants
 
   # Choices for trend and C&U days back pulldowns
   WEEK_CHOICES = {
-    7  => _("1 Week"),
-    14 => _("2 Weeks"),
-    21 => _("3 Weeks"),
-    28 => _("4 Weeks")
+    7  => N_("1 Week"),
+    14 => N_("2 Weeks"),
+    21 => N_("3 Weeks"),
+    28 => N_("4 Weeks")
     # 60 => "2 Months",   # Removed longer times when on demand daily rollups was added in sprint 59 due to performance
     # 90 => "3 Months",
     # 180 => "6 Months"
@@ -342,17 +342,17 @@ module UiConstants
 
   # Choices for C&U last hour real time minutes back pulldown
   REALTIME_CHOICES = {
-    10.minutes => _("10 Minutes"),
-    15.minutes => _("15 Minutes"),
-    30.minutes => _("30 Minutes"),
-    45.minutes => _("45 Minutes"),
-    1.hour     => _("1 Hour")
+    10.minutes => N_("10 Minutes"),
+    15.minutes => N_("15 Minutes"),
+    30.minutes => N_("30 Minutes"),
+    45.minutes => N_("45 Minutes"),
+    1.hour     => N_("1 Hour")
   }
 
   # Choices for Target options show pulldown
   TARGET_TYPE_CHOICES = {
-    "EmsCluster" => _("Clusters"),
-    "Host"       => _("Hosts")
+    "EmsCluster" => N_("Clusters"),
+    "Host"       => N_("Hosts")
   }
 
   # Choices for the trend limit percent pulldowns
@@ -391,10 +391,10 @@ module UiConstants
 
   # Source pulldown in VM Options
   PLANNING_VM_MODES = {
-    :allocated => _("Allocation"),
-    :reserved  => _("Reservation"),
-    :used      => _("Usage"),
-    :manual    => _("Manual Input")
+    :allocated => N_("Allocation"),
+    :reserved  => N_("Reservation"),
+    :used      => N_("Usage"),
+    :manual    => N_("Manual Input")
   }
   VALID_PLANNING_VM_MODES = PLANNING_VM_MODES.keys.index_by(&:to_s)
 
@@ -416,14 +416,14 @@ module UiConstants
                [N_("Finished"), "Finished"]].freeze
 
   PROV_STATES = {
-    "pending_approval" => _("Pending Approval"),
-    "approved"         => _("Approved"),
-    "denied"           => _("Denied")
+    "pending_approval" => N_("Pending Approval"),
+    "approved"         => N_("Approved"),
+    "denied"           => N_("Denied")
   }
   PROV_TIME_PERIODS = {
-    1  => _("Last 24 Hours"),
-    7  => _("Last 7 Days"),
-    30 => _("Last 30 Days")
+    1  => N_("Last 24 Hours"),
+    7  => N_("Last 7 Days"),
+    30 => N_("Last 30 Days")
   }
 
   ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.name] }
@@ -431,11 +431,11 @@ module UiConstants
   # ALL_TIMEZONES = ActiveSupport::TimeZone.all.collect{|tz| tz.utc_offset % 3600 == 0 ? ["(GMT#{tz.formatted_offset}) #{tz.name}",tz.name] : nil}.compact
 
   CATEGORY_CHOICES = {}
-  CATEGORY_CHOICES["services"] = _("Services")
-  CATEGORY_CHOICES["software"] = _("Software")
-  CATEGORY_CHOICES["system"] = _("System")
-  CATEGORY_CHOICES["accounts"] = _("User Accounts")
-  CATEGORY_CHOICES["vmconfig"] = _("VM Configuration")
+  CATEGORY_CHOICES["services"] = N_("Services")
+  CATEGORY_CHOICES["software"] = N_("Software")
+  CATEGORY_CHOICES["system"] = N_("System")
+  CATEGORY_CHOICES["accounts"] = N_("User Accounts")
+  CATEGORY_CHOICES["vmconfig"] = N_("VM Configuration")
   # CATEGORY_CHOICES["vmevents"] = "VM Events"
 
   # Assignment choices
@@ -443,55 +443,89 @@ module UiConstants
 
   # This set of assignments was created for miq_alerts
   ASSIGN_TOS["ExtManagementSystem"] = {
-    "enterprise"                 => _("The Enterprise"),
-    "ext_management_system"      => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ems_infra")},
-    "ext_management_system-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "ems_infra")}
+    "enterprise"                 => N_("The Enterprise"),
+    "ext_management_system"      => PostponedTranslation.new(N_("Selected %{tables}")) do
+                                      {:tables => ui_lookup(:tables => "ems_infra")}
+                                    end,
+    "ext_management_system-tags" => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                                      {:tables => ui_lookup(:tables => "ems_infra")}
+                                    end
   }
   ASSIGN_TOS["EmsCluster"] = {
-    "ems_cluster"      => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ems_cluster")},
-    "ems_cluster-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "ems_cluster")}
+    "ems_cluster"      => PostponedTranslation.new(N_("Selected %{tables}")) do
+                            {:tables => ui_lookup(:tables => "ems_cluster")}
+                          end,
+    "ems_cluster-tags" => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                            {:tables => ui_lookup(:tables => "ems_cluster")}
+                          end
   }.merge(ASSIGN_TOS["ExtManagementSystem"])
   ASSIGN_TOS["Host"] = {
-    "host"      => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "host")},
-    "host-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "host")}
+    "host"      => PostponedTranslation.new(N_("Selected %{tables}")) do
+                     {:tables => ui_lookup(:tables => "host")}
+                   end,
+    "host-tags" => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                     {:tables => ui_lookup(:tables => "host")}
+                   end
   }.merge(ASSIGN_TOS["EmsCluster"])
   ASSIGN_TOS["Vm"] = {
-    "ems_folder"         => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ems_folder")},
-    "resource_pool"      => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "resource_pool")},
-    "resource_pool-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "resource_pool")},
-    "vm-tags"            => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "vm")}
+    "ems_folder"         => PostponedTranslation.new(N_("Selected %{tables}")) do
+                              {:tables => ui_lookup(:tables => "ems_folder")}
+                            end,
+    "resource_pool"      => PostponedTranslation.new(N_("Selected %{tables}")) do
+                              {:tables => ui_lookup(:tables => "resource_pool")}
+                            end,
+    "resource_pool-tags" => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                              {:tables => ui_lookup(:tables => "resource_pool")}
+                            end,
+    "vm-tags"            => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                              {:tables => ui_lookup(:tables => "vm")}
+                            end
   }.merge(ASSIGN_TOS["Host"])
   ASSIGN_TOS["Storage"] = {
-    "enterprise"   => _("The Enterprise"),
-    "storage"      => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "storage")},
-    "storage-tags" => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "storage")},
-    "tenant"       => _("Tenants")
+    "enterprise"   => N_("The Enterprise"),
+    "storage"      => PostponedTranslation.new(N_("Selected %{tables}")) do
+                        {:tables => ui_lookup(:tables => "storage")}
+                      end,
+    "storage-tags" => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                        {:tables => ui_lookup(:tables => "storage")}
+                      end,
+    "tenant"       => N_("Tenants")
   }
   ASSIGN_TOS["MiqServer"] = {
-    "miq_server" => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "miq_server")},
+    "miq_server" => PostponedTranslation.new(N_("Selected %{tables}")) do
+                      {:tables => ui_lookup(:tables => "miq_server")}
+                    end,
   }
 
   # This set of assignments was created for chargeback_rates
   ASSIGN_TOS[:chargeback_storage] = ASSIGN_TOS["Storage"]
   ASSIGN_TOS[:chargeback_compute] = {
-    "enterprise"            => _("The Enterprise"),
-    "ext_management_system" => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ext_management_systems")},
-    "ems_cluster"           => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ems_cluster")},
-    "ems_container"         => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "ems_container")},
-    "vm-tags"               => _("Tagged %{tables}") % {:tables => ui_lookup(:tables => "vm")},
-    "tenant"                => _("Tenants")
+    "enterprise"            => N_("The Enterprise"),
+    "ext_management_system" => PostponedTranslation.new(N_("Selected %{tables}")) do
+                                 {:tables => ui_lookup(:tables => "ext_management_systems")}
+                               end,
+    "ems_cluster"           => PostponedTranslation.new(N_("Selected %{tables}")) do
+                                 {:tables => ui_lookup(:tables => "ems_cluster")}
+                               end,
+    "ems_container"         => PostponedTranslation.new(N_("Selected %{tables}")) do
+                                 {:tables => ui_lookup(:tables => "ems_container")}
+                               end,
+    "vm-tags"               => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                                 {:tables => ui_lookup(:tables => "vm")}
+                               end,
+    "tenant"                => N_("Tenants")
   }
 
-  EXP_COUNT_TYPE = [_("Count of"), "count"].freeze  # Selection for count based filters
-  EXP_FIND_TYPE = [_("Find"), "find"].freeze        # Selection for find/check filters
+  EXP_COUNT_TYPE = [N_("Count of"), "count"].freeze  # Selection for count based filters
+  EXP_FIND_TYPE = [N_("Find"), "find"].freeze        # Selection for find/check filters
   EXP_TYPES = [                           # All normal filters
-    [_("Field"), "field"],
+    [N_("Field"), "field"],
     EXP_COUNT_TYPE,
-    [_("Tag"), "tag"],
+    [N_("Tag"), "tag"],
     EXP_FIND_TYPE
   ]
   VM_EXP_TYPES = [                        # Special VM registry filter
-    [_("Registry"), "regkey"]
+    [N_("Registry"), "regkey"]
   ]
 
   # Snapshot ages for delete_snapshots_by_age action type

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -31,7 +31,9 @@ class TreeBuilderAlertProfile < TreeBuilder
       open_node("xx-#{db}")
 
       # Actual translation should happen in TreeNodeBuilder
-      text = PostponedTranslation.new(N_("%s Alert Profiles"), ui_lookup(:model => db)).to_proc
+      text = PostponedTranslation.new(N_("%{model} Alert Profiles")) do
+        {:model => ui_lookup(:model => db)}
+      end.to_proc
       {:id => db, :text => text, :image => db.underscore.downcase, :tip => text}
     end
 

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -9,7 +9,8 @@
       %label.col-md-2.control-label
         = _('Assign To')
       .col-md-8
-        - options = Array(ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].invert)
+        - options = ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].map do |k, v|
+          [v.kind_of?(PostponedTranslation) ? v.translate : _(v), k]
         = select_tag("cbshow_typ", options_for_select([[nothing, "nil"]] + options, @edit[:new][:cbshow_typ]),
                     "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
       :javascript

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -35,7 +35,7 @@
           = _("Show")
         %dd
           = select_tag("perf_minutes",
-                       options_for_select(REALTIME_CHOICES.invert.sort_by { |_name, value| value },
+                       options_for_select(REALTIME_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last),
                        @perf_options[:rt_minutes]),
                        "data-miq_sparkle_on" => true,
                        :class    => "selectpicker")
@@ -63,7 +63,7 @@
             = _("Show")
           %dd
             = select_tag("perf_days",
-                          options_for_select(WEEK_CHOICES.invert.sort_by { |_name, value| value },
+                          options_for_select(WEEK_CHOICES.map { |k, v| [_(v), k] }.sort,
                             @perf_options[:days].to_i),
                           "data-miq_sparkle_on" => true,
                           :class    => "selectpicker")

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -14,11 +14,11 @@
   -# Get all of the expression types, then remove the count and/or find based ones if model has none
   - unless exp_model == "_display_filter_"
     -# Not valid for secondary display filter
-    - exptypes = EXP_TYPES
+    - exptypes = EXP_TYPES.map { |x| [_(x[0]), x[1]] }
     - unless MiqExpression.miq_adv_search_lists(exp_model, :exp_available_counts).length > 0
-      - exptypes -= [EXP_COUNT_TYPE]
+      - exptypes -= [[_(EXP_COUNT_TYPE[0]), EXP_COUNT_TYPE[1]]]
     - unless MiqExpression.miq_adv_search_lists(exp_model, :exp_available_finds).length > 0
-      - exptypes -= [EXP_FIND_TYPE]
+      - exptypes -= [[_(EXP_FIND_TYPE[0]), EXP_FIND_TYPE[1]]]
   #exp_atom_editor_div
     %fieldset{:style => "width:auto; padding-left: 6px; padding-top: 6px;"}
       %ul.searchtoolbar
@@ -47,7 +47,7 @@
         - else
           - if exp_model == "Vm"
             = select_tag('chosen_typ',
-              options_for_select(["<#{_('Choose')}>"] + exptypes + VM_EXP_TYPES, @edit[@expkey][:exp_typ]),
+              options_for_select(["<#{_('Choose')}>"] + exptypes + VM_EXP_TYPES.map { |x| [_(x[0]), x[1]] }, @edit[@expkey][:exp_typ]),
               :multiple              => false,
               :class                 => "widthed",
               "data-miq_sparkle_on"  => true,

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -84,7 +84,7 @@
         = _('Source')
       .col-md-8
         = select_tag("vm_mode",
-                      options_for_select(PLANNING_VM_MODES.invert.sort, @sb[:planning][:options][:vm_mode]),
+                      options_for_select(PLANNING_VM_MODES.map { |k, v| [_(v), k] }.sort, @sb[:planning][:options][:vm_mode]),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)
@@ -174,7 +174,7 @@
         = _('Show')
       .col-md-8
         = select_tag("target_typ",
-                      options_for_select(TARGET_TYPE_CHOICES.invert.sort_by(&:last), @sb[:planning][:options][:target_typ]),
+                      options_for_select(TARGET_TYPE_CHOICES.map { |k, v| [_(v), k] }.sort_by(&:last), @sb[:planning][:options][:target_typ]),
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true)

--- a/app/views/miq_capacity/_planning_report.html.haml
+++ b/app/views/miq_capacity/_planning_report.html.haml
@@ -11,6 +11,6 @@
     - if @sb[:planning][:rpt].extras[:vm_profile]
       = render :partial => "planning_vm_profile"
   - if @perf_record
-    %p= _("* Information shown is based on available trend data going back %s.") % WEEK_CHOICES[@sb[:planning][:options][:days]].downcase
+    %p= _("* Information shown is based on available trend data going back %s.") % _(WEEK_CHOICES[@sb[:planning][:options][:days]])
   - else
     = render :partial => "planning_instructions"

--- a/app/views/miq_capacity/_planning_summary.html.haml
+++ b/app/views/miq_capacity/_planning_summary.html.haml
@@ -43,6 +43,6 @@
         = render :partial => "planning_vm_profile"
 
   - if @perf_record
-    %p= _("* Information shown is based on available trend data going back %s.") % WEEK_CHOICES[@sb[:planning][:options][:days]].downcase
+    %p= _("* Information shown is based on available trend data going back %s.") % _(WEEK_CHOICES[@sb[:planning][:options][:days]])
   - else
     = render :partial => "planning_instructions"

--- a/app/views/miq_capacity/_planning_vm_profile.html.haml
+++ b/app/views/miq_capacity/_planning_vm_profile.html.haml
@@ -3,7 +3,7 @@
 %dl.dl-horizontal
   %dt= _('Source')
   %dd
-    = h(PLANNING_VM_MODES[@sb[:planning][:options][:submitted_vm_mode]])
+    = h(_(PLANNING_VM_MODES[@sb[:planning][:options][:submitted_vm_mode]]))
 
   - if @sb[:planning][:vm_opts][:cpu] && @sb[:planning][:options][:trend_cpu] && @sb[:planning][:rpt].extras[:vm_profile][:cpu]
     %dt= _('CPU Speed')
@@ -30,7 +30,7 @@
 %dl.dl-horizontal
   %dt= _('Show')
   %dd
-    = h(TARGET_TYPE_CHOICES[@sb[:planning][:options][:target_typ]])
+    = h(_(TARGET_TYPE_CHOICES[@sb[:planning][:options][:target_typ]]))
 
   - if @sb[:planning][:vm_opts][:cpu] && @sb[:planning][:options][:trend_cpu] && @sb[:planning][:rpt].extras[:vm_profile][:cpu]
     %dt= _('CPU Speed')
@@ -57,7 +57,7 @@
 %dl.dl-horizontal
   %dt= _('Trend for Past')
   %dd
-    = h(WEEK_CHOICES[@sb[:planning][:options][:days].to_i])
+    = h(_(WEEK_CHOICES[@sb[:planning][:options][:days].to_i]))
   %dt= _('Time Profile')
   %dd
     - if @sb[:planning][:options][:time_profile].nil?

--- a/app/views/miq_capacity/_utilization_options.html.haml
+++ b/app/views/miq_capacity/_utilization_options.html.haml
@@ -9,7 +9,7 @@
         = _('Trends for past')
       .col-md-10
         = select_tag("#{cap_type}_days",
-          options_for_select(WEEK_CHOICES.invert.sort_by(&:last), @sb[:util][:options][:days].to_i),
+          options_for_select(WEEK_CHOICES.map {|k, v| [_(v), k]}.sort, @sb[:util][:options][:days].to_i),
           "class"               => "selectpicker")
         :javascript
           miqInitSelectPicker();

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -14,7 +14,7 @@
         = _('Assign To')
       .col-md-8
         = select_tag('chosen_assign_to',
-          options_for_select([["<#{_('Nothing')}>", nil]] + ASSIGN_TOS[@alert_profile.mode].invert.sort, @assign[:new][:assign_to]),
+          options_for_select([["<#{_('Nothing')}>", nil]] + ASSIGN_TOS[@alert_profile.mode].map { |k, v| [v.kind_of?(PostponedTranslation) ? v.translate : _(v), k] }.sort, @assign[:new][:assign_to]),
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();

--- a/app/views/miq_request/_prov_options.html.haml
+++ b/app/views/miq_request/_prov_options.html.haml
@@ -45,7 +45,7 @@
         = _("Request Date:")
       .col-md-8
         = select_tag("time_period",
-                      options_for_select(Array(PROV_TIME_PERIODS.invert).sort_by(&:last), res_type[:time_period]),
+                      options_for_select(PROV_TIME_PERIODS.map { |k, v| [_(v), k] }.sort_by(&:last), res_type[:time_period]),
                       :class    => "selectpicker")
         :javascript
           miqInitSelectPicker();

--- a/app/views/ops/_ap_form_set.html.haml
+++ b/app/views/ops/_ap_form_set.html.haml
@@ -16,7 +16,7 @@
                 - checked = @selected.include? k if @selected
                 .col-md-4{:align => "left", :nowrap => "", :valign => "top"}
                   = hidden_field("item", "type", :value => "category")
-                  = check_box_tag("check_#{k}", v, checked,
+                  = check_box_tag("check_#{k}", _(v), checked,
                     "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
                     "data-miq_observe_checkbox" => {:url => url}.to_json)
-                  = v
+                  = _(v)

--- a/app/views/report/_form_formatting.html.haml
+++ b/app/views/report/_form_formatting.html.haml
@@ -8,7 +8,7 @@
         = _('Page Size')
       .col-md-8
         = select_tag('pdf_page_size',
-          options_for_select(PDF_PAGE_SIZES.invert.sort, @edit[:new][:pdf_page_size]),
+          options_for_select(PDF_PAGE_SIZES.map { |k, v| [_(v), v] }.sort, @edit[:new][:pdf_page_size]),
           :multiple             => false,
           :class                => "selectpicker")
         :javascript

--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -18,7 +18,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "daily", :id => "daily_span") do
           = _("every")
           = select_tag("timer_days",
-            options_for_select(TIMER_DAYS, @edit[:new][:timer].days),
+            options_for_select(TIMER_DAYS.map { |x, y| [_(x), y] }, @edit[:new][:timer].days),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -26,7 +26,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "hourly", :id => "hourly_span") do
           = _("every")
           = select_tag("timer_hours",
-            options_for_select(TIMER_HOURS, @edit[:new][:timer].hours),
+            options_for_select(TIMER_HOURS.map { |x, y| [_(x), y] }, @edit[:new][:timer].hours),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -34,7 +34,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "weekly", :id => "weekly_span") do
           = _("every")
           = select_tag("timer_weeks",
-            options_for_select(TIMER_WEEKS, @edit[:new][:timer].weeks),
+            options_for_select(TIMER_WEEKS.map { |x, y| [_(x), y] }, @edit[:new][:timer].weeks),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -42,7 +42,7 @@
         = hidden_span_if(@edit[:new][:timer].typ.downcase != "monthly", :id => "monthly_span") do
           = _("every")
           = select_tag("timer_months",
-            options_for_select(TIMER_MONTHS, @edit[:new][:timer].months),
+            options_for_select(TIMER_MONTHS.map { |x, y| [_(x), y] }, @edit[:new][:timer].months),
             :class => "selectpicker")
           :javascript
             miqInitSelectPicker();

--- a/lib/postponed_translation.rb
+++ b/lib/postponed_translation.rb
@@ -3,24 +3,23 @@
 
 # example:
 #
-# PostponedTranslation.new( _N("%s Alert Profiles"), "already translated string" )
-# PostponedTranslation.new( _N("%{foo} Alert Profiles"), { :foo => "already translated string" })
+# PostponedTranslation.new( _N("%s Alert Profiles")) { "already translated string" }
+# PostponedTranslation.new( _N("%{model} Alert Profiles")) do {:model => ui_lookup(:models => variable)} end
 
 class PostponedTranslation
-  def initialize(string, *args)
+  def initialize(string, &block)
     @string = string
-    @args = args
-    @args = args.first if args.length == 1 && args.first.kind_of?(Hash)
+    @block = block
   end
 
   # meant to catch cases where PostponedTranslation is not supported
   def to_s
     $log.warn("PostponedTranslation#to_s should not be called - leaving untranslated")
-    @string % @args
+    @string % @block.call
   end
 
   def translate
-    _(@string) % @args
+    _(@string) % @block.call
   end
 
   # when we have a generic Proc support - TreeBuilder for example

--- a/spec/lib/postponed_translation_spec.rb
+++ b/spec/lib/postponed_translation_spec.rb
@@ -1,20 +1,22 @@
 describe PostponedTranslation do
   context "translate" do
     it "calls Kernel#format" do
-      pt = PostponedTranslation.new("Test %s", "foo")
+      pt = PostponedTranslation.new("Test %s") { "foo" }
       expect(pt.translate).to eq("Test foo")
 
-      pt = PostponedTranslation.new("Test %s%d", "foo", 5)
+      pt = PostponedTranslation.new("Test %s%d") { ["foo", 5] }
       expect(pt.translate).to eq("Test foo5")
 
-      pt = PostponedTranslation.new("Test %{bar}", :bar => "foo")
+      pt = PostponedTranslation.new("Test %{bar}") do
+             {:bar => "foo"}
+           end
       expect(pt.translate).to eq("Test foo")
     end
   end
 
   context "#to_proc" do
     it "returns a Proc" do
-      pt = PostponedTranslation.new("Test %s", "foo")
+      pt = PostponedTranslation.new("Test %s") { "foo" }
       expect(pt.to_proc).to be_kind_of(Proc)
     end
   end


### PR DESCRIPTION
Changes:

* Modify PostponedTranslation to receive block as an argument. This change is to make sure
the block given is evaluated at the same moment when we're calling `.call()` or `.translate()`,
not when we're constructing the object.

* Use delayed translations for UI constants. These constants are loaded at application startup and
therefore need to be translated when the constants are being used.

Not all constants have been addressed, the rest will be addressed in a later PR.

https://bugzilla.redhat.com/show_bug.cgi?id=1340437
https://bugzilla.redhat.com/show_bug.cgi?id=1340426
https://bugzilla.redhat.com/show_bug.cgi?id=1275614
https://bugzilla.redhat.com/show_bug.cgi?id=1233072