### PR TITLE
Automate - Added control for service resolution provision order.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -13,10 +13,30 @@ object:
   schema:
   - field:
       aetype: state
-      name: pre1
+      name: sequencer
       display_name: 
       datatype: string
       priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_serviceprovision_status(status => 'Processing Sequencer')
+      on_exit: update_serviceprovision_status(status => 'Processed Sequencer')
+      on_error: update_serviceprovision_status(status => 'Error Processing Sequencer')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: pre1
+      display_name: 
+      datatype: string
+      priority: 2
       owner: 
       default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/Preprovision"
       substitute: true
@@ -36,7 +56,7 @@ object:
       name: pre2
       display_name: 
       datatype: string
-      priority: 2
+      priority: 3
       owner: 
       default_value: 
       substitute: true
@@ -56,7 +76,7 @@ object:
       name: pre3
       display_name: 
       datatype: string
-      priority: 3
+      priority: 4
       owner: 
       default_value: 
       substitute: true
@@ -76,7 +96,7 @@ object:
       name: pre4
       display_name: 
       datatype: string
-      priority: 4
+      priority: 5
       owner: 
       default_value: 
       substitute: true
@@ -96,7 +116,7 @@ object:
       name: pre5
       display_name: 
       datatype: string
-      priority: 5
+      priority: 6
       owner: 
       default_value: 
       substitute: true
@@ -116,7 +136,7 @@ object:
       name: provision
       display_name: 
       datatype: string
-      priority: 6
+      priority: 7
       owner: 
       default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/Provision"
       substitute: true
@@ -136,7 +156,7 @@ object:
       name: checkprovisioned
       display_name: 
       datatype: string
-      priority: 7
+      priority: 8
       owner: 
       default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/CheckProvisioned"
       substitute: true
@@ -156,7 +176,7 @@ object:
       name: post1
       display_name: 
       datatype: string
-      priority: 8
+      priority: 9
       owner: 
       default_value: "/Cloud/Orchestration/Provisioning/StateMachines/Methods/PostProvision"
       substitute: true
@@ -176,7 +196,7 @@ object:
       name: post2
       display_name: 
       datatype: string
-      priority: 9
+      priority: 10
       owner: 
       default_value: 
       substitute: true
@@ -196,7 +216,7 @@ object:
       name: post3
       display_name: 
       datatype: string
-      priority: 10
+      priority: 11
       owner: 
       default_value: 
       substitute: true
@@ -216,7 +236,7 @@ object:
       name: post4
       display_name: 
       datatype: string
-      priority: 11
+      priority: 12
       owner: 
       default_value: 
       substitute: true
@@ -236,7 +256,7 @@ object:
       name: post5
       display_name: 
       datatype: string
-      priority: 12
+      priority: 13
       owner: 
       default_value: 
       substitute: true
@@ -256,7 +276,7 @@ object:
       name: EmailOwner
       display_name: 
       datatype: string
-      priority: 13
+      priority: 14
       owner: 
       default_value: "/Cloud/Orchestration/Provisioning/Email/ServiceProvision_complete?event=service_provisioned"
       substitute: true
@@ -276,7 +296,7 @@ object:
       name: Finished
       display_name: 
       datatype: string
-      priority: 14
+      priority: 15
       owner: 
       default_value: "/System/CommonMethods/StateMachineMethods/service_provision_finished"
       substitute: true

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/catalogiteminitization.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/catalogiteminitization.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: default
   fields:
+  - sequencer:
+      value: "/Service/Provisioning/StateMachines/Methods/GroupSequenceCheck"
   - pre1:
       value: "/Service/Provisioning/StateMachines/Methods/CatalogItemInitialization"
   - pre2:

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -13,10 +13,30 @@ object:
   schema:
   - field:
       aetype: state
-      name: pre1
+      name: sequencer
       display_name: 
       datatype: string
       priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_serviceprovision_status(status => 'Processing Sequencer')
+      on_exit: update_serviceprovision_status(status => 'Processed Sequencer')
+      on_error: update_serviceprovision_status(status => 'Error Processing Sequencer')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: pre1
+      display_name: 
+      datatype: string
+      priority: 2
       owner: 
       default_value: Method::preprovision
       substitute: true
@@ -36,7 +56,7 @@ object:
       name: pre2
       display_name: 
       datatype: string
-      priority: 2
+      priority: 3
       owner: 
       default_value: 
       substitute: true
@@ -56,7 +76,7 @@ object:
       name: pre3
       display_name: 
       datatype: string
-      priority: 3
+      priority: 4
       owner: 
       default_value: 
       substitute: true
@@ -76,7 +96,7 @@ object:
       name: pre4
       display_name: 
       datatype: string
-      priority: 4
+      priority: 5
       owner: 
       default_value: 
       substitute: true
@@ -96,7 +116,7 @@ object:
       name: pre5
       display_name: 
       datatype: string
-      priority: 5
+      priority: 6
       owner: 
       default_value: 
       substitute: true
@@ -116,7 +136,7 @@ object:
       name: provision
       display_name: 
       datatype: string
-      priority: 6
+      priority: 7
       owner: 
       default_value: Method::provision
       substitute: true
@@ -136,7 +156,7 @@ object:
       name: checkprovisioned
       display_name: 
       datatype: string
-      priority: 7
+      priority: 8
       owner: 
       default_value: Method::check_provisioned
       substitute: true
@@ -156,7 +176,7 @@ object:
       name: post1
       display_name: 
       datatype: string
-      priority: 8
+      priority: 9
       owner: 
       default_value: Method::post_provision
       substitute: true
@@ -176,7 +196,7 @@ object:
       name: post2
       display_name: 
       datatype: string
-      priority: 9
+      priority: 10
       owner: 
       default_value: 
       substitute: true
@@ -196,7 +216,7 @@ object:
       name: post3
       display_name: 
       datatype: string
-      priority: 10
+      priority: 11
       owner: 
       default_value: 
       substitute: true
@@ -216,7 +236,7 @@ object:
       name: post4
       display_name: 
       datatype: string
-      priority: 11
+      priority: 12
       owner: 
       default_value: 
       substitute: true
@@ -236,7 +256,7 @@ object:
       name: post5
       display_name: 
       datatype: string
-      priority: 12
+      priority: 13
       owner: 
       default_value: 
       substitute: true
@@ -256,7 +276,7 @@ object:
       name: EmailOwner
       display_name: 
       datatype: string
-      priority: 13
+      priority: 14
       owner: 
       default_value: "/ConfigurationManagement/AnsibleTower/Service/Provisioning/Email/ServiceProvision_complete?event=service_provisioned"
       substitute: true
@@ -276,7 +296,7 @@ object:
       name: Finished
       display_name: 
       datatype: string
-      priority: 14
+      priority: 15
       owner: 
       default_value: "/System/CommonMethods/StateMachineMethods/service_provision_finished"
       substitute: true

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/provision_from_bundle.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/provision_from_bundle.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: default
   fields:
+  - sequencer:
+      value: "/Service/Provisioning/StateMachines/Methods/GroupSequenceCheck"
   - pre1:
       value: "/Service/Provisioning/StateMachines/Methods/CatalogItemInitialization"
   - pre2:

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__class__.yaml
@@ -13,10 +13,30 @@ object:
   schema:
   - field:
       aetype: state
-      name: pre1
+      name: sequencer
       display_name: 
       datatype: string
       priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_serviceprovision_status(status => 'Processing Sequencer')
+      on_exit: update_serviceprovision_status(status => 'Processed Sequencer')
+      on_error: update_serviceprovision_status(status => 'Error Processing Sequencer')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: pre1
+      display_name: 
+      datatype: string
+      priority: 2
       owner: 
       default_value: 
       substitute: true
@@ -36,7 +56,7 @@ object:
       name: pre2
       display_name: 
       datatype: string
-      priority: 2
+      priority: 3
       owner: 
       default_value: 
       substitute: true
@@ -56,7 +76,7 @@ object:
       name: pre3
       display_name: 
       datatype: string
-      priority: 3
+      priority: 4
       owner: 
       default_value: 
       substitute: true
@@ -76,7 +96,7 @@ object:
       name: pre4
       display_name: 
       datatype: string
-      priority: 4
+      priority: 5
       owner: 
       default_value: 
       substitute: true
@@ -96,7 +116,7 @@ object:
       name: pre5
       display_name: 
       datatype: string
-      priority: 5
+      priority: 6
       owner: 
       default_value: 
       substitute: true
@@ -116,7 +136,7 @@ object:
       name: configurechilddialog
       display_name: 
       datatype: string
-      priority: 6
+      priority: 7
       owner: 
       default_value: 
       substitute: true
@@ -136,7 +156,7 @@ object:
       name: provision
       display_name: 
       datatype: string
-      priority: 7
+      priority: 8
       owner: 
       default_value: "/Service/Provisioning/StateMachines/Methods/Provision"
       substitute: true
@@ -156,7 +176,7 @@ object:
       name: checkprovisioned
       display_name: 
       datatype: string
-      priority: 8
+      priority: 9
       owner: 
       default_value: "/Service/Provisioning/StateMachines/Methods/CheckProvisioned"
       substitute: true
@@ -176,7 +196,7 @@ object:
       name: post1
       display_name: 
       datatype: string
-      priority: 9
+      priority: 10
       owner: 
       default_value: 
       substitute: true
@@ -196,7 +216,7 @@ object:
       name: post2
       display_name: 
       datatype: string
-      priority: 10
+      priority: 11
       owner: 
       default_value: 
       substitute: true
@@ -216,7 +236,7 @@ object:
       name: post3
       display_name: 
       datatype: string
-      priority: 11
+      priority: 12
       owner: 
       default_value: 
       substitute: true
@@ -236,7 +256,7 @@ object:
       name: post4
       display_name: 
       datatype: string
-      priority: 12
+      priority: 13
       owner: 
       default_value: 
       substitute: true
@@ -256,7 +276,7 @@ object:
       name: post5
       display_name: 
       datatype: string
-      priority: 13
+      priority: 14
       owner: 
       default_value: 
       substitute: true
@@ -276,7 +296,7 @@ object:
       name: EmailOwner
       display_name: 
       datatype: string
-      priority: 14
+      priority: 15
       owner: 
       default_value: "/Service/Provisioning/Email/ServiceProvision_complete?event=service_provisioned"
       substitute: true
@@ -296,7 +316,7 @@ object:
       name: Finished
       display_name: 
       datatype: string
-      priority: 15
+      priority: 16
       owner: 
       default_value: "/System/CommonMethods/StateMachineMethods/service_provision_finished"
       substitute: true

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/catalogiteminitialization.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/catalogiteminitialization.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: 
   fields:
+  - sequencer:
+      value: "/Service/Provisioning/StateMachines/Methods/GroupSequenceCheck"
   - pre1:
       value: "/Service/Provisioning/StateMachines/Methods/DialogParser"
   - pre2:

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/clone_to_service.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/clone_to_service.yaml
@@ -8,5 +8,5 @@ object:
     inherits: 
     description: clone_to_service
   fields:
-  - pre1:
+  - sequencer:
       value: "/Service/Provisioning/StateMachines/Methods/GroupSequenceCheck"


### PR DESCRIPTION
Modified  /Service/Provisioning/StateMachines/CatalogItemInitialization instance

and added GroupSequenceCheck method to run first.

This will allow provision services items in Service Bundles to run in order.

https://trello.com/c/TrW9f1IA