### PR TITLE
Gracefully stop httpd when starting the server

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -85,7 +85,7 @@ module MiqServer::EnvironmentManagement
     def prep_apache_proxying
       return unless MiqEnvironment::Command.supports_apache?
 
-      MiqApache::Control.kill_all
+      MiqApache::Control.stop
       MiqUiWorker.install_apache_proxy_config
       MiqWebServiceWorker.install_apache_proxy_config
       MiqWebsocketWorker.install_apache_proxy_config


### PR DESCRIPTION
Previously we would `killall -9 httpd` when starting the server.
This would leave around some IPC information in `/run/httpd` which could prevent the httpd service from coming up cleanly again with the error message `AH01179: balancer slotmem_create failed` in the miq_apache.log file.

This changes `MiqServer.prep_apache_proxying` to use a graceful shutdown instead which does not leave any files around in `/run/httpd`.

https://bugzilla.redhat.com/show_bug.cgi?id=1337525