### PR TITLE
Quicker access to determine chargeback

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -183,6 +183,6 @@ class Chargeback < ActsAsArModel
   end
 
   def self.db_is_chargeback?(db)
-    subclasses.collect(&:to_s).include?(db)
+    db && db.safe_constantize < Chargeback
   end
 end # class Chargeback


### PR DESCRIPTION
accessing `subclasses` takes ~50ms each. There are only 17 groups, but this really adds up.

navigating in page:

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  8,925.1 |   44 |    24.2 |       59 |`/ops/tree_select/` **before**
|    411.2 |   44 |    14.0 |       59 |`/ops/tree_select/` **after**

This fixes performance issues introduced by #8989

/cc @lpichler this work for you?