### PR TITLE
Missing spec for migration AddGroupAndUserColumnsToMiqWidgetContents

### DIFF
--- a/spec/migrations/20140218232357_add_group_and_user_columns_to_miq_widget_contents_spec.rb
+++ b/spec/migrations/20140218232357_add_group_and_user_columns_to_miq_widget_contents_spec.rb
@@ -1,0 +1,23 @@
+require_migration
+
+describe AddGroupAndUserColumnsToMiqWidgetContents do
+  shared_examples "removing widget contents" do
+    let(:miq_widget_content_stub) { migration_stub(:MiqWidgetContent) }
+
+    it "removes all existing widget content" do
+      miq_widget_content_stub.create!
+
+      migrate
+
+      expect(miq_widget_content_stub.all).to be_empty
+    end
+  end
+
+  migration_context :up do
+    include_examples "removing widget contents"
+  end
+
+  migration_context :down do
+    include_examples "removing widget contents"
+  end
+end


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/6739

add missing spec for migration:

https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20140218232357_add_group_and_user_columns_to_miq_widget_contents.rb

cc @jrafanie @Fryguy 