### PR TITLE
Use hostname for Azure computerName option

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -61,7 +61,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
         :osProfile       => {
           :adminUserName => options[:root_username],
           :adminPassword => root_password,
-          :computerName  => dest_name
+          :computerName  => dest_hostname
         },
         :storageProfile  => {
           :osDisk        => {

--- a/app/models/miq_provision/options_helper.rb
+++ b/app/models/miq_provision/options_helper.rb
@@ -3,6 +3,10 @@ module MiqProvision::OptionsHelper
     get_option(:vm_target_name)
   end
 
+  def dest_hostname
+    get_option(:vm_target_hostname)
+  end
+
   def dest_cluster
     @dest_cluster ||= EmsCluster.find_by_id(get_option(:dest_cluster))
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1344103

This bug was uncovered through ordering an Azure service catalog item. In this scenario the name will auto appending  `_####` to make it unique. This name however cannot be used as windows machine hostname because it contains `_`.  The corresponding valid hostname is already prepared in the options with key `:vm_target_hostname`. 