### PR TITLE
Hamlit updated to v2.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,7 @@ gem "fog-vcloud-director",            "~>0.1.6",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false
-gem "hamlit",                         "~>2.0.0",       :require => false
-gem "hamlit-rails",                   "~>0.1.0"
+gem "hamlit",                         "~>2.7.0"
 gem "hashie",                         ">=3.4.6",       :require => false
 gem "high_voltage",                   "~>2.4.0"
 gem "htauth",                         "2.0.0",         :require => false

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -1,4 +1,4 @@
-require 'hamlit-rails'
+require 'hamlit'
 class GenericMailer < ActionMailer::Base
   include Vmdb::Logging
 

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -20,8 +20,6 @@ module MiqWebServerWorkerMixin
     end
 
     def preload_for_worker_role
-      require 'hamlit-rails'
-
       # Make these constants globally available
       ::UiConstants
 

--- a/spec/support/view_helper.rb
+++ b/spec/support/view_helper.rb
@@ -1,5 +1,3 @@
-require 'hamlit-rails'
-
 module Spec
   module Support
     module ViewHelper

--- a/spec/support/view_spec_helper.rb
+++ b/spec/support/view_spec_helper.rb
@@ -1,0 +1,30 @@
+module ViewSpecHelper
+  def show_element(resp, id)
+    set_element_visibility(resp, id, true)
+  end
+
+  def hide_element(resp, id)
+    set_element_visibility(resp, id, false)
+  end
+
+  private
+
+  def set_element_visibility(resp, id, visible)
+    c = Capybara.string(resp)
+    node = c.find(id, :visible => :all)
+    node.native["style"] = node.native["style"].gsub(/display\s*:[^;]+/, "display:#{visible ? "show" : "none"}")
+    c.native.to_s
+  end
+
+  def set_controller_for_view(controller_name)
+    controller.request.path_parameters[:controller] = controller_name
+  end
+
+  def set_controller_for_view_to_be_restful
+    allow(controller).to receive(:restful?).and_return(true)
+  end
+
+  def set_controller_for_view_to_be_nonrestful
+    allow(controller).to receive(:restful?).and_return(false)
+  end
+end


### PR DESCRIPTION
The `hamlit-rails` is not maintained at all and we don't need the provided generators at all.