### PR TITLE
Revert "Automate - Retirement - Remove miq_provision and/or tag code …

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -4,6 +4,8 @@
 
 # Get vm from root object
 vm = $evm.root['vm']
+category = "lifecycle"
+tag = "retire_full"
 
 removal_type = $evm.inputs['removal_type'].downcase
 $evm.set_state_var('vm_removed_from_provider', false)
@@ -12,9 +14,11 @@ if vm
   ems = vm.ext_management_system
   case removal_type
   when "remove_from_disk"
-    $evm.log('info', "Removing VM:<#{vm.name}> from provider:<#{ems.try(:name)}>")
-    vm.remove_from_disk(false)
-    $evm.set_state_var('vm_removed_from_provider', true)
+    if vm.miq_provision || vm.tagged_with?(category, tag)
+      $evm.log('info', "Removing VM:<#{vm.name}> from provider:<#{ems.try(:name)}>")
+      vm.remove_from_disk(false)
+      $evm.set_state_var('vm_removed_from_provider', true)
+    end
   when "unregister"
     $evm.log('info', "Unregistering VM:<#{vm.name}> from provider:<#{ems.try(:name)}")
     vm.unregister

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -4,6 +4,8 @@
 
 # Get vm from root object
 vm = $evm.root['vm']
+category = "lifecycle"
+tag = "retire_full"
 
 removal_type = $evm.inputs['removal_type'].downcase
 $evm.set_state_var('vm_removed_from_provider', false)
@@ -12,9 +14,11 @@ if vm
   ems = vm.ext_management_system
   case removal_type
   when "remove_from_disk"
-    $evm.log('info', "Removing VM:<#{vm.name}> from provider:<#{ems.try(:name)}>")
-    vm.remove_from_disk(false)
-    $evm.set_state_var('vm_removed_from_provider', true)
+    if vm.miq_provision || vm.tagged_with?(category, tag)
+      $evm.log('info', "Removing VM:<#{vm.name}> from provider:<#{ems.try(:name)}>")
+      vm.remove_from_disk(false)
+      $evm.set_state_var('vm_removed_from_provider', true)
+    end
   when "unregister"
     $evm.log('info', "Unregistering VM:<#{vm.name}> from provider:<#{ems.try(:name)}")
     vm.unregister

--- a/spec/automation/unit/method_validation/remove_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/remove_from_provider_spec.rb
@@ -7,6 +7,7 @@ describe "remove_from_provider Method Validation" do
     @vm         = FactoryGirl.create(:vm_vmware, :host => @host,
                  :ems_id => @ems.id, :name => "testVM", :raw_power_state => "poweredOn",
                  :registered => true)
+    @vm.tag_with("retire_full", :ns => "/managed", :cat => "lifecycle")
     @ins  = "/Infrastructure/VM/Retirement/StateMachines/Methods/RemoveFromProvider"
   end
 


### PR DESCRIPTION
ManageIQ domain retirement state machine default behavior was changed in PR #6290 to remove the restriction that the VM has to either be: 1. created by us, 2. tagged with lifecycle/retire_full. This PR reverts the prior change and puts those restrictions back in place.  

By DEFAULT, CF will delete machines/instances that CF provisioned when retirement is executed. CF will NOT delete machines it had not provisioned.
https://bugzilla.redhat.com/show_bug.cgi?id=1346962

This reverts commit 3e1b9e236fff5ef0d346c60c206c437d5caf0261.