### PR TITLE
Use explicit reload to force collection association for network inventory.

### DIFF
--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -241,7 +241,7 @@ module EmsRefresh::SaveInventoryNetwork
   end
 
   def save_cloud_subnet_network_ports_inventory(network_port, hashes)
-    deletes = network_port.cloud_subnet_network_ports(true).dup
+    deletes = network_port.cloud_subnet_network_ports.reload.dup
 
     hashes.each do |h|
       %i(cloud_subnet).each do |relation|


### PR DESCRIPTION
This fixes a deprecation warning in the save_inventory_network.rb file.

```
DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated 
and will be removed in Rails 5.1. Please call `reload` on the result collection proxy instead. (called from 
save_cloud_subnet_network_ports_inventory at /Users/dberger/Repositories/manageiq-
djberg96/app/models/ems_refresh/save_inventory_network.rb:244)
```

Originally mentioned in https://github.com/ManageIQ/manageiq/issues/8996