### PR TITLE
Missing specs for migrations Add[Draft|Orderable]OrchestrationTemplates

### DIFF
--- a/spec/migrations/20150311181430_add_draft_to_orchestration_templates_spec.rb
+++ b/spec/migrations/20150311181430_add_draft_to_orchestration_templates_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe AddDraftToOrchestrationTemplates do
+  let(:orchestration_template_stub) { migration_stub(:OrchestrationTemplate) }
+
+  migration_context :up do
+    it "sets false to draft column" do
+      orchestration_template = orchestration_template_stub.create!
+
+      migrate
+
+      expect(orchestration_template.reload.draft).to be_falsey
+    end
+  end
+end

--- a/spec/migrations/20160203101130_add_orderable_to_orchestration_templates_spec.rb
+++ b/spec/migrations/20160203101130_add_orderable_to_orchestration_templates_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe AddOrderableToOrchestrationTemplates do
+  let(:orchestration_template_stub) { migration_stub(:OrchestrationTemplate) }
+
+  migration_context :up do
+    it "sets true to column orderable" do
+      orchestration_template = orchestration_template_stub.create!
+
+      migrate
+
+      expect(orchestration_template.reload.orderable).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/6739

There were missing specs for migrations:

https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20160203101130_add_orderable_to_orchestration_templates.

https://github.com/ManageIQ/manageiq/blob/master/spec/migrations/20160203101130_add_orderable_to_orchestration_templates_spec.rb

cc @Fryguy @jrafanie 
