### PR TITLE
set default single quad icon for service & service templates

### DIFF
--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -6,6 +6,6 @@ class ServiceDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "/pictures/#{picture.basename}" if try(:picture)
+    try(:picture) ? "/pictures/#{picture.basename}" : "100/service"
   end
 end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -6,6 +6,6 @@ class ServiceTemplateDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "/pictures/#{picture.basename}" if try(:picture)
+    try(:picture) ? "/pictures/#{picture.basename}" : "100/service_template"
   end
 end

--- a/spec/views/layouts/quadicon/_single_quad.html.haml_spec.rb
+++ b/spec/views/layouts/quadicon/_single_quad.html.haml_spec.rb
@@ -1,0 +1,29 @@
+describe "rendering single quadicon for service" do
+  before(:each) do
+    @settings = {:quadicons => {:service => false}}
+    @item = FactoryGirl.build(:service)
+    @layout = "service"
+  end
+
+  it "doesn't display IP Address in the tooltip" do
+    render :partial => "layouts/quadicon/single_quad",
+           :locals  => {:size => "72",
+                        :typ  => "grid",
+                        :item => @item}
+  end
+end
+
+describe "rendering single quadicon for Orchestration Template type Catalog Item" do
+  before(:each) do
+    @settings = {:quadicons => {:service_template => false}}
+    @item = FactoryGirl.build(:service_template_orchestration)
+    @layout = "service"
+  end
+
+  it "doesn't display IP Address in the tooltip" do
+    render :partial => "layouts/quadicon/single_quad",
+           :locals  => {:size => "72",
+                        :typ  => "grid",
+                        :item => @item}
+  end
+end


### PR DESCRIPTION
In absence of custom image, use default quad icon for Services & Service Templates.

https://bugzilla.redhat.com/show_bug.cgi?id=1341873

having no default quad icon set, it was blowing up on list of services when changing view to grid/tile. Same issue was observed in catalogs explorer after adding a Orchestration type catalog item with no custom image.

@dclarizio please review.