### PR TITLE
MiqQueue purge timer refactoring

### DIFF
--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -37,14 +37,12 @@ module Metric::Purging
 
   def self.purge_timer(ts, interval)
     MiqQueue.put_unless_exists(
-      :class_name    => name,
-      :method_name   => "purge",
-      :role          => "ems_metrics_processor",
-      :queue_name    => "ems_metrics_processor",
-      :state         => ["ready", "dequeue"],
-      :args_selector => ->(args) { args.kind_of?(Array) && args.last == interval }
+      :class_name  => name,
+      :method_name => "purge_#{interval}",
+      :role        => "ems_metrics_processor",
+      :queue_name  => "ems_metrics_processor"
     ) do |_msg, find_options|
-      find_options.merge(:args => [ts, interval])
+      find_options.merge(:args => [ts])
     end
   end
 
@@ -74,6 +72,18 @@ module Metric::Purging
     end
     _log.info("Purged #{count_tag_values} associated tag values.")
     count_tag_values
+  end
+
+  def self.purge_daily(older_than, window = nil, total_limit = nil, &block)
+    purge(older_than, "daily", window, total_limit, &block)
+  end
+
+  def self.purge_hourly(older_than, window = nil, total_limit = nil, &block)
+    purge(older_than, "hourly", window, total_limit, &block)
+  end
+
+  def self.purge_realtime(older_than, window = nil, total_limit = nil, &block)
+    purge(older_than, "realtime", window, total_limit, &block)
   end
 
   def self.purge(older_than, interval, window = nil, total_limit = nil, &block)

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -18,28 +18,26 @@ module VmdbMetric::Purging
 
     def purge_daily_timer(ts = nil)
       interval = "daily"
-      mode = :date  # Only support :date mode, not :remaining mode
       ts ||= purge_date(interval) || 6.months.ago.utc
-      purge_timer(mode, ts, interval)
+      purge_timer(ts, interval)
     end
 
     def purge_hourly_timer(ts = nil)
       interval = "hourly"
-      mode = :date  # Only support :date mode, not :remaining mode
       ts ||= purge_date(interval) || 6.months.ago.utc
-      purge_timer(mode, ts, interval)
+      purge_timer(ts, interval)
     end
 
-    def purge_timer(mode, value, interval)
+    def purge_timer(value, interval)
       MiqQueue.put_unless_exists(
         :class_name    => name,
-        :method_name   => "purge",
+        :method_name   => "purge_by_date",
         :role          => "database_operations",
         :queue_name    => "generic",
         :state         => ["ready", "dequeue"],
         :args_selector => ->(args) { args.kind_of?(Array) && args.last == interval }
       ) do |_msg, find_options|
-        find_options.merge(:args => [mode, value, interval])
+        find_options.merge(:args => [value, interval])
       end
     end
 
@@ -51,6 +49,7 @@ module VmdbMetric::Purging
       send("purge_count_by_#{mode}", value, interval)
     end
 
+    # deprecated, calling purge_by_date directly
     def purge(mode, value, interval, window = nil, &block)
       send("purge_by_#{mode}", value, interval, window, &block)
     end

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -12,12 +12,11 @@ describe Metric::Purging do
         q.each do |qi|
           expect(qi).to have_attributes(
             :class_name  => described_class.name,
-            :method_name => "purge"
           )
         end
 
-        modes = q.collect { |qi| qi.args.last }
-        expect(modes).to match_array %w(daily hourly realtime)
+        modes = q.collect { |qi| qi[:method_name] }
+        expect(modes).to match_array %w(purge_daily purge_hourly purge_realtime)
       end
     end
 


### PR DESCRIPTION
High level
--------------

In order to switch away from `MiqQueue`, we need to remove updates to the `queues` table. I'm just going through and deleting the low hanging fruit.

**Before:**

We often want to insert unique records into the queue. In a few places, uniqueness depends upon arguments in `args`. Read another way, `args` is currently part of the selection/uniqueness criteria. And essentially part of the addressing of the message. This field is big and can't be properly queried in the database. (read: all possible records are brought into ruby so we can determine if it is unique)

**After:**

Instead of using `args` as the delivery/uniqueness envelope, this pr moves the interesting portion of the arguments into the `method` (the method name itself). There are a fixed number of arguments available (3) so this does not increase the messaging surface area much. The delivery envelope no longer contains `args` and only the queue record of interest are now brought back. Better yet, determination of uniqueness can be done 100% by the queue and not rely upon ruby.

Low level
--------

**before:**

Looks up purge names by interval. interval is part of `args` so all possible records are brought back and an `args_selector` proc is used to help the queue determine if records already exist.

**after:**

The purge interval is part of the `message` so only matching records are brought back and uniqueness is done 100% in the database without using `args_selector`.

~~@Fryguy would you prefer `put_unless_exists`? I'd like most of this change even if we go that route. I just thought you were challenging the need for `put_unless_exists` for most of these requests~~ **YES** - **DONE**