### PR TITLE
Update markup for pin/unpin icons in the tertiary navigation

### DIFF
--- a/app/views/layouts/_vertical_navbar.html.haml
+++ b/app/views/layouts/_vertical_navbar.html.haml
@@ -45,7 +45,7 @@
           - else
             .nav-pf-secondary-nav{:id => "#menu-#{menu_section.id}"}
               .nav-item-pf-header
-                %a.secondary-collapse-toggle-pf.fa.fa-arrow-circle-o-left{"data-toggle" => "collapse-secondary-nav"}
+                %a.secondary-collapse-toggle-pf{"data-toggle" => "collapse-secondary-nav"}
                 %span
                   = h(_(menu_section.name))
               %ul.list-group


### PR DESCRIPTION
The fontawesome classes are obsolete and can cause issues in the future.

https://bugzilla.redhat.com/show_bug.cgi?id=1344412