### PR TITLE
Timeline download buttons should show only when a report is available

### DIFF
--- a/app/helpers/application_helper/button/timeline_download.rb
+++ b/app/helpers/application_helper/button/timeline_download.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::TimelineDownload < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    self[:title] = N_("Choose a Timeline from the menus on the left.") if disabled?
+  end
+
+  def disabled?
+    @record.nil?
+  end
+end

--- a/app/helpers/application_helper/toolbar/timeline_center.rb
+++ b/app/helpers/application_helper/toolbar/timeline_center.rb
@@ -5,18 +5,21 @@ class ApplicationHelper::Toolbar::TimelineCenter < ApplicationHelper::Toolbar::B
       'fa fa-file-text-o fa-lg',
       N_('Download this Timeline data in text format'),
       nil,
-      :url => "/render_txt"),
+      :url => "/render_txt",
+      :klass => ApplicationHelper::Button::TimelineDownload),
     button(
       :timeline_csv,
       'fa fa-file-text-o fa-lg',
       N_('Download this Timeline data in CSV format'),
       nil,
-      :url => "/render_csv"),
+      :url => "/render_csv",
+      :klass => ApplicationHelper::Button::TimelineDownload),
     button(
       :timeline_pdf,
       'fa fa-file-pdf-o fa-lg',
       N_('Download this Timeline data in PDF format'),
       nil,
-      :url => "/render_pdf"),
+      :url => "/render_pdf",
+      :klass => ApplicationHelper::Button::TimelineDownload)
   ])
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1346594

Before
![timelines-before](https://cloud.githubusercontent.com/assets/6648365/16386435/114586b8-3c91-11e6-8766-192467bd693b.jpg)

After
![timelines-after](https://cloud.githubusercontent.com/assets/6648365/16386444/183b21e4-3c91-11e6-8ac1-e6d5af3dfeff.jpg)
