### PR TITLE
Use a regular put for ntp settings changes

### DIFF
--- a/app/models/miq_server/queue_management.rb
+++ b/app/models/miq_server/queue_management.rb
@@ -57,15 +57,14 @@ module MiqServer::QueueManagement
   def ntp_reload_queue
     return unless MiqEnvironment::Command.is_appliance? # matches ntp_reload's guard clause
 
-    MiqQueue.put_or_update(
+    MiqQueue.put(
       :class_name  => "MiqServer",
       :instance_id => id,
       :method_name => "ntp_reload",
       :server_guid => guid,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :args => [server_ntp_settings],
       :zone        => my_zone
-    ) do |msg, item|
-      _log.info("Previous ntp_reload is still running, skipping...Resource: [#{self.class.name}], id: [#{id}]") unless msg.nil?
-      item.merge(:priority => MiqQueue::HIGH_PRIORITY, :args => [server_ntp_settings])
-    end
+    )
   end
 end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -131,13 +131,7 @@ describe MiqServer do
         end
 
         it "will queue up a message with high priority" do
-          expect(message.priority).to eq(MiqQueue::HIGH_PRIORITY)
-        end
-
-        it "will not requeue if one exists" do
-          expect(MiqQueue.where(queue_cond).count).to eq(1)
-          @miq_server.ntp_reload_queue
-          expect(MiqQueue.where(queue_cond).count).to eq(1)
+          expect(MiqQueue.where(queue_cond)).not_to be_nil
         end
       end
 


### PR DESCRIPTION
There is no need to modify the queue inline for these changes.
Yes, it will update this resource twice in a row on each server, but
not the end of the world