### PR TITLE
Services - Expose provision_priority to automate.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_task.rb
@@ -1,6 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceServiceTemplateProvisionTask < MiqAeServiceMiqRequestTask
     expose :service_resource, :association => true
+    expose :provision_priority
 
     def dialog_options
       options[:dialog] || {}


### PR DESCRIPTION
Service Bundles contain Service Items. The provision index(provision_priority) is set on the service resource to specify the provisioning order(configuration settings are also required)

Currently, automate methods require additional code to get the index. Exposing provision_priority will reduce the amount of automate code and helps make Services easier to use and customize. 

https://trello.com/c/VFv0vSGb
