### PR TITLE
Break up RelativeDatetime specs

### DIFF
--- a/spec/models/miq_expression/relative_datetime_spec.rb
+++ b/spec/models/miq_expression/relative_datetime_spec.rb
@@ -1,79 +1,288 @@
 RSpec.describe MiqExpression::RelativeDatetime do
   describe ".normalize" do
-    context "Testing expression conversion to ruby with relative dates and times" do
-      around { |example| Timecop.freeze("2011-01-11 17:30 UTC") { example.run } }
+    around { |example| Timecop.freeze("2011-01-11 17:30 UTC") { example.run } }
 
-      it "does something" do
-        # Test <value> <interval> Ago
-        expect(described_class.normalize("3 Hours Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 14:00:00 UTC")
-        expect(described_class.normalize("3 Hours Ago", "UTC").utc.to_s).to eq("2011-01-11 14:00:00 UTC")
-        expect(described_class.normalize("3 Hours Ago", "UTC", "end").utc.to_s).to eq("2011-01-11 14:59:59 UTC")
+    context "n Hours Ago" do
+      it "non-UTC" do
+        result = described_class.normalize("3 Hours Ago", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-11 14:00:00 UTC")
+      end
 
-        expect(described_class.normalize("3 Days Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-08 05:00:00 UTC")
-        expect(described_class.normalize("3 Days Ago", "UTC").utc.to_s).to eq("2011-01-08 00:00:00 UTC")
-        expect(described_class.normalize("3 Days Ago", "UTC", "end").utc.to_s).to eq("2011-01-08 23:59:59 UTC")
+      it "UTC" do
+        result = described_class.normalize("3 Hours Ago", "UTC")
+        expect(result).to eq("2011-01-11 14:00:00 UTC")
+      end
 
-        expect(described_class.normalize("3 Weeks Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-12-20 05:00:00 UTC")
-        expect(described_class.normalize("3 Weeks Ago", "UTC").utc.to_s).to eq("2010-12-20 00:00:00 UTC")
+      it "end mode" do
+        result = described_class.normalize("3 Hours Ago", "UTC", "end")
+        expect(result).to eq("2011-01-11 14:59:59.999999 UTC")
+      end
+    end
 
-        expect(described_class.normalize("4 Months Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-09-01 04:00:00 UTC")
-        expect(described_class.normalize("4 Months Ago", "UTC").utc.to_s).to eq("2010-09-01 00:00:00 UTC")
-        expect(described_class.normalize("4 Months Ago", "UTC", "end").utc.to_s).to eq("2010-09-30 23:59:59 UTC")
+    context "n Days Ago" do
+      it "non-UTC" do
+        result = described_class.normalize("3 Days Ago", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-08 05:00:00 UTC")
+      end
 
-        expect(described_class.normalize("1 Quarter Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-10-01 04:00:00 UTC")
-        expect(described_class.normalize("1 Quarter Ago", "UTC").utc.to_s).to eq("2010-10-01 00:00:00 UTC")
-        expect(described_class.normalize("1 Quarter Ago", "UTC", "end").utc.to_s).to eq("2010-12-31 23:59:59 UTC")
+      it "UTC" do
+        result = described_class.normalize("3 Days Ago", "UTC")
+        expect(result).to eq("2011-01-08 00:00:00 UTC")
+      end
 
-        expect(described_class.normalize("3 Quarters Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-04-01 04:00:00 UTC")
-        expect(described_class.normalize("3 Quarters Ago", "UTC").utc.to_s).to eq("2010-04-01 00:00:00 UTC")
-        expect(described_class.normalize("3 Quarters Ago", "UTC", "end").utc.to_s).to eq("2010-06-30 23:59:59 UTC")
+      it "end mode" do
+        result = described_class.normalize("3 Days Ago", "UTC", "end")
+        expect(result).to eq("2011-01-08 23:59:59.999999999 UTC")
+      end
+    end
 
-        # Test Now, Today, Yesterday
-        expect(described_class.normalize("Now", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
-        expect(described_class.normalize("Now", "UTC").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
-        expect(described_class.normalize("Now", "UTC", "end").utc.to_s).to eq("2011-01-11 17:59:59 UTC")
+    context "n Weeks Ago" do
+      it "non-UTC" do
+        result = described_class.normalize("3 Weeks Ago", "Eastern Time (US & Canada)")
+        expect(result).to eq("2010-12-20 05:00:00 UTC")
+      end
 
-        expect(described_class.normalize("Today", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 05:00:00 UTC")
-        expect(described_class.normalize("Today", "UTC").utc.to_s).to eq("2011-01-11 00:00:00 UTC")
-        expect(described_class.normalize("Today", "UTC", "end").utc.to_s).to eq("2011-01-11 23:59:59 UTC")
+      it "UTC" do
+        result = described_class.normalize("3 Weeks Ago", "UTC")
+        expect(result).to eq("2010-12-20 00:00:00 UTC")
+      end
+    end
 
-        expect(described_class.normalize("Yesterday", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-10 05:00:00 UTC")
-        expect(described_class.normalize("Yesterday", "UTC").utc.to_s).to eq("2011-01-10 00:00:00 UTC")
-        expect(described_class.normalize("Yesterday", "UTC", "end").utc.to_s).to eq("2011-01-10 23:59:59 UTC")
+    context "n Months Ago" do
+      it "non-UTC" do
+        result = described_class.normalize("4 Months Ago", "Eastern Time (US & Canada)")
+        expect(result).to eq("2010-09-01 04:00:00 UTC")
+      end
 
-        # Test Last ...
-        expect(described_class.normalize("Last Hour", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 16:00:00 UTC")
-        expect(described_class.normalize("Last Hour", "UTC").utc.to_s).to eq("2011-01-11 16:00:00 UTC")
-        expect(described_class.normalize("Last Hour", "UTC", "end").utc.to_s).to eq("2011-01-11 16:59:59 UTC")
+      it "UTC" do
+        result = described_class.normalize("4 Months Ago", "UTC")
+        expect(result).to eq("2010-09-01 00:00:00 UTC")
+      end
 
-        expect(described_class.normalize("Last Week", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-03 05:00:00 UTC")
-        expect(described_class.normalize("Last Week", "UTC").utc.to_s).to eq("2011-01-03 00:00:00 UTC")
-        expect(described_class.normalize("Last Week", "UTC", "end").utc.to_s).to eq("2011-01-09 23:59:59 UTC")
+      it "end mode" do
+        result = described_class.normalize("4 Months Ago", "UTC", "end")
+        expect(result).to eq("2010-09-30 23:59:59.999999999 UTC")
+      end
+    end
 
-        expect(described_class.normalize("Last Month", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-12-01 05:00:00 UTC")
-        expect(described_class.normalize("Last Month", "UTC").utc.to_s).to eq("2010-12-01 00:00:00 UTC")
-        expect(described_class.normalize("Last Month", "UTC", "end").utc.to_s).to eq("2010-12-31 23:59:59 UTC")
+    context "1 Quarter Ago" do
+      it "non-UTC" do
+        result = described_class.normalize("1 Quarter Ago", "Eastern Time (US & Canada)")
+        expect(result).to eq("2010-10-01 04:00:00 UTC")
+      end
 
-        expect(described_class.normalize("Last Quarter", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-10-01 04:00:00 UTC")
-        expect(described_class.normalize("Last Quarter", "UTC").utc.to_s).to eq("2010-10-01 00:00:00 UTC")
-        expect(described_class.normalize("Last Quarter", "UTC", "end").utc.to_s).to eq("2010-12-31 23:59:59 UTC")
+      it "UTC" do
+        result = described_class.normalize("1 Quarter Ago", "UTC")
+        expect(result).to eq("2010-10-01 00:00:00 UTC")
+      end
 
-        # Test This ...
-        expect(described_class.normalize("This Hour", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
-        expect(described_class.normalize("This Hour", "UTC").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
-        expect(described_class.normalize("This Hour", "UTC", "end").utc.to_s).to eq("2011-01-11 17:59:59 UTC")
+      it "end mode" do
+        result = described_class.normalize("1 Quarter Ago", "UTC", "end")
+        expect(result).to eq("2010-12-31 23:59:59.999999999 UTC")
+      end
+    end
 
-        expect(described_class.normalize("This Week", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-10 05:00:00 UTC")
-        expect(described_class.normalize("This Week", "UTC").utc.to_s).to eq("2011-01-10 00:00:00 UTC")
-        expect(described_class.normalize("This Week", "UTC", "end").utc.to_s).to eq("2011-01-16 23:59:59 UTC")
+    context "n Quarters Ago" do
+      it "non-UTC" do
+        result = described_class.normalize("3 Quarters Ago", "Eastern Time (US & Canada)")
+        expect(result).to eq("2010-04-01 04:00:00 UTC")
+      end
 
-        expect(described_class.normalize("This Month", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-01 05:00:00 UTC")
-        expect(described_class.normalize("This Month", "UTC").utc.to_s).to eq("2011-01-01 00:00:00 UTC")
-        expect(described_class.normalize("This Month", "UTC", "end").utc.to_s).to eq("2011-01-31 23:59:59 UTC")
+      it "UTC" do
+        result = described_class.normalize("3 Quarters Ago", "UTC")
+        expect(result).to eq("2010-04-01 00:00:00 UTC")
+      end
 
-        expect(described_class.normalize("This Quarter", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-01 05:00:00 UTC")
-        expect(described_class.normalize("This Quarter", "UTC").utc.to_s).to eq("2011-01-01 00:00:00 UTC")
-        expect(described_class.normalize("This Quarter", "UTC", "end").utc.to_s).to eq("2011-03-31 23:59:59 UTC")
+      it "end mode" do
+        result = described_class.normalize("3 Quarters Ago", "UTC", "end")
+        expect(result).to eq("2010-06-30 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "Now" do
+      it "non-UTC" do
+        result = described_class.normalize("Now", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-11 17:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("Now", "UTC")
+        expect(result).to eq("2011-01-11 17:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("Now", "UTC", "end")
+        expect(result).to eq("2011-01-11 17:59:59.999999 UTC")
+      end
+    end
+
+    context "Today" do
+      it "non-UTC" do
+        result = described_class.normalize("Today", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-11 05:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("Today", "UTC")
+        expect(result).to eq("2011-01-11 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("Today", "UTC", "end")
+        expect(result).to eq("2011-01-11 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "Yesterday" do
+      it "non-UTC" do
+        result = described_class.normalize("Yesterday", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-10 05:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("Yesterday", "UTC")
+        expect(result).to eq("2011-01-10 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("Yesterday", "UTC", "end")
+        expect(result).to eq("2011-01-10 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "Last Hour" do
+      it "non-UTC" do
+        result = described_class.normalize("Last Hour", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-11 16:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("Last Hour", "UTC")
+        expect(result).to eq("2011-01-11 16:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("Last Hour", "UTC", "end")
+        expect(result).to eq("2011-01-11 16:59:59.999999 UTC")
+      end
+    end
+
+    context "Last Week" do
+      it "non-UTC" do
+        result = described_class.normalize("Last Week", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-03 05:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("Last Week", "UTC")
+        expect(result).to eq("2011-01-03 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("Last Week", "UTC", "end")
+        expect(result).to eq("2011-01-09 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "Last Month" do
+      it "non-UTC" do
+        result = described_class.normalize("Last Month", "Eastern Time (US & Canada)")
+        expect(result).to eq("2010-12-01 05:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("Last Month", "UTC")
+        expect(result).to eq("2010-12-01 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("Last Month", "UTC", "end")
+        expect(result).to eq("2010-12-31 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "Last Quarter" do
+      it "non-UTC" do
+        result = described_class.normalize("Last Quarter", "Eastern Time (US & Canada)")
+        expect(result).to eq("2010-10-01 04:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("Last Quarter", "UTC")
+        expect(result).to eq("2010-10-01 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("Last Quarter", "UTC", "end")
+        expect(result).to eq("2010-12-31 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "This Hour" do
+      it "non-UTC" do
+        result = described_class.normalize("This Hour", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-11 17:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("This Hour", "UTC")
+        expect(result).to eq("2011-01-11 17:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("This Hour", "UTC", "end")
+        expect(result).to eq("2011-01-11 17:59:59.999999 UTC")
+      end
+    end
+
+    context "This Week" do
+      it "non-UTC" do
+        result = described_class.normalize("This Week", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-10 05:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("This Week", "UTC")
+        expect(result).to eq("2011-01-10 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("This Week", "UTC", "end")
+        expect(result).to eq("2011-01-16 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "This Month" do
+      it "non-UTC" do
+        result = described_class.normalize("This Month", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-01 05:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("This Month", "UTC")
+        expect(result).to eq("2011-01-01 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("This Month", "UTC", "end")
+        expect(result).to eq("2011-01-31 23:59:59.999999999 UTC")
+      end
+    end
+
+    context "This Quarter" do
+      it "non-UTC" do
+        result = described_class.normalize("This Quarter", "Eastern Time (US & Canada)")
+        expect(result).to eq("2011-01-01 05:00:00 UTC")
+      end
+
+      it "UTC" do
+        result = described_class.normalize("This Quarter", "UTC")
+        expect(result).to eq("2011-01-01 00:00:00 UTC")
+      end
+
+      it "end mode" do
+        result = described_class.normalize("This Quarter", "UTC", "end")
+        expect(result).to eq("2011-03-31 23:59:59.999999999 UTC")
       end
     end
   end


### PR DESCRIPTION
There were 50 different expectations for different test cases here under
one test. Breaking them up gives a better idea of what's being tested at
quick glance and will provide better feedback for failures.

Closer inspection of the code here revealed that some expectations
required the result to be appended with `.utc.to_s` whereas most did
not. This is because there are mixed degrees of accuracy in different
results. The expectations were updated to reflect this.

@miq-bot add-label test, core
@miq-bot assign @gtanzillo 