### PR TITLE
[WIP] Removed Alias of address to hostname

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -108,8 +108,6 @@ class ExtManagementSystem < ApplicationRecord
            :to => :default_endpoint,
            :allow_nil => true
 
-  alias_method :address, :hostname # TODO: Remove all callers of address
-
   virtual_column :ipaddress,               :type => :string,  :uses => :endpoints
   virtual_column :hostname,                :type => :string,  :uses => :endpoints
   virtual_column :port,                    :type => :integer, :uses => :endpoints

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -61,7 +61,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def connect(options = {})
-    options[:hostname] ||= address
+    options[:hostname] ||= hostname
     options[:port] ||= port
     options[:user] ||= authentication_userid(options[:auth_type])
     options[:pass] ||= authentication_password(options[:auth_type])

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -46,7 +46,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       }
       extra_options[:domain_id] = keystone_v3_domain_id
 
-      osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
+      osh = OpenstackHandle::Handle.new(username, password, hostname, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}
       osh
     end

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -73,7 +73,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     path = default_endpoint.path
     _log.info("Using stored API path '#{path}'.") unless path.blank?
 
-    server   = options[:ip] || address
+    server   = options[:ip] || hostname
     port     = options[:port] || self.port
     username = options[:user] || authentication_userid(options[:auth_type])
     password = options[:pass] || authentication_password(options[:auth_type])

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -66,7 +66,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
       $log.log_hashes(@exclude_props)
     end
 
-    @ems_ids_for_notify = MiqVimBrokerWorker.emses_to_monitor.each_with_object({}) { |e, h| h[[e.address, e.authentication_userid]] = e.id }
+    @ems_ids_for_notify = MiqVimBrokerWorker.emses_to_monitor.each_with_object({}) { |e, h| h[[e.hostname, e.authentication_userid]] = e.id }
 
     # Set notify method at the class level for new connections, and at the
     #   instance level for existing connections.
@@ -281,7 +281,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   end
 
   def preload(ems)
-    vim = @vim_broker_server.getMiqVim(ems.address, *ems.auth_user_pwd)
+    vim = @vim_broker_server.getMiqVim(ems.hostname, *ems.auth_user_pwd)
   ensure
     vim.disconnect rescue nil
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -846,7 +846,8 @@ class VmOrTemplate < ApplicationRecord
     [ext_management_system, "ems", host, "host"].each_slice(2) do |ems, type|
       if ems
         params[type] = {
-          :address    => ems.address,
+          # TODO: (Julian) Removing instances of address. Hopfully this won't be missed.
+          # :address    => ems.address,
           :hostname   => ems.hostname,
           :ipaddress  => ems.ipaddress,
           :username   => ems.authentication_userid,

--- a/gems/pending/util/miq_fault_tolerant_vim.rb
+++ b/gems/pending/util/miq_fault_tolerant_vim.rb
@@ -8,7 +8,7 @@ class MiqFaultTolerantVim
 
     @erec     = options[:ems]
     auth_type = options[:auth_type] || :ws
-    ip        = options[:ip] || @erec.address
+    ip        = options[:ip] || @erec.hostname
     user      = options[:user] || @erec.authentication_userid(auth_type)
     pass      = options[:pass] || @erec.authentication_password(auth_type)
     @ems      = [ip, user, pass]

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -175,7 +175,7 @@ describe MiqVimBrokerWorker::Runner do
       @miq_vim_broker = double('miq_vim_broker')
       @vim_handle     = double('vim_handle')
       @vim_broker_worker.instance_variable_set(:@vim_broker_server, @miq_vim_broker)
-      expect(@miq_vim_broker).to receive(:getMiqVim).once.with(@ems.address, *@ems.auth_user_pwd).and_return(@vim_handle)
+      expect(@miq_vim_broker).to receive(:getMiqVim).once.with(@ems.hostname, *@ems.auth_user_pwd).and_return(@vim_handle)
       expect(@vim_handle).to receive(:disconnect).once
       @vim_broker_worker.preload(@ems)
     end
@@ -208,7 +208,7 @@ describe MiqVimBrokerWorker::Runner do
         it "will handle queued Vm updates properly" do
           vm = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
           event = {
-            :server       => @ems.address,
+            :server       => @ems.hostname,
             :username     => @ems.authentication_userid,
             :objType      => "VirtualMachine",
             :op           => "update",
@@ -230,7 +230,7 @@ describe MiqVimBrokerWorker::Runner do
         it "will handle queued Host updates properly" do
           host = FactoryGirl.create(:host_with_ref, :ext_management_system => @ems)
           event = {
-            :server       => @ems.address,
+            :server       => @ems.hostname,
             :username     => @ems.authentication_userid,
             :objType      => "HostSystem",
             :op           => "update",
@@ -251,7 +251,7 @@ describe MiqVimBrokerWorker::Runner do
 
         it "will ignore updates to unknown properties" do
           vm = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
-          @vim_broker_worker.instance_variable_get(:@queue).enq(:server       => @ems.address,
+          @vim_broker_worker.instance_variable_get(:@queue).enq(:server       => @ems.hostname,
                                                                 :username     => @ems.authentication_userid,
                                                                 :objType      => "VirtualMachine",
                                                                 :op           => "update",
@@ -268,7 +268,7 @@ describe MiqVimBrokerWorker::Runner do
           @vim_broker_worker.instance_variable_set(:@exclude_props, "VirtualMachine" => {"summary.runtime.powerState" => nil})
 
           vm = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
-          @vim_broker_worker.instance_variable_get(:@queue).enq(:server       => @ems.address,
+          @vim_broker_worker.instance_variable_get(:@queue).enq(:server       => @ems.hostname,
                                                                 :username     => @ems.authentication_userid,
                                                                 :objType      => "VirtualMachine",
                                                                 :op           => "update",
@@ -301,7 +301,7 @@ describe MiqVimBrokerWorker::Runner do
           vm2  = FactoryGirl.create(:vm_with_ref, :ext_management_system => ems2)
 
           event = {
-            :server       => ems2.address,
+            :server       => ems2.hostname,
             :username     => ems2.authentication_userid,
             :objType      => "VirtualMachine",
             :op           => "update",
@@ -322,7 +322,7 @@ describe MiqVimBrokerWorker::Runner do
 
         it "will reconnect to an EMS" do
           event = {
-            :server   => @ems.address,
+            :server   => @ems.hostname,
             :username => @ems.authentication_userid,
             :op       => "MiqVimRemoved",
             :error    => "Connection timed out",
@@ -338,7 +338,7 @@ describe MiqVimBrokerWorker::Runner do
           ems_2 = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone_2)
 
           event = {
-            :server   => ems_2.address,
+            :server   => ems_2.hostname,
             :username => ems_2.authentication_userid,
             :op       => "MiqVimRemoved",
           }


### PR DESCRIPTION
Found uses of `address` and changed to `hostname`, tests seem to be green, but I'm sure there are a few more around.

I'm assuming as `address` was just an alias to `hostname` their usage should have been identical in the code?

This is part of a plan of tidying up usages of Endpoints around the code, to enable ease of use of adding multiple endpoints in places that they weren't used before.

/cc @Fryguy @blomquisg
