### PR TITLE
Limit the amount of records pulled into memory at once

### DIFF
--- a/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
+++ b/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
@@ -126,14 +126,14 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
 
   def up
     say_with_time("Converting MiqReportResult#report to a serialized hash") do
-      MiqReportResult.where('report IS NOT NULL').each do |rr|
+      MiqReportResult.where('report IS NOT NULL').find_each do |rr|
         val = rr.serialize_report_to_hash(rr.read_attribute(:report), self)
         rr.update_attribute(:report, val) if val
       end
     end
 
     say_with_time("Converting BinaryBlob report results to a serialized hash") do
-      BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').each do |bb|
+      BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').find_each do |bb|
         if bb.resource
           val = bb.serialize_report_to_hash(bb.binary, self)
           bb.binary = val if val
@@ -144,14 +144,14 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
 
   def down
     say_with_time("Converting MiqReportResult#report back to a serialized MiqReport") do
-      MiqReportResult.where('report IS NOT NULL').each do |rr|
+      MiqReportResult.where('report IS NOT NULL').find_each do |rr|
         val = rr.serialize_hash_to_report(rr.read_attribute(:report), :miq_report_result, self)
         rr.update_attribute(:report, val) if val
       end
     end
 
     say_with_time("Converting BinaryBlob report results back to a serialized MiqReport") do
-      BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').each do |bb|
+      BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').find_each do |bb|
         if bb.resource
           val = bb.serialize_hash_to_report(bb.binary, :binary_blob, self)
           bb.binary = val if val


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1337159

This is a simple tactical change to the migration to alleviate the memory pressure in large databases.  In our candidate database that has ~65000 BinaryBlob records, the `find` ends up consuming all of the memory on the appliance, moving it into swap, and the migration takes something like 7 hours.  This should alleviate the memory pressure, allow GC to do its job, and not hit swap, which should allow the migration to complete in less time.

This is not a final fix, as it will still take hours, just hopefully not as many (hard to test locally because I'd have to run for 7 hours :wink:).  After this change, the majority of the time is spent in YAML.dump/load land, but I am having a very hard time getting that to parallelize in a migration (due to transactions and postgres connections not playing nice in parallel).

@gtanzillo Please review