### PR TITLE
Remove require try

### DIFF
--- a/gems/pending/util/vmdb-logger.rb
+++ b/gems/pending/util/vmdb-logger.rb
@@ -1,5 +1,4 @@
 require 'logger'
-require 'active_support/core_ext/object/try'
 
 class VMDBLogger < Logger
   def initialize(*args)
@@ -31,7 +30,7 @@ class VMDBLogger < Logger
   end
 
   def filename
-    logdev.try(:filename)
+    logdev.filename unless logdev.nil?
   end
 
   alias_method :filename=, :logdev=


### PR DESCRIPTION
vmdb-logger should not require any active-support files so
that it can be included in code that does not (and cannot)
use active-support.

Currently the VixDiskLibServer runs in a very vanilla environment
so as to not run into any conflicts with versions of SSL required
by the VMWare VixDiskLib (vddk). This change allows vmdb-logger
to provide this support.

This issue was first reported here: https://github.com/ManageIQ/manageiq/issues/8984

@Fryguy as discussed.  Please merge.  @roliveri @hsong-rh for your enjoyment.