### PR TITLE
Validate that start value is not greater than finish value in chargeback rate form

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -141,7 +141,6 @@ class ChargebackRateDetail < ApplicationRecord
   # Check that tiers are complete and disjoint
   def contiguous_tiers?
     error = false
-    ambiguous_error = false
 
     # Note, we use sort_by vs. order since we need to call this method against
     # the in memory chargeback_tiers association and NOT hit the database.
@@ -160,15 +159,12 @@ class ChargebackRateDetail < ApplicationRecord
         error = true if tier.ends_with_infinity?
       end
 
-      ambiguous_error = ambiguous_tier?(tier)
-
-      break if error || ambiguous_error
+      break if error
     end
 
     errors.add(:chargeback_tiers, _("must start at zero and not contain any gaps between start and prior end value.")) if error
-    errors.add(:chargeback_tiers, _("contains ambiguous intervals.")) if ambiguous_error
 
-    !(error || ambiguous_error)
+    !error
   end
 
   def first_tier?(tier,tiers)
@@ -189,10 +185,6 @@ class ChargebackRateDetail < ApplicationRecord
 
   def consecutive_tiers?(tier, previous_tier)
     tier.start == previous_tier.finish
-  end
-
-  def ambiguous_tier?(tier)
-    tier.start == tier.finish
   end
 
   def self.default_rate_details_for(rate_type)

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -3,6 +3,7 @@ class ChargebackTier < ApplicationRecord
   validates :fixed_rate, :variable_rate, :numericality => true
   validates :start,  :numericality => {:greater_than_or_equal_to => 0, :less_than => Float::INFINITY}
   validates :finish, :numericality => {:greater_than_or_equal_to => 0}
+  validate :continuity?
 
   default_scope { order(:start => :asc) }
 
@@ -22,5 +23,11 @@ class ChargebackTier < ApplicationRecord
 
   def ends_with_infinity?
     finish == Float::INFINITY
+  end
+
+  def continuity?
+    is_continuous = start < finish
+    errors.add(:finish, "value must be greater than start value.") unless is_continuous
+    is_continuous
   end
 end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -267,15 +267,6 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       expect(cbd.contiguous_tiers?).to be false
     end
 
-    it "returns validation error when tiers are ambiguous" do
-      cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :finish => 5)
-      cbt2 = FactoryGirl.build(:chargeback_tier, :start => 5, :finish => 5)
-      cbt3 = FactoryGirl.build(:chargeback_tier, :start => 5, :finish => Float::INFINITY)
-      cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt1, cbt2, cbt3])
-
-      expect(cbd.contiguous_tiers?).to be_falsey
-    end
-
     it "must contain one start" do
       cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :finish => 1)
       cbt2 = FactoryGirl.build(:chargeback_tier, :start => 0, :finish => Float::INFINITY)


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/9043
we found another case with issue when start value is greater than  finish value


cc @gtanzillo @tledesma 