### PR TITLE
Dockerfile inject CONTAINER=true ENV variable at build-time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,8 @@ RUN ${APPLIANCE_ROOT}/setup && \
     mkdir ${APP_ROOT}/log/apache && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \
-    echo "export APP_ROOT=${APP_ROOT}" >> /etc/default/evm
+    echo "export APP_ROOT=${APP_ROOT}" >> /etc/default/evm && \
+    echo "export CONTAINER=true" >> /etc/default/evm
 
 ## Change workdir to application root, build/install gems
 WORKDIR ${APP_ROOT}


### PR DESCRIPTION
This offers a reliable way to check if we are running inside a container.
The variable is exported from /etc/default/evm just as the rest of EVM related vars.

See discussion on #8896