### PR TITLE
[api] Fix security groups identifier

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -877,7 +877,7 @@
         :identifier: rbac_role_delete
   :security_groups:
     :description: Security Groups
-    identifier: security_group
+    :identifier: security_group
     :options:
     - :collection
     :methods: *70174834086080


### PR DESCRIPTION
It was keyed as a string where every other identifier is keyed as a symbol.

@miq-bot add-label api
@miq-bot assign @abellotti 