### PR TITLE
Add sort flavors by id

### DIFF
--- a/app/views/vm_common/_resize.html.haml
+++ b/app/views/vm_common/_resize.html.haml
@@ -16,7 +16,7 @@
         = _('Choose Flavor')
       .col-md-8
         = select_tag('flavor',
-            options_for_select(@flavors.sort),
+            options_for_select(@flavors.sort_by),
             :class             => "selectpicker",
             "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
             :multiple          => false,


### PR DESCRIPTION
The flavor list in re configure host was sorted in Alpha Numeric.
Now its sorted by ID and as a result by its size
![25245ea4b7](https://cloud.githubusercontent.com/assets/8054645/15930416/1f0ec706-2e53-11e6-9cfd-311babc3db89.jpg)

