### PR TITLE
Making the refresh parser for middleware more robust

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
@@ -71,8 +71,8 @@ module ManageIQ::Providers
           :nativeid          => datasource.id,
           :ems_ref           => datasource.path
         }
-        unless config.empty? || config['value'].empty?
-          data[:properties] = config['value'].select { |k, _| k != 'Username' && k != 'Password' }
+        if !config.empty? && !config['value'].empty? && config['value'].respond_to?(:except)
+          data[:properties] = config['value'].except('Username', 'Password')
         end
         data
       end


### PR DESCRIPTION
Fixes #9196

I wasn't able to reproduce the issue @himdel saw, but I assume it was caused by calling the refresh on an uninitialized Hawkular. This 1 liner makes sure the .select method is not called if the object is not a Hash. The stacktrace told that it was failing because it was called on a string.

@miq-bot add_label providers/hawkular, bug