### PR TITLE
Virtual total cleanup

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -476,18 +476,6 @@ class ExtManagementSystem < ApplicationRecord
     ["#{events_table_name(assoc)}.ems_id = ?", id]
   end
 
-  def total_miq_templates
-    miq_templates.size
-  end
-
-  def total_hosts
-    hosts.size
-  end
-
-  def total_clusters
-    ems_clusters.size
-  end
-
   def total_storages
     HostStorage.where(:host_id => host_ids).count("DISTINCT storage_id")
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -14,6 +14,7 @@ require 'HostScanProfiles'
 
 class Host < ApplicationRecord
   include NewWithTypeStiMixin
+  include VirtualTotalMixin
 
   VENDOR_TYPES = {
     # DB            Displayed
@@ -115,9 +116,6 @@ class Host < ApplicationRecord
   virtual_column :v_owning_cluster,             :type => :string,      :uses => :ems_cluster
   virtual_column :v_owning_datacenter,          :type => :string,      :uses => :all_relationships
   virtual_column :v_owning_folder,              :type => :string,      :uses => :all_relationships
-  virtual_column :v_total_storages,             :type => :integer,     :uses => :storages
-  virtual_column :v_total_vms,                  :type => :integer,     :uses => :vms
-  virtual_column :v_total_miq_templates,        :type => :integer,     :uses => :miq_templates
   virtual_column :total_vcpus,                  :type => :integer,     :uses => :cpu_total_cores
   virtual_column :num_cpu,                      :type => :integer,     :uses => :hardware
   virtual_column :cpu_total_cores,              :type => :integer,     :uses => :hardware
@@ -154,6 +152,10 @@ class Host < ApplicationRecord
   virtual_has_many  :file_shares,          :class_name => 'SniaFileShare'
   virtual_has_many  :storage_volumes,      :class_name => 'CimStorageVolume'
   virtual_has_many  :logical_disks,        :class_name => 'CimLogicalDisk'
+
+  virtual_total :v_total_storages, :storages
+  virtual_total :v_total_vms, :vms
+  virtual_total :v_total_miq_templates, :miq_templates
 
   alias_method :datastores, :storages    # Used by web-services to return datastores as the property name
 
@@ -1519,19 +1521,6 @@ class Host < ApplicationRecord
   def v_owning_datacenter
     o = owning_datacenter
     o ? o.name : ""
-  end
-
-  # Virtual cols for relationship counts
-  def v_total_storages
-    storages.size
-  end
-
-  def v_total_vms
-    vms.size
-  end
-
-  def v_total_miq_templates
-    miq_templates.size
   end
 
   def miq_scsi_luns

--- a/app/models/mixins/virtual_total_mixin.rb
+++ b/app/models/mixins/virtual_total_mixin.rb
@@ -19,9 +19,13 @@ module VirtualTotalMixin
         send(relation).try(:size) || 0
       end
 
-      # allow this attribute to be sorted in the database
-      if (reflection = reflect_on_association(relation))
-        arel = options[:arel] || lambda do |t|
+      reflection = reflect_on_association(relation)
+
+      if options.key?(:arel)
+        arel = options.dup.delete(:arel)
+        arel = nil if !arel || !reflection
+      elsif reflection && reflection.macro == :has_many && !reflection.options[:through]
+        arel = lambda do |t|
           foreign_table = reflection.klass.arel_table
           # need db access for the keys, so delaying all this lookup until call time
           local_key = reflection.active_record_primary_key
@@ -30,6 +34,9 @@ module VirtualTotalMixin
           Arel::Nodes::Grouping.new(foreign_table.project(Arel.star.count)
                                                  .where(t[local_key].eq(foreign_table[foreign_key])))
         end
+      end
+
+      if arel
         virtual_attribute name, :integer, :uses => options[:uses] || relation, :arel => arel
       else
         virtual_attribute name, :integer, **options

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -16,7 +16,7 @@ class SecurityGroup < ApplicationRecord
   has_and_belongs_to_many :vms
   has_and_belongs_to_many :network_ports
 
-  virtual_total :total_vms, :vms
+  virtual_total :total_vms, :vms, :arel => nil
 
   def self.non_cloud_network
     where(:cloud_network_id => nil)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -156,42 +156,42 @@ describe ExtManagementSystem do
     end
   end
 
-  context "with virtual columns" do
+  context "with virtual totals" do
     before(:each) do
       @ems = FactoryGirl.create(:ems_vmware)
-      (1..5).each { |i| FactoryGirl.create(:vm_vmware, :ext_management_system => @ems, :name => "vm_#{i}") }
+      (1..2).each { |i| FactoryGirl.create(:vm_vmware, :ext_management_system => @ems, :name => "vm_#{i}") }
     end
 
     it "#total_vms_on" do
-      expect(@ems.total_vms_on).to eq(5)
+      expect(@ems.total_vms_on).to eq(2)
     end
 
     it "#total_vms_off" do
       expect(@ems.total_vms_off).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "poweredOff") }
-      expect(@ems.total_vms_off).to eq(5)
+      expect(@ems.total_vms_off).to eq(2)
     end
 
     it "#total_vms_unknown" do
       expect(@ems.total_vms_unknown).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "unknown") }
-      expect(@ems.total_vms_unknown).to eq(5)
+      expect(@ems.total_vms_unknown).to eq(2)
     end
 
     it "#total_vms_never" do
       expect(@ems.total_vms_never).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "never") }
-      expect(@ems.total_vms_never).to eq(5)
+      expect(@ems.total_vms_never).to eq(2)
     end
 
     it "#total_vms_suspended" do
       expect(@ems.total_vms_suspended).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "suspended") }
-      expect(@ems.total_vms_suspended).to eq(5)
+      expect(@ems.total_vms_suspended).to eq(2)
     end
 
     %w(total_vms_on total_vms_off total_vms_unknown total_vms_never total_vms_suspended).each do |vcol|

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -199,6 +199,33 @@ describe ExtManagementSystem do
         expect(described_class).to have_virtual_column "#{vcol}", :integer
       end
     end
+
+    it "#total_vms" do
+      expect(@ems.total_vms).to eq(2)
+    end
+
+    it "#total_vms_and_templates" do
+      FactoryGirl.create(:template_vmware, :ext_management_system => @ems)
+      expect(@ems.total_vms_and_templates).to eq(3)
+    end
+
+    it "#total_miq_templates" do
+      FactoryGirl.create(:template_vmware, :ext_management_system => @ems)
+      expect(@ems.total_miq_templates).to eq(1)
+    end
+  end
+
+  describe "#total_clusters" do
+    it "knows it has none" do
+      ems = FactoryGirl.create(:ems_vmware)
+      expect(ems.total_clusters).to eq(0)
+    end
+
+    it "knows it has one" do
+      ems = FactoryGirl.create(:ems_vmware)
+      FactoryGirl.create(:ems_cluster, :ext_management_system => ems)
+      expect(ems.total_clusters).to eq(1)
+    end
   end
 
   context "validates" do

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -369,4 +369,31 @@ describe Host do
       expect(host.ems_cluster).not_to be_nil
     end
   end
+
+  describe "#v_total_storages" do
+    it "counts" do
+      host = FactoryGirl.create(:host)
+      host.storages.create(FactoryGirl.attributes_for(:storage))
+      expect(host.v_total_storages).to eq(1)
+      expect(Host.attribute_supported_by_sql?(:v_total_storages)).to be false
+    end
+  end
+
+  describe "#v_total_vms" do
+    it "counts" do
+      host = FactoryGirl.create(:host)
+      FactoryGirl.create(:vm, :host => host)
+      expect(host.v_total_vms).to eq(1)
+      expect(Host.attribute_supported_by_sql?(:v_total_vms)).to be true
+    end
+  end
+
+  describe "#v_total_miq_templates" do
+    it "counts" do
+      host = FactoryGirl.create(:host)
+      FactoryGirl.create(:template, :host => host)
+      expect(host.v_total_miq_templates).to eq(1)
+      expect(Host.attribute_supported_by_sql?(:v_total_miq_templates)).to be true
+    end
+  end
 end

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -1,5 +1,5 @@
 describe VirtualTotalMixin do
-  describe ".virtual_total (with real relation ems#total_vms)" do
+  describe ".virtual_total (with real has_many relation ems#total_vms)" do
     let(:base_model) { ExtManagementSystem }
     it "sorts by total" do
       ems0 = model_with_children(0)
@@ -31,6 +31,10 @@ describe VirtualTotalMixin do
       expect(model_with_children(2).total_vms).to eq(2)
     end
 
+    it "is not defined in sql" do
+      expect(base_model.attribute_supported_by_sql?(:total_vms)).to be(true)
+    end
+
     def model_with_children(count)
       FactoryGirl.create(:resource_pool).tap do |pool|
         count.times do |_i|
@@ -38,6 +42,25 @@ describe VirtualTotalMixin do
           vm.with_relationship_type("ems_metadata") { vm.set_parent pool }
         end
       end
+    end
+  end
+
+  describe ".virtual_total (with through relation (host#v_total_storages)" do
+    let(:base_model) { Host }
+
+    it "calculates totals locally" do
+      expect(model_with_children(0).v_total_storages).to eq(0)
+      expect(model_with_children(2).v_total_storages).to eq(2)
+    end
+
+    it "is not defined in sql" do
+      expect(base_model.attribute_supported_by_sql?(:v_total_storages)).to be(false)
+    end
+
+    def model_with_children(count)
+      FactoryGirl.create(:host).tap do |host|
+        count.times { host.storages.create(FactoryGirl.attributes_for(:storage)) }
+      end.reload
     end
   end
 end

--- a/spec/models/security_group_spec.rb
+++ b/spec/models/security_group_spec.rb
@@ -9,4 +9,16 @@ describe SecurityGroup do
   it ".non_cloud_network" do
     expect(SecurityGroup.non_cloud_network).to eq([@sg2])
   end
+
+  describe "#total_vms" do
+    it "counts vms" do
+      sg = FactoryGirl.create(:security_group)
+      2.times { sg.vms.create(FactoryGirl.attributes_for(:vm)) }
+      expect(sg.reload.total_vms).to eq(2)
+    end
+
+    it "doesnt support sql" do
+      expect(SecurityGroup.attribute_supported_by_sql?(:total_vms)).to be false
+    end
+  end
 end


### PR DESCRIPTION
Fixed `virtual_total` (think `virtual_attribute` for totals) to only generated sql for `has_many` relationships.
It was trying to generate sql for `has_and_belongs_to_many` and `has_many :through` but they are a little different. Will circle back at a later time to get performance gains for those other columns.

see [below] for details on what exactly is `virtual_total`.
[below]: https://github.com/ManageIQ/manageiq/pull/9263#issuecomment-227633692

**before:**

A `virtual_total` was generating bad sql with an exception:

```
PG::UndefinedColumn: ERROR:  column vms.security_group_id does not exist
```

https://bugzilla.redhat.com/show_bug.cgi?id=1343454

**after:**

1. only provides sql support for simple relations
2. adds tests around more of the columns and the base cases.
3. added `virtual totals` for `Host` and `SecurityGroup`, so we can test the various uses cases and have better test coverage, ensure sql is disabled where it was not supported.
4. removed unneeded methods from `ExtManagementSystem`

/cc @Ladas There is a higher level problem. `vm_totals` is not calculated the same for all security groups. So the `virtual_total` will never be able to be generic / calculated.