### PR TITLE
[WIP] Use the database to count by vm state

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -496,8 +496,9 @@ class ExtManagementSystem < ApplicationRecord
     HostStorage.where(:host_id => host_ids).count("DISTINCT storage_id")
   end
 
-  def vm_count_by_state(state)
-    vms.inject(0) { |t, vm| vm.power_state == state ? t + 1 : t }
+  def vm_count_by_state()
+    raw_power_state = VmOrTemplate.calculate_state(state)
+    vms.where(:raw_power_state => raw_power_state).count
   end
 
   def total_vms_on;        vm_count_by_state("on");        end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1939,5 +1939,14 @@ class VmOrTemplate < ApplicationRecord
     Arel::Nodes::NamedFunction.new('COALESCE', values)
   end
 
+  # TODO: add states for other vms
+  def self.calculate_raw_power_state(state)
+    case state
+    when "on" then "poweredOn"
+    when "off" then "poweredOff"
+    when "suspended" then "suspended"
+    end
+  end
+
   include DeprecatedCpuMethodsMixin
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -300,4 +300,14 @@ describe ExtManagementSystem do
       expect(tenant.ext_management_systems).to include(ems)
     end
   end
+
+  describe "#vm_count_by_state" do
+    it "counts state" do
+      ems = FactoryGirl.create(:ext_management_system)
+      FactoryGirl.create(:vm, :raw_power_state => "poweredOn", :ext_management_system => ems)
+      FactoryGirl.create(:vm, :raw_power_state => "poweredOn", :ext_management_system => ems)
+      FactoryGirl.create(:vm, :raw_power_state => "poweredOff, :ext_management_system => ems)
+      expect(ems.vm_count_by_state("on")).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
~~blocked on #9154~~

Instead of bringing back all VMs to count, lookup the database value on the db.