### PR TITLE
Chart tooltip titles

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1666,11 +1666,16 @@ function add_expanding_icon(element){
 }
 
 function chartData(type, data, data2) {
+  if(type == undefined){
+    return;
+  }
+  // set maximum count of x axis tick labels
   if(_.isObject(data.miq) && data.miq.performance){
     data.axis.x.tick.centered = true;
     data.axis.x.tick.culling = {max: 5}
   }
 
+  // set formating function for tooltip and y tick labels
   if (_.isObject(data.axis) && _.isObject(data.axis.y) && _.isObject(data.axis.y.tick) && _.isObject(data.axis.y.tick.format)) {
     var o = data.axis.y.tick.format;
     data.axis.y.tick.format = ManageIQ.charts.formatters[o.function].c3(o.options);
@@ -1685,6 +1690,23 @@ function chartData(type, data, data2) {
   if(_.isObject(config.tooltip)) {
     config.tooltip.contents = undefined;
   }
+
+  // tooltips have full name even if labels are shortened
+  if (_.isObject(data.axis.x) && _.isObject(data.axis.x.categories)) {
+    var tooltips = []
+    for (var i = 0; i <  data.axis.x.categories.length; i++ ) {
+        tooltips.push(data.axis.x.categories[i]);
+        data.axis.x.categories[i] = ManageIQ.charts.formatters.string_truncate(data.axis.x.categories[i], {length:7});
+    }
+    
+    if(_.isObject(data.tooltip.format)){
+      data.tooltip.format.title =  function (x) { return tooltips[x]; }
+    }
+    else {
+      data.tooltip.format =  { title: function (x) { return tooltips[x]; }}
+    }
+  }
+
   return _.defaultsDeep({}, data, config, data2);
 }
 

--- a/app/views/layouts/_perf_chart_js.html.haml
+++ b/app/views/layouts/_perf_chart_js.html.haml
@@ -1,53 +1,58 @@
 - if chart_data[chart_index][:xml2]
   %div{"style" => "margin-bottom: 50px"}
     .card-pf
-      .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}"}
-        .card-pf-heading
-          %h2.card-pf-title= charts[chart_index][:title]
-        .card-pf-body
-          = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}")
-          .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
-      %ul.dropdown-menu{"role"            => "menu",
-                        "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}",
-                        "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}",
-                        "style"           => "position:fixed;"}
-      :javascript
-        $("#miq_chart_parent_#{chart_set}_#{chart_index}").on('hidden.bs.dropdown', function() {
-          $("#miq_chartmenu_#{chart_set}_#{chart_index}").empty();
-          $("#miq_chart_parent_#{chart_set}_#{chart_index} .overlay").hide();
-        });
-      .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}_2"}
-        .card-pf-body
-          = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}_2")
-          .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
-      %ul.dropdown-menu{"role"            => "menu",
-                        "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}_2",
-                        "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}_2",
-                        "style"           => "position: fixed;"}
-      :javascript
-        $('body').addClass('cards-pf');
-        $("#miq_chart_parent_#{chart_set}_#{chart_index}_2").on('hidden.bs.dropdown', function() {
-          $("#miq_chartmenu_#{chart_set}_#{chart_index}_2").empty();
-          $("#miq_chart_parent_#{chart_set}_#{chart_index}_2 .overlay").hide();
-        });
+      %div
+        .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}"}
+          %div
+            .card-pf-heading
+              %h2.card-pf-title= charts[chart_index][:title]
+            .overlay-container{"style" => "position: relative"}
+              .card-pf-body
+                = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}")
+                .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
+          %ul.dropdown-menu{"role"            => "menu",
+                          "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}",
+                          "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}",
+                          "style"           => "position:fixed;"}
+        :javascript
+          $("#miq_chart_parent_#{chart_set}_#{chart_index}").on('hidden.bs.dropdown', function() {
+            $("#miq_chartmenu_#{chart_set}_#{chart_index}").empty();
+            $("#miq_chart_parent_#{chart_set}_#{chart_index} .overlay").hide();
+          });
+        .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}_2"}
+          %div
+            .overlay-container{"style" => "position: relative"}
+              .card-pf-body
+                = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}_2")
+                .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
+          %ul.dropdown-menu{"role"            => "menu",
+                          "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}_2",
+                          "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}_2",
+                          "style"           => "position: fixed;"}
+        :javascript
+          $("#miq_chart_parent_#{chart_set}_#{chart_index}_2").on('hidden.bs.dropdown', function() {
+            $("#miq_chartmenu_#{chart_set}_#{chart_index}_2").empty();
+            $("#miq_chart_parent_#{chart_set}_#{chart_index}_2 .overlay").hide();
+          });
 - else
   .card-pf
     .chart_parent{"id" => "miq_chart_parent_#{chart_set}_#{chart_index}", "style" => "margin-bottom: 50px"}
-      .card-pf-heading
-        %h2.card-pf-title= charts[chart_index][:title]
-      .card-pf-body
-        = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}")
-        .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
-        - if chart_data[chart_index][:zoom_url]
-          %div
-            %a{:href => '#', :onClick => chart_data[chart_index][:zoom_url]}
-              %img{:src => image_path(zoom_icon(chart_data[chart_index][:zoom_url]))}
-    %ul.dropdown-menu{"role"            => "menu",
-                      "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}",
-                      "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}",
-                      "style"           => "position: fixed;"}
+      %div
+        .card-pf-heading
+          %h2.card-pf-title= charts[chart_index][:title]
+        .card-pf-body
+          .overlay-container{"style" => "position: relative"}
+            = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}")
+            .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
+          - if chart_data[chart_index][:zoom_url]
+            %div
+              %a{:href => '#', :onClick => chart_data[chart_index][:zoom_url]}
+                %img{:src => image_path(zoom_icon(chart_data[chart_index][:zoom_url]))}
+      %ul.dropdown-menu{"role"            => "menu",
+                        "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}",
+                        "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}",
+                        "style"           => "position: fixed;"}
     :javascript
-      $('body').addClass('cards-pf');
       miqChartBindEvents("#{chart_set}", #{chart_index});
       $("#miq_chart_parent_#{chart_set}_#{chart_index}").on('hidden.bs.dropdown', function() {
         $("#miq_chartmenu_#{chart_set}_#{chart_index}").empty();

--- a/lib/report_formatter.rb
+++ b/lib/report_formatter.rb
@@ -17,5 +17,5 @@ module ReportFormatter
   BLANK_VALUE = "Unknown"         # Chart constant for nil or blank key values
   CRLF = "\r\n"
   LEGEND_LENGTH = 21              # Top legend text limit
-  LABEL_LENGTH = 7                # Chart label text limit
+  LABEL_LENGTH = 21               # Chart label text limit
 end

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -49,7 +49,8 @@ module ReportFormatter
       mri.chart = {
         :miqChart => type,
         :data     => {:columns => [], :names => {}},
-        :axis     => {}
+        :axis     => {},
+        :tooltip  => {}
       }
 
       if chart_is_2d?


### PR DESCRIPTION
Increase label length to 21, move chart text formatting from ruby to JS.

Display full name in tooltip even if its shortened on X axis.

![screenshot from 2016-06-02 16-29-00](https://cloud.githubusercontent.com/assets/9535558/15748428/25d3f59e-28df-11e6-828d-48a11324f3dd.png)
