### PR TITLE
Fixes misspelling of “address” on Floating IP list screen.

### DIFF
--- a/product/views/FloatingIp.yaml
+++ b/product/views/FloatingIp.yaml
@@ -45,7 +45,7 @@ col_order:
 
 # Column titles, in order
 headers:
-- Adress
+- Address
 - Fixed Address
 - Instance name
 - Network Provider


### PR DESCRIPTION
Purpose or Intent
-----------------
Fixes a typo on the Floating IP screen.

Before:
![screen shot 2016-06-14 at 11 17 11 am](https://cloud.githubusercontent.com/assets/39493/16056680/75bf7344-322b-11e6-9964-115ce2c57960.png)

After:
![screen shot 2016-06-14 at 12 13 53 pm](https://cloud.githubusercontent.com/assets/39493/16056686/7c55d05e-322b-11e6-969d-59aa0b172612.png)




Fixes [BZ 1344081](https://bugzilla.redhat.com/show_bug.cgi?id=1344081)

