### PR TITLE
Automate - Quota enforcement for user fix

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/limits.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/limits.rb
@@ -85,7 +85,7 @@ def set_root_limit_values(quota_max, quota_warn)
 end
 
 def model_and_tag_quota_values
-  $evm.log(:info, "Getting Group and Tag Quota Values.")
+  $evm.log(:info, "Getting #{$evm.root['quota_source_type']} and Tag Quota source Values.")
   quota_max = {}
   quota_warn = {}
   QUOTA_ATTRIBUTES.each do |name|

--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/quota_source.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/quota_source.rb
@@ -5,8 +5,11 @@
 @miq_request = $evm.root['miq_request']
 $evm.root['quota_source_type'] = $evm.parent['quota_source_type'] || $evm.object['quota_source_type']
 
-if $evm.root['quota_source_type'].casecmp('group').zero?
+case $evm.root['quota_source_type'].downcase
+when 'group'
   $evm.root['quota_source'] = @miq_request.requester.current_group
+when 'user'
+  $evm.root['quota_source'] = @miq_request.requester
 else
   $evm.root['quota_source'] = @miq_request.tenant
   $evm.root['quota_source_type'] = 'tenant'

--- a/spec/automation/unit/method_validation/quota_source_spec.rb
+++ b/spec/automation/unit/method_validation/quota_source_spec.rb
@@ -27,4 +27,11 @@ describe "Quota Validation" do
     expect(root['quota_source']).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqGroup)
     expect(root['quota_source_type']).to eq('group')
   end
+
+  it "user source" do
+    ws = run_automate_method(@miq_provision_request, 'user')
+    root = ws.root
+    expect(root['quota_source']).to be_kind_of(MiqAeMethodService::MiqAeServiceUser)
+    expect(root['quota_source_type']).to eq('user')
+  end
 end


### PR DESCRIPTION
Quota currently supports tenant, group and user as quota sources.

Fixed problem where user as quota source was not supported.

Fixed limits method to log the quota source.

Added new spec test for user quota source.

https://bugzilla.redhat.com/show_bug.cgi?id=1342180