### PR TITLE
Change to encode if special characters exist in scanning results

### DIFF
--- a/gems/pending/util/xml/miq_rexml.rb
+++ b/gems/pending/util/xml/miq_rexml.rb
@@ -144,7 +144,16 @@ module REXML
         self.name = first
         # This is the old method that does not handle HTML encoded strings properly
         # @value = second.to_s
-        @value = Text.unnormalize(second.to_s, nil)
+        begin
+          @value = Text.unnormalize(second.to_s, nil)
+        rescue => err
+          if err.class == ::Encoding::CompatibilityError
+            second_utf8 = second.to_s.force_encoding('UTF-8')
+            @value = Text.unnormalize(second_utf8, nil)
+          else
+            $log.error "Encoding error: #{second_utf8}" if $log
+          end
+        end
         # This line is to support REXML shipped with version 1.8.6 patch 111 and above
         @normalized = second.to_s
       else


### PR DESCRIPTION
The special characters existing in the scanning result will cause UI to display empty information. Add encoding logic to handle this case.


https://bugzilla.redhat.com/show_bug.cgi?id=1343720