### PR TITLE
Automate | Fix validate_quota method to properly set the request.message.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/validate_quota.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/validate_quota.rb
@@ -76,24 +76,21 @@ def check_quotas
 end
 
 def check_quota_results
-  message = ""
   unless @max_exceeded.empty?
     max_message = message_text(nil, "Request exceeds maximum allowed for the following: ", @max_exceeded)
-    message = set_exceeded_results(message, max_message, :quota_max_exceeded, "error")
+    @miq_request.set_message(set_exceeded_results(max_message, :quota_max_exceeded, "error"))
     return
   end
   unless @warn_exceeded.empty?
     warn_message = message_text('warn_', "Request exceeds warning limits for the following: ", @warn_exceeded)
-    message = set_exceeded_results(message, warn_message, :quota_warn_exceeded, "ok")
+    @miq_request.set_message(set_exceeded_results(warn_message, :quota_warn_exceeded, "ok"))
   end
-  @miq_request.set_message(message[0..250])
 end
 
-def set_exceeded_results(request_message, new_message, request_option, ae_result_text)
-  request_message += new_message
-  @miq_request.set_option(request_option, request_message)
+def set_exceeded_results(new_message, request_option, ae_result_text)
+  @miq_request.set_option(request_option, new_message)
   $evm.root['ae_result'] = ae_result_text
-  request_message
+  new_message
 end
 
 def message_text(type, msg, exceeded_hash)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -26,7 +26,7 @@ module MiqAeMethodService
     association :approvers
 
     def set_message(value)
-      object_send(:update_attributes, :message => value)
+      object_send(:update_attributes, :message => value.try!(:truncate, 255))
     end
 
     def description=(new_description)

--- a/spec/automation/unit/method_validation/validate_quota_spec.rb
+++ b/spec/automation/unit/method_validation/validate_quota_spec.rb
@@ -39,6 +39,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('error')
       @miq_request.reload
       expect(@miq_request.options[:quota_max_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
 
     it "failure warn memory" do
@@ -50,6 +51,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('ok')
       @miq_request.reload
       expect(@miq_request.options[:quota_warn_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
 
     it "failure max vms" do
@@ -61,6 +63,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('error')
       @miq_request.reload
       expect(@miq_request.options[:quota_max_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
 
     it "failure warn vms" do
@@ -72,6 +75,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('ok')
       @miq_request.reload
       expect(@miq_request.options[:quota_warn_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
 
     it "failure max cpu" do
@@ -83,6 +87,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('error')
       @miq_request.reload
       expect(@miq_request.options[:quota_max_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
 
     it "failure warn cpu" do
@@ -94,6 +99,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('ok')
       @miq_request.reload
       expect(@miq_request.options[:quota_warn_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
 
     it "failure max storage" do
@@ -105,6 +111,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('error')
       @miq_request.reload
       expect(@miq_request.options[:quota_max_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
 
     it "failure warn storage" do
@@ -116,6 +123,7 @@ describe "Quota Validation" do
       expect(ws.root['ae_result']).to eql('ok')
       @miq_request.reload
       expect(@miq_request.options[:quota_warn_exceeded]).to eql(err_msg)
+      expect(@miq_request.message).to eql(err_msg)
     end
   end
 end


### PR DESCRIPTION
 Fixed quota exceeded message and modified tests to check request.message.

https://bugzilla.redhat.com/show_bug.cgi?id=1333698