### PR TITLE
2 places missing "require 'azure-armrest'"

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -10,6 +10,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
   end
 
   def verify_credentials(_auth_type = nil, options = {})
+    require 'azure-armrest'
     connect(options)
   rescue Azure::Armrest::UnauthorizedException
     raise MiqException::MiqHostError, _("Incorrect credentials - check your Azure Client ID and Client Key")

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -1,3 +1,4 @@
+require 'azure-armrest'
 describe ManageIQ::Providers::Azure::CloudManager do
   it ".ems_type" do
     expect(described_class.ems_type).to eq('azure')


### PR DESCRIPTION
Caused random spec failures depending on run order
```    
    Failures:
    
      1) ManageIQ::Providers::Azure::CloudManager#connectivity #validation handles incorrect password
         Failure/Error: Azure::Armrest::UnauthorizedException.new(nil, nil, nil))
    
         NameError:
           uninitialized constant Azure
         # ./spec/models/manageiq/providers/azure/cloud_manager_spec.rb:57:in `block (4 levels) in <top (required)>'
    
      2) ManageIQ::Providers::Azure::CloudManager#connectivity #validation handles unknown error
         Failure/Error: expect { @e.verify_credentials }.to raise_error(MiqException::MiqHostError, /Unexpected response returned*/)
    
           expected MiqException::MiqHostError with message matching /Unexpected response returned*/, got #<NameError: uninitialized constant ManageIQ::Providers::Azure::ManagerMixin::Azure> with backtrace:
             # ./app/models/manageiq/providers/azure/manager_mixin.rb:14:in `rescue in verify_credentials'
             # ./app/models/manageiq/providers/azure/manager_mixin.rb:13:in `verify_credentials'
             # ./spec/models/manageiq/providers/azure/cloud_manager_spec.rb:52:in `block (5 levels) in <top (required)>'
             # ./spec/models/manageiq/providers/azure/cloud_manager_spec.rb:52:in `block (4 levels) in <top (required)>'
         # ./spec/models/manageiq/providers/azure/cloud_manager_spec.rb:52:in `block (4 levels) in <top (required)>'
```