### PR TITLE
[WIP] Add angular's timeline to middleware

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,11 +18,13 @@
 //= require sprintf
 //= require numeral
 //= require miq_api
+//= require rxjs/dist/rx.all
 //= require miq_angular_application
 //= require_tree ./directives/
 //= require_tree ./services/
 //= require_tree ./controllers/
 //= require d3
+//= require d3-tip/index
 //= require c3
 //= require lodash
 //= require kubernetes-topology-graph/dist/topology-graph
@@ -75,3 +77,4 @@
 //= require resizable_sidebar
 //= require xml_display
 //= require miq_c3
+//= require hawkular-charts/dist/hawkular-charts

--- a/app/assets/javascripts/controllers/providers/_module_timeline.js
+++ b/app/assets/javascripts/controllers/providers/_module_timeline.js
@@ -1,0 +1,1 @@
+miqHttpInject(angular.module('miq.timeline', ['hawkular.charts']))

--- a/app/assets/javascripts/controllers/providers/timeline_controller.js
+++ b/app/assets/javascripts/controllers/providers/timeline_controller.js
@@ -1,0 +1,38 @@
+(function(){
+
+  function subscribeToSubject() {
+    ManageIQ.angular.rxSubject.subscribe(function(event) {
+      this.onNewData(event);
+    }.bind(this),
+    function (err) {
+      console.log('Error: ' + err);
+    },
+    function () {
+      console.log('Completed');
+    });
+  }
+
+  var TimelineController = function($scope) {
+    this.$scope = $scope;
+    subscribeToSubject.bind(this)();
+  }
+
+  TimelineController.prototype.onNewData = function(event) {
+    if (event.data.events) {
+      this.timelineData = event.data.events;
+      this.timelineSettings = event.settings[0];
+      this.timelineSettings.startTimestamp = new Date(this.timelineSettings.st_time).getTime();
+      this.timelineSettings.endTimestamp = new Date(this.timelineSettings.end_time).getTime();
+      _.each(this.timelineData, function(item) {
+        item.html = item.description;
+        item.timestamp = new Date(item.start).getTime();
+      }.bind(this))
+      this.$scope.$apply();
+    }
+  }
+
+  TimelineController.$inject = ['$scope'];
+
+  miqHttpInject(angular.module('miq.timeline'))
+  .controller('miqTimlineController', TimelineController)
+})();

--- a/app/assets/javascripts/controllers/providers/timeline_controller.js
+++ b/app/assets/javascripts/controllers/providers/timeline_controller.js
@@ -5,16 +5,29 @@
       this.onNewData(event);
     }.bind(this),
     function (err) {
-      console.log('Error: ' + err);
+      console.error('Angular RxJs Error: ', err);
     },
     function () {
-      console.log('Completed');
+      console.debug('Angular RxJs subject completed, no more events to catch.');
     });
   }
 
   var TimelineController = function($scope) {
     this.$scope = $scope;
     subscribeToSubject.bind(this)();
+    this.$scope.$on(Charts.EventNames.TIMELINE_CHART_TIMERANGE_CHANGED, function (event, data) {
+      this.filterData(data[0].getTime(), data[1].getTime());
+    }.bind(this));
+  }
+
+  TimelineController.prototype.filterData = function(startTime, endTime) {
+    this.timelineSettings.startTimestamp = startTime;
+    this.timelineSettings.endTimestamp = endTime;
+    this.timelineData.filter(function (value) {
+        return new Date(value.timestamp) >= this.timelineSettings.startTimestamp
+          && new Date(value.timestamp) <= this.timelineSettings.endTimestamp;
+      }.bind(this));
+    this.$scope.$digest();
   }
 
   TimelineController.prototype.onNewData = function(event) {

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -4,7 +4,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'frapontillo.bootstrap-switch',
 ]);
 miqHttpInject(ManageIQ.angular.app);
-
+ManageIQ.angular.rxSubject = new Rx.Subject();
 function miqHttpInject(angular_app) {
   angular_app.config(['$httpProvider', function($httpProvider) {
     $httpProvider.defaults.headers.common['X-CSRF-Token'] = function() {
@@ -25,4 +25,8 @@ function miqCallAngular(data) {
   ManageIQ.angular.scope.$apply(function() {
     ManageIQ.angular.scope[data.name].apply(ManageIQ.angular.scope, data.args);
   });
+}
+
+function sendDataWithRx(data) {
+  ManageIQ.angular.rxSubject.onNext(data);
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,4 +24,5 @@
  *= require container_topology
  *= require service_dialogs
  *= require xml_display
+ *= require hawkular-charts/dist/css/hawkular-charts.css
 */

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -13,6 +13,12 @@ textarea { width: 98.5%; border: 1px solid #d1d1d1; padding: 7px; line-height: 1
 
 /* end modified Patternfly code */
 
+.miq-overview-timeline {
+  height: 50px;
+  margin-left: -73px;
+  margin-top: -54px;
+}
+
 fieldset {
   position: relative;
   margin: 0 7px 20px 0px;

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -3,6 +3,7 @@ class EmsMiddlewareController < ApplicationController
 
   before_action :check_privileges
   before_action :get_session_data
+  before_action :set_angular_apps
   after_action :cleanup_action
   after_action :set_session_data
 
@@ -21,5 +22,10 @@ class EmsMiddlewareController < ApplicationController
   def listicon_image(item, _view)
     icon = item.decorate.try(:listicon_image)
     "svg/#{icon}.svg"
+  end
+
+  private
+  def set_angular_apps
+    @show_timeline_ng_app = "miq.timeline"
   end
 end

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -25,6 +25,7 @@ class EmsMiddlewareController < ApplicationController
   end
 
   private
+  
   def set_angular_apps
     @show_timeline_ng_app = "miq.timeline"
   end

--- a/app/views/layouts/_timeline.html.haml
+++ b/app/views/layouts/_timeline.html.haml
@@ -16,7 +16,6 @@
     theme.ether.backgroundColors.unshift("#c9c9c9");
     theme.ether.backgroundColors[1] = theme.ether.backgroundColors[0];
     var d = Timeline.DateTime.parseGregorianDateTime("#{bands[0][:center_position]}")
-
   var bandInfos = [
   -# Create the bandInfos array elements from the bands array
   - bands.each_with_index do |band, idx|

--- a/app/views/layouts/_tl_detail.html.haml
+++ b/app/views/layouts/_tl_detail.html.haml
@@ -1,12 +1,16 @@
 #tl_div
   - if @report && @report.table && @report.table.data.blank?
   - elsif @report
-    %fieldset
-      #miq_timeline{:style => "height: 450px; overflow: hidden; border: 1px solid #aaa;"}
-      = render(:partial => "layouts/timeline",
-        :locals         => {:bands => @report.timeline[:bands],
-          :tl_json                 => @tl_json.to_s.html_safe,
-          :data_action             => "timeline_data",
-          :position_time           => session[:tl_position]})
-      - if @report.filter_summary
-        = @report.filter_summary
+    - if @show_timeline_ng_app
+      %script{:type => "text/javascript"}
+        sendDataWithRx({data: #{@tl_json.to_s.html_safe}, settings: #{@report.timeline[:bands].to_json.html_safe}});
+    - else
+      %fieldset
+        #miq_timeline{:style => "height: 450px; overflow: hidden; border: 1px solid #aaa;"}
+        = render(:partial => "layouts/timeline",
+          :locals         => {:bands => @report.timeline[:bands],
+            :tl_json                 => @tl_json.to_s.html_safe,
+            :data_action             => "timeline_data",
+            :position_time           => session[:tl_position]})
+        - if @report.filter_summary
+          = @report.filter_summary

--- a/app/views/layouts/_tl_ng_detail.html.haml
+++ b/app/views/layouts/_tl_ng_detail.html.haml
@@ -1,4 +1,9 @@
-%div{"data-ng-app" => "#{@show_timeline_ng_app.to_s}", "ng-controller" => "miqTimlineController as timelineCtrl"}
+%div{"data-ng-app" => @show_timeline_ng_app.to_s, "ng-controller" => "miqTimlineController as timelineCtrl"}
   %hk-timeline-chart{"events" => "timelineCtrl.timelineData",
     "start-timestamp" => "{{timelineCtrl.timelineSettings.startTimestamp}}",
     "end-timestamp" => "{{timelineCtrl.timelineSettings.endTimestamp}}"}
+  .miq-overview-timeline
+    %hk-context-chart{"data" => "timelineCtrl.overviewData",
+      "show-y-axis-values" => "false",
+      "start-timestamp" => "{{timelineCtrl.timelineSettings.startTimestamp}}",
+      "end-timestamp" => "{{timelineCtrl.timelineSettings.endTimestamp}}"}

--- a/app/views/layouts/_tl_ng_detail.html.haml
+++ b/app/views/layouts/_tl_ng_detail.html.haml
@@ -1,0 +1,4 @@
+%div{"data-ng-app" => "#{@show_timeline_ng_app.to_s}", "ng-controller" => "miqTimlineController as timelineCtrl"}
+  %hk-timeline-chart{"events" => "timelineCtrl.timelineData",
+    "start-timestamp" => "{{timelineCtrl.timelineSettings.startTimestamp}}",
+    "end-timestamp" => "{{timelineCtrl.timelineSettings.endTimestamp}}"}

--- a/app/views/layouts/_tl_show.html.haml
+++ b/app/views/layouts/_tl_show.html.haml
@@ -6,3 +6,5 @@
 = render :partial => "layouts/flash_msg"
 = render :partial => "layouts/tl_options"
 = render :partial => 'layouts/tl_detail'
+- if @show_timeline_ng_app
+  = render :partial => 'layouts/tl_ng_detail'

--- a/bower.json
+++ b/bower.json
@@ -44,6 +44,7 @@
     "phantomjs-polyfill": "^0.0.2",
     "fetch": "^1.0.0",
     "rxjs": "^4.1.0",
-    "d3-tip": "^0.6.7"
+    "d3-tip": "^0.6.7",
+    "hawkular-charts": "karelhala/hawkular-charts#442d8bd2c4389cd74e9f5ac7651b4edca467d0c9"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -42,6 +42,8 @@
     "spice-html5-bower": "himdel/spice-html5-bower#^0.1.5",
     "es6-shim": "^0.35.0",
     "phantomjs-polyfill": "^0.0.2",
-    "fetch": "^1.0.0"
+    "fetch": "^1.0.0",
+    "rxjs": "^4.1.0",
+    "d3-tip": "^0.6.7"
   }
 }


### PR DESCRIPTION
We have developed timeline controller in angular for easier implementation of this component in hawkular charts, so let's use them in middleware provider. So far it's only possible to filter by selecting area of graph, but it's not possible to move graph. We should wait for @mtho11 on this, he's our graph hero.

Enabling this is done in each controller by adding
```ruby
before_action :set_angular_apps
def set_angular_apps
    @show_timeline_ng_app = "miq.timeline"
end
```

I had to introduce new variable with this different name than in #7623 because there can be more than one ng-app for provider and this way it will not be broken after merging these two things together.

I have to do some changes to @mtho11 implementation of timeline graph (showing html partial which is generated on server and position tooltip to left if it might be outside screen, and some other small tweaks)

Data are still generated on server and rendered in ``timeline.rb``, I tried getting out ``@tl_json`` variable out of this file, but I was unable to refactor this complex file. If someone more skillfull could refactor this file later it can be done with proper ajax requests, instead refreshing html partial each time user changes filter.

I've tested this on containers providers since this is only provider for me which has some timeline data.
![angular-timeline](https://cloud.githubusercontent.com/assets/3439771/15933727/1f10983e-2e61-11e6-81e4-499fcb81c9c9.gif)

And this is how it used to look like:
![selection_029](https://cloud.githubusercontent.com/assets/3439771/15934014/3eca7310-2e62-11e6-9309-01ed8c00ec0f.png)

@miq-bot add_label wip, ui, providers/hawkular 