### PR TITLE
define aggregation mixin uses for all

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -51,10 +51,6 @@ class EmsCluster < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include AggregationMixin
-  # Since we've overridden the implementation of methods from AggregationMixin,
-  # we must also override the :uses portion of the virtual columns.
-  override_aggregation_mixin_virtual_columns_uses(:all_hosts, :hosts)
-  override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, :vms_and_templates)
 
   include Metric::CiMixin
   include MiqPolicyMixin

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -12,6 +12,7 @@ class EmsFolder < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include AggregationMixin
+  aggregation_mixin_virtual_columns_use :all_relationships
   include MiqPolicyMixin
 
   virtual_has_many :vms_and_templates, :uses => :all_relationships

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -87,10 +87,6 @@ class ExtManagementSystem < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include AggregationMixin
-  # Since we've overridden the implementation of methods from AggregationMixin,
-  # we must also override the :uses portion of the virtual columns.
-  override_aggregation_mixin_virtual_columns_uses(:all_hosts, :hosts)
-  override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, :vms_and_templates)
 
   include AuthenticationMixin
   include Metric::CiMixin

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -17,10 +17,6 @@ class MiqEnterprise < ApplicationRecord
   acts_as_miq_taggable
 
   include AggregationMixin
-  # Since we've overridden the implementation of methods from AggregationMixin,
-  # we must also override the :uses portion of the virtual columns.
-  override_aggregation_mixin_virtual_columns_uses(:all_hosts, :hosts)
-  override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, :vms_and_templates)
 
   include MiqPolicyMixin
   include Metric::CiMixin

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -21,10 +21,6 @@ class MiqRegion < ApplicationRecord
   include UuidMixin
   include NamingSequenceMixin
   include AggregationMixin
-  # Since we've overridden the implementation of methods from AggregationMixin,
-  # we must also override the :uses portion of the virtual columns.
-  override_aggregation_mixin_virtual_columns_uses(:all_hosts, :hosts)
-  override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, :vms_and_templates)
 
   include MiqPolicyMixin
   include Metric::CiMixin

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -1,15 +1,15 @@
 module AggregationMixin
   extend ActiveSupport::Concern
   included do
-    virtual_column :aggregate_cpu_speed,       :type => :integer, :uses => :all_relationships
-    virtual_column :aggregate_cpu_total_cores, :type => :integer, :uses => :all_relationships
-    virtual_column :aggregate_physical_cpus,   :type => :integer, :uses => :all_relationships
-    virtual_column :aggregate_memory,          :type => :integer, :uses => :all_relationships
-    virtual_column :aggregate_vm_cpus,         :type => :integer, :uses => :all_relationships
-    virtual_column :aggregate_vm_memory,       :type => :integer, :uses => :all_relationships
-    virtual_column :aggregate_disk_capacity,   :type => :integer, :uses => :all_relationships
+    virtual_column :aggregate_cpu_speed,       :type => :integer, :uses => :hosts
+    virtual_column :aggregate_cpu_total_cores, :type => :integer, :uses => :hosts
+    virtual_column :aggregate_physical_cpus,   :type => :integer, :uses => :hosts
+    virtual_column :aggregate_memory,          :type => :integer, :uses => :hosts
+    virtual_column :aggregate_vm_cpus,         :type => :integer, :uses => :vms_and_templates
+    virtual_column :aggregate_vm_memory,       :type => :integer, :uses => :vms_and_templates
+    virtual_column :aggregate_disk_capacity,   :type => :integer, :uses => :hosts
 
-    virtual_column :aggregate_logical_cpus, :type => :integer, :uses => :all_relationships # Deprecated
+    virtual_column :aggregate_logical_cpus, :type => :integer, :uses => :hosts # Deprecated
 
     # Helper method to override the virtual_column :uses definitions in the
     # event that the all_* methods are overridden
@@ -28,6 +28,12 @@ module AggregationMixin
         define_virtual_include "aggregate_vm_cpus",   new_uses
         define_virtual_include "aggregate_vm_memory", new_uses
       end
+    end
+
+    def self.aggregation_mixin_virtual_columns_use(hosts, vms = nil)
+      vms ||= hosts
+      override_aggregation_mixin_virtual_columns_uses(:all_hosts, hosts)
+      override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, vms)
     end
   end
 

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -11,29 +11,18 @@ module AggregationMixin
 
     virtual_column :aggregate_logical_cpus, :type => :integer, :uses => :hosts # Deprecated
 
-    # Helper method to override the virtual_column :uses definitions in the
-    # event that the all_* methods are overridden
-    def self.override_aggregation_mixin_virtual_columns_uses(type, new_uses)
-      case type
-      when :all_hosts
-        define_virtual_include "aggregate_cpu_speed",       new_uses
-        define_virtual_include "aggregate_cpu_total_cores", new_uses
-        define_virtual_include "aggregate_physical_cpus",   new_uses
-        define_virtual_include "aggregate_memory",          new_uses
-        define_virtual_include "aggregate_disk_capacity",   new_uses
-
-        define_virtual_include "aggregate_logical_cpus", new_uses # Deprecated
-
-      when :all_vms_and_templates
-        define_virtual_include "aggregate_vm_cpus",   new_uses
-        define_virtual_include "aggregate_vm_memory", new_uses
-      end
-    end
-
     def self.aggregation_mixin_virtual_columns_use(hosts, vms = nil)
       vms ||= hosts
-      override_aggregation_mixin_virtual_columns_uses(:all_hosts, hosts)
-      override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, vms)
+      define_virtual_include "aggregate_cpu_speed",       hosts
+      define_virtual_include "aggregate_cpu_total_cores", hosts
+      define_virtual_include "aggregate_physical_cpus",   hosts
+      define_virtual_include "aggregate_memory",          hosts
+      define_virtual_include "aggregate_disk_capacity",   hosts
+
+      define_virtual_include "aggregate_logical_cpus", hosts # Deprecated
+
+      define_virtual_include "aggregate_vm_cpus",   vms
+      define_virtual_include "aggregate_vm_memory", vms
     end
   end
 

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -13,9 +13,7 @@ class ResourcePool < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include AggregationMixin
-  # Since we've overridden the implementation of methods from AggregationMixin,
-  # we must also override the :uses portion of the virtual columns.
-  override_aggregation_mixin_virtual_columns_uses(:all_hosts, :all_relationships)
+  aggregation_mixin_virtual_columns_use :all_relationships
 
   include MiqPolicyMixin
   include AsyncDeleteMixin

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -26,10 +26,6 @@ class Zone < ApplicationRecord
 
   include Metric::CiMixin
   include AggregationMixin
-  # Since we've overridden the implementation of methods from AggregationMixin,
-  # we must also override the :uses portion of the virtual columns.
-  override_aggregation_mixin_virtual_columns_uses(:all_hosts, :hosts)
-  override_aggregation_mixin_virtual_columns_uses(:all_vms_and_templates, :vms_and_templates)
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)


### PR DESCRIPTION
Currently working on improving these queries for talk.
Saw this and thought I'd just fix.
Am trying to just delete all of this soon enough

**before:**

- 5 aggregation mixin override the defaults use to `vms` and `hosts`
- 1 keeps default uses of `all_relationships`
- 1 overrides to `all_relationships` (seems unneeded)

**after:**

- single common method 
- all classes call this value

**implementation details:**

define single method `aggregation_mixin_virtual_columns_use`
defaults to use hosts and vms table since it is 5 to 2
