### PR TITLE
[api] Make sure collection list in entrypoint is returned sorted.

### DIFF
--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -30,7 +30,7 @@ class ApiController
     end
 
     def entrypoint_collections
-      collection_config.each.collect do |collection_name, collection_specification|
+      collection_config.sort.collect do |collection_name, collection_specification|
         if collection_specification[:options].include?(:collection)
           {
             :name        => collection_name,

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -16,4 +16,13 @@ RSpec.describe "API entrypoint" do
 
     expect(%w(en en_US)).to include(response_hash['settings']['locale'])
   end
+
+  it "collection query is sorted" do
+    api_basic_authorize
+
+    run_get entrypoint_url
+
+    collection_names = response_hash['collections'].map { |c| c['name'] }
+    expect(collection_names).to eq(collection_names.sort)
+  end
 end


### PR DESCRIPTION
With the ever growing api.yml file, it's getting harder to keep
manually sorted. This PR makes sure the collection list being
returned is sorted.