### PR TITLE
Make Live Migrate work when called from outside of an explorer view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,7 @@ class ApplicationController < ActionController::Base
   include_concern 'TreeSupport'
   include_concern 'SysprepAnswerFile'
   include_concern 'ReportDownloads'
+  include_concern 'VmCloudProcessing'
 
   before_action :reset_toolbar
   before_action :set_session_tenant, :except => [:window_sizes]

--- a/app/controllers/application_controller/vm_cloud_processing.rb
+++ b/app/controllers/application_controller/vm_cloud_processing.rb
@@ -1,0 +1,131 @@
+module ApplicationController::VmCloudProcessing
+  extend ActiveSupport::Concern
+
+  def live_migrate
+    assert_privileges("instance_live_migrate")
+    @display = params[:display]
+
+    ids = find_checked_items
+    if !ids.empty?
+      record_id = ids[0]
+    else
+      record_id = params[:id]
+    end
+
+    @record = find_by_id_filtered(VmOrTemplate, record_id) # Set the VM object
+    if @record.is_available?(:live_migrate) && !@record.ext_management_system.nil?
+      drop_breadcrumb(
+        :name => _("Live Migrate Instance '%{name}'") % {:name => @record.name},
+        :url  => "/vm_cloud/live_migrate"
+      ) unless @explorer
+      @in_a_form = true
+      @refresh_partial = "vm_common/live_migrate"
+    else
+      add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
+        :instance => ui_lookup(:table => 'vm_cloud'),
+        :name     => @record.name,
+        :details  => @record.is_available_now_error_message(:live_migrate)}, :error)
+    end
+  end
+  alias_method :instance_live_migrate, :live_migrate
+
+  def live_migrate_form_fields
+    assert_privileges("instance_live_migrate")
+    @record = find_by_id_filtered(VmOrTemplate, params[:id])
+    hosts = []
+    unless @record.ext_management_system.nil?
+      # wrap in a rescue block in the event the connection to the provider fails
+      begin
+        connection = @record.ext_management_system.connect
+        current_hostname = connection.handled_list(:servers).find do |s|
+          s.name == @record.name
+        end.os_ext_srv_attr_hypervisor_hostname
+        # OS requires its own name for the host be used in the migrate API, so get the
+        # provider hostname from fog.
+        hosts = connection.hosts.select { |h| h.service_name == "compute" && h.host_name != current_hostname }.map do |h|
+          {:name => h.host_name, :id => h.host_name}
+        end
+      rescue
+        hosts = []
+      end
+    end
+    render :json => {
+      :hosts => hosts
+    }
+  end
+
+  def live_migrate_vm
+    assert_privileges("instance_live_migrate")
+    @record = find_by_id_filtered(VmOrTemplate, params[:id])
+
+    case params[:button]
+    when "cancel"
+      cancel_action(_("Live Migration of %{model} \"%{name}\" was cancelled by the user") % {
+        :model => ui_lookup(:table => 'vm_cloud'),
+        :name  => @record.name
+      })
+    when "submit"
+      if @record.is_available?(:live_migrate)
+        if params['auto_select_host'] == 'on'
+          hostname = nil
+        else
+          hostname = params[:destination_host]
+        end
+        block_migration = params[:block_migration]
+        disk_over_commit = params[:disk_over_commit]
+        begin
+          @record.live_migrate(
+            :hostname         => hostname,
+            :block_migration  => block_migration == 'on',
+            :disk_over_commit => disk_over_commit == 'on'
+          )
+          add_flash(_("Live Migrating %{instance} \"%{name}\"") % {
+            :instance => ui_lookup(:table => 'vm_cloud'),
+            :name     => @record.name})
+        rescue => ex
+          add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
+            :instance => ui_lookup(:table => 'vm_cloud'),
+            :name     => @record.name,
+            :details  => get_error_message_from_fog(ex.to_s)}, :error)
+        end
+      else
+        add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
+          :instance => ui_lookup(:table => 'vm_cloud'),
+          :name     => @record.name,
+          :details  => @record.is_available_now_error_message(:live_migrate)}, :error)
+      end
+      if @explorer
+        params[:id] = @record.id.to_s # reset id in params for show
+        @record = nil
+        @sb[:action] = nil
+        replace_right_cell
+      else
+        @breadcrumbs.pop if @breadcrumbs
+        session[:edit] = nil
+        session[:flash_msgs] = @flash_array.dup if @flash_array
+        render :update do |page|
+          page << javascript_prologue
+          page.redirect_to :action => "show", :id => @record.id.to_s
+        end
+      end
+    end
+  end
+
+  def cancel_action(message)
+    if @explorer
+      session[:edit] = nil
+      add_flash(message)
+      @record = @sb[:action] = nil
+      replace_right_cell
+    else
+      @breadcrumbs.pop if @breadcrumbs
+      render :update do |page|
+        page << javascript_prologue
+        page.redirect_to :action    => @lastaction,
+                         :id        => @record.id,
+                         :display   => @display,
+                         :flash_msg => message
+      end
+    end
+  end
+end

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -29,6 +29,8 @@ class CloudVolumeController < ApplicationController
     return tag("CloudVolume") if params[:pressed] == "cloud_volume_tag"
     delete_volumes if params[:pressed] == 'cloud_volume_delete'
 
+    live_migrate if params[:pressed] == 'instance_live_migrate'
+
     if @flash_array
       show_list
       replace_gtl_main_div
@@ -52,6 +54,12 @@ class CloudVolumeController < ApplicationController
           page << javascript_prologue
           page.redirect_to :action => "detach", :id => checked_volume_id
         end
+      end
+    elsif params[:pressed] == "instance_live_migrate"
+      checked_vm_id = find_checked_items[0]
+      render :update do |page|
+        page << javascript_prologue
+        page.redirect_to :controller => "vm_cloud", :action => "live_migrate", :id => checked_vm_id
       end
     elsif params[:pressed] == "cloud_volume_edit"
       checked_volume_id = get_checked_volume_id(params)

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -104,97 +104,6 @@ class VmCloudController < ApplicationController
     end
   end
 
-  def live_migrate
-    assert_privileges("instance_live_migrate")
-    @record = find_by_id_filtered(VmOrTemplate, params[:id]) # Set the VM object
-    if @record.is_available?(:live_migrate) && !@record.ext_management_system.nil?
-      drop_breadcrumb(
-        :name => _("Live Migrate Instance '%{name}'") % {:name => @record.name},
-        :url  => "/vm_cloud/live_migrate"
-      ) unless @explorer
-      @in_a_form = true
-      @refresh_partial = "vm_common/live_migrate"
-    else
-      add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
-        :instance => ui_lookup(:table => 'vm_cloud'),
-        :name     => @record.name,
-        :details  => @record.is_available_now_error_message(:live_migrate)}, :error)
-    end
-  end
-  alias_method :instance_live_migrate, :live_migrate
-
-  def live_migrate_form_fields
-    assert_privileges("instance_live_migrate")
-    @record = find_by_id_filtered(VmOrTemplate, params[:id])
-    hosts = []
-    unless @record.ext_management_system.nil?
-      # wrap in a rescue block in the event the connection to the provider fails
-      begin
-        connection = @record.ext_management_system.connect
-        current_hostname = connection.handled_list(:servers).find do |s|
-          s.name == @record.name
-        end.os_ext_srv_attr_hypervisor_hostname
-        # OS requires its own name for the host be used in the migrate API, so get the
-        # provider hostname from fog.
-        hosts = connection.hosts.select { |h| h.service_name == "compute" && h.host_name != current_hostname }.map do |h|
-          {:name => h.host_name, :id => h.host_name}
-        end
-      rescue
-        hosts = []
-      end
-    end
-    render :json => {
-      :hosts => hosts
-    }
-  end
-
-  def live_migrate_vm
-    assert_privileges("instance_live_migrate")
-    @record = find_by_id_filtered(VmOrTemplate, params[:id])
-
-    case params[:button]
-    when "cancel"
-      cancel_action(_("Live Migration of %{model} \"%{name}\" was cancelled by the user") % {
-        :model => ui_lookup(:table => 'vm_cloud'),
-        :name  => @record.name
-      })
-    when "submit"
-      if @record.is_available?(:live_migrate)
-        if params['auto_select_host'] == 'on'
-          hostname = nil
-        else
-          hostname = params[:destination_host]
-        end
-        block_migration = params[:block_migration]
-        disk_over_commit = params[:disk_over_commit]
-        begin
-          @record.live_migrate(
-            :hostname         => hostname,
-            :block_migration  => block_migration == 'on',
-            :disk_over_commit => disk_over_commit == 'on'
-          )
-          add_flash(_("Live Migrating %{instance} \"%{name}\"") % {
-            :instance => ui_lookup(:table => 'vm_cloud'),
-            :name     => @record.name})
-        rescue => ex
-          add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
-            :instance => ui_lookup(:table => 'vm_cloud'),
-            :name     => @record.name,
-            :details  => get_error_message_from_fog(ex.to_s)}, :error)
-        end
-      else
-        add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
-          :instance => ui_lookup(:table => 'vm_cloud'),
-          :name     => @record.name,
-          :details  => @record.is_available_now_error_message(:live_migrate)}, :error)
-      end
-      params[:id] = @record.id.to_s # reset id in params for show
-      @record = nil
-      @sb[:action] = nil
-      replace_right_cell
-    end
-  end
-
   def attach
     assert_privileges("instance_attach")
     @volume_choices = {}
@@ -317,13 +226,6 @@ class VmCloudController < ApplicationController
       @record = @sb[:action] = nil
       replace_right_cell
     end
-  end
-
-  def cancel_action(message)
-    session[:edit] = nil
-    add_flash(message)
-    @record = @sb[:action] = nil
-    replace_right_cell
   end
 
   def evacuate

--- a/app/views/vm_cloud/_live_migrate.html.haml
+++ b/app/views/vm_cloud/_live_migrate.html.haml
@@ -47,11 +47,27 @@
           %select{:name      => 'destination_host_id',
                   'ng-model' => 'vmCloudModel.host',
                   'ng-options' => 'host.name as host.name for host in hosts track by host.id'}
-
+- if @explorer
   %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
                   'paging_div_buttons_state_enabled' => true,
                   'paging_div_buttons_id'            => "angular_paging_div_buttons",
                   'paging_div_buttons_type'          => "Submit"}
+- else
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on
+          = button_tag(t = _('Submit'),
+            :class   => "btn btn-primary",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "submit")}');")
+          = button_tag(t = _('Cancel'),
+            :class   => "btn btn-default",
+            :alt     => t,
+            :title   => t,
+            :onclick => "miqAjaxButton('#{url_for(:action => "live_migrate_vm", :id => "#{@record.id}", :button => "cancel")}');")
+
 
 :javascript
   ManageIQ.angular.app.value('vmCloudLiveMigrateFormId', '#{@record.id}');

--- a/app/views/vm_cloud/live_migrate.html.haml
+++ b/app/views/vm_cloud/live_migrate.html.haml
@@ -1,0 +1,1 @@
+= render :partial => 'live_migrate'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2335,6 +2335,7 @@ Vmdb::Application.routes.draw do
         tagging_edit
         resize
         migrate
+        live_migrate
         live_migrate_form_fields
         attach
         detach


### PR DESCRIPTION
This PR refactors the Live Migrate action to work when called from outside of an explorer view, and wires up the CloudVolumeController so that it can handle when that button is clicked while drilling down into a volume's instance relationships.

This is intended as a partial fix for https://bugzilla.redhat.com/show_bug.cgi?id=1334275 and https://bugzilla.redhat.com/show_bug.cgi?id=1339198, which revealed that buttons on the Instance list toolbar don't work when you navigate to it from a Cloud Volume or Provider.

If this is the right approach and reviewers are satisfied with it, I'll make similar changes to fix the rest of the broken buttons.

@h-kataria @tzumainn 