### PR TITLE
Fix inconsistency on the monitoring button between pages

### DIFF
--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -30,19 +30,19 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
       t,
       :items => [
         button(
-          :container_node_perf,
-          'product product-monitoring fa-lg',
-          N_('Show Capacity & Utilization data for this Node'),
-          N_('Utilization'),
-          :url       => "/show",
-          :url_parms => "?display=performance"),
-        button(
           :container_node_timeline,
           'product product-timeline fa-lg',
           N_('Show Timelines for this Node'),
           N_('Timelines'),
           :url       => "/show",
           :url_parms => "?display=timeline"),
+        button(
+          :container_node_perf,
+          'product product-monitoring fa-lg',
+          N_('Show Capacity & Utilization data for this Node'),
+          N_('Utilization'),
+          :url       => "/show",
+          :url_parms => "?display=performance"),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -41,19 +41,19 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
       t,
       :items => [
         button(
+          :ems_container_timeline,
+          'product product-timeline fa-lg',
+          N_('Show Timelines for this #{ui_lookup(:table=>"ems_container")}'),
+          N_('Timelines'),
+          :klass     => ApplicationHelper::Button::EmsContainerTimeline,
+          :url_parms => "?display=timeline"),
+        button(
           :ems_container_perf,
           'product product-monitoring fa-lg',
           N_('Show Capacity & Utilization data for this Provider'),
           N_('Utilization'),
           :klass     => ApplicationHelper::Button::EmsContainerPerformance,
           :url_parms => "?display=performance"),
-        button(
-          :ems_container_timeline,
-          'product product-timeline fa-lg',
-          N_('Show Timelines for this #{ui_lookup(:table=>"ems_container")}'),
-          N_('Timelines'),
-          :klass     => ApplicationHelper::Button::EmsContainerTimeline,
-          :url_parms => "?display=timeline")
       ]
     ),
   ])


### PR DESCRIPTION
Bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1341740

with the fix:
![monitor_after](https://cloud.githubusercontent.com/assets/11769555/15805723/4b358628-2b3b-11e6-8776-d584ded3feec.png)

before:
![monitor_before](https://cloud.githubusercontent.com/assets/11769555/15805724/53725262-2b3b-11e6-9f8d-c6005320ec85.png)
