### PR TITLE
Disable 'Upload' button when no file is chosen

### DIFF
--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -25,7 +25,18 @@
         :javascript
           $(":file").filestyle({icon: false, placeholder: "No file chosen"});
       .col-md-6
-        = submit_tag(_("Upload"), :class => "btn btn-default", :id => "upload_atags")
+        = submit_tag(_("Upload"), :class => "btn btn-default", :id => "upload_atags", :disabled => true)
+        :javascript
+          $("#upload_file").on("change",
+            function(){
+              if ($(this).val()){
+                $('#upload_atags').prop('disabled', false);
+              }
+              else {
+                $('#upload_atags').prop('disabled', true);
+              }
+            }
+          );
 %hr
 %h3
   = _('Export')


### PR DESCRIPTION
We allowed click on 'Upload' when a user has not chosen any file to upload, what finished with unexpected error.

Bugfix disables the upload button until a user chooses a file to upload.

https://bugzilla.redhat.com/show_bug.cgi?id=1342451