### PR TITLE
Assign MiqTask to LogFile early during log collection

### DIFF
--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -156,6 +156,7 @@ module MiqServer::LogManagement
 
     delete_old_requested_logs
     logfile = LogFile.current_logfile
+    logfile.update_attributes(:miq_task_id => taskid)
     begin
       log_files << logfile
       save
@@ -185,7 +186,6 @@ module MiqServer::LogManagement
         :logging_ended_on   => log_end,
         :name               => name,
         :description        => desc,
-        :miq_task_id        => task.id
       )
 
       logfile.upload


### PR DESCRIPTION
This is useful when an error occurs during the process. We use
```log_file.miq_task.message``` to render log collection status to the
end-user.

Previously, when an error occurred just before this assignment, user
could live under impression that the log collection was successful.

**Before**
![before](https://cloud.githubusercontent.com/assets/6666052/15743689/8acc2128-28c7-11e6-811f-76dd0f7b8dda.jpg)
**After**
![after](https://cloud.githubusercontent.com/assets/6666052/15743694/90442cea-28c7-11e6-82bf-02a068f47706.jpg)
