### PR TITLE
Remove require_nested :Runner where it's not implemented (yet)

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure/network_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Azure::NetworkManager::EventCatcher < ::MiqEventCatcher
-  require_nested :Runner
-
   def self.ems_class
     ManageIQ::Providers::Azure::NetworkManager
   end

--- a/app/models/manageiq/providers/azure/network_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/azure/network_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Azure::NetworkManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "azure_network"
 
   def friendly_name


### PR DESCRIPTION
Purpose or Intent
-----------------
The Runner class is not yet implemented here and presence of the requires here would lead
to the following error when doing `rake gettext:store_model_attributes':

```

LoadError: No such file to load --
manageiq/providers/azure/network_manager/event_catcher/runner
lib/extensions/require_nested.rb:11:in `require_nested'
app/models/manageiq/providers/azure/network_manager/event_catcher.rb:2:in `<class:EventCatcher>'
app/models/manageiq/providers/azure/network_manager/event_catcher.rb:1:in `<top (required)>'
```


Steps for Testing/QA
--------------------

`rake gettext:store_model_attributes`