### PR TITLE
Don't put user objects onto miq_queue in tests

### DIFF
--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -65,12 +65,12 @@ describe MiqWidget do
       end
 
       it "admin user" do
-        @widget.queue_generate_content_for_users_or_group(@user1)
+        @widget.queue_generate_content_for_users_or_group(@user1.userid)
         expect(MiqQueue.exists?(@queue_conditions)).to be_truthy
       end
 
       it "array of users" do
-        @widget.queue_generate_content_for_users_or_group([@user1, @user2])
+        @widget.queue_generate_content_for_users_or_group([@user1.userid, @user2.userid])
         expect(MiqQueue.exists?(@queue_conditions)).to be_truthy
       end
 


### PR DESCRIPTION
In the actual code, this is not a problem.
But in these tests, they are putting User objects onto miq_queue