### PR TITLE
Include all of last second of hour

### DIFF
--- a/app/models/miq_expression/relative_datetime.rb
+++ b/app/models/miq_expression/relative_datetime.rb
@@ -1,7 +1,7 @@
 class MiqExpression::RelativeDatetime
   def self.beginning_or_end_of_hour(ts, mode)
     ts_str = ts.iso8601
-    ts_str[14..18] = mode == "end" ? "59:59" : "00:00"
+    ts_str[14..18] = mode == "end" ? "59:59.999999" : "00:00"
     Time.parse(ts_str)
   end
 

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -302,7 +302,7 @@ describe MiqExpression do
       it "generates the SQL for a FROM expression with a 'Last Hour'/'This Hour' value for a datetime field" do
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"last_scan_on\" BETWEEN '2011-01-11 16:00:00' AND '2011-01-11 17:59:59'")
+        expect(sql).to eq("\"vms\".\"last_scan_on\" BETWEEN '2011-01-11 16:00:00' AND '2011-01-11 17:59:59.999999'")
       end
 
       it "generates the SQL for a FROM expression with a 'Last Week'/'Last Week' value for a date field" do
@@ -338,7 +338,7 @@ describe MiqExpression do
       it "generates the SQL for an IS expression with an 'n Hours Ago' value for a datetime field" do
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"last_scan_on\" BETWEEN '2011-01-11 14:00:00' AND '2011-01-11 14:59:59'")
+        expect(sql).to eq("\"vms\".\"last_scan_on\" BETWEEN '2011-01-11 14:00:00' AND '2011-01-11 14:59:59.999999'")
       end
     end
 
@@ -458,7 +458,7 @@ describe MiqExpression do
         it "finds the correct instances for an IS expression with a datetime field and 'n Hours Ago'" do
           _vm1 = FactoryGirl.create(:vm_vmware, :last_scan_on => Time.zone.parse("13:59:59.999999"))
           vm2 = FactoryGirl.create(:vm_vmware, :last_scan_on => Time.zone.parse("14:00:00"))
-          vm3 = FactoryGirl.create(:vm_vmware, :last_scan_on => Time.zone.parse("14:59:59")) # BUG: Won't include 59.999999
+          vm3 = FactoryGirl.create(:vm_vmware, :last_scan_on => Time.zone.parse("14:59:59.999999"))
           _vm4 = FactoryGirl.create(:vm_vmware, :last_scan_on => Time.zone.parse("15:00:00"))
           filter = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
           result = Vm.where(filter.to_sql.first)


### PR DESCRIPTION
Before, the upper limit of a relative datetime would include the first
microsecond of the last second of the hour, but not the remaining
microseconds. The fix addresses this to include the remaining
microseconds. Incidentally this brings it more into line with the way
Arel calculates date ranges.

@miq-bot add-label bug, core, dargo/no
@miq-bot assign @gtanzillo