### PR TITLE
Don't run a rake task from the host_storages migration

### DIFF
--- a/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
+++ b/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
@@ -40,7 +40,5 @@ class FixHostStorageReplicationOnUpgrade < ActiveRecord::Migration
     say_with_time("Deleting sync state for #{old_name}") do
       RrSyncState.where(:table_name => old_name).delete_all
     end
-
-    Rake::Task['evm:dbsync:prepare_replication_without_sync'].invoke
   end
 end

--- a/spec/migrations/20151208150956_fix_host_storage_replication_on_upgrade_spec.rb
+++ b/spec/migrations/20151208150956_fix_host_storage_replication_on_upgrade_spec.rb
@@ -32,9 +32,6 @@ describe FixHostStorageReplicationOnUpgrade do
       it "reinstalls replication for the new table name" do
         pending_change_stub.create!(:change_table => "hosts_storages")
         sync_state_stub.create!(:table_name => "hosts_storages")
-        task = double
-        expect(Rake::Task).to receive(:[]).with("evm:dbsync:prepare_replication_without_sync").and_return(task)
-        expect(task).to receive(:invoke)
 
         migrate
 


### PR DESCRIPTION
This migration was created to fix some issues associated with adding and assigning a primary key to the `host_storages` table when replication is enabled.

`prepare_replication_without_sync` attempts to retrieve the replication worker settings; which as of #7432, requires the `settings_changes` table be present. This command will now fail because that table is added in a later migration.

Removing this command will not cause an issue as rubyrep accounts for all unconfigured tables at first startup. We could also require running `rake evm:dbsync:prepare_replication_without_sync` after migration during upgrades.

https://bugzilla.redhat.com/show_bug.cgi?id=1344112