### PR TITLE
When reading hawkular metrics we can get a TypeError Exception.

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
@@ -171,7 +171,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       # Sorting and removing last entry because always incomplete
       # as it's still in progress.
       norm_data = (data.sort_by { |x| x['start'] }).slice(0..-2)
-      norm_data.reject { |x| x.values.include?('NaN') }
+      norm_data.reject { |x| x.values.include?('NaN') || x['empty'] == true }
     end
 
     def compute_derivative(counters)


### PR DESCRIPTION
What happen:
If the Hawkular data struct is empty we get the error.
What should happen:
We should check for empty data structs.

Example of an empty data struct:
{"start"=>1464856460000, "end"=>1464856480000, "empty"=>true}

Issue: https://github.com/ManageIQ/manageiq/issues/9096
