### PR TITLE
Require azure-armrest before referencing constants

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -1,3 +1,5 @@
+require 'azure-armrest'
+
 describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_azure_with_authentication) }
   let(:template) { FactoryGirl.create(:orchestration_template_azure_with_content) }


### PR DESCRIPTION
master is currently red