### PR TITLE
[Darga] Fix container image compliance history tree

### DIFF
--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -85,7 +85,7 @@ module ContainersCommonMixin
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
       update_session_for_compliance_history(record, count)
-      drop_breadcrumb_for_compliance_history(record, controller_name)
+      drop_breadcrumb_for_compliance_history(record, controller_name, count)
       @showtype = @display
     elsif @display == "container_groups" || session[:display] == "container_groups" && params[:display].nil?
       show_container_display(record, "container_groups", ContainerGroup)
@@ -124,7 +124,7 @@ module ContainersCommonMixin
     session[:squash_open] = (count == 1)
   end
 
-  def drop_breadcrumb_for_compliance_history(record, controller_name)
+  def drop_breadcrumb_for_compliance_history(record, controller_name, count)
     if count == 1
       drop_breadcrumb(:name => _("%{name} (Latest Compliance Check)") % {:name => record.name},
                       :url  => "/#{controller_name}/show/#{record.id}?display=#{@display}&refresh=n")


### PR DESCRIPTION
This fix is only for the Darga branch.
The bug was introduced in 6a80d907b5cacab26639ec75c1437f26782a8060 and fixed for master on 32d05dbe090e5f5a0920f21641d78842de719fb7