### PR TITLE
Remove titles from Bootstrap Select drop-downs

### DIFF
--- a/app/assets/javascripts/directives/selectpickerForSelectTag.js
+++ b/app/assets/javascripts/directives/selectpickerForSelectTag.js
@@ -14,6 +14,9 @@ ManageIQ.angular.app.directive('selectpickerForSelectTag', function() {
           $(scope['form_' + ctrl.$name]).addClass('span12').selectpicker('setStyle');
         }
       });
+      scope.$watch('loaded.bs.select', function() {
+        $('.bootstrap-select button').removeAttr('title');
+      });
     }
   }
 });


### PR DESCRIPTION
Purpose or Intent
-----------------
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1343872

It removes HTML entities from the tooltip by explicitly setting the title attribute.

**Before**
![screen shot 2016-06-16 at 9 39 27 am](https://cloud.githubusercontent.com/assets/39493/16126215/06206a20-33ac-11e6-800c-56e36ef7b23e.png)

------------

**After**
![screen shot 2016-06-16 at 9 32 37 am](https://cloud.githubusercontent.com/assets/39493/16126236/1d09711e-33ac-11e6-9d8e-12309ad6cbb4.png)
