### PR TITLE
Hawkular transactions livemetrics

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -2,49 +2,37 @@ module ManageIQ::Providers
   class Hawkular::MiddlewareManager::LiveMetricsCapture
     class MetricValidationError < RuntimeError; end
 
-    MetricsResource = Struct.new(:id, :feed, :path)
-
     def initialize(target)
       @target = target
       @ems = @target.ext_management_system
       @gauges = @ems.metrics_client.gauges
       @counters = @ems.metrics_client.counters
       @avail = @ems.metrics_client.avail
+      @included_children = @target.class.included_children
+      @supported_metrics = @target.class.supported_metrics
     end
 
     def fetch_metrics_available
-      resource = MetricsResource.new
-      resource.id = @target.nativeid
-      resource.feed = extract_feed(@target.ems_ref)
-      resource.path = @target.ems_ref
-      metrics_available = @ems.metrics_resource(resource.path).collect do |metric|
-        next unless @target.class.supported_metrics[metric.name]
-        {
-          :id   => metric.id,
-          :name => @target.class.supported_metrics[metric.name],
-          :type => metric.type,
-          :unit => metric.unit
-        }
+      metrics_available = @ems.metrics_resource(@target.ems_ref).collect do |metric|
+        next unless @supported_metrics[metric.name]
+        parse_metric(metric)
       end.compact
-      if @target.class.included_children
-        fetch_children_metrics(resource, metrics_available)
+      fetch_child_metrics(@target.ems_ref, metrics_available) if @included_children
+      metrics_available
+    end
+
+    def fetch_child_metrics(resource_path, metrics_available)
+      children = @ems.child_resources(resource_path)
+      children.select { |child| @included_children.include?(child.name) }.each do |child|
+        @ems.metrics_resource(child.path).select { |metric| @supported_metrics[metric.name] }.each do |metric|
+          metrics_available << parse_metric(metric)
+        end
       end
       metrics_available
     end
 
-    def fetch_children_metrics(resource, metrics_available)
-      children = @ems.child_resources(resource.path)
-      children.select { |child| @target.class.included_children.include?(child.name) }.each do |child|
-        @ems.metrics_resource(child.path).select { |metric| @target.class.supported_metrics[metric.name] }.each do |metric|
-          metrics_available << {
-            :id   => metric.id,
-            :name => @target.class.supported_metrics[metric.name],
-            :type => metric.type,
-            :unit => metric.unit
-          }
-        end
-      end
-      metrics_available
+    def parse_metric(metric)
+      {:id => metric.id, :name => @supported_metrics[metric.name], :type => metric.type, :unit => metric.unit}
     end
 
     def collect_live_metric(metric, start_time, end_time, interval)

--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers
       @avail = @ems.metrics_client.avail
     end
 
-    def metrics_available
+    def fetch_metrics_available
       resource = MetricsResource.new
       resource.id = @target.nativeid
       resource.feed = extract_feed(@target.ems_ref)

--- a/app/models/mixins/live_metrics_mixin.rb
+++ b/app/models/mixins/live_metrics_mixin.rb
@@ -5,7 +5,7 @@ module LiveMetricsMixin
 
   class MetricValidationError < RuntimeError; end
 
-  delegate :metrics_available, :to => :metrics_capture
+  delegate :fetch_metrics_available, :to => :metrics_capture
   delegate :collect_live_metric, :to => :metrics_capture
 
   included do
@@ -18,8 +18,12 @@ module LiveMetricsMixin
       processed
     end
 
+    def metrics_available
+      @metrics_available ||= fetch_metrics_available
+    end
+
     def first_and_last_capture(interval_name = "realtime")
-      firsts, lasts = metrics_capture.metrics_available.collect do |metric| #
+      firsts, lasts = metrics_available.collect do |metric| #
         metrics_capture.first_and_last_capture(metric)
       end.transpose
       adjust_timestamps(firsts, lasts, interval_name)

--- a/app/models/mixins/live_metrics_mixin.rb
+++ b/app/models/mixins/live_metrics_mixin.rb
@@ -23,7 +23,7 @@ module LiveMetricsMixin
     end
 
     def first_and_last_capture(interval_name = "realtime")
-      firsts, lasts = metrics_available.collect do |metric| #
+      firsts, lasts = metrics_available.collect do |metric|
         metrics_capture.first_and_last_capture(metric)
       end.transpose
       adjust_timestamps(firsts, lasts, interval_name)

--- a/app/models/mixins/live_metrics_mixin.rb
+++ b/app/models/mixins/live_metrics_mixin.rb
@@ -44,13 +44,23 @@ module LiveMetricsMixin
   end
 
   module ClassMethods
-    def supported_metrics
-      @supported_metrics ||= load_supported_metrics
+    def included_children
+      @live_metrics_config ||= load_live_metrics_config
+      @live_metrics_config['included_children']
     end
 
-    def load_supported_metrics
+    def supported_metrics
+      @live_metrics_config ||= load_live_metrics_config
+      @live_metrics_config['supported_metrics']
+    end
+
+    def load_live_metrics_config
       live_metrics_file = File.join(LIVE_METRICS_DIR, "#{name.demodulize.underscore}.yaml")
-      File.exist?(live_metrics_file) ? YAML.load_file(live_metrics_file).reduce({}, :merge) : {}
+      live_metrics_config = File.exist?(live_metrics_file) ? YAML.load_file(live_metrics_file) : {}
+      if live_metrics_config['supported_metrics']
+        live_metrics_config['supported_metrics'] = live_metrics_config['supported_metrics'].reduce({}, :merge)
+      end
+      live_metrics_config
     end
   end
 end

--- a/product/charts/layouts/daily_perf_charts/MiddlewareServer.yaml
+++ b/product/charts/layouts/daily_perf_charts/MiddlewareServer.yaml
@@ -24,3 +24,13 @@
   - mw_aggregated_active_web_sessions
   - mw_aggregated_expired_web_sessions
   - mw_aggregated_rejected_web_sessions
+
+- :title: Transactions
+  :type: Line
+  :columns:
+  - mw_tx_committed
+  - mw_tx_timeout
+  - mw_tx_heuristics
+  - mw_tx_application_rollbacks
+  - mw_tx_aborted
+  - mw_tx_resource_rollbacks

--- a/product/charts/layouts/hourly_perf_charts/MiddlewareServer.yaml
+++ b/product/charts/layouts/hourly_perf_charts/MiddlewareServer.yaml
@@ -24,3 +24,13 @@
   - mw_aggregated_active_web_sessions
   - mw_aggregated_expired_web_sessions
   - mw_aggregated_rejected_web_sessions
+
+- :title: Transactions
+  :type: Line
+  :columns:
+  - mw_tx_committed
+  - mw_tx_timeout
+  - mw_tx_heuristics
+  - mw_tx_application_rollbacks
+  - mw_tx_aborted
+  - mw_tx_resource_rollbacks

--- a/product/charts/layouts/realtime_perf_charts/MiddlewareServer.yaml
+++ b/product/charts/layouts/realtime_perf_charts/MiddlewareServer.yaml
@@ -24,3 +24,13 @@
   - mw_aggregated_active_web_sessions
   - mw_aggregated_expired_web_sessions
   - mw_aggregated_rejected_web_sessions
+
+- :title: Transactions
+  :type: Line
+  :columns:
+  - mw_tx_committed
+  - mw_tx_timeout
+  - mw_tx_heuristics
+  - mw_tx_application_rollbacks
+  - mw_tx_aborted
+  - mw_tx_resource_rollbacks

--- a/product/charts/miq_reports/vim_perf_daily_middleware_server.yaml
+++ b/product/charts/miq_reports/vim_perf_daily_middleware_server.yaml
@@ -31,6 +31,12 @@ cols:
 - mw_aggregated_active_web_sessions
 - mw_aggregated_expired_web_sessions
 - mw_aggregated_rejected_web_sessions
+- mw_tx_committed
+- mw_tx_timeout
+- mw_tx_heuristics
+- mw_tx_application_rollbacks
+- mw_tx_aborted
+- mw_tx_resource_rollbacks
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -47,6 +53,12 @@ col_order:
 - mw_aggregated_active_web_sessions
 - mw_aggregated_expired_web_sessions
 - mw_aggregated_rejected_web_sessions
+- mw_tx_committed
+- mw_tx_timeout
+- mw_tx_heuristics
+- mw_tx_application_rollbacks
+- mw_tx_aborted
+- mw_tx_resource_rollbacks
 
 # Column titles, in order
 headers:
@@ -60,6 +72,12 @@ headers:
 - Active
 - Expired
 - Rejected
+- Committed
+- Timed-out
+- Heuristic
+- Application Failure
+- Aborted
+- Resource Failure
 
 # Condition expression for search filtering
 conditions: 
@@ -96,6 +114,12 @@ graph:
     - mw_aggregated_active_web_sessions
     - mw_aggregated_expired_web_sessions
     - mw_aggregated_rejected_web_sessions
+    - mw_tx_committed
+    - mw_tx_timeout
+    - mw_tx_heuristics
+    - mw_tx_application_rollbacks
+    - mw_tx_aborted
+    - mw_tx_resource_rollbacks
 
 # Dimensions of graph (1 or 2)
 #   Note: specifying 2 for a single dimension graph may not return expected results

--- a/product/charts/miq_reports/vim_perf_hourly_middleware_server.yaml
+++ b/product/charts/miq_reports/vim_perf_hourly_middleware_server.yaml
@@ -31,6 +31,12 @@ cols:
 - mw_aggregated_active_web_sessions
 - mw_aggregated_expired_web_sessions
 - mw_aggregated_rejected_web_sessions
+- mw_tx_committed
+- mw_tx_timeout
+- mw_tx_heuristics
+- mw_tx_application_rollbacks
+- mw_tx_aborted
+- mw_tx_resource_rollbacks
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -47,6 +53,12 @@ col_order:
 - mw_aggregated_active_web_sessions
 - mw_aggregated_expired_web_sessions
 - mw_aggregated_rejected_web_sessions
+- mw_tx_committed
+- mw_tx_timeout
+- mw_tx_heuristics
+- mw_tx_application_rollbacks
+- mw_tx_aborted
+- mw_tx_resource_rollbacks
 
 # Column titles, in order
 headers:
@@ -60,6 +72,12 @@ headers:
 - Active
 - Expired
 - Rejected
+- Committed
+- Timed-out
+- Heuristic
+- Application Failure
+- Aborted
+- Resource Failure
 
 # Condition expression for search filtering
 conditions:
@@ -96,6 +114,12 @@ graph:
     - mw_aggregated_active_web_sessions
     - mw_aggregated_expired_web_sessions
     - mw_aggregated_rejected_web_sessions
+    - mw_tx_committed
+    - mw_tx_timeout
+    - mw_tx_heuristics
+    - mw_tx_application_rollbacks
+    - mw_tx_aborted
+    - mw_tx_resource_rollbacks
 
 # Dimensions of graph (1 or 2)
 #   Note: specifying 2 for a single dimension graph may not return expected results

--- a/product/charts/miq_reports/vim_perf_realtime_middleware_server.yaml
+++ b/product/charts/miq_reports/vim_perf_realtime_middleware_server.yaml
@@ -31,6 +31,12 @@ cols:
 - mw_aggregated_active_web_sessions
 - mw_aggregated_expired_web_sessions
 - mw_aggregated_rejected_web_sessions
+- mw_tx_committed
+- mw_tx_timeout
+- mw_tx_heuristics
+- mw_tx_application_rollbacks
+- mw_tx_aborted
+- mw_tx_resource_rollbacks
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -47,6 +53,12 @@ col_order:
 - mw_aggregated_active_web_sessions
 - mw_aggregated_expired_web_sessions
 - mw_aggregated_rejected_web_sessions
+- mw_tx_committed
+- mw_tx_timeout
+- mw_tx_heuristics
+- mw_tx_application_rollbacks
+- mw_tx_aborted
+- mw_tx_resource_rollbacks
 
 # Column titles, in order
 headers:
@@ -60,6 +72,12 @@ headers:
 - Active
 - Expired
 - Rejected
+- Committed
+- Timed-out
+- Heuristic
+- Application Failure
+- Aborted
+- Resource Failure
 
 # Condition expression for search filtering
 conditions:
@@ -96,6 +114,12 @@ graph:
     - mw_aggregated_active_web_sessions
     - mw_aggregated_expired_web_sessions
     - mw_aggregated_rejected_web_sessions
+    - mw_tx_committed
+    - mw_tx_timeout
+    - mw_tx_heuristics
+    - mw_tx_application_rollbacks
+    - mw_tx_aborted
+    - mw_tx_resource_rollbacks
 
 # Dimensions of graph (1 or 2)
 #   Note: specifying 2 for a single dimension graph may not return expected results

--- a/product/live_metrics/middleware_datasource.yaml
+++ b/product/live_metrics/middleware_datasource.yaml
@@ -14,3 +14,4 @@ supported_metrics:
   - Datasource Pool Metrics~Timed Out: mw_ds_timed_out
   - Datasource Pool Metrics~Average Get Time: mw_ds_average_get_time
   - Datasource Pool Metrics~Average Creation Time: mw_ds_average_creation_time
+

--- a/product/live_metrics/middleware_datasource.yaml
+++ b/product/live_metrics/middleware_datasource.yaml
@@ -8,9 +8,9 @@
 #   Format:
 #   - Provider native metric id: MiQ metric id
 #
-- Datasource Pool Metrics~Available Count: mw_ds_available_count
-- Datasource Pool Metrics~In Use Count: mw_ds_in_use_count
-- Datasource Pool Metrics~Timed Out: mw_ds_timed_out
-- Datasource Pool Metrics~Average Get Time: mw_ds_average_get_time
-- Datasource Pool Metrics~Average Creation Time: mw_ds_average_creation_time
-
+supported_metrics:
+  - Datasource Pool Metrics~Available Count: mw_ds_available_count
+  - Datasource Pool Metrics~In Use Count: mw_ds_in_use_count
+  - Datasource Pool Metrics~Timed Out: mw_ds_timed_out
+  - Datasource Pool Metrics~Average Get Time: mw_ds_average_get_time
+  - Datasource Pool Metrics~Average Creation Time: mw_ds_average_creation_time

--- a/product/live_metrics/middleware_server.yaml
+++ b/product/live_metrics/middleware_server.yaml
@@ -35,3 +35,4 @@ supported_metrics:
   - Transactions Metrics~Number of Timed Out Transactions: mw_tx_timeout
   - Transactions Metrics~Number of Nested Transactions: mw_tx_nested
   - Transactions Metrics~Number of Heuristics: mw_tx_heuristics
+

--- a/product/live_metrics/middleware_server.yaml
+++ b/product/live_metrics/middleware_server.yaml
@@ -8,18 +8,30 @@
 #   Format:
 #   - Provider native metric id: MiQ metric id
 #
-- WildFly Memory Metrics~Heap Used: mw_heap_used
-- WildFly Memory Metrics~Heap Max: mw_heap_max
-- WildFly Memory Metrics~Heap Committed: mw_heap_committed
-- WildFly Memory Metrics~NonHeap Used: mw_non_heap_used
-- WildFly Memory Metrics~NonHeap Committed: mw_non_heap_committed
-- WildFly Memory Metrics~Accumulated GC Duration: mw_accumulated_gc_duration
-- WildFly Aggregated Web Metrics~Aggregated Servlet Request Time: mw_agregated_servlet_time
-- WildFly Aggregated Web Metrics~Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
-- WildFly Aggregated Web Metrics~Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
-- WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions
-- WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions: mw_aggregated_expired_web_sessions
-- WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions: mw_aggregated_max_active_web_sessions
-- WildFly Threading Metrics~Thread Count: mw_thread_count
-- Server Availability~App Server: mw_availability_app_server
+included_children:
+  - Transaction Manager
 
+supported_metrics:
+  - WildFly Memory Metrics~Heap Used: mw_heap_used
+  - WildFly Memory Metrics~Heap Max: mw_heap_max
+  - WildFly Memory Metrics~Heap Committed: mw_heap_committed
+  - WildFly Memory Metrics~NonHeap Used: mw_non_heap_used
+  - WildFly Memory Metrics~NonHeap Committed: mw_non_heap_committed
+  - WildFly Memory Metrics~Accumulated GC Duration: mw_accumulated_gc_duration
+  - WildFly Aggregated Web Metrics~Aggregated Servlet Request Time: mw_agregated_servlet_time
+  - WildFly Aggregated Web Metrics~Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
+  - WildFly Aggregated Web Metrics~Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
+  - WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions
+  - WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions: mw_aggregated_expired_web_sessions
+  - WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions: mw_aggregated_max_active_web_sessions
+  - WildFly Threading Metrics~Thread Count: mw_thread_count
+  - Server Availability~App Server: mw_availability_app_server
+  - Transactions Metrics~Number of Aborted Transactions: mw_tx_aborted
+  - Transactions Metrics~Number of In-Flight Transactions: mw_tx_inflight
+  - Transactions Metrics~Number of Committed Transactions: mw_tx_committed
+  - Transactions Metrics~Number of Transactions: mw_tx_total
+  - Transactions Metrics~Number of Application Rollbacks: mw_tx_application_rollbacks
+  - Transactions Metrics~Number of Resource Rollbacks: mw_tx_resource_rollbacks
+  - Transactions Metrics~Number of Timed Out Transactions: mw_tx_timeout
+  - Transactions Metrics~Number of Nested Transactions: mw_tx_nested
+  - Transactions Metrics~Number of Heuristics: mw_tx_heuristics

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -13,20 +13,48 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   let(:eap) do
     FactoryGirl.create(:hawkular_middleware_server,
                        :name                  => 'Local',
-                       :feed                  => '377fadac-98eb-4a53-bf3b-89c21bccd8ba',
+                       :feed                  => '27e06e8f-6e5d-45cd-8353-c1f9d4dfe991',
                        :ems_ref               => '/t;hawkular'\
-                                                 '/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/r;Local~~',
+                                                 '/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~',
                        :nativeid              => 'Local~~',
                        :ext_management_system => ems_hawkular)
   end
 
+  let(:expected_metrics) do
+    {
+      "WildFly Memory Metrics~Heap Used"                                  => "mw_heap_used",
+      "WildFly Memory Metrics~Heap Max"                                   => "mw_heap_max",
+      "WildFly Memory Metrics~Heap Committed"                             => "mw_heap_committed",
+      "WildFly Memory Metrics~NonHeap Used"                               => "mw_non_heap_used",
+      "WildFly Memory Metrics~NonHeap Committed"                          => "mw_non_heap_committed",
+      "WildFly Memory Metrics~Accumulated GC Duration"                    => "mw_accumulated_gc_duration",
+      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
+      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
+      "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
+      "WildFly Threading Metrics~Thread Count"                            => "mw_thread_count",
+      "Server Availability~App Server"                                    => "mw_availability_app_server",
+      "Transactions Metrics~Number of Aborted Transactions"               => "mw_tx_aborted",
+      "Transactions Metrics~Number of In-Flight Transactions"             => "mw_tx_inflight",
+      "Transactions Metrics~Number of Committed Transactions"             => "mw_tx_committed",
+      "Transactions Metrics~Number of Transactions"                       => "mw_tx_total",
+      "Transactions Metrics~Number of Application Rollbacks"              => "mw_tx_application_rollbacks",
+      "Transactions Metrics~Number of Resource Rollbacks"                 => "mw_tx_resource_rollbacks",
+      "Transactions Metrics~Number of Timed Out Transactions"             => "mw_tx_timeout",
+      "Transactions Metrics~Number of Nested Transactions"                => "mw_tx_nested",
+      "Transactions Metrics~Number of Heuristics"                         => "mw_tx_heuristics"
+    }.freeze
+  end
+
   it "#collect_live_metrics for all metrics available" do
-    start_time = Time.new(2016, 6, 20, 16, 0, 0, "+02:00")    # Fixed time for testing
-    end_time = Time.new(2016, 6, 20, 17, 0, 0, "+02:00")      # Fixed time for testing
+    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")    # Fixed time for testing
+    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")      # Fixed time for testing
     interval = 3600                                           # Interval in seconds
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
-                     :decode_compressed_response     => true) do # , :record => :new_episodes) do
+                     :decode_compressed_response     => true, :record => :new_episodes) do
       metrics_available = eap.metrics_available
       metrics_data = eap.collect_live_metrics(metrics_available, start_time, end_time, interval)
       keys = metrics_data.keys
@@ -35,8 +63,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for three metrics" do
-    start_time = Time.new(2016, 6, 20, 16, 0, 0, "+02:00")    # Fixed time for testing
-    end_time = Time.new(2016, 6, 20, 17, 0, 0, "+02:00")      # Fixed time for testing
+    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")    # Fixed time for testing
+    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")      # Fixed time for testing
     interval = 3600                                           # Interval in seconds
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
@@ -63,23 +91,16 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#supported_metrics" do
-    expected_metrics = {
-      "WildFly Memory Metrics~Heap Used"                                  => "mw_heap_used",
-      "WildFly Memory Metrics~Heap Max"                                   => "mw_heap_max",
-      "WildFly Memory Metrics~Heap Committed"                             => "mw_heap_committed",
-      "WildFly Memory Metrics~NonHeap Used"                               => "mw_non_heap_used",
-      "WildFly Memory Metrics~NonHeap Committed"                          => "mw_non_heap_committed",
-      "WildFly Memory Metrics~Accumulated GC Duration"                    => "mw_accumulated_gc_duration",
-      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
-      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
-      "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
-      "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
-      "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
-      "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
-      "WildFly Threading Metrics~Thread Count"                            => "mw_thread_count",
-      "Server Availability~App Server"                                    => "mw_availability_app_server"
-    }.freeze
     supported_metrics = MiddlewareServer.supported_metrics
     expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
+  end
+
+  it "#metrics_available" do
+    VCR.use_cassette(described_class.name.underscore.to_s,
+                     :allow_unused_http_interactions => true,
+                     :decode_compressed_response     => true) do # , :record => :new_episodes) do
+      metrics_available = eap.metrics_available
+      metrics_available.each { |metric| expect(expected_metrics.has_value?(metric[:name])).to be(true) }
+    end
   end
 end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -49,9 +49,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for all metrics available" do
-    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")    # Fixed time for testing
-    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")      # Fixed time for testing
-    interval = 3600                                           # Interval in seconds
+    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")
+    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")
+    interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
                      :decode_compressed_response     => true, :record => :new_episodes) do
@@ -63,9 +63,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for three metrics" do
-    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")    # Fixed time for testing
-    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")      # Fixed time for testing
-    interval = 3600                                           # Interval in seconds
+    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")
+    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")
+    interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
                      :decode_compressed_response     => true) do # , :record => :new_episodes) do
@@ -100,7 +100,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
                      :allow_unused_http_interactions => true,
                      :decode_compressed_response     => true) do # , :record => :new_episodes) do
       metrics_available = eap.metrics_available
-      metrics_available.each { |metric| expect(expected_metrics.has_value?(metric[:name])).to be(true) }
+      metrics_available.each { |metric| expect(expected_metrics.value?(metric[:name])).to be(true) }
     end
   end
 end

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_server.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/377fadac-98eb-4a53-bf3b-89c21bccd8ba/resources/Local~~/metrics?sort=id
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -33,7 +33,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:50 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       X-Total-Count:
       - '14'
       Connection:
@@ -43,185 +43,185 @@ http_interactions:
       Content-Length:
       - '10061'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/377fadac-98eb-4a53-bf3b-89c21bccd8ba/resources/Local~~/metrics?sort=id>;
+      - <http://localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;AI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;AI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability",
           "name" : "Server Availability~Server Availability",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;Server%20Availability~Server%20Availability",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Server%20Availability~Server%20Availability",
             "name" : "Server Availability~Server Availability",
             "unit" : "NONE",
             "type" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
-          "id" : "AI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~AT~Server Availability~Server Availability"
+          "id" : "AI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~AT~Server Availability~Server Availability"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
           "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
           "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
           "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
           "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
           "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
           "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
           "name" : "WildFly Memory Metrics~Accumulated GC Duration",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
             "name" : "WildFly Memory Metrics~Accumulated GC Duration",
             "unit" : "MILLISECONDS",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
           "name" : "WildFly Memory Metrics~Heap Committed",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Memory%20Metrics~Heap%20Committed",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Heap%20Committed",
             "name" : "WildFly Memory Metrics~Heap Committed",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Memory Metrics~Heap Committed"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Heap Committed"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max",
           "name" : "WildFly Memory Metrics~Heap Max",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Memory%20Metrics~Heap%20Max",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Heap%20Max",
             "name" : "WildFly Memory Metrics~Heap Max",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Memory Metrics~Heap Max"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
           "name" : "WildFly Memory Metrics~Heap Used",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Memory%20Metrics~Heap%20Used",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Heap%20Used",
             "name" : "WildFly Memory Metrics~Heap Used",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Memory Metrics~Heap Used"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
           "name" : "WildFly Memory Metrics~NonHeap Committed",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
             "name" : "WildFly Memory Metrics~NonHeap Committed",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
           "name" : "WildFly Memory Metrics~NonHeap Used",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
             "name" : "WildFly Memory Metrics~NonHeap Used",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
         }, {
-          "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/m;MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
           "name" : "WildFly Threading Metrics~Thread Count",
           "type" : {
-            "path" : "/t;hawkular/f;377fadac-98eb-4a53-bf3b-89c21bccd8ba/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Threading%20Metrics~Thread%20Count",
             "name" : "WildFly Threading Metrics~Thread Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
-          "id" : "MI~R~[377fadac-98eb-4a53-bf3b-89c21bccd8ba/Local~~]~MT~WildFly Threading Metrics~Thread Count"
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:50 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/AI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/children
     body:
       encoding: US-ASCII
       string: ''
@@ -252,21 +252,144 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
+      X-Total-Count:
+      - '13'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '322'
+      - '5059'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/children>;
+        rel="current"
     body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"downtimeDuration":0,"lastDowntime":0,"uptimeRatio":1.0,"downtimeCount":0,"empty":false},{"start":1466431200000,"end":1466434800000,"downtimeDuration":0,"lastDowntime":0,"uptimeRatio":1.0,"downtimeCount":0,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "name" : "ExampleDS",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Datasource",
+            "name" : "Datasource",
+            "id" : "Datasource"
+          },
+          "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "name" : "h2",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;JDBC%20Driver",
+            "name" : "JDBC Driver",
+            "id" : "JDBC Driver"
+          },
+          "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
+          "name" : "hawkular-command-gateway-war.war",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
+            "name" : "Deployment",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-command-gateway-war.war"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
+          "name" : "hawkular-metrics-component.war",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
+            "name" : "Deployment",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics-component.war"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
+          "name" : "hawkular-alerts-actions-email.war",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
+            "name" : "Deployment",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-alerts-actions-email.war"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
+          "name" : "hawkular-wildfly-agent-download.war",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
+            "name" : "Deployment",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
+          "name" : "hawkular-inventory-dist.war",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
+            "name" : "Deployment",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-inventory-dist.war"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
+          "name" : "hawkular-alerts-rest.war",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
+            "name" : "Deployment",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-alerts-rest.war"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
+          "name" : "hawkular-rest-api.war",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
+            "name" : "Deployment",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "name" : "Transaction Manager",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Transaction%20Manager",
+            "name" : "Transaction Manager",
+            "id" : "Transaction Manager"
+          },
+          "id" : "Local~/subsystem=transactions"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
+          "name" : "Messaging Server [default]",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Messaging%20Server",
+            "name" : "Messaging Server",
+            "id" : "Messaging Server"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "name" : "Hawkular WildFly Agent",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Hawkular%20WildFly%20Agent",
+            "name" : "Hawkular WildFly Agent",
+            "id" : "Hawkular WildFly Agent"
+          },
+          "id" : "Local~/subsystem=hawkular-wildfly-agent"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "name" : "Socket Binding Group [standard-sockets]",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Socket%20Binding%20Group",
+            "name" : "Socket Binding Group",
+            "id" : "Socket Binding Group"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets"
+        } ]
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/Local~%2Fsubsystem=transactions/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -297,21 +420,135 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
+      X-Total-Count:
+      - '9'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '306'
+      - '6950'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/Local~%2Fsubsystem%3Dtransactions/metrics?sort=id>;
+        rel="current"
     body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":60,"empty":false},{"start":1466431200000,"end":1466434800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
+          "name" : "Transactions Metrics~Number of Aborted Transactions",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
+            "name" : "Transactions Metrics~Number of Aborted Transactions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Aborted Transactions"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Aborted Transactions"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
+          "name" : "Transactions Metrics~Number of Application Rollbacks",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
+            "name" : "Transactions Metrics~Number of Application Rollbacks",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Application Rollbacks"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Application Rollbacks"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions",
+          "name" : "Transactions Metrics~Number of Committed Transactions",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Committed%20Transactions",
+            "name" : "Transactions Metrics~Number of Committed Transactions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Committed Transactions"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Committed Transactions"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics",
+          "name" : "Transactions Metrics~Number of Heuristics",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Heuristics",
+            "name" : "Transactions Metrics~Number of Heuristics",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Heuristics"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Heuristics"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
+          "name" : "Transactions Metrics~Number of In-Flight Transactions",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
+            "name" : "Transactions Metrics~Number of In-Flight Transactions",
+            "unit" : "NONE",
+            "type" : "GAUGE",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of In-Flight Transactions"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of In-Flight Transactions"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions",
+          "name" : "Transactions Metrics~Number of Nested Transactions",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Nested%20Transactions",
+            "name" : "Transactions Metrics~Number of Nested Transactions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Nested Transactions"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Nested Transactions"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
+          "name" : "Transactions Metrics~Number of Resource Rollbacks",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
+            "name" : "Transactions Metrics~Number of Resource Rollbacks",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Resource Rollbacks"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Resource Rollbacks"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
+          "name" : "Transactions Metrics~Number of Timed Out Transactions",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
+            "name" : "Transactions Metrics~Number of Timed Out Transactions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Timed Out Transactions"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Timed Out Transactions"
+        }, {
+          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions",
+          "name" : "Transactions Metrics~Number of Transactions",
+          "type" : {
+            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Transactions",
+            "name" : "Transactions Metrics~Number of Transactions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 30,
+            "id" : "Transactions Metrics~Number of Transactions"
+          },
+          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Transactions"
+        } ]
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/rate?bucketDuration=3600s&end=1466434800001&start=1466427600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -342,637 +579,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '306'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":59,"empty":false},{"start":1466431200000,"end":1466434800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '320'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":-8.0,"avg":-8.0,"median":-8.0,"max":-8.0,"sum":-480.0,"samples":60,"empty":false},{"start":1466431200000,"end":1466434800000,"min":-8.0,"avg":-8.0,"median":-8.0,"max":-8.0,"sum":-480.0,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/rate?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '306'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":59,"empty":false},{"start":1466431200000,"end":1466434800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/rate?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '306'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":59,"empty":false},{"start":1466431200000,"end":1466434800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/rate?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '306'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":59,"empty":false},{"start":1466431200000,"end":1466434800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/rate?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '397'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":9.0,"avg":17.64685497642349,"median":11.557991925242128,"max":52.0,"sum":1041.164443608986,"samples":59,"empty":false},{"start":1466431200000,"end":1466434800000,"min":10.0,"avg":17.622883962628613,"median":13.556107716778884,"max":45.0,"sum":1057.3730377577162,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '426'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":5.11705088E8,"avg":5.1866938026666665E8,"median":5.1876414990294075E8,"max":5.24812288E8,"sum":3.1120162816E10,"samples":60,"empty":false},{"start":1466431200000,"end":1466434800000,"min":5.05413632E8,"avg":5.161353216E8,"median":5.160929791458407E8,"max":5.23239424E8,"sum":3.0968119296E10,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '432'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":5.11705088E8,"avg":5.1866938026666665E8,"median":5.1876414990294075E8,"max":5.24812288E8,"sum":3.1120162816E10,"samples":60,"empty":false},{"start":1466431200000,"end":1466434800000,"min":5.05413632E8,"avg":5.1616153599999994E8,"median":5.165101512767589E8,"max":5.23239424E8,"sum":3.096969216E10,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '433'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":3.2222804E8,"avg":4.049930767333332E8,"median":4.0979912307032865E8,"max":4.86772744E8,"sum":4.8599169208E10,"samples":120,"empty":false},{"start":1466431200000,"end":1466434800000,"min":3.50925376E8,"avg":4.310672720000001E8,"median":4.3291977333402425E8,"max":5.08875368E8,"sum":5.1297005368E10,"samples":119,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '431'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":3.54353152E8,"avg":3.545453909333332E8,"median":3.546004221653527E8,"max":3.54680832E8,"sum":2.1272723456E10,"samples":60,"empty":false},{"start":1466431200000,"end":1466434800000,"min":3.54680832E8,"avg":3.5475073706666654E8,"median":3.5477877450324875E8,"max":3.5487744E8,"sum":2.1285044224E10,"samples":60,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '431'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":3.36709896E8,"avg":3.369991993333334E8,"median":3.370526535814712E8,"max":3.37192472E8,"sum":4.043990392E10,"samples":120,"empty":false},{"start":1466431200000,"end":1466434800000,"min":3.37127488E8,"avg":3.372265454789915E8,"median":3.372245928021324E8,"max":3.37373016E8,"sum":4.0129958912E10,"samples":119,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?bucketDuration=3600s&end=1466434800001&start=1466427600000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '386'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1466427600000,"end":1466431200000,"min":1430.0,"avg":1431.8999999999999,"median":1431.7922514675515,"max":1435.0,"sum":42957.0,"samples":30,"empty":false},{"start":1466431200000,"end":1466434800000,"min":1431.0,"avg":1432.5666666666666,"median":1432.1120852083195,"max":1437.0,"sum":42977.0,"samples":30,"empty":false},{"start":1466434800000,"end":1466438400000,"empty":true}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/AI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466409667001,"value":"up"}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/AI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466439503000,"value":"up"}]'
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -981,12 +588,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697020,"value":0.0}]'
+      string: '[{"timestamp":1466587073008,"value":0.0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1017,7 +624,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:51 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1026,12 +633,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503007,"value":0.0}]'
+      string: '[{"timestamp":1466675971001,"value":0.0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:51 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1062,7 +669,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1071,12 +678,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697025,"value":0}]'
+      string: '[{"timestamp":1466587073034,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1107,7 +714,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1116,12 +723,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503011,"value":0}]'
+      string: '[{"timestamp":1466675971006,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1152,7 +759,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1161,12 +768,12 @@ http_interactions:
       - '42'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697016,"value":-8.0}]'
+      string: '[{"timestamp":1466587073002,"value":-7.0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1197,7 +804,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1206,12 +813,12 @@ http_interactions:
       - '42'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503005,"value":-8.0}]'
+      string: '[{"timestamp":1466675971003,"value":-7.0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1242,7 +849,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1251,12 +858,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697003,"value":0}]'
+      string: '[{"timestamp":1466587073007,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1287,7 +894,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1296,12 +903,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503001,"value":0}]'
+      string: '[{"timestamp":1466675971002,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1332,7 +939,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1341,12 +948,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697013,"value":0}]'
+      string: '[{"timestamp":1466587073014,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1377,7 +984,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1386,12 +993,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503003,"value":0}]'
+      string: '[{"timestamp":1466675971007,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1422,7 +1029,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1431,12 +1038,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697023,"value":0}]'
+      string: '[{"timestamp":1466587073030,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1467,7 +1074,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1476,12 +1083,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503009,"value":0}]'
+      string: '[{"timestamp":1466675971005,"value":0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1512,7 +1119,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1521,12 +1128,12 @@ http_interactions:
       - '42'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697004,"value":3962}]'
+      string: '[{"timestamp":1466587073017,"value":2877}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1557,7 +1164,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1566,12 +1173,12 @@ http_interactions:
       - '42'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503002,"value":3723}]'
+      string: '[{"timestamp":1466675971003,"value":8320}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1602,7 +1209,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1611,12 +1218,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697026,"value":5.05413632E8}]'
+      string: '[{"timestamp":1466587073008,"value":4.51411968E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1647,7 +1254,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1656,12 +1263,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503011,"value":4.13663232E8}]'
+      string: '[{"timestamp":1466675971001,"value":3.47078656E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1692,7 +1299,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1701,12 +1308,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697009,"value":5.05413632E8}]'
+      string: '[{"timestamp":1466587073018,"value":4.77626368E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1737,7 +1344,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1746,12 +1353,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503002,"value":4.77626368E8}]'
+      string: '[{"timestamp":1466675971002,"value":4.77626368E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1782,7 +1389,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1791,12 +1398,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409667022,"value":3.68733336E8}]'
+      string: '[{"timestamp":1466587043010,"value":2.91170712E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1827,7 +1434,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1836,12 +1443,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439510002,"value":3.12969344E8}]'
+      string: '[{"timestamp":1466675967012,"value":2.77421952E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1872,7 +1479,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1881,12 +1488,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409697018,"value":3.24599808E8}]'
+      string: '[{"timestamp":1466587073013,"value":2.78986752E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1917,7 +1524,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1926,12 +1533,12 @@ http_interactions:
       - '49'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439503005,"value":3.2407552E8}]'
+      string: '[{"timestamp":1466675974000,"value":2.9229056E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1962,7 +1569,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1971,12 +1578,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409667023,"value":3.06499216E8}]'
+      string: '[{"timestamp":1466587043023,"value":2.60806648E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2007,21 +1614,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '49'
+      - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439510003,"value":3.0791556E8}]'
+      string: '[{"timestamp":1466675967015,"value":2.74720936E8}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2052,21 +1659,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:35 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '44'
+      - '43'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466409757027,"value":1416.0}]'
+      string: '[{"timestamp":1466587133016,"value":854.0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B377fadac-98eb-4a53-bf3b-89c21bccd8ba%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2097,16 +1704,1816 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 20 Jun 2016 16:18:52 GMT
+      - Thu, 23 Jun 2016 09:59:36 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '44'
+      - '43'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466439443013,"value":1408.0}]'
+      string: '[{"timestamp":1466675965004,"value":849.0}]'
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 16:18:52 GMT
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043017,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967001,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043017,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967001,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043011,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967012,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043014,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967014,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043022,"value":0.0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967014,"value":0.0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043015,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967014,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043009,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967012,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043026,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967015,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466587043007,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1466675967011,"value":0}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '246'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":-7.0,"avg":-7.0,"median":-7.0,"max":-7.0,"sum":-224.0,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '285'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":15.0,"avg":30.621003804460255,"median":26.770489404701543,"max":80.0,"sum":949.2511179382681,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '302'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":3.38690048E8,"avg":3.6197171200000006E8,"median":3.578944918551577E8,"max":4.12614656E8,"sum":1.1583094784E10,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '287'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":4.77626368E8,"avg":4.77626368E8,"median":4.77626368E8,"max":4.77626368E8,"sum":1.5284043776E10,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '294'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":2.17532352E8,"avg":2.48390008E8,"median":2.4639471284073105E8,"max":2.82220992E8,"sum":1.614535052E10,"samples":65,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '292'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":2.6017792E8,"avg":2.81786368E8,"median":2.8377350722703856E8,"max":2.86588928E8,"sum":9.017163776E9,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '303'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":2.42853744E8,"avg":2.6605683778461537E8,"median":2.6748501020246232E8,"max":2.70352656E8,"sum":1.7293694456E10,"samples":65,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '275'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":847.0,"avg":850.4374999999999,"median":850.8492063492064,"max":855.0,"sum":13607.0,"samples":16,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":65,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:37 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:37 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:37 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 23 Jun 2016 09:59:37 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+    http_version: 
+  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1662329/15786954/98cfd9ec-29bf-11e6-8878-222652e264b2.png)

This PR includes #8860, #9081 and #9104. It will be rebased once the previous ones are merged.
The goal of this PR is to extend LiveMetrics configuration to allow to add metrics of children.
By default, LiveMetrics is targeted into a single resource, but in Hawkular there is a corner case where metrics of a sub-resource are shown at parent level.
With this change now we can cover this specific use case to support "transactions" metrics at "MiddlewareServer" level.
@miq-bot add_label providers/hawkular
@miq-bot add_label enhancement