### PR TITLE
Ensure bundled AS is on the load path

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -107,7 +107,7 @@ end
 begin
   require 'date'
   require 'rubygems'
-  $:.unshift("#{Gem.loaded_specs['activesupport'].full_gem_path}/lib")
+  require 'bundler/setup'
   require 'active_support/all'
   require 'socket'
   Socket.do_not_reverse_lookup = true  # turn off reverse DNS resolution


### PR DESCRIPTION
This part of the automation engine assumes that Active Support is
available to ruby via Gem.loaded_specs and can be put on the load
path. If you vendorize your gems this will not (necessarily) be the case
and the script will error out, so requiring 'bundler/setup' is needed to
put the bundled gem on the load path.