### PR TITLE
[WIP] Change migration to batch update records in parallel.

### DIFF
--- a/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
+++ b/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
@@ -2,7 +2,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
   module Serializer
     YAML_ATTRS = [:table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                   :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
-                  :report_run_time, :chart, :reserved]
+                  :report_run_time, :chart, :reserved].to_set
 
     def serialize_report_to_hash(val, migration)
       if val.include?("!ruby/object:MiqReport")

--- a/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
+++ b/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
@@ -4,14 +4,14 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
                   :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
                   :report_run_time, :chart, :reserved].to_set
 
-    def serialize_report_to_hash(val, migration)
+    def self.serialize_report_to_hash(val, klass, id, migration)
       if val.include?("!ruby/object:MiqReport")
         val.sub!(/MiqReport/, 'Hash')
       elsif val.starts_with?('--- !')
-        migration.say "#{self.class} Id: #{id} is not an MiqReport object, skipping conversion"
+        migration.say "#{klass} id: #{id} does not contain an MiqReport object, skipping conversion", :subitem
         return
       else
-        raise "unexpected format of report attribute encountered, '#{val.inspect}'"
+        raise "unexpected format of report attribute encountered, '#{val.inspect.truncate(10000)}'"
       end
       raw_hash = YAML.load(val)
       # MiqReport was serialized as an Array with 1 element in miq_report_results
@@ -22,9 +22,9 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
       YAML.dump(new_hash)
     end
 
-    def serialize_hash_to_report(val, from, migration)
+    def self.serialize_hash_to_report(val, from, klass, id, migration)
       if val.starts_with?('--- !')
-        migration.say "#{self.class} Id: #{id} is not a Hash, skipping conversion"
+        migration.say "#{klass} id: #{id} does not contain a Hash, skipping conversion", :subitem
       elsif val.starts_with?("---")
         new_hash = {'attributes' => {}}
         YAML.load(val).each do |k, v|
@@ -38,29 +38,17 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
           YAML.dump(new_hash).sub(/---/, "--- !ruby/object:MiqReport")
         end
       else
-        raise "unexpected format of report attribute encountered, '#{val.inspect}'"
+        raise "unexpected format of report attribute encountered, '#{val.inspect.truncate(10000)}'"
       end
     end
   end
 
   class MiqReportResult < ActiveRecord::Base
-    include Serializer
   end
 
   class BinaryBlobPart < ActiveRecord::Base
     def self.default_part_size
       @default_part_size ||= 1.megabyte
-    end
-
-    def inspect
-      # Clean up inspect so that we don't flood script/console
-      attrs = attribute_names.inject("{") { |s, n| s << "#{n.inspect}=>#{n == "data" ? "\"...\"" : read_attribute(n).inspect}, "; s }
-      attrs.chomp!(", ")
-      attrs << "}"
-      iv = instance_variables.inject(" ") { |s, v| s << "#{v}=#{v == "@attributes" ? attrs : instance_variable_get(v).inspect}, "; s }
-      iv.chomp!(", ")
-      iv.rstrip!
-      "#{to_s.chop}#{iv}>"
     end
 
     def data
@@ -82,8 +70,6 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
   class BinaryBlob < ActiveRecord::Base
     has_many :binary_blob_parts, -> { order(:id) }, :class_name => 'FixSerializedReportsForRailsFour::BinaryBlobPart'
     belongs_to :resource, :class_name => 'FixSerializedReportsForRailsFour::MiqReportResult'
-
-    include Serializer
 
     def delete_binary
       self.md5 = self.size = self.part_size = nil
@@ -127,7 +113,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
   def up
     say_with_time("Converting MiqReportResult#report to a serialized hash") do
       MiqReportResult.where('report IS NOT NULL').find_each do |rr|
-        val = rr.serialize_report_to_hash(rr.read_attribute(:report), self)
+        val = Serializer.serialize_report_to_hash(rr.report, rr.class, rr.id, self)
         rr.update_attribute(:report, val) if val
       end
     end
@@ -135,7 +121,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
     say_with_time("Converting BinaryBlob report results to a serialized hash") do
       BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').find_each do |bb|
         if bb.resource
-          val = bb.serialize_report_to_hash(bb.binary, self)
+          val = Serializer.serialize_report_to_hash(bb.binary, bb.class, bb.id, self)
           bb.binary = val if val
         end
       end
@@ -145,7 +131,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
   def down
     say_with_time("Converting MiqReportResult#report back to a serialized MiqReport") do
       MiqReportResult.where('report IS NOT NULL').find_each do |rr|
-        val = rr.serialize_hash_to_report(rr.read_attribute(:report), :miq_report_result, self)
+        val = Serializer.serialize_hash_to_report(rr.report, :miq_report_result, rr.class, rr.id, self)
         rr.update_attribute(:report, val) if val
       end
     end
@@ -153,7 +139,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration
     say_with_time("Converting BinaryBlob report results back to a serialized MiqReport") do
       BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').find_each do |bb|
         if bb.resource
-          val = bb.serialize_hash_to_report(bb.binary, :binary_blob, self)
+          val = Serializer.serialize_hash_to_report(bb.binary, :binary_blob, bb.class, bb.id, self)
           bb.binary = val if val
         end
       end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -33,7 +33,7 @@ gem "net-sftp",                "~>2.1.2",           :require => false
 gem "nokogiri",                "~>1.6.8",           :require => false
 gem "openscap",                "~>0.4.3",           :require => false
 gem "ovirt",                   "~>0.13.0",          :require => false
-gem "parallel",                "~>1.9",             :require => false # For OvirtInventory
+gem "parallel",                "~>1.9",             :require => false # For OvirtInventory and a migration
 gem "pg",                      "~>0.18.2",          :require => false
 gem "pg-dsn_parser",           "~>0.1.0",           :require => false
 gem "psych",                   "~>2.0.12"

--- a/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
+++ b/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
@@ -1,12 +1,12 @@
 require_migration
 
 describe FixSerializedReportsForRailsFour do
-  let(:report_result_stub)  { migration_stub(:MiqReportResult) }
-  let(:binary_blob)  { migration_stub(:BinaryBlob) }
+  let(:report_result_stub) { migration_stub(:MiqReportResult) }
+  let(:binary_blob_stub)   { migration_stub(:BinaryBlob) }
   let(:data_dir) { File.join(Rails.root, 'spec/migrations/data', File.basename(__FILE__, '.rb')) }
 
   migration_context :up do
-    before(:each) do
+    before do
       @raw_report   = File.read(File.join(data_dir, 'miq_report_obj.yaml'))
       @raw_blob     = File.read(File.join(data_dir, 'binary_blob_obj.yaml'))
       @raw_blob_csv = File.read(File.join(data_dir, 'binary_blob_csv.yaml'))
@@ -29,7 +29,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "migrates existing binary blobs serialized as MiqReport objects to Hashes" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,
@@ -48,7 +48,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "skips existing binary blobs serialized as CSV" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,
@@ -91,7 +91,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "migrates existing binary blobs serialized as Hashes objects to MiqReports" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,
@@ -110,7 +110,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "skips existing binary blobs serialized as CSV" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,

--- a/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
+++ b/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
@@ -5,6 +5,11 @@ describe FixSerializedReportsForRailsFour do
   let(:binary_blob_stub)   { migration_stub(:BinaryBlob) }
   let(:data_dir) { File.join(Rails.root, 'spec/migrations/data', File.basename(__FILE__, '.rb')) }
 
+#TODO: Needs specs for
+#  reentrance
+#  ignoring orphaned BBs
+#  actual verification of the data, not just expect(x).to be_a(Hash)
+
   migration_context :up do
     before do
       @raw_report   = File.read(File.join(data_dir, 'miq_report_obj.yaml'))


### PR DESCRIPTION
- MiqReportResults data migration is done simply using find_in_batches.
- BinaryBlob data migration uses parallel gem to do the YAML conversions
  in separate processes since it is the majority of the time spent.

https://bugzilla.redhat.com/show_bug.cgi?id=1337159

Locally, with 8 processors, I was able to complete the conversion of the BinaryBlob records in about an hour.  I haven't tried to run it without this PR, but I've heard rumors of it taking 7 hours, so, about 85% improvement?  Memory-wise the parent process is now using about 1.8GB of memory, and each subprocess RSS was about 600MB (showing about 400MB shared with the parent, so about +200MB per subprocess).

Here's what it looks like with the resurrected batch logging (with timings and ETA!):

``` text
-- Converting BinaryBlob report results to a serialized hash
   -> Processing 32555 rows
   -> 1000 rows (3.07% - 1000 total - 250.85s - ETA: about 2 hours)
   -> 1000 rows (6.14% - 2000 total - 87.50s - ETA: about 1 hour)
   -> 1000 rows (9.22% - 3000 total - 59.65s - ETA: about 1 hour)
   -> 1000 rows (12.29% - 4000 total - 87.62s - ETA: about 1 hour)
   -> 1000 rows (15.36% - 5000 total - 127.30s - ETA: about 1 hour)
   -> 1000 rows (18.43% - 6000 total - 57.12s - ETA: about 1 hour)
   -> 1000 rows (21.50% - 7000 total - 55.53s - ETA: 44 minutes)
   -> 1000 rows (24.57% - 8000 total - 104.80s - ETA: 42 minutes)
   -> 1000 rows (27.65% - 9000 total - 181.62s - ETA: 44 minutes)
   -> 1000 rows (30.72% - 10000 total - 114.89s - ETA: 42 minutes)
   -> 1000 rows (33.79% - 11000 total - 109.74s - ETA: 40 minutes)
   -> 1000 rows (36.86% - 12000 total - 85.69s - ETA: 38 minutes)
   -> 1000 rows (39.93% - 13000 total - 75.47s - ETA: 35 minutes)
   -> 1000 rows (43.00% - 14000 total - 146.55s - ETA: 34 minutes)
   -> 1000 rows (46.08% - 15000 total - 108.91s - ETA: 32 minutes)
   -> 1000 rows (49.15% - 16000 total - 164.40s - ETA: 31 minutes)
   -> 1000 rows (52.22% - 17000 total - 109.69s - ETA: 29 minutes)
   -> 1000 rows (55.29% - 18000 total - 116.20s - ETA: 28 minutes)
   -> 1000 rows (58.36% - 19000 total - 130.72s - ETA: 26 minutes)
   -> 1000 rows (61.43% - 20000 total - 139.72s - ETA: 24 minutes)
   -> 1000 rows (64.51% - 21000 total - 116.95s - ETA: 22 minutes)
   -> 1000 rows (67.58% - 22000 total - 152.10s - ETA: 21 minutes)
   -> 1000 rows (70.65% - 23000 total - 128.17s - ETA: 19 minutes)
   -> 1000 rows (73.72% - 24000 total - 125.33s - ETA: 17 minutes)
   -> 1000 rows (76.79% - 25000 total - 146.08s - ETA: 15 minutes)
   -> 1000 rows (79.86% - 26000 total - 112.75s - ETA: 13 minutes)
   -> 1000 rows (82.94% - 27000 total - 165.07s - ETA: 11 minutes)
   -> 1000 rows (86.01% - 28000 total - 107.26s - ETA: 9 minutes)
   -> 1000 rows (89.08% - 29000 total - 106.25s - ETA: 7 minutes)
   -> 1000 rows (92.15% - 30000 total - 107.57s - ETA: 5 minutes)
   -> 1000 rows (95.22% - 31000 total - 76.85s - ETA: 3 minutes)
   -> 1000 rows (98.30% - 32000 total - 84.35s - ETA: 1 minute)
   -> 555 rows (100.00% - 32555 total - 37.13s - ETA: less than 5 seconds)
   -> 3783.3003s
```

Marked as WIP because I have a number of TODO items
- Make the specs pass 😅 
- Do the down migrations 😜 
- Add specs for reentrance (already modified records)
- Add specs for ignoring orphaned BBs
- Add specs for actual verification of the data, not just `expect(x).to be_a(Hash)`.  Since the Serializer is decoupled from ActiveRecord, this can actually be unit tested with raw values and doesn't have to be part of the migrations specs themselves.
- There are a few other microoptimziations, but they didn't seem to make much improvement, so need to decide.
  -  YAML_ATTRS can be an Array of Strings instead of an Array of Symbols, so `.to_s` isn't called over and over, which might lessen the number of allocations by quite a bit.  However, I have to verify the Strings aren't being shared in the final YAML dump
  - The query where we need to ignore orphaned BinaryBlob records can be done all in SQL with a LEFT OUTER JOIN, instead of post-filtering in Ruby, however, when I actually coded this, it made little difference in savings.  It might be worth looking at again once this is more complete.
    - Additionally, we can use scopes to make the querying more efficient, such as using a scope to eliminate orphaned BinaryBlobs as described above, but then reusing that scope with `.limit(1000).includes(:binary_blob_parts)` in the inner loop to avoid the id manipulations.  We'd have to measure, but as I saw no benefits with the original scope, I don't expect much benefits with reusing it for the inner scope.
  - `binary=` calls `.delete_binary`, which does `binary_blob_parts.delete_all` then `save!`, then it updates `binary_blob_parts` with the new records, then calls `save!` again.  All in all, this is 4 trips to the database, when only 2 are necessary, so there may be some savings there.  However, the average time spent in this migration was almost entirely in YAML.dump/load and writing to the database was relatively small.  We might gain minutes, but that's about it.  Note that these same SQL problems [exist in the current model](https://github.com/ManageIQ/manageiq/blob/3c3daca5d0b1bcc27d1f18c6a4e29b2e410e10e0/app/models/binary_blob.rb#L25-L41) as well

@gtanzillo @jrafanie Please review
