### PR TITLE
Fixing broken chargeback_controller test

### DIFF
--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -83,7 +83,7 @@ describe ChargebackController do
         parent_reports = controller.instance_variable_get(:@parent_reports)
 
         tree_id = "#{ApplicationRecord.compress_id(chargeback_report.id)}-0"
-        expected_result = {chargeback_report.miq_report_results.first.name => tree_id}
+        expected_result = {chargeback_report.miq_report_results.first.miq_report.name => tree_id}
         expect(parent_reports).to eq(expected_result)
       end
     end

--- a/spec/factories/miq_report_result.rb
+++ b/spec/factories/miq_report_result.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
   end
 
   factory :miq_chargeback_report_result, :parent => :miq_report_result do
-    sequence(:name) { |n| "Test Report #{seq_padded_for_sorting(n)}" }
+    sequence(:name) { |n| "Test Chargeback Report Result #{seq_padded_for_sorting(n)}" }
     db "ChargebackVm"
     report_source "Requested by user"
   end


### PR DESCRIPTION
- The test was originally broken when it was created in d2766f7ddc2f2f7928e9a6f but still passing because the names of the report and report result were the same.
- It was comparing MiqReportResult#name to MiqReport#name
- Also, changed the name in the factory for the miq_report_result so that it's different from the line in the miq_report factory and obvious