### PR TITLE
Do not apply time profile if metric record represent daily aggregation

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -149,13 +149,14 @@ module Metric::Common
   Vmdb::Deprecation.deprecate_methods(self, :v_derived_logical_cpus_used => :v_derived_cpu_total_cores_used)
 
   # Applies the given time profile to this metric record
+  # unless record already refer to some time profile (which were used for aggregation)
   def apply_time_profile(profile)
-    unless profile.ts_in_profile?(timestamp)
+    if time_profile_id || profile.ts_in_profile?(timestamp)
+      self.inside_time_profile = true
+    else
       self.inside_time_profile = false
       nil_out_values_for_apply_time_profile
       _log.debug("Hourly Timestamp: [#{timestamp}] is outside of time profile: [#{profile.description}]")
-    else
-      self.inside_time_profile = true
     end
     inside_time_profile
   end

--- a/spec/models/metric/common_spec.rb
+++ b/spec/models/metric/common_spec.rb
@@ -36,6 +36,23 @@ describe Metric::Common do
       res = metric.apply_time_profile(profile)
       expect(res).to be_falsey
     end
+    
+    it "returns true if time profile were used for aggregation (and rollup record reffer to it)" do
+      profile = FactoryGirl.create(:time_profile,
+                                   :description => "foo",
+                                   :profile     => {:tz    => "New Delhi",
+                                                    :days  => [1],
+                                                    :hours => [1]})
+      profile_aggr = FactoryGirl.create(:time_profile,
+                                        :description => "used_for_daily_aggregation",
+                                        :profile     => {:tz    => "UTC",
+                                                         :days  => (2..4),
+                                                         :hours => TimeProfile::ALL_HOURS})
+
+      metric.time_profile_id = profile_aggr.id
+      res = metric.apply_time_profile(profile)
+      expect(res).to be_truthy
+    end
   end
 
   it ".v_derived_cpu_total_cores_used" do


### PR DESCRIPTION
Issue: Current logic in applying time profile to metric rollups does not differentiate between hourly and daily records. As a result, applying time profile with unchecked time slot 12-1 am to any daily trend report will filter out all daily rollup records since timestamp in daily record is 00:00.
Metric record with daily aggregation already refer to time profile (time_profile_id field)  which was used for aggregation and do not need to be altered

Fix:  do not apply any time profile if time_profile_id is not nil in metric rollup record

@miq-bot add-label bug, reporting, wip
/cc @Fryguy 