### PR TITLE
Sort the tags and tags' categories case insensitive

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -313,12 +313,6 @@ module ApplicationController::Tags
         @entries.delete(a.description)                          # Remove them from the selection list
       end
     end
-
-    if @entries.length == 0                             # No entries left to choose from
-      @entries[_("<All values are assigned>")] = "select"
-    else
-      @entries[_("<Select a value to assign>")] = "select"
-    end
   end
 
   # Build the @edit elements for the tag edit screen
@@ -379,12 +373,6 @@ module ApplicationController::Tags
       if a.parent.description == @edit[:cat].description  # If they match the category
         @entries.delete(a.description)                    # Remove them from the selection list
       end
-    end
-
-    if @entries.length == 0                             # No entries left to choose from
-      @entries[_("<All values are assigned>")] = "select"
-    else
-      @entries[_("<Select a value to assign>")] = "select"
     end
   end
 

--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -12,7 +12,7 @@
             - if session[:assigned_filters].include?(cat_key.downcase)
               - @categories.delete(cat_key)
           = select_tag("tag_cat",
-            options_for_select(@categories.sort, @edit[:cat].name),
+            options_for_select(@categories.sort_by{|key, _| key.downcase}, @edit[:cat].name),
             "data-miq_observe"     => {:url => url}.to_json,
             "class"                => "selectpicker")
           :javascript

--- a/app/views/layouts/_tag_edit_cat_tags.html.haml
+++ b/app/views/layouts/_tag_edit_cat_tags.html.haml
@@ -1,7 +1,9 @@
 - url = url_for(:action => 'tag_edit_form_field_changed', :id => @sb[:rec_id] || @edit[:object_ids][0])
 #cat_tags_div
+  - tags = @entries.sort_by { |key, _| key.downcase }
+  - options = @entries.empty? ? [[_("<All values are assigned>"), "select"]] : [[_("<Select a value to assign>"), "select"]] + tags
   = select_tag("tag_add",
-    options_for_select(@entries.sort, "select"),
+    options_for_select(options, "select"),
     "data-miq_observe" => {:url => url}.to_json,
     "class"            => "selectpicker")
   :javascript


### PR DESCRIPTION
The tags and tag categories are sorted case sensitive in the dropdown list. They should be sorted case-insensitive

https://bugzilla.redhat.com/show_bug.cgi?id=1238580

