### PR TITLE
Redefine the limits of the tiers intervals

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -16,11 +16,18 @@ class ChargebackRateDetail < ApplicationRecord
     fixed_rate = 0.0
     variable_rate = 0.0
     chargeback_tiers.each do |tier|
-      next if value < rate_adjustment(tier.start)
-      next if value >= rate_adjustment(tier.finish)
-      fixed_rate = tier.fixed_rate
-      variable_rate = tier.variable_rate
-      break
+      if tier.starts_with_zero?
+        next if value > rate_adjustment(tier.finish)
+        fixed_rate = tier.fixed_rate
+        variable_rate = tier.variable_rate
+        break
+      else
+        next if value <= rate_adjustment(tier.start)
+        next if value > rate_adjustment(tier.finish)
+        fixed_rate = tier.fixed_rate
+        variable_rate = tier.variable_rate
+        break
+      end
     end
     return fixed_rate, variable_rate
   end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -15,19 +15,13 @@ class ChargebackRateDetail < ApplicationRecord
   def find_rate(value)
     fixed_rate = 0.0
     variable_rate = 0.0
-    chargeback_tiers.each do |tier|
-      if tier.starts_with_zero?
-        next if value > rate_adjustment(tier.finish)
-        fixed_rate = tier.fixed_rate
-        variable_rate = tier.variable_rate
-        break
-      else
-        next if value <= rate_adjustment(tier.start)
-        next if value > rate_adjustment(tier.finish)
-        fixed_rate = tier.fixed_rate
-        variable_rate = tier.variable_rate
-        break
-      end
+    tier_found, = chargeback_tiers.select do |tier|
+      tier.starts_with_zero? && value.zero? ||
+      value > rate_adjustment(tier.start) && value <= rate_adjustment(tier.finish)
+    end
+    unless tier_found.nil?
+      fixed_rate = tier_found.fixed_rate
+      variable_rate = tier_found.variable_rate
     end
     return fixed_rate, variable_rate
   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -9,14 +9,19 @@ describe ChargebackRateDetail do
     end
   end
 
-  it "#find_rate" do
-    cvalue   = 50.0
-    cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :finish => 10, :fixed_rate => 3.0, :variable_rate => 0.3)
-    cbt2 = FactoryGirl.build(:chargeback_tier, :start => 10, :finish => 50, :fixed_rate => 2.0, :variable_rate => 0.2)
-    cbt3 = FactoryGirl.build(:chargeback_tier, :start => 50, :finish => Float::INFINITY, :fixed_rate => 1.0, :variable_rate => 0.1)
-    cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt3, cbt2, cbt1])
+  describe "#find_rate" do
+    let(:cvalue) { {"val1" => 0.0, "val2" => 10.0, "val3" => 20.0, "val4" => 50.0} }
+    let(:cbt1) { FactoryGirl.build(:chargeback_tier, :start => 0, :finish => 10, :fixed_rate => 3.0, :variable_rate => 0.3) }
+    let(:cbt2) { FactoryGirl.build(:chargeback_tier, :start => 10, :finish => 50, :fixed_rate => 2.0, :variable_rate => 0.2) }
+    let(:cbt3) { FactoryGirl.build(:chargeback_tier, :start => 50, :finish => Float::INFINITY, :fixed_rate => 1.0, :variable_rate => 0.1) }
+    let(:cbd) { FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt3, cbt2, cbt1]) }
 
-    expect(cbd.find_rate(cvalue)).to eq([cbt2.fixed_rate, cbt2.variable_rate])
+    it "finds proper rate according the value" do
+      expect(cbd.find_rate(cvalue["val1"])).to eq([cbt1.fixed_rate, cbt1.variable_rate])
+      expect(cbd.find_rate(cvalue["val2"])).to eq([cbt1.fixed_rate, cbt1.variable_rate])
+      expect(cbd.find_rate(cvalue["val3"])).to eq([cbt2.fixed_rate, cbt2.variable_rate])
+      expect(cbd.find_rate(cvalue["val4"])).to eq([cbt2.fixed_rate, cbt2.variable_rate])
+    end
   end
 
   it "#cost" do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -9,6 +9,16 @@ describe ChargebackRateDetail do
     end
   end
 
+  it "#find_rate" do
+    cvalue   = 50.0
+    cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :finish => 10, :fixed_rate => 3.0, :variable_rate => 0.3)
+    cbt2 = FactoryGirl.build(:chargeback_tier, :start => 10, :finish => 50, :fixed_rate => 2.0, :variable_rate => 0.2)
+    cbt3 = FactoryGirl.build(:chargeback_tier, :start => 50, :finish => Float::INFINITY, :fixed_rate => 1.0, :variable_rate => 0.1)
+    cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt3, cbt2, cbt1])
+
+    expect(cbd.find_rate(cvalue)).to eq([cbt2.fixed_rate, cbt2.variable_rate])
+  end
+
   it "#cost" do
     cvalue   = 42.0
     fixed_rate = 5.0


### PR DESCRIPTION
The limits of the tiers intervals are defined in the following way:
[0, 50)
[50, 100)
...
so if the value is 50, the second interval will be chosen.
But we have thought that the best way would be as follows:
[0,50]
(50,100]
...
in this case, the first interval will be the chosen.

cc @delaluzparra @sergio-ocon 