### PR TITLE
Move MiqExpression.is_plural? -> Field#plural?

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -190,7 +190,7 @@ module ApplicationController::Filter
           @edit[@expkey][:exp_value] = nil                          # Clear the value
           @edit[:suffix] = nil                                      # Clear the suffix
           unless params[:chosen_field] == "<Choose>"
-            if @edit[@expkey][:exp_model] != "_display_filter_" && MiqExpression.is_plural?(@edit[@expkey][:exp_field])
+            if @edit[@expkey][:exp_model] != "_display_filter_" && MiqExpression::Field.parse(@edit[@expkey][:exp_field]).plural?
               @edit[@expkey][:exp_key] = "CONTAINS"                 # CONTAINS only valid for plural tables
             else
               @edit[@expkey][:exp_key] = nil unless MiqExpression.get_col_operators(@edit[@expkey][:exp_field]).include?(@edit[@expkey][:exp_key])  # Remove if not in list

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1429,20 +1429,6 @@ class MiqExpression
     end
   end
 
-  def self.is_plural?(field)
-    parts = field.split("-").first.split(".")
-    macro = nil
-    model = model_class(parts.shift)
-    parts.each do |assoc|
-      ref = model.reflection_with_virtual(assoc.to_sym)
-      return false if ref.nil?
-
-      macro = ref.macro
-      model = ref.klass
-    end
-    [:has_many, :has_and_belongs_to_many].include?(macro)
-  end
-
   def self.atom_error(field, operator, value)
     return false if operator == "DEFAULT" # No validation needed for style DEFAULT operator
 

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -36,7 +36,7 @@ class MiqExpression::Field
   def reflections
     klass = model
     associations.collect do |association|
-      klass.reflect_on_association(association).tap do |reflection|
+      klass.reflection_with_virtual(association).tap do |reflection|
         raise ArgumentError, "One or more associations are invalid: #{associations.join(", ")}" unless reflection
         klass = reflection.klass
       end

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -33,6 +33,11 @@ class MiqExpression::Field
     column_type == :string
   end
 
+  def plural?
+    return false if reflections.empty?
+    [:has_many, :has_and_belongs_to_many].include?(reflections.last.macro)
+  end
+
   def reflections
     klass = model
     associations.collect do |association|

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -131,4 +131,26 @@ RSpec.describe MiqExpression::Field do
       expect(field.target).to eq(GuestApplication)
     end
   end
+
+  describe "#plural?" do
+    it "returns false if the column is on a 'belongs_to' association" do
+      field = described_class.new(Vm, ["storage"], "region_description")
+      expect(field).not_to be_plural
+    end
+
+    it "returns false if the column is on a 'has_one' association" do
+      field = described_class.new(Vm, ["hardware"], "guest_os")
+      expect(field).not_to be_plural
+    end
+
+    it "returns true if the column is on a 'has_many' association" do
+      field = described_class.new(Host, ["vms"], "name")
+      expect(field).to be_plural
+    end
+
+    it "returns true if the column is on a 'has_and_belongs_to_many' association" do
+      field = described_class.new(Vm, ["storages"], "name")
+      expect(field).to be_plural
+    end
+  end
 end

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe MiqExpression::Field do
       expect(field.reflections).to match([an_object_having_attributes(:klass => Account)])
     end
 
-    it "raises an error if the field has virtual associations" do
+    it "can handle virtual associations" do
       field = described_class.new(Vm, ["processes"], "name")
-      expect { field.reflections }.to raise_error(/One or more associations are invalid: processes/)
+      expect(field.reflections).to match([an_object_having_attributes(:klass => OsProcess)])
     end
 
     it "raises an error if the field has invalid associations" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -1281,13 +1281,6 @@ describe MiqExpression do
     end
   end
 
-  describe ".is_plural?" do
-    it "should return true if assotiation of field is 'has_many' or 'has_and_belongs_to_many'" do
-      field = 'ManageIQ::Providers::InfraManager::Vm.storage-region_description' # vm belong_to storage
-      expect(MiqExpression.is_plural?(field)).to be_falsey
-    end
-  end
-
   describe ".atom_error" do
     it "should return false if value can be evaluated as regular expression" do
       value = '123[)'


### PR DESCRIPTION
The former takes a field as an argument, so this method will be more at
home on the Field class, where it can lean on the behavior of
Field#reflections (so can be simplified).

@miq-bot add-label core, refactoring, darga/no
@miq-bot assign @gtanzillo 