### PR TITLE
Deprecate the replication worker

### DIFF
--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -242,7 +242,7 @@
               miqSelectPickerEvent('proxy_worker_threshold', "#{url}")
       %fieldset
         %h3
-          = _("Replication Worker")
+          = _("Replication Worker (Deprecated)")
         .form-horizontal
           .form-group
             %label.col-md-2.control-label


### PR DESCRIPTION
The rubyrep based replication worker is now deprecated in favor of the pglogical replication backend.

This is configured through the replication tab on the Settings -> Region page