### PR TITLE
Don't use N_() in textual summaries

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -131,9 +131,9 @@ module EmsContainerHelper::TextualSummary
   def textual_endpoints
     return unless @ems.connection_configurations.hawkular
 
-    [{:label => N_('Hawkular Host Name'),
+    [{:label => _('Hawkular Host Name'),
       :value => @ems.connection_configurations.hawkular.endpoint.hostname},
-     {:label => N_('Hawkular API Port'),
+     {:label => _('Hawkular API Port'),
       :value => @ems.connection_configurations.hawkular.endpoint.port}]
   end
 end

--- a/app/helpers/ems_middleware_helper/textual_summary.rb
+++ b/app/helpers/ems_middleware_helper/textual_summary.rb
@@ -61,9 +61,9 @@ module EmsMiddlewareHelper::TextualSummary
   end
 
   def textual_topology
-    {:label => N_('Topology'),
+    {:label => _('Topology'),
      :image => 'topology',
      :link  => url_for(:controller => 'middleware_topology', :action => 'show', :id => @ems.id),
-     :title => N_('Show topology')}
+     :title => _('Show topology')}
   end
 end


### PR DESCRIPTION
`N_()` is just a gettext identity function used when we want to do delayed translation.
If we want to have the string actually translated, we need to use `_()`.