### PR TITLE
Increase replication worker's memory threshold

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1264,6 +1264,7 @@
         :poll_method: :normal
         :queue_timeout: 120.minutes
     :replication_worker:
+      :memory_threshold: 400.megabytes
       :poll: 1.seconds
       :replication:
         :destination:


### PR DESCRIPTION
Previously it was 200 megabytes which was causing the monitor to bring the worker down during normal operation

Specifically we were seeing:
```
[----] W, [2016-05-31T16:00:18.919310 #59454:81798c]  WARN -- : MIQ(MiqServer#validate_worker) Worker [MiqReplicationWorker] with ID: [60], PID: [64278], GUID: [426555ac-276a-11e6-88ea-001a4a223919] process memory usage [238391000] exceeded limit [209715200], requesting worker to exit
[----] I, [2016-05-31T16:00:18.924719 #59454:81798c]  INFO -- : MIQ(MiqQueue.put) Message id: [687],  id: [], Zone: [default], Role: [], Server: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [MiqEvent.raise_evm_event], Timeout: [600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: [["MiqServer", 1], "evm_worker_memory_exceeded", {:event_details=>"Worker [MiqReplicationWorker] with ID: [60], PID: [64278], GUID: [426555ac-276a-11e6-88ea-001a4a223919] process memory usage [238391000] exceeded limit [209715200], requesting worker to exit", :type=>"MiqReplicationWorker"}]
[----] I, [2016-05-31T16:00:18.924891 #59454:81798c]  INFO -- : MIQ(MiqServer#stop_worker) Stopping Worker [MiqReplicationWorker] with ID: [60], PID: [64278], GUID: [426555ac-276a-11e6-88ea-001a4a223919], status [started]...
[----] I, [2016-05-31T16:00:18.929673 #59454:81798c]  INFO -- : MIQ(MiqQueue.put) Message id: [688],  id: [], Zone: [default], Role: [], Server: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [MiqEvent.raise_evm_event], Timeout: [600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: [["MiqServer", 1], "evm_worker_stop", {:event_details=>"Stopping Worker [MiqReplicationWorker] with ID: [60], PID: [64278], GUID: [426555ac-276a-11e6-88ea-001a4a223919], status [started]...", :type=>"MiqReplicationWorker"}]
[----] I, [2016-05-31T16:00:18.932902 #59454:81798c]  INFO -- : MIQ(MiqServer#worker_set_message) Worker [MiqReplicationWorker] with ID: [60], PID: [64278], GUID: [426555ac-276a-11e6-88ea-001a4a223919] is being requested to exit
```
in the evm.log file

https://bugzilla.redhat.com/show_bug.cgi?id=1341291