### PR TITLE
pluggable providers: remove provider specific constants from helpers

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -43,7 +43,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_ipaddress
-    return nil if @ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager)
+    return nil if @ems.ipaddress.blank?
     {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
   end
 

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -178,10 +178,8 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_host_default_vnc_port_range
-    return nil unless @ems.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
-    value = @ems.host_default_vnc_port_start.blank? ?
-        "" :
-        "#{@ems.host_default_vnc_port_start} - #{@ems.host_default_vnc_port_end}"
+    return nil if @ems.host_default_vnc_port_start.blank?
+    value = "#{@ems.host_default_vnc_port_start} - #{@ems.host_default_vnc_port_end}"
     {:label => _("%{title} Default VNC Port Range") % {:title => title_for_host}, :value => value}
   end
 end

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -38,7 +38,7 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_ipaddress
-    return nil if @ems.kind_of?(ManageIQ::Providers::Amazon::CloudManager)
+    return nil if @ems.ipaddress.blank?
     {:label => _("Discovered IP Address"), :value => @ems.ipaddress}
   end
 

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -313,7 +313,7 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_processes
-    return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
+    return nil if @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
     h = {:label => _("Running Processes"), :image => "processes"}
     date = last_date(:processes)
     if date.nil?
@@ -329,7 +329,7 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_event_logs
-    return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
+    return nil if @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
     num = @record.operating_system.nil? ? 0 : @record.operating_system.number_of(:event_logs)
     h = {:label => _("Event Logs"), :image => "event_logs", :value => (num == 0 ? _("Not Available") : _("Available"))}
     if num > 0
@@ -341,7 +341,7 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_vmsafe_enable
-    return nil if @record.vmsafe_enable || @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
+    return nil if @record.vmsafe_enable || @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
     {:label => _("Enable"), :value => "false"}
   end
 
@@ -405,26 +405,26 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_boot_time
-    return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
+    return nil if @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
     date = @record.boot_time
     {:label => _("Last Boot Time"), :value => (date.nil? ? _("N/A") : format_timezone(date))}
   end
 
   def textual_state_changed_on
-    return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
+    return nil if @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
     date = @record.state_changed_on
     {:label => _("State Changed On"), :value => (date.nil? ? _("N/A") : format_timezone(date))}
   end
 
   def textual_virtualization_type
-    return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
-    v_type = @record.hardware.try(:virtualization_type)
+    v_type = @record.hardware.try!(:virtualization_type)
+    return nil if v_type.blank?
     {:label => _("Virtualization Type"), :value => v_type.to_s}
   end
 
   def textual_root_device_type
-    return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
-    rd_type = @record.hardware.try(:root_device_type)
+    rd_type = @record.hardware.try!(:root_device_type)
+    return nil if rd_type.blank?
     {:label => _("Root Device Type"), :value => rd_type.to_s}
   end
 end

--- a/app/helpers/vm_helper.rb
+++ b/app/helpers/vm_helper.rb
@@ -20,12 +20,12 @@ module VmHelper
   end
 
   def textual_cloud_network
-    return nil unless @record.kind_of?(ManageIQ::Providers::Amazon::CloudManager::Vm)
+    return nil unless @record.kind_of?(ManageIQ::Providers::CloudManager::Vm)
     {:label => _("Virtual Private Cloud"), :value => @record.cloud_network ? @record.cloud_network.name : _('None')}
   end
 
   def textual_cloud_subnet
-    return nil unless @record.kind_of?(ManageIQ::Providers::Amazon::CloudManager::Vm)
+    return nil unless @record.kind_of?(ManageIQ::Providers::CloudManager::Vm)
     {:label => _("Cloud Subnet"), :value => @record.cloud_subnet ? @record.cloud_subnet.name : _('None')}
   end
 


### PR DESCRIPTION
this follows the pattern to display information if it is available

again, I'm not 100% sure if we sometimes want to show an empty text with a label.

@miq-bot add_labels ui, providers