### PR TITLE
Make a temporary directory for converter spec

### DIFF
--- a/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
@@ -11,8 +11,8 @@ module MiqAeDatastoreConverter
     end
     def setup_export_dir
       @domain     = 'TEST'
-      @export_dir = File.join(Dir.tmpdir, "rspec_export_tests")
-      @zip_file   = File.join(Dir.tmpdir, "yaml_model.zip")
+      @export_dir = File.join(Dir.mktmpdir, "rspec_export_tests")
+      @zip_file   = File.join(Dir.mktmpdir, "yaml_model.zip")
       FileUtils.rm_rf(@export_dir) if File.exist?(@export_dir)
       FileUtils.rm_rf(@zip_file)   if File.exist?(@zip_file)
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
Since we implemented parallel tests we are seeing sporadic failures in automate import/export specs. We have two specs that use the same directory and zip file name under TmpDir and depending on when they run they step on each others directories.

https://travis-ci.org/ManageIQ/manageiq/jobs/137310258

