### PR TITLE
Update EMS hostname uniq validation for OpenStack Domain

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -40,6 +40,17 @@ class ManageIQ::Providers::Openstack::CloudManager < EmsCloud
     )
   end
 
+  def hostname_uniqueness_valid?
+    return unless hostname_required?
+    return unless hostname.present? # Presence is checked elsewhere
+
+    existing_providers = Endpoint.where(:hostname => hostname.downcase)
+                                 .where.not(:resource_id => id).includes(:resource)
+                                 .select { |endpoint| endpoint.resource.uid_ems == keystone_v3_domain_id }
+
+    errors.add(:hostname, "has already been taken") if existing_providers.any?
+  end
+
   def supports_port?
     true
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -50,6 +50,20 @@ describe ManageIQ::Providers::Openstack::CloudManager do
       expect($log).to receive(:error)
       expect(@ems.event_monitor_available?).to be_falsey
     end
+
+    it "fails uniqueness check for same hostname with same or without domains" do
+      dup_ems = FactoryGirl.build(:ems_openstack_with_authentication)
+      taken_hostname = @ems.endpoints.first.hostname
+      dup_ems.endpoints.first.hostname = taken_hostname
+      expect(dup_ems.valid?).to be_falsey
+    end
+
+    it "passes uniqueness check for same hostname with different domains" do
+      dup_ems = FactoryGirl.build(:ems_openstack_with_authentication, :uid_ems => 'my_domain')
+      taken_hostname = @ems.endpoints.first.hostname
+      dup_ems.endpoints.first.hostname = taken_hostname
+      expect(dup_ems.valid?).to be_truthy
+    end
   end
 
   it "event_monitor_options" do


### PR DESCRIPTION
Keystone v3 introduced Domain, which is a namespace for OpenStack objects.
Two OpenStack Providers with different domains can live together now.

This affects only OpenStack Cloud Provider.