### PR TITLE
Delayed translation of UI constants, part 2

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -260,12 +260,12 @@ module ReportController::Widgets
       # If a folder node is selected
       get_all_widgets(WIDGET_CONTENT_TYPE[@sb[:nodes][1]])
       @right_cell_div  = "widget_list"
-      @right_cell_text = _("%{typ} %{model}") % {:typ => WIDGET_TYPES[@sb[:nodes][1]].singularize, :model => ui_lookup(:models => "MiqWidget")}
+      @right_cell_text = _("%{typ} %{model}") % {:typ => _(SINGULAR_WIDGET_TYPES[@sb[:nodes][1]]), :model => ui_lookup(:models => "MiqWidget")}
     else
       @record = @widget = MiqWidget.find_by_id(from_cid(@sb[:nodes].last))
       @widget_running = true if ["running", "queued"].include?(@widget.status.downcase)
       typ = WIDGET_CONTENT_TYPE.invert[@widget.content_type]
-      content_type = WIDGET_TYPES[typ].singularize
+      content_type = _(SINGULAR_WIDGET_TYPES[typ])
       @right_cell_text = _("%{typ} %{model} \"%{name}\"") % {:typ => content_type, :name => @widget.title, :model => ui_lookup(:model => "MiqWidget")}
       @right_cell_div  = "widget_list"
       @sb[:wtype] = WIDGET_CONTENT_TYPE.invert[@widget.content_type]

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -541,56 +541,85 @@ module UiConstants
 
   # FROM Date/Time expression atom selectors
   FROM_HOURS = [
-    _("This Hour"),
-    _("Last Hour"),
-  ] + Array.new(22) { |i| _("%{number} Hours Ago") % {:number => i + 2} }
+    N_('This Hour'),
+    N_('Last Hour'),
+    N_('2 Hours Ago'),
+    N_('3 Hours Ago'),
+    N_('4 Hours Ago'),
+    N_('5 Hours Ago'),
+    N_('6 Hours Ago'),
+    N_('7 Hours Ago'),
+    N_('8 Hours Ago'),
+    N_('9 Hours Ago'),
+    N_('10 Hours Ago'),
+    N_('11 Hours Ago'),
+    N_('12 Hours Ago'),
+    N_('13 Hours Ago'),
+    N_('14 Hours Ago'),
+    N_('15 Hours Ago'),
+    N_('16 Hours Ago'),
+    N_('17 Hours Ago'),
+    N_('18 Hours Ago'),
+    N_('19 Hours Ago'),
+    N_('20 Hours Ago'),
+    N_('21 Hours Ago'),
+    N_('22 Hours Ago'),
+    N_('23 Hours Ago')
+  ]
   FROM_DAYS = [
-    _("Today"),
-    _("Yesterday"),
-    _("2 Days Ago"),
-    _("3 Days Ago"),
-    _("4 Days Ago"),
-    _("5 Days Ago"),
-    _("6 Days Ago"),
-    _("7 Days Ago"),
-    _("14 Days Ago")
+    N_('Today'),
+    N_('Yesterday'),
+    N_('2 Days Ago'),
+    N_('3 Days Ago'),
+    N_('4 Days Ago'),
+    N_('5 Days Ago'),
+    N_('6 Days Ago'),
+    N_('7 Days Ago'),
+    N_('14 Days Ago')
   ]
   FROM_WEEKS = [
-    _("This Week"),
-    _("Last Week"),
-    _("2 Weeks Ago"),
-    _("3 Weeks Ago"),
-    _("4 Weeks Ago")
+    N_('This Week'),
+    N_('Last Week'),
+    N_('2 Weeks Ago'),
+    N_('3 Weeks Ago'),
+    N_('4 Weeks Ago')
   ]
   FROM_MONTHS = [
-    _("This Month"),
-    _("Last Month"),
-    _("2 Months Ago"),
-    _("3 Months Ago"),
-    _("4 Months Ago"),
-    _("6 Months Ago")
+    N_('This Month'),
+    N_('Last Month'),
+    N_('2 Months Ago'),
+    N_('3 Months Ago'),
+    N_('4 Months Ago'),
+    N_('6 Months Ago')
   ]
   FROM_QUARTERS = [
-    _("This Quarter"),
-    _("Last Quarter"),
-    _("2 Quarters Ago"),
-    _("3 Quarters Ago"),
-    _("4 Quarters Ago")
+    N_('This Quarter'),
+    N_('Last Quarter'),
+    N_('2 Quarters Ago'),
+    N_('3 Quarters Ago'),
+    N_('4 Quarters Ago')
   ]
   FROM_YEARS = [
-    _("This Year"),
-    _("Last Year"),
-    _("2 Years Ago"),
-    _("3 Years Ago"),
-    _("4 Years Ago")
+    N_('This Year'),
+    N_('Last Year'),
+    N_('2 Years Ago'),
+    N_('3 Years Ago'),
+    N_('4 Years Ago')
   ]
 
   # Need this for display purpose to map with id
   WIDGET_TYPES = {
-    "r"  => _("Reports"),
-    "c"  => _("Charts"),
-    "rf" => _("RSS Feeds"),
-    "m"  => _("Menus")
+    "r"  => N_('Reports'),
+    "c"  => N_('Charts'),
+    "rf" => N_('RSS Feeds'),
+    "m"  => N_('Menus')
+  }
+
+  SINGULAR_WIDGET_TYPES = {
+    "r"  => N_('Report'),
+    "c"  => N_('Chart'),
+    "rf" => N_('RSS Feed'),
+    "m"  => N_('Menu')
   }
   # Need this for mapping with MiqWidget record content_type field
   WIDGET_CONTENT_TYPE = {

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -15,7 +15,7 @@ class TreeBuilderReportWidgets < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = WIDGET_TYPES.collect { |k, v| {:id => k, :text => v, :image => 'folder', :tip => v} }
+    objects = WIDGET_TYPES.collect { |k, v| {:id => k, :text => _(v), :image => 'folder', :tip => _(v)} }
     count_only_or_objects(count_only, objects, nil)
   end
 

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -83,7 +83,7 @@
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? FROM_HOURS : [])
           - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
           = select_tag('chosen_from_1',
-            options_for_select(opts, @edit[@expkey][:exp_value][0]),
+            options_for_select(HASH[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :multiple              => false,
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -63,7 +63,7 @@
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? FROM_HOURS : [])
           - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
           = select_tag('chosen_from_1',
-            options_for_select(opts, @edit[@expkey][:exp_value][0]),
+            options_for_select(Hash[opts.map{|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :multiple              => false,
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
@@ -183,7 +183,7 @@
               - opts = (@edit[@expkey][:val2][:type] == :datetime ? FROM_HOURS : [])
               - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
               = select_tag('chosen_from_2',
-                options_for_select(opts, @edit[@expkey][:exp_cvalue][0]),
+                options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_cvalue][0]),
                 :multiple              => false,
                 "data-miq_sparkle_on"  => true,
                 "data-miq_sparkle_off" => true,

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -59,7 +59,7 @@
                   - elsif [:datetime, :date].include?(field_type)
                     - opts = (field_type == :datetime ? FROM_HOURS : []) + FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
                     = select_tag("styleval_#{f_idx}_#{s_idx}",
-                      options_for_select(opts, styles[s_idx][:value]),
+                      options_for_select(Hash[opts.map {|x| [_(x), x]}], styles[s_idx][:value]),
                       :multiple              => false,
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true,


### PR DESCRIPTION
Use delayed translations for UI constants. These constants are loaded at application startup
and therefore need to be translated when the constants are being used.

Continuation of pr #9086