### PR TITLE
Don't refer to "menu option above" as it's now on left side

### DIFF
--- a/app/views/layouts/_exception_contents.html.haml
+++ b/app/views/layouts/_exception_contents.html.haml
@@ -8,14 +8,14 @@
   %fieldset
     %font{:style => "font-size: 116%;color: black"} &#x2460;
     = _("Accessing Management Engine from multiple tabs or windows of the same browser on a single machine.")
-    = _("Close any duplicate browser sessions, then select a menu option above.")
+    = _("Close any duplicate browser sessions, then select an option from the menu.")
 
   %fieldset
     %font{:style => "font-size: 116%;color: black"} &#x2461;
     = _("Pressing the back button during a session.")
     %br
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-    = _("Close any duplicate browser sessions, then select a menu option above.")
+    = _("Close any duplicate browser sessions, then select an option from the menu.")
 
   %fieldset
     %font{:style => "font-size: 116%;color: black"} &#x2462;


### PR DESCRIPTION
The menu is no longer above:
![screenshot-localhost 3000 2016-06-15 14-09-55](https://cloud.githubusercontent.com/assets/273688/16078138/b492b088-3305-11e6-98cb-43f7bee36013.png)

I wasn't sure how to refer to its left position non-awkwardly ("select a menu option from the left"?) so chose to just say "an option from the menu".
On many screens (as in the screenshot above) there is an explorer directly to the left of the message, which some users could think is also a "menu".

The old string has `ja` and `zh-CN` translations.  Should the PR do anything to them?