### PR TITLE
Call rbac once for trend reports

### DIFF
--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -50,12 +50,12 @@ module MiqReport::Generator::Trend
     # Build and filter trend data from performance data
     build_apply_time_profile(results)
     results = klass.build(results, db_options)
-    results = Rbac.filtered(results, :class        => db,
-                                     :filter       => conditions,
-                                     :limit        => options[:limit],
-                                     :userid       => options[:userid],
-                                     :miq_group_id => options[:miq_group_id])
 
+     if conditions
+      tz = User.find_by_userid(options[:userid]).get_timezone if options[:userid]
+      results = results.reject { |obj| conditions.lenient_evaluate(obj, tz) }
+    end
+    results = results[0...options[:limit]] if options[:limit]
     [results]
   end
 


### PR DESCRIPTION
**before:**
run rbac to filter performance data.
run rbac to apply limit and filter for these results
This second call to rbac is not actually using rbac but just using the limit and filter functionality.
Rbac no longer supports just providing limit/filter, for objects that don't respond to rbac. So it is blowing up.

**after:**
run rbac to filter performance data (same)
Just manually apply the filter and limit to the result set

/cc @martinpovolny or @yrudman did you bring this to my attention? Ideas on how build a spec for this? 