### PR TITLE
CodeClimate Issues in MiqDisk Modules

### DIFF
--- a/gems/pending/disk/MiqDisk.rb
+++ b/gems/pending/disk/MiqDisk.rb
@@ -8,6 +8,14 @@ class MiqDisk
   def self.getDisk(dInfo, probes = nil)
     $log.debug "MiqDisk::getDisk: baseOnly = #{dInfo.baseOnly}" if $log
     if (dm = DiskProbe.getDiskMod(dInfo, probes))
+      if dInfo.mountMode.nil? || dInfo.mountMode == "r"
+        dInfo.mountMode = "r"
+        dInfo.fileMode = "r"
+      elsif dInfo.mountMode == "rw"
+        dInfo.fileMode = "r+"
+      else
+        raise "Unrecognized mountMode: #{dInfo.mountMode}"
+      end
       d = new(dm, dInfo.clone, 0)
       if dInfo.baseOnly
         $log.debug "MiqDisk::getDisk: baseOnly = true, returning parent: #{d.getBase.dInfo.fileName}" if $log

--- a/gems/pending/disk/modules/MSVSDiffDisk.rb
+++ b/gems/pending/disk/modules/MSVSDiffDisk.rb
@@ -23,18 +23,7 @@ module MSVSDiffDisk
     end
     MSCommon.d_init_common(dInfo, @ms_disk_file) unless dInfo.baseOnly
 
-    # Get parent locators.
-    @locators = []
-    1.upto(8) do|idx|
-      @locators << MSCommon::PARENT_LOCATOR.decode(MSCommon.header["parent_loc#{idx}"])
-      next if @locators[idx - 1]['platform_code'] == "\000\000\000\000"
-      locator = @locators[idx - 1]
-      if locator['platform_code'] == "W2ku"
-        getParentPathWin(locator)
-        getParent(locator)
-      end
-    end
-    raise "No compatible parent locator found" if @parent == nil
+    parent_locators
   end
 
   def getBase
@@ -68,6 +57,21 @@ module MSVSDiffDisk
   # // Helpers.
 
   private
+
+  def parent_locators
+    # Get parent locators.
+    @locators = []
+    1.upto(8) do|idx|
+      @locators << MSCommon::PARENT_LOCATOR.decode(MSCommon.header["parent_loc#{idx}"])
+      next if @locators[idx - 1]['platform_code'] == "\000\000\000\000"
+      locator = @locators[idx - 1]
+      if locator['platform_code'] == "W2ku"
+        getParentPathWin(locator)
+        getParent(locator)
+      end
+    end
+    raise "No compatible parent locator found" if @parent == nil
+  end
 
   def getParent(locator)
     if locator.key?('fileName')

--- a/gems/pending/disk/modules/MSVSDiffDisk.rb
+++ b/gems/pending/disk/modules/MSVSDiffDisk.rb
@@ -6,20 +6,12 @@ module MSVSDiffDisk
   def d_init
     self.diskType = "MSVS Differencing"
     self.blockSize = MSCommon::SECTOR_LENGTH
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
     if dInfo.hyperv_connection
       @hyperv_connection = dInfo.hyperv_connection
       @ms_disk_file      = MSCommon.connect_to_hyperv(dInfo)
     else
       @hyperv_connection = nil
-      @ms_disk_file      = MiqLargeFile.open(dInfo.fileName, fileMode) unless dInfo.baseOnly
+      @ms_disk_file      = MiqLargeFile.open(dInfo.fileName, dInfo.fileMode) unless dInfo.baseOnly
     end
     MSCommon.d_init_common(dInfo, @ms_disk_file) unless dInfo.baseOnly
 
@@ -61,7 +53,7 @@ module MSVSDiffDisk
   def parent_locators
     # Get parent locators.
     @locators = []
-    1.upto(8) do|idx|
+    1.upto(8) do |idx|
       @locators << MSCommon::PARENT_LOCATOR.decode(MSCommon.header["parent_loc#{idx}"])
       next if @locators[idx - 1]['platform_code'] == "\000\000\000\000"
       locator = @locators[idx - 1]
@@ -70,7 +62,7 @@ module MSVSDiffDisk
         getParent(locator)
       end
     end
-    raise "No compatible parent locator found" if @parent == nil
+    raise "No compatible parent locator found" if @parent.nil?
   end
 
   def getParent(locator)

--- a/gems/pending/disk/modules/MSVSDynamicDisk.rb
+++ b/gems/pending/disk/modules/MSVSDynamicDisk.rb
@@ -4,18 +4,10 @@ module MSVSDynamicDisk
   def d_init
     self.diskType = "MSVS Dynamic"
     self.blockSize = MSCommon::SECTOR_LENGTH
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
     @ms_disk_file = if dInfo.hyperv_connection
                       MSCommon.connect_to_hyperv(dInfo)
                     else
-                      MiqLargeFile.open(dInfo.fileName, fileMode)
+                      MiqLargeFile.open(dInfo.fileName, dInfo.fileMode)
                     end
     MSCommon.d_init_common(dInfo, @ms_disk_file)
   end

--- a/gems/pending/disk/modules/MSVSFixedDisk.rb
+++ b/gems/pending/disk/modules/MSVSFixedDisk.rb
@@ -5,19 +5,10 @@ module MSVSFixedDisk
     @diskType = "MSVSFixed"
     @blockSize = 512
 
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
-
     if dInfo.hyperv_connection
       @ms_flat_disk_file = MSCommon.connect_to_hyperv(dInfo)
     else
-      @ms_flat_disk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
+      @ms_flat_disk_file = MiqLargeFile.open(dInfo.fileName, dInfo.fileMode)
     end
   end
 

--- a/gems/pending/disk/modules/QcowDisk.rb
+++ b/gems/pending/disk/modules/QcowDisk.rb
@@ -102,15 +102,7 @@ module QcowDisk
     self.diskType = "QCOW"
     self.blockSize = SECTOR_SIZE
 
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      @fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      @fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
-
+    @fileMode = dInfo.fileMode
     @filename = dInfo.fileName
     @dOffset = dInfo.offset
     @downstreamDisk = dInfo.downstreamDisk

--- a/gems/pending/disk/modules/RawDisk.rb
+++ b/gems/pending/disk/modules/RawDisk.rb
@@ -5,17 +5,8 @@ module RawDisk
     self.diskType = "Raw"
     self.blockSize = 512
 
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
-
     @dOffset = dInfo.offset
-    @rawDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
+    @rawDisk_file = MiqLargeFile.open(dInfo.fileName, dInfo.fileMode)
   end
 
   def getBase

--- a/gems/pending/disk/modules/VMWareCowdDisk.rb
+++ b/gems/pending/disk/modules/VMWareCowdDisk.rb
@@ -24,17 +24,9 @@ module VMWareCowdDisk
   def d_init
     self.diskType = "VMWare CopyOnWrite"
     self.blockSize = 512
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
     @dParent = @dInfo.parent
 
-    @vmwareCowDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
+    @vmwareCowDisk_file = MiqLargeFile.open(dInfo.fileName, dInfo.fileMode)
     buf = @vmwareCowDisk_file.read(SIZEOF_COWD_EXTENT_HEADER)
     @EsxSparseHeader = OpenStruct.new(COWD_EXTENT_HEADER.decode(buf))
 

--- a/gems/pending/disk/modules/VMWareSparseDisk.rb
+++ b/gems/pending/disk/modules/VMWareSparseDisk.rb
@@ -24,15 +24,7 @@ module VMWareSparseDisk
   def d_init
     self.diskType = "VMWare Sparse"
     self.blockSize = 512
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
-    @vmwareSparseDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
+    @vmwareSparseDisk_file = MiqLargeFile.open(dInfo.fileName, dInfo.fileMode)
     buf = @vmwareSparseDisk_file.read(SIZEOF_SPARSE_EXTENT_HEADER)
     @sparseHeader = OpenStruct.new(SPARSE_EXTENT_HEADER.decode(buf))
     @grainSize = @sparseHeader.grainSize

--- a/gems/pending/disk/modules/VhdxDisk.rb
+++ b/gems/pending/disk/modules/VhdxDisk.rb
@@ -189,18 +189,10 @@ module VhdxDisk
   end
 
   def connection_to_file(dInfo)
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode     = "r"
-      file_mode           = "r"
-    elsif dInfo.mountMode == "rw"
-      file_mode           = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
     if dInfo.hyperv_connection
       @vhdx_file = connect_to_hyperv(dInfo)
     else
-      @vhdx_file = MiqLargeFile.open(@file_name, file_mode)
+      @vhdx_file = MiqLargeFile.open(@file_name, dInfo.fileMode)
     end
     @vhdx_file
   end

--- a/gems/pending/disk/modules/VixDiskMod.rb
+++ b/gems/pending/disk/modules/VixDiskMod.rb
@@ -6,13 +6,10 @@ module VixDiskMod
     @vdi = dInfo.vixDiskInfo
     @connection = @vdi[:connection]
 
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
+    if dInfo.fileMode == "r"
       fileMode = VixDiskLib::VIXDISKLIB_FLAG_OPEN_READ_ONLY
-    elsif dInfo.mountMode == "rw"
+    elsif dInfo.fileMode == "r+"
       fileMode = 0
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
     end
 
     dInfo.fileName = @vdi[:fileName]


### PR DESCRIPTION
Code Climate has called out complex and duplicated code in several disk modules.

The exact same processing for the mountMode occurs in the d_init method of eight different disk modules.    This code will be bumped up a level into MiqDisk.getDisk before passing
control to the modules themselves.

In addition the MSVSDiffDisk d_init processing of parent_locators adds to the complexity of the method.
It will be pulled out into its own method.

@jrafanie 60-ish lines deleted.  @roliveri @Fryguy please review and merge if appropriate.