### PR TITLE
Consolidate how we check for MiqTask completion

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1144,7 +1144,7 @@ module ApplicationController::Performance
     if params[:task_id]                             # Came in after async report generation
       miq_task = MiqTask.find(params[:task_id])     # Not first time, read the task record
       begin
-        if miq_task.status == 'Error' || miq_task.miq_report_result.nil?
+        unless miq_task.results_ready?
           add_flash(_("Error while generating report: #{miq_task.message}"), :error)
           return
         end

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -60,7 +60,7 @@ module ApplicationController::ReportDownloads
     end
 
     miq_task = MiqTask.find(params[:task_id])
-    if miq_task.task_results.blank? || miq_task.status != "Ok" # Check to see if any results came back or status not Ok
+    if !miq_task.results_ready?
       add_flash(_("Report generation returned: Status [%{status}] Message [%{message}]") % {:status => miq_task.status, :message => miq_task.message}, :error)
       render :update do |page|
         page << javascript_prologue

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -277,7 +277,7 @@ module ApplicationController::Timelines
       miq_task = MiqTask.find(params[:task_id])     # Not first time, read the task record
       @report = miq_task.task_results
 
-      if miq_task.task_results.blank? || miq_task.status != "Ok"  # Check to see if any results came back or status not Ok
+      if !miq_task.results_ready?
         add_flash(_("Error building timeline %{error_message}") % {:error_message => miq_task.message}, :error)
       else
         @timeline = @timeline_filter = true

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -745,7 +745,7 @@ class DashboardController < ApplicationController
     miq_task = MiqTask.find(params[:task_id]) # Not first time, read the task record
     @report  = miq_task.task_results
     session[:rpt_task_id] = miq_task.id
-    if miq_task.task_results.blank? || miq_task.status != "Ok" # Check to see if any results came back or status not Ok
+    unless miq_task.results_ready?
       add_flash(_("Error building timeline  %{error_message}") % {:error_message => miq_task.message}, :error)
       return
     end

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -28,7 +28,7 @@ module MiqPolicyController::Rsop
         end
       else
         miq_task = MiqTask.find(params[:task_id])     # Not first time, read the task record
-        if miq_task.task_results.blank?               # Check to see if any results came back
+        if !miq_task.results_ready?
           add_flash(_("Policy Simulation generation returned: %{error_message}") % {:error_message => miq_task.message}, :error)
         else
           @sb[:rsop][:results] = miq_task.task_results

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -172,7 +172,7 @@ module OpsController::Settings::RHN
   def rhn_fire_available_organizations
     if params[:task_id] # wait_for_task is done --> read the task record
       miq_task = MiqTask.find(params[:task_id])
-      if miq_task.status != 'Ok'
+      if !miq_task.results_ready?
         add_flash(_("Credential validation returned: %{message}") % {:message => miq_task.message}, :error)
       else
         # task succeeded, we have the hash of org names to org keys in miq_task.task_results

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -46,7 +46,7 @@ module ReportController::Reports
     end
     miq_task = MiqTask.find(params[:task_id])     # Not first time, read the task record
     rpt = miq_task.task_results
-    if miq_task.task_results.blank? || miq_task.status != "Ok"  # Check to see if any results came back or status not Ok
+    if !miq_task.results_ready?
       add_flash(_("Report preview generation returned: Status [%{status}] Message [%{message}]") % {:status => miq_task.status, :message => miq_task.message},
                 :error)
     else

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1337,7 +1337,7 @@ module VmCommon
   # Task complete, show error or launch console using VNC/MKS/VMRC task info
   def console_after_task(console_type)
     miq_task = MiqTask.find(params[:task_id])
-    if miq_task.status == "Error" || miq_task.task_results.blank?
+    unless miq_task.results_ready?
       add_flash(_("Console access failed: %{message}") % {:message => miq_task.message}, :error)
     end
     render :update do |page|

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -4,6 +4,7 @@ class GitRepository < ApplicationRecord
   validates :url, :format => URI::regexp(%w(http https)), :allow_nil => false
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
+  validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
 
   has_many :git_branches, :dependent => :destroy
   has_many :git_tags, :dependent => :destroy

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -762,7 +762,7 @@ module MiqReport::Generator
 
       # Reload the task after the _async_generate_table has updated it
       task.reload
-      if task.status != "Ok"
+      if !task.results_ready?
         _log.warn("Generating report table with taskid [#{taskid}]... Failed to complete, '#{task.message}'")
         return
       else

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -155,6 +155,10 @@ class MiqTask < ApplicationRecord
     end
   end
 
+  def results_ready?
+    status == STATUS_OK && !task_results.blank?
+  end
+
   def queue_callback(state, status, message, result)
     if status.casecmp(STATUS_OK) == 0
       message = MESSAGE_TASK_COMPLETED_SUCCESSFULLY

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -273,4 +273,21 @@ describe MiqTask do
       expect(message.zone).to eq(@zone)
     end
   end
+
+  describe '#results_ready?' do
+    before(:each) { @miq_task = FactoryGirl.create(:miq_task_plain) }
+    it 'returns false when task_results are missing' do
+      expect(@miq_task.task_results).to be_blank
+      expect(@miq_task.status).to eq(MiqTask::STATUS_OK)
+      expect(@miq_task.results_ready?).to be_falsey
+    end
+    it 'returns false when status is error' do
+      @miq_task.error('bang')
+      expect(@miq_task.results_ready?).to be_falsey
+    end
+    it 'returns true when status is ok and results are not blank' do
+      @miq_task.task_results = 'x'
+      expect(@miq_task.results_ready?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
There are multiple way different controllers check for MiqTask being successfully built and for it having the data available. Let's have a single way how to check completion and let's push that down to the model.

Fixes #9184

@miq-bot add_label refactoring, core, wip