### PR TITLE
Menu: generalize dashboard#maintab.

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -38,7 +38,7 @@ module Menu
         Menu::Section.new(:svc, N_("Services"), 'fa pficon-service fa-2x', [
           Menu::Item.new('services',       N_('My Services'), 'service',             {:feature => 'service', :any => true},             '/service/explorer'),
           Menu::Item.new('catalogs',       N_('Catalogs'),    'catalog',             {:feature => 'catalog', :any => true},             '/catalog/explorer'),
-          Menu::Item.new('vm_or_template', N_('Workloads'),   'vm_explorer_accords', {:feature => 'vm_explorer_accords', :any => true}, '/vm_or_template/explorer'),
+          Menu::Item.new('vm_or_template', N_('Workloads'),   'vm_explorer',         {:feature => 'vm_explorer', :any => true},         '/vm_or_template/explorer'),
           Menu::Item.new('miq_request_vm', N_('Requests'),    'miq_request',         {:feature => 'miq_request_show_list'},             '/miq_request?typ=vm')
         ])
       end
@@ -50,7 +50,7 @@ module Menu
           Menu::Item.new('cloud_tenant',        N_('Tenants'),             'cloud_tenant',              {:feature => 'cloud_tenant_show_list'},                  '/cloud_tenant'),
           Menu::Item.new('cloud_volume',        N_('Volumes'),             'cloud_volume',              {:feature => 'cloud_volume_show_list'},                  '/cloud_volume'),
           Menu::Item.new('flavor',              N_('Flavors'),             'flavor',                    {:feature => 'flavor_show_list'},                        '/flavor'),
-          Menu::Item.new('vm_cloud',            N_('Instances'),           'vm_cloud_explorer',         {:feature => 'vm_cloud_explorer_accords', :any => true}, '/vm_cloud/explorer'),
+          Menu::Item.new('vm_cloud',            N_('Instances'),           'vm_cloud_explorer',         {:feature => 'vm_cloud_explorer', :any => true}, '/vm_cloud/explorer'),
           Menu::Item.new('orchestration_stack', N_('Stacks'),              'orchestration_stack',       {:feature => 'orchestration_stack_show_list'},           '/orchestration_stack'),
           Menu::Item.new('auth_key_pair_cloud', N_('Key Pairs'),           'auth_key_pair_cloud',       {:feature => 'auth_key_pair_cloud_show_list'},           '/auth_key_pair_cloud'),
           Menu::Item.new('cloud_object_store_container',
@@ -70,7 +70,7 @@ module Menu
           Menu::Item.new('ems_cluster',      clusters_name,          'ems_cluster',   {:feature => 'ems_cluster_show_list'},   '/ems_cluster'),
           Menu::Item.new('host',             hosts_name,             'host',          {:feature => 'host_show_list'},          '/host'),
           Menu::Item.new('vm_infra',         N_('Virtual Machines'), 'vm_infra_explorer',
-                         {:feature => 'vm_infra_explorer_accords', :any => true},
+                         {:feature => 'vm_infra_explorer', :any => true},
                          '/vm_infra/explorer'),
           Menu::Item.new('resource_pool',    N_('Resource Pools'),   'resource_pool', {:feature => 'resource_pool_show_list'}, '/resource_pool'),
           Menu::Item.new('storage',          deferred_ui_lookup(:tables => 'storages'),

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -18,13 +18,13 @@ module Menu
 
       def cloud_inteligence_menu_section
         Menu::Section.new(:vi, N_("Cloud Intel"), 'fa fa-dashboard fa-2x', [
-          Menu::Item.new('dashboard',  N_('Dashboard'),  'dashboard',  {:feature => 'dashboard_view'},           '/dashboard/'),
+          Menu::Item.new('dashboard',  N_('Dashboard'),  'dashboard',  {:feature => 'dashboard_view'},           '/dashboard/show'),
           Menu::Item.new('report',     N_('Reports'),    'miq_report', {:feature => 'miq_report', :any => true}, '/report/explorer'),
           # Menu::Item.new('usage',    N_('Usage'),      'usage',      {:feature => 'usage'},                    '/report/usage/'), #  / Hiding usage for now - release 5.2
           Settings.product.consumption ? consumption_menu_section : nil,
           Menu::Item.new('chargeback', N_('Chargeback'), 'chargeback', {:feature => 'chargeback', :any => true}, '/chargeback/explorer'),
           Menu::Item.new('timeline',   N_('Timelines'),  'timeline',   {:feature => 'timeline'},                 '/dashboard/timeline/'),
-          Menu::Item.new('rss',        N_('RSS'),        'rss',        {:feature => 'rss'},                      '/alert/')
+          Menu::Item.new('rss',        N_('RSS'),        'rss',        {:feature => 'rss'},                      '/alert/show_list')
         ].compact)
       end
 

--- a/app/presenters/menu/section.rb
+++ b/app/presenters/menu/section.rb
@@ -41,6 +41,19 @@ module Menu
      end.present?
     end
 
+    def default_redirect_url
+      items.each do |item|
+        next unless item.visible?
+        if item.kind_of?(Item)
+          return item.url
+        else
+          section_result = item.default_redirect_url
+          return section_result if section_result
+        end
+      end
+      false
+    end
+
     def preprocess_sections(section_hash)
       items.each do |el|
         if el.kind_of?(Section)

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -240,17 +240,16 @@ describe DashboardController do
     end
 
     main_tabs = {
-      :clo => "vm_cloud_explorer",
-      :inf => "vm_infra_explorer",
-      :svc => "vm_explorer_accords"
+      :clo => ["vm_cloud_explorer", 'vm_cloud/explorer'],
+      :inf => ["vm_infra_explorer", 'vm_infra/explorer'],
+      :svc => ["vm_explorer",       'vm_or_template/explorer'],
     }
-    main_tabs.each do |tab, feature|
+    main_tabs.each do |tab, (feature, url)|
       it "for tab ':#{tab}'" do
         login_as FactoryGirl.create(:user, :features => feature)
         session[:tab_url] = {}
         post :maintab, :params => { :tab => tab }
-        url_controller = Menu::Manager.section(:set).features_recursive.find { |f| f.ends_with?("_explorer") }
-        expect(response.body).to include("#{DashboardController::EXPLORER_FEATURE_LINKS[url_controller]}/explorer")
+        expect(response.body).to include(url)
       end
     end
   end
@@ -267,8 +266,7 @@ describe DashboardController do
     it "for Configure maintab" do
       session[:tab_url] = {}
       post :maintab, :params => { :tab => "set" }
-      url_controller = Menu::Manager.section(:set).features_recursive.find { |f| f.ends_with?("_explorer") }
-      expect(response.body).to include("#{DashboardController::EXPLORER_FEATURE_LINKS[url_controller]}/explorer")
+      expect(response.body).to include("ops/explorer")
     end
   end
 


### PR DESCRIPTION
Remove ugly case in dashboard#maintab and implement the needed behavior in a generic way using Menu::Manager making it one less place that needs to be changed when changing menu structure or adding items.

Test by clicking on menu sections making sure that you get somewhere for the first click as well as that the last clicked item is remembered (and you get there) when you click a section.