### PR TITLE
Add coverage for MiqExpression#to_sql date/time

### DIFF
--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -187,14 +187,19 @@ describe MiqExpression do
     end
 
     context "date/time support" do
-      it "generates the SQL for an EQUAL expression" do
+      it "generates the SQL for an EQUAL expression with a datetime field" do
         sql, * = MiqExpression.new("EQUAL" => {"field" => "Vm-boot_time", "value" => "2016-01-01"}).to_sql
         expect(sql).to eq("\"vms\".\"boot_time\" = '2016-01-01 00:00:00'")
       end
 
-      it "generates the SQL for a = expression" do
+      it "generates the SQL for a = expression with a datetime field" do
         sql, * = MiqExpression.new("=" => {"field" => "Vm-boot_time", "value" => "2016-01-01"}).to_sql
         expect(sql).to eq("\"vms\".\"boot_time\" = '2016-01-01 00:00:00'")
+      end
+
+      it "generates the SQL for a = expression with a date field" do
+        sql, * = described_class.new("=" => {"field" => "Vm-retires_on", "value" => "2016-01-01"}).to_sql
+        expect(sql).to eq(%q("vms"."retires_on" = '2016-01-01'))
       end
 
       it "generates the SQL for an AFTER expression" do
@@ -221,16 +226,26 @@ describe MiqExpression do
         expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10'")
       end
 
-      it "generates the SQL for a >= expression" do
+      it "generates the SQL for a >= expression with a date field" do
         exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
         expect(sql).to eq("\"vms\".\"retires_on\" >= '2011-01-10'")
       end
 
-      it "generates the SQL for a <= expression" do
+      it "generates the SQL for a >= expression with a datetime field" do
+        sql, * = described_class.new(">=" => {"field" => "Vm-last_scan_on", "value" => "2016-01-01"}).to_sql
+        expect(sql).to eq(%q("vms"."last_scan_on" >= '2016-01-01 00:00:00'))
+      end
+
+      it "generates the SQL for a <= expression with a date field" do
         exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
         expect(sql).to eq("\"vms\".\"retires_on\" <= '2011-01-10'")
+      end
+
+      it "generates the SQL for a <= expression with a datetime field" do
+        sql, * = described_class.new("<=" => {"field" => "Vm-last_scan_on", "value" => "2016-01-01"}).to_sql
+        expect(sql).to eq(%q("vms"."last_scan_on" <= '2016-01-01 23:59:59.999999'))
       end
 
       it "generates the SQL for an AFTER expression with date/time" do
@@ -243,6 +258,16 @@ describe MiqExpression do
         exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
         sql, * = exp.to_sql
         expect(sql).to eq("\"vms\".\"last_scan_on\" > '2011-01-10 09:00:00'")
+      end
+
+      it "generates the SQL for a != expression with a date field" do
+        sql, * = described_class.new("!=" => {"field" => "Vm-retires_on", "value" => "2016-01-01"}).to_sql
+        expect(sql).to eq(%q("vms"."retires_on" != '2016-01-01'))
+      end
+
+      it "generates the SQL for a != expression with a datetime field" do
+        sql, * = described_class.new("!=" => {"field" => "Vm-last_scan_on", "value" => "2016-01-01"}).to_sql
+        expect(sql).to eq(%q("vms"."last_scan_on" != '2016-01-01 00:00:00'))
       end
 
       it "generates the SQL for an IS expression" do


### PR DESCRIPTION
When some of this code was unDRY'd it was revealed that we lacked coverage for a few of the paths concerned with dates and times in `MiqExpression#to_arel`. Adding these tests gets us back up to 100% for this method.

@miq-bot add-label test, core
@miq-bot assign @gtanzillo 

