### PR TITLE
Corrections to kubernetes events -> EmsEvent -> refresh.

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
   extend ActiveSupport::Concern
+
+  # https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/container/event.go
   # 'Created', 'Failed', 'Started', 'Killing', 'Stopped' and 'Unhealthy' are in fact container related events,
   # returned as part of a pod event.
   ENABLED_EVENTS = {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -669,7 +669,7 @@
       - compute.instance.shelve.end
       - compute.instance.unshelve.end
       - compute.instance.shelve_offload.end
-      - NODE_REBOOT
+      - NODE_REBOOTED
       - NODE_NODESCHEDULABLE
       - NODE_NODENOTSCHEDULABLE
       :detail:

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/KUBERNETES.class/node_rebooted.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/KUBERNETES.class/node_rebooted.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: NODE_REBOOT
+    name: NODE_REBOOTED
     inherits: 
     description: 
   fields:


### PR DESCRIPTION
Fixes to existing functionality split off #8815.
3 EmsEvent names didn't match Automate method names, so they didn't schedule refresh as intented.
(details in individal commit messages)

@miq-bot add_label bug, providers/containers, events, darga/yes
Should be backported as #8815 also targetted to Darga depends on this.