### PR TITLE
delete miq_policy_import on delete

### DIFF
--- a/app/services/miq_policy_import_service.rb
+++ b/app/services/miq_policy_import_service.rb
@@ -44,7 +44,7 @@ class MiqPolicyImportService
   end
 
   def queue_deletion(import_file_upload_id)
-    MiqQueue.put_or_update(
+    MiqQueue.put(
       :class_name  => "ImportFileUpload",
       :instance_id => import_file_upload_id,
       :deliver_on  => 1.day.from_now,

--- a/spec/services/miq_policy_import_service_spec.rb
+++ b/spec/services/miq_policy_import_service_spec.rb
@@ -56,7 +56,7 @@ describe MiqPolicyImportService do
     context "when the import does not raise an error" do
       before do
         allow(MiqPolicy).to receive(:import).with("file contents", :preview => true).and_return(:uploaded => "content")
-        allow(MiqQueue).to receive(:put_or_update)
+        allow(MiqQueue).to receive(:put)
         allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
       end
 
@@ -71,7 +71,7 @@ describe MiqPolicyImportService do
 
       it "queues deletion of the object" do
         Timecop.freeze(2014, 3, 4) do
-          expect(MiqQueue).to receive(:put_or_update).with(
+          expect(MiqQueue).to receive(:put).with(
             :class_name  => "ImportFileUpload",
             :instance_id => 1,
             :deliver_on  => 1.day.from_now,


### PR DESCRIPTION
High level:

In order to switch away from `MiqQueue`, we need to remove updates to the Queue. Just going through and deleting the low hanging fruit.

Actual:

no need to `put_or_update` since a block is not given. 
The `deliver_on` field will always make this request unique, so no need to `update_unless_exists` - it will never exist.
It also will not get called multiple times, so that is unneeded.