### PR TITLE
EmsEvent::Automate#parse_policy_parameters: always return 3 values.

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -94,7 +94,6 @@ class EmsEvent
       _log.debug("Target object: [#{target.inspect}]")
       _log.debug("Policy source: [#{policy_src}]")
 
-      return if target.nil? || policy_event.nil? || policy_src.nil?
       [target, policy_event, policy_src]
     end
 


### PR DESCRIPTION
This is a no-op, just simplification.

Same check whether any of them is nil is done in the only caller anyway:
https://github.com/cben/manageiq/blob/eeeccd995774b9c75e0141eb3cda76a5bfed6b2b/app/models/ems_event/automate.rb#L19-L20
Previously caller could try to destructure `a, b, c = nil` which
I'm dismayed to see is not an error but sets all 3 to nil,
so it behaved the same but it was hard to understand why.

@miq-bot  add_label events, technical debt
The code is same on darga => darga/yes and darga/no look equally safe to me.