### PR TITLE
Api for openshift container deployments

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -59,6 +59,7 @@ class ApiController < ApplicationController
   include_concern 'AutomationRequests'
   include_concern 'Categories'
   include_concern 'Conditions'
+  include_concern 'ContainerDeployments'
   include_concern 'CustomAttributes'
   include_concern 'Events'
   include_concern 'Features'

--- a/app/controllers/api_controller/container_deployments.rb
+++ b/app/controllers/api_controller/container_deployments.rb
@@ -1,0 +1,17 @@
+class ApiController
+  module ContainerDeployments
+    def show_container_deployments
+      validate_api_action
+      if @req[:c_id] == "container_deployment_data"
+        render_resource :container_deployments, :data => ContainerDeploymentService.new.all_data
+      else
+        show_generic(:container_deployments)
+      end
+    end
+
+    def create_resource_container_deployments(_type, _id, data)
+      deployment = ContainerDeployment.new
+      deployment.create_deployment(data, @auth_user_obj)
+    end
+  end
+end

--- a/app/services/container_deployment_service.rb
+++ b/app/services/container_deployment_service.rb
@@ -1,0 +1,54 @@
+class ContainerDeploymentService
+  def all_data
+    {
+      :provision => possible_provision_providers,
+      :providers => possible_providers_and_vms
+    }.compact
+  end
+
+  def possible_provision_providers
+    providers = ExtManagementSystem.includes(:vm_or_template).select do |m|
+      m.instance_of?(ManageIQ::Providers::Amazon::CloudManager) ||
+        m.instance_of?(ManageIQ::Providers::Redhat::InfraManager)
+    end
+    providers.map do |provider|
+      {:provider => provider, :templates => templates(provider.miq_templates)}
+    end
+  end
+
+  def templates(templates)
+    templates.map do |template|
+      {
+        :cpu       => template.cpu_total_cores,
+        :memory    => template.mem_cpu,
+        :disk_size => ApplicationController.helpers.number_to_human_size(template.disks.first ? template.disks.first.size : 0),
+        :name      => template.name,
+        :ems_id    => template.ems_id,
+        :id        => template.id
+      }
+    end
+  end
+
+  def possible_providers_and_vms
+    providers = ExtManagementSystem.includes(:vm_or_template).select do |m|
+      m.kind_of?(ManageIQ::Providers::CloudManager) || m.kind_of?(ManageIQ::Providers::InfraManager)
+    end
+    providers.map do |provider|
+      {:provider => provider, :vms => optional_vms(provider.vms)}
+    end
+  end
+
+  def optional_vms(vms)
+    optional_vms = vms.select { |vm| !vm.hardware.ipaddresses.empty? }
+    optional_vms.map do |vm|
+      {
+        :cpu       => vm.hardware.cpu_total_cores,
+        :memory    => vm.hardware.memory_mb,
+        :disk_size => ApplicationController.helpers.number_to_human_size(vm.disks.first ? vm.disks.first.size : 0),
+        :name      => vm.name,
+        :ems_id    => vm.ems_id,
+        :id        => vm.id
+      }
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -154,6 +154,24 @@
       :delete:
       - :name: delete
         :identifier: chargeback_rates_delete
+  :container_deployments:
+    :description: Container Provider Deployment
+    :identifier: container_deployment
+    :klass: ContainerDeployment
+    :methods: *70174834084700
+    :options:
+    - :collection
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: container_deployment_show
+      :post:
+      - :name: create
+        :identifier: container_deployment_create
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: container_deployment_show
   :currencies:
     :description: Currencies
     :identifier: currency

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3234,6 +3234,30 @@
       :description: Re-check Authentication Status of Containers Providers
       :feature_type: control
       :identifier: ems_container_recheck_auth_status
+    - :name: Container Deployments
+      :description: Container Deployments
+      :feature_type: node
+      :identifier: container_deployment
+      :hidden: true
+      :children:
+      - :name: View
+        :description: View Container Deployments
+        :feature_type: view
+        :identifier: container_deployment_view
+        :children:
+        - :name: Container Deployment Show
+          :description:  Container Deployment Show
+          :feature_type: view
+          :identifier: container_deployment_show
+      - :name: Operate
+        :description: Perform Operations on Container Deployment
+        :feature_type: control
+        :identifier: container_deployment_control
+        :children:
+        - :name: Container Deployment Create
+          :description: Container Deployment Create
+          :feature_type: control
+          :identifier: container_deployment_create
   - :name: Modify
     :description: Modify Containers Providers
     :feature_type: admin

--- a/spec/factories/container_deployment.rb
+++ b/spec/factories/container_deployment.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :container_deployment, :class => "ContainerDeployment" do
+  end
+end

--- a/spec/factories/container_deployment_node.rb
+++ b/spec/factories/container_deployment_node.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :container_deployment_node, :class => "ContainerDeploymentNode" do
+  end
+end

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1046 }
+  let(:expected_feature_count) { 1051 }
 
   # - container_dashboard
   # - miq_report_widget_editor

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -232,5 +232,10 @@ describe ApiController do
       FactoryGirl.create(:zone, :name => "api zone")
       test_collection_query(:zones, zones_url, Zone)
     end
+
+    it "query ContainerDeployments" do
+      FactoryGirl.create(:container_deployment)
+      test_collection_query(:container_deployments, container_deployments_url, ContainerDeployment)
+    end
   end
 end

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -1,0 +1,16 @@
+describe ApiController do
+  it "supports collect-data with GET" do
+    allow_any_instance_of(ContainerDeploymentService).to receive(:cloud_init_template_id).and_return(1)
+    api_basic_authorize collection_action_identifier(:container_deployments, :read, :get)
+    run_get container_deployments_url + "/container_deployment_data"
+    expect_request_success
+    expect_hash_to_have_only_keys(response_hash["data"], %w(providers provision))
+  end
+
+  it "creates container deployment with POST" do
+    allow_any_instance_of(ContainerDeployment).to receive(:create_deployment).and_return(true)
+    api_basic_authorize collection_action_identifier(:container_deployments, :create)
+    run_post(container_deployments_url, gen_request(:create, :example_data => true))
+    expect_request_success
+  end
+end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -93,7 +93,8 @@ module ApiSpecHelper
                      policy_profiles providers provision_dialogs provision_requests rates
                      reports request_tasks requests resource_pools results roles security_groups
                      servers service_dialogs service_catalogs service_orders service_requests
-                     service_templates services settings tags tasks templates tenants users vms zones)
+                     service_templates services settings tags tasks templates tenants users vms zones
+                     container_deployments)
 
     define_entrypoint_url_methods
     define_url_methods(collections)


### PR DESCRIPTION
This pr adds functionality needed for creating a ContainerDeployment.
It adds four entrypoints:
- creating a ContainerDeployment using POST.
- getting all the data needed for the user in order to create his own deployment (providers, vms, templates)  using GET. (using the ContainerDeploymentService to get the data)
- getting a single ContainerDeployment using GET.
- getting ContainerDeployments using GET.