### PR TITLE
Reset the column cache after adding default_miq_group_id to tenants

### DIFF
--- a/db/migrate/20151021174044_add_tenant_default_group.rb
+++ b/db/migrate/20151021174044_add_tenant_default_group.rb
@@ -1,5 +1,8 @@
 class AddTenantDefaultGroup < ActiveRecord::Migration
+  class Tenant < ActiveRecord::Base; end
+
   def change
     add_column :tenants, :default_miq_group_id, :bigint
+    Tenant.reset_column_information
   end
 end


### PR DESCRIPTION
Before this change, rails was not aware of the column if it was added in the same process that it was queried in.

Specifically the column cache [here](https://github.com/rails/rails/blob/ff4092894ee920e44a615179c20daf3cf318d604/activerecord/lib/active_record/connection_adapters/schema_cache.rb#L61-L65) is not reset after the `add_column` call so for https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20151021174140_assign_tenant_default_group.rb#L5 to work properly, we need to reset the info manually.

For example, the column would be added, but when we tried to set the value in 20151021174140_assign_tenant_default_group.rb we would silently fail or get a backtrace with:

`99000000000001 is out of range for ActiveModel::Type::Integer with limit 4`

After this change, the column value is set correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1344112