### PR TITLE
Don't squash EmsEvent purge queue calls

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -361,12 +361,13 @@ class EmsEvent < EventStream
   end
 
   def self.purge_queue(ts)
-    MiqQueue.put_or_update(
+    MiqQueue.put(
       :class_name  => name,
       :method_name => "purge",
       :role        => "event",
-      :queue_name  => "ems"
-    ) { |_msg, item| item.merge(:args => [ts]) }
+      :queue_name  => "ems",
+      :args        => [ts],
+    )
   end
 
   def self.purge(older_than, window = nil, limit = nil)

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -294,26 +294,13 @@ describe EmsEvent do
         described_class.purge_queue(purge_time)
       end
 
-      it "with nothing in the queue" do
+      it "submits to the queue" do
         q = MiqQueue.all
         expect(q.length).to eq(1)
         expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [purge_time]
-        )
-      end
-
-      it "with item already in the queue" do
-        new_purge_time = (Time.now + 20).round
-        described_class.purge_queue(new_purge_time)
-
-        q = MiqQueue.all
-        expect(q.length).to eq(1)
-        expect(q.first).to have_attributes(
-          :class_name  => described_class.name,
-          :method_name => "purge",
-          :args        => [new_purge_time]
         )
       end
     end


### PR DESCRIPTION
Purpose or Intent
-----------------

When putting work into miq queue, we want to manipulate the queue less. While my primary goal was to remove `MiqQueue.put_or_update`, when I was modifying purging queries, I ran across this which used `MiqQueue.put_unless_exists`. While it is less invasive, it still queries the queue, which is best to remove.

This one allows multiple ems purge calls. This may cause a little more work, but the same amount of data will be deleted at the end of the day.  And it is just a local request (vs a call over to an ems or something)

This was pulled out of #9232 - since that PR really had nothing to do with ems events.

/cc @lfu @Fryguy FYI