### PR TITLE
Disable timelines button when no timeline data is available for provider

### DIFF
--- a/app/helpers/application_helper/button/ems_cloud_timeline.rb
+++ b/app/helpers/application_helper/button/ems_cloud_timeline.rb
@@ -1,5 +1,0 @@
-class ApplicationHelper::Button::EmsCloudTimeline < ApplicationHelper::Button::Basic
-  def skip?
-    !@record.is_available?(:timeline)
-  end
-end

--- a/app/helpers/application_helper/button/ems_infra_timeline.rb
+++ b/app/helpers/application_helper/button/ems_infra_timeline.rb
@@ -1,5 +1,0 @@
-class ApplicationHelper::Button::EmsInfraTimeline < ApplicationHelper::Button::Basic
-  def skip?
-    !@record.is_available?(:timeline)
-  end
-end

--- a/app/helpers/application_helper/button/ems_timeline.rb
+++ b/app/helpers/application_helper/button/ems_timeline.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::EmsTimeline < ApplicationHelper::Button::Basic
+  def skip?
+    !@record.is_available?(:timeline)
+  end
+
+  def disabled?
+    !(@record.has_events? || @record.has_events?(:policy_events))
+  end
+
+  def calculate_properties
+    super
+    self[:hidden] = true if skip?
+    self[:title] = N_("No Timeline data has been collected for this Provider") if disabled?
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -66,7 +66,7 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
           'product product-timeline fa-lg',
           N_('Show Timelines for this #{ui_lookup(:table=>"ems_cloud")}'),
           N_('Timelines'),
-          :klass     => ApplicationHelper::Button::EmsCloudTimeline,
+          :klass     => ApplicationHelper::Button::EmsTimeline,
           :url_parms => "?display=timeline"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -77,7 +77,7 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
           'product product-timeline fa-lg',
           N_('Show Timelines for this #{ui_lookup(:table=>"ems_infra")}'),
           N_('Timelines'),
-          :klass     => ApplicationHelper::Button::EmsInfraTimeline,
+          :klass     => ApplicationHelper::Button::EmsTimeline,
           :url_parms => "?display=timeline"),
       ]
     ),

--- a/spec/helpers/application_helper/buttons/ems_timeline.rb
+++ b/spec/helpers/application_helper/buttons/ems_timeline.rb
@@ -1,0 +1,39 @@
+describe ApplicationHelper::Button::EmsTimeline do
+  describe '#disabled?' do
+    it "when the timeline action is available then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :has_events? => true)}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the timeline action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false, :has_events? => false)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the timeline action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false, :has_events? => false)}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("No Timeline data has been collected for this Provider")
+    end
+
+    it "when the timeline is available, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :has_events? => true)}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1735,6 +1735,21 @@ describe ApplicationHelper do
         expect(result).to be(false)
       end
     end
+
+    context "when record class = ExtManagementSystem" do
+      before do
+        @record = FactoryGirl.create(:ems_amazon)
+      end
+
+      context "and id = ems_cloud_timeline" do
+        before { @id = "ems_cloud_timeline" }
+
+        it "hide timelines button for EC2 provider" do
+          allow(@record).to receive(:has_events?).and_return(false)
+          expect(subject).to be_truthy
+        end
+      end
+    end
   end # end of build_toolbar_hide_button
 
   describe "#build_toolbar_disable_button" do


### PR DESCRIPTION
- Also hide Monitoring button group when there are no buttons under it.

https://bugzilla.redhat.com/show_bug.cgi?id=1342224
https://bugzilla.redhat.com/show_bug.cgi?id=1342217

before:
![before](https://cloud.githubusercontent.com/assets/3450808/15759412/8c8c1346-28dc-11e6-8c8d-738086ab7131.png)
![before2](https://cloud.githubusercontent.com/assets/3450808/15759432/940a2a54-28dc-11e6-8b98-6ad89c975aa7.png)

after:
when timeline data is not available
![providers_timeline_button_disabled]
(https://cloud.githubusercontent.com/assets/3450808/15759437/9a2166b4-28dc-11e6-8ab5-5dc921e78b79.png)

for EC2 that does not support timeline button
![ec2_provider_after](https://cloud.githubusercontent.com/assets/3450808/15759447/9e64cc16-28dc-11e6-9554-8ad9e2760d84.png)

when timeline data is available:
![after1](https://cloud.githubusercontent.com/assets/3450808/15759569/2ae787d2-28dd-11e6-80a1-515047b033e2.png)

@martinpovolny @dclarizio please review/merge