### PR TITLE
Deduplicate configured system toolbars

### DIFF
--- a/app/helpers/application_helper/toolbar/configured_system/lifecycle_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/lifecycle_mixin.rb
@@ -1,0 +1,24 @@
+module ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
+  def included(included_class)
+    button_group('provider_foreman_lifecycle', [
+      select(
+        :provider_foreman_lifecycle_choice,
+        'fa fa-recycle fa-lg',
+        t = N_('Lifecycle'),
+        t,
+        :enabled => true,
+        :items   => [
+          included_class.button(
+            :configured_system_provision,
+            'pficon pficon-add-circle-o fa-lg',
+            t = N_('Provision Configured Systems'),
+            t,
+            :url       => "provision",
+            :url_parms => "main_div",
+            :enabled   => false,
+            :onwhen    => "1+"),
+        ]
+      ),
+    ])
+  end
+end

--- a/app/helpers/application_helper/toolbar/configured_system/policy_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/policy_mixin.rb
@@ -1,0 +1,23 @@
+module ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
+  def included(included_class)
+    button_group('provider_foreman_policy', [
+      select(
+        :provider_foreman_policy_choice,
+        'fa fa-shield fa-lg',
+        t = N_('Policy'),
+        t,
+        :items => [
+          included_class.button(
+            :configured_system_tag,
+            'pficon pficon-edit fa-lg',
+            N_('Edit Tags for this Configured System'),
+            N_('Edit Tags'),
+            :url       => "tagging",
+            :url_parms => "main_div",
+            :enabled   => false,
+            :onwhen    => "1+"),
+        ]
+      ),
+    ])
+  end
+end

--- a/app/helpers/application_helper/toolbar/configured_system_ansible_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_ansible_center.rb
@@ -1,21 +1,3 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemAnsibleCenter < ApplicationHelper::Toolbar::Basic
-  button_group('provider_foreman_policy', [
-    select(
-      :provider_foreman_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :configured_system_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Configured System'),
-          N_('Edit Tags'),
-          :url       => "tagging",
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+  include ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/configured_system_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_foreman_center.rb
@@ -1,24 +1,5 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemForemanCenter < ApplicationHelper::Toolbar::Basic
-  button_group('provider_foreman_lifecycle', [
-    select(
-      :provider_foreman_lifecycle_choice,
-      'fa fa-recycle fa-lg',
-      t = N_('Lifecycle'),
-      t,
-      :enabled => true,
-      :items   => [
-        button(
-          :configured_system_provision,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Provision Configured Systems'),
-          t,
-          :url       => "provision",
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+  include ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
   button_group('provider_foreman_policy', [
     select(
       :provider_foreman_policy_choice,

--- a/app/helpers/application_helper/toolbar/configured_system_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_foreman_center.rb
@@ -1,22 +1,4 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemForemanCenter < ApplicationHelper::Toolbar::Basic
   include ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
-  button_group('provider_foreman_policy', [
-    select(
-      :provider_foreman_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :configured_system_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Configured System'),
-          N_('Edit Tags'),
-          :url       => "tagging",
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+  include ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/configured_systems_ansible_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_ansible_center.rb
@@ -1,21 +1,3 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemsAnsibleCenter < ApplicationHelper::Toolbar::Basic
-  button_group('provider_foreman_policy', [
-    select(
-      :provider_foreman_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :configured_system_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Configured System'),
-          N_('Edit Tags'),
-          :url       => "tagging",
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+  include ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb
@@ -1,24 +1,5 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemsForemanCenter < ApplicationHelper::Toolbar::Basic
-  button_group('provider_foreman_lifecycle', [
-    select(
-      :provider_foreman_lifecycle_choice,
-      'fa fa-recycle fa-lg',
-      t = N_('Lifecycle'),
-      t,
-      :enabled => true,
-      :items   => [
-        button(
-          :configured_system_provision,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Provision Configured Systems'),
-          t,
-          :url       => "provision",
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+  include ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
   button_group('provider_foreman_policy', [
     select(
       :provider_foreman_policy_choice,

--- a/app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb
@@ -1,22 +1,4 @@
 class ApplicationHelper::Toolbar::ConfiguredSystemsForemanCenter < ApplicationHelper::Toolbar::Basic
   include ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
-  button_group('provider_foreman_policy', [
-    select(
-      :provider_foreman_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :configured_system_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Configured System'),
-          N_('Edit Tags'),
-          :url       => "tagging",
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+  include ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
 end


### PR DESCRIPTION
Leverage mixins to reuse duplicated code.  Should resolve issues here: https://codeclimate.com/github/ManageIQ/manageiq/ApplicationHelper::Toolbar::ConfiguredSystemsForemanCenter