### PR TITLE
Correct plural ui_lookup for tables => ems_network

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_networks_center.rb
@@ -9,20 +9,20 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
         button(
           :ems_network_refresh,
           'fa fa-refresh fa-lg',
-          N_('Refresh relationships and power states for all items related to the selected #{ui_lookup(:tables=>"ems_networks")}'),
+          N_('Refresh relationships and power states for all items related to the selected #{ui_lookup(:tables=>"ems_network")}'),
           N_('Refresh Relationships and Power States'),
           :url_parms => "main_div",
-          :confirm   => N_("Refresh relationships and power states for all items related to the selected \#{ui_lookup(:tables=>\"ems_networks\")}?"),
+          :confirm   => N_("Refresh relationships and power states for all items related to the selected \#{ui_lookup(:tables=>\"ems_network\")}?"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected #{ui_lookup(:tables=>"ems_networks")} from the VMDB'),
-          N_('Remove #{ui_lookup(:tables=>"ems_networks")} from the VMDB'),
+          N_('Remove selected #{ui_lookup(:tables=>"ems_network")} from the VMDB'),
+          N_('Remove #{ui_lookup(:tables=>"ems_network")} from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"ems_networks\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"ems_networks\")}?"),
+          :confirm   => N_("Warning: The selected \#{ui_lookup(:tables=>\"ems_network\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected \#{ui_lookup(:tables=>\"ems_network\")}?"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]
@@ -40,7 +40,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
         button(
           :ems_network_protect,
           'pficon pficon-edit fa-lg',
-          N_('Manage Policies for the selected #{ui_lookup(:tables=>"ems_networks")}'),
+          N_('Manage Policies for the selected #{ui_lookup(:tables=>"ems_network")}'),
           N_('Manage Policies'),
           :url_parms => "main_div",
           :enabled   => false,
@@ -48,7 +48,7 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
         button(
           :ems_network_tag,
           'pficon pficon-edit fa-lg',
-          N_('Edit Tags for the selected #{ui_lookup(:tables=>"ems_networks")}'),
+          N_('Edit Tags for the selected #{ui_lookup(:tables=>"ems_network")}'),
           N_('Edit Tags'),
           :url_parms => "main_div",
           :enabled   => false,


### PR DESCRIPTION
```
ui_lookup(:tables=>"ems_networks")
=> "Ems Networks"

ui_lookup(:tables=>"ems_network")
=> "»Network Providers«"
```

Before:
![np-before](https://cloud.githubusercontent.com/assets/6648365/15778690/114ff064-2998-11e6-9b4a-d84737c6af2e.jpg)

After:
![np-after](https://cloud.githubusercontent.com/assets/6648365/15778689/1148b574-2998-11e6-8777-949bf7f7bf6c.jpg)
