### PR TITLE
Handle text for Floating Ips in grid views

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -110,6 +110,9 @@ module QuadiconHelper
       elsif db == "StorageManager"
         link_to(truncate_for_quad(row['name']),
                 url_for_db("storage_manager", "show"), :title => h(row['name']))
+      elsif db == "FloatingIp"
+        link_to(truncate_for_quad(item.address),
+                url_for_db(db, "show"), :title => h(item.address))
       else
         if @explorer
           column = case db

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -16,7 +16,7 @@ describe QuadiconHelper do
 
   describe "#render_quadicon_text" do
     before(:each) do
-      @settings = {:display => {:quad_truncate => "front"}}
+      @settings = {:display => {:quad_truncate => "m"}}
     end
 
     subject { helper.render_quadicon_text(item, row) }

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -15,19 +15,40 @@ describe QuadiconHelper do
   end
 
   describe "#render_quadicon_text" do
+    before(:each) do
+      @settings = {:display => {:quad_truncate => "front"}}
+    end
+
     subject { helper.render_quadicon_text(item, row) }
 
-    let(:item) do
-      FactoryGirl.create(:vm_vmware)
-    end
-
     let(:row) do
-      Ruport::Data::Record.new(:id => 10000000000534)
+      Ruport::Data::Record.new(:id => 10000000000534, "name" => name)
     end
 
-    it "render text for a vmware vm" do
-      expect(subject).to have_selector('a')
+    context "text for a VM" do
+      let(:item) do
+        FactoryGirl.create(:vm_vmware, :name => "vm_0000000000001")
+      end
+
+      let(:name) { item.name }
+
+      it "renders text for a vmware vm" do
+        expect(subject).to have_link("vm_00...00001")
+      end
     end
+
+    context "text for Floating IP" do
+      let(:item) do
+        FactoryGirl.create(:floating_ip_openstack)
+      end
+
+      let(:name) { nil }
+
+      it "renders a label for Floating IPs" do
+        expect(subject).to have_link(item.address)
+      end
+    end
+
   end
 
   describe "truncate text for quad icons" do

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -22,7 +22,7 @@ describe QuadiconHelper do
     subject { helper.render_quadicon_text(item, row) }
 
     let(:row) do
-      Ruport::Data::Record.new(:id => 10000000000534, "name" => name)
+      Ruport::Data::Record.new(:id => 10_000_000_000_534, "name" => name)
     end
 
     context "text for a VM" do
@@ -48,7 +48,6 @@ describe QuadiconHelper do
         expect(subject).to have_link(item.address)
       end
     end
-
   end
 
   describe "truncate text for quad icons" do


### PR DESCRIPTION

This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1344044

I found that the existing spec for `render_quadicon_text` would always pass as it was checking for presence of an anchor tag and this method always returns one even if there is no text. This PR improves that and adds a spec for the Floating IP case.

It does, however, add additional conditional branching "smell". Refactoring led to larger code changes and so I intend to do this in another PR.

**Before:**

![screen shot 2016-06-15 at 2 07 41 pm](https://cloud.githubusercontent.com/assets/39493/16097410/9d78eea6-3302-11e6-9b62-0ebc6e072663.png)


**After**

![screen shot 2016-06-15 at 2 07 49 pm](https://cloud.githubusercontent.com/assets/39493/16097431/a4b05164-3302-11e6-8d0f-da66b20e6c3d.png)


> * https://bugzilla.redhat.com/show_bug.cgi?id=1344044
