### PR TITLE
Query for type-containing columns in migrations

### DIFF
--- a/db/migrate/20150109142457_namespace_ems_classes.rb
+++ b/db/migrate/20150109142457_namespace_ems_classes.rb
@@ -1,4 +1,6 @@
 class NamespaceEmsClasses < ActiveRecord::Migration
+  include MigrationHelper
+
   NAME_MAP = Hash[*%w(
     EmsCloud                               ManageIQ::Providers::CloudManager
     HostCloud                              ManageIQ::Providers::CloudManager::Host
@@ -23,58 +25,7 @@ class NamespaceEmsClasses < ActiveRecord::Migration
     VmVmware                               ManageIQ::Providers::Vmware::InfraManager::Vm
   )]
 
-  STI_TABLES = %w(
-    authentications
-    availability_zones
-    cloud_resource_quotas
-    cloud_tenants
-    cloud_volume_snapshots
-    cloud_volumes
-    customization_templates
-    dialog_fields
-    ext_management_systems
-    file_depots
-    flavors
-    floating_ips
-    hosts
-    jobs
-    miq_ae_classes
-    miq_cim_instances
-    miq_request_tasks
-    miq_requests
-    miq_storage_metrics
-    miq_workers
-    orchestration_stacks
-    orchestration_templates
-    pxe_images
-    pxe_menus
-    security_groups
-    service_templates
-    services
-    storage_managers
-    storage_metrics_metadata
-    vmdb_tables
-    vms
-  )
-
-  def remap(mapping)
-    condition_list = mapping.keys.map { |s| connection.quote(s) }.join(',')
-    case_expr = "CASE type " + mapping.map { |before, after| "WHEN #{connection.quote before} THEN #{connection.quote after}" }.join(' ') + " END"
-
-    STI_TABLES.each do |table|
-      execute "UPDATE #{table} SET type = #{case_expr} WHERE type IN (#{condition_list})"
-    end
-  end
-
-  def up
-    say_with_time "Rename class references for Vmware" do
-      remap(NAME_MAP)
-    end
-  end
-
-  def down
-    say_with_time "Rename class references for Vmware" do
-      remap(NAME_MAP.invert)
-    end
+  def change
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150630100251_namespace_ems_amazon.rb
+++ b/db/migrate/20150630100251_namespace_ems_amazon.rb
@@ -1,4 +1,6 @@
 class NamespaceEmsAmazon < ActiveRecord::Migration
+  include MigrationHelper
+
   NAME_MAP = Hash[*%w(
     AuthKeyPairCloud                           ManageIQ::Providers::CloudManager::AuthKeyPair
 
@@ -23,58 +25,7 @@ class NamespaceEmsAmazon < ActiveRecord::Migration
     ManageIQ::Providers::Amazon::CloudManager::OrchestrationServiceOptionConverter
   )]
 
-  STI_TABLES = %w(
-    authentications
-    availability_zones
-    cloud_resource_quotas
-    cloud_tenants
-    cloud_volume_snapshots
-    cloud_volumes
-    customization_templates
-    dialog_fields
-    ext_management_systems
-    file_depots
-    flavors
-    floating_ips
-    hosts
-    jobs
-    miq_ae_classes
-    miq_cim_instances
-    miq_request_tasks
-    miq_requests
-    miq_storage_metrics
-    miq_workers
-    orchestration_stacks
-    orchestration_templates
-    pxe_images
-    pxe_menus
-    security_groups
-    service_templates
-    services
-    storage_managers
-    storage_metrics_metadata
-    vmdb_tables
-    vms
-  )
-
-  def remap(mapping)
-    condition_list = mapping.keys.map { |s| connection.quote(s) }.join(',')
-    case_expr = "CASE type " + mapping.map { |before, after| "WHEN #{connection.quote before} THEN #{connection.quote after}" }.join(' ') + " END"
-
-    STI_TABLES.each do |table|
-      execute "UPDATE #{table} SET type = #{case_expr} WHERE type IN (#{condition_list})"
-    end
-  end
-
-  def up
-    say_with_time "Rename class references for Amazon" do
-      remap(NAME_MAP)
-    end
-  end
-
-  def down
-    say_with_time "Rename class references for Amazon" do
-      remap(NAME_MAP.invert)
-    end
+  def change
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150714053019_namespace_ems_redhat.rb
+++ b/db/migrate/20150714053019_namespace_ems_redhat.rb
@@ -1,4 +1,6 @@
 class NamespaceEmsRedhat < ActiveRecord::Migration
+  include MigrationHelper
+
   NAME_MAP = Hash[*%w(
     EmsRedhat                                  ManageIQ::Providers::Redhat::CloudManager
     AvailabilityZoneRedhat                     ManageIQ::Providers::Redhat::CloudManager::AvailabilityZone
@@ -18,58 +20,7 @@ class NamespaceEmsRedhat < ActiveRecord::Migration
     VmRedhat                                   ManageIQ::Providers::Redhat::CloudManager::Vm
   )]
 
-  STI_TABLES = %w(
-    authentications
-    availability_zones
-    cloud_resource_quotas
-    cloud_tenants
-    cloud_volume_snapshots
-    cloud_volumes
-    customization_templates
-    dialog_fields
-    ext_management_systems
-    file_depots
-    flavors
-    floating_ips
-    hosts
-    jobs
-    miq_ae_classes
-    miq_cim_instances
-    miq_request_tasks
-    miq_requests
-    miq_storage_metrics
-    miq_workers
-    orchestration_stacks
-    orchestration_templates
-    pxe_images
-    pxe_menus
-    security_groups
-    service_templates
-    services
-    storage_managers
-    storage_metrics_metadata
-    vmdb_tables
-    vms
-  )
-
-  def remap(mapping)
-    condition_list = mapping.keys.map { |s| connection.quote(s) }.join(',')
-    case_expr = "CASE type " + mapping.map { |before, after| "WHEN #{connection.quote before} THEN #{connection.quote after}" }.join(' ') + " END"
-
-    STI_TABLES.each do |table|
-      execute "UPDATE #{table} SET type = #{case_expr} WHERE type IN (#{condition_list})"
-    end
-  end
-
-  def up
-    say_with_time "Rename class references for RedHat" do
-      remap(NAME_MAP)
-    end
-  end
-
-  def down
-    say_with_time "Rename class references for RedHat" do
-      remap(NAME_MAP.invert)
-    end
+  def change
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150716021334_fix_redhat_namespace.rb
+++ b/db/migrate/20150716021334_fix_redhat_namespace.rb
@@ -1,4 +1,6 @@
 class FixRedhatNamespace < ActiveRecord::Migration
+  include MigrationHelper
+
   NAME_MAP = Hash[*%w(
     ManageIQ::Providers::Redhat::CloudManager
     ManageIQ::Providers::Redhat::InfraManager
@@ -22,58 +24,7 @@ class FixRedhatNamespace < ActiveRecord::Migration
     HostRedhat                             ManageIQ::Providers::Redhat::InfraManager::Host
   )]
 
-  STI_TABLES = %w(
-    authentications
-    availability_zones
-    cloud_resource_quotas
-    cloud_tenants
-    cloud_volume_snapshots
-    cloud_volumes
-    customization_templates
-    dialog_fields
-    ext_management_systems
-    file_depots
-    flavors
-    floating_ips
-    hosts
-    jobs
-    miq_ae_classes
-    miq_cim_instances
-    miq_request_tasks
-    miq_requests
-    miq_storage_metrics
-    miq_workers
-    orchestration_stacks
-    orchestration_templates
-    pxe_images
-    pxe_menus
-    security_groups
-    service_templates
-    services
-    storage_managers
-    storage_metrics_metadata
-    vmdb_tables
-    vms
-  )
-
-  def remap(mapping)
-    condition_list = mapping.keys.map { |s| connection.quote(s) }.join(',')
-    case_expr = "CASE type " + mapping.map { |before, after| "WHEN #{connection.quote before} THEN #{connection.quote after}" }.join(' ') + " END"
-
-    STI_TABLES.each do |table|
-      execute "UPDATE #{table} SET type = #{case_expr} WHERE type IN (#{condition_list})"
-    end
-  end
-
-  def up
-    say_with_time "Rename class references for RedHat" do
-      remap(NAME_MAP)
-    end
-  end
-
-  def down
-    say_with_time "Rename class references for RedHat" do
-      remap(NAME_MAP.invert)
-    end
+  def change
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150724030353_namespace_ems_foreman.rb
+++ b/db/migrate/20150724030353_namespace_ems_foreman.rb
@@ -1,4 +1,6 @@
 class NamespaceEmsForeman < ActiveRecord::Migration
+  include MigrationHelper
+
   NAME_MAP = Hash[*%w(
     ConfigurationManager                        ManageIQ::Providers::ConfigurationManager
     ProvisioningManager                         ManageIQ::Providers::ProvisioningManager
@@ -12,58 +14,7 @@ class NamespaceEmsForeman < ActiveRecord::Migration
     ProvisioningManagerForeman                  ManageIQ::Providers::Foreman::ProvisioningManager
   )]
 
-  STI_TABLES = %w(
-    authentications
-    availability_zones
-    cloud_resource_quotas
-    cloud_tenants
-    cloud_volume_snapshots
-    cloud_volumes
-    customization_templates
-    dialog_fields
-    ext_management_systems
-    file_depots
-    flavors
-    floating_ips
-    hosts
-    jobs
-    miq_ae_classes
-    miq_cim_instances
-    miq_request_tasks
-    miq_requests
-    miq_storage_metrics
-    miq_workers
-    orchestration_stacks
-    orchestration_templates
-    pxe_images
-    pxe_menus
-    security_groups
-    service_templates
-    services
-    storage_managers
-    storage_metrics_metadata
-    vmdb_tables
-    vms
-  )
-
-  def remap(mapping)
-    condition_list = mapping.keys.map { |s| connection.quote(s) }.join(',')
-    case_expr = "CASE type " + mapping.map { |before, after| "WHEN #{connection.quote before} THEN #{connection.quote after}" }.join(' ') + " END"
-
-    STI_TABLES.each do |table|
-      execute "UPDATE #{table} SET type = #{case_expr} WHERE type IN (#{condition_list})"
-    end
-  end
-
-  def up
-    say_with_time "Rename class references for Foreman" do
-      remap(NAME_MAP)
-    end
-  end
-
-  def down
-    say_with_time "Rename class references for Foreman" do
-      remap(NAME_MAP.invert)
-    end
+  def change
+    rename_class_references(NAME_MAP)
   end
 end


### PR DESCRIPTION
Query for type-containing columns, instead of listing them - then I think I can create more uniform specs for similar migration.

it was introduced https://github.com/matthewd/manageiq/commit/57face9800fbc5a837792e434c1a2a968e65ea7b

cc @jrafanie @Fryguy 