### PR TITLE
Fix sort menu that would drop down instead of up

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1345,10 +1345,9 @@ function miqSerializeField(element, field_name) {
 }
 
 function miqInitSelectPicker() {
-  $('.selectpicker').selectpicker();
   $('.selectpicker').selectpicker({
-    style: 'btn-info',
-    size: 10
+    size: 10,
+    dropupAuto: false
   });
   $('.bootstrap-select > button[title]').not('.selectpicker').tooltip({container: 'none'});
 }


### PR DESCRIPTION
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1344005

The bootstrap-select menu was trying to guess if it should be dropping-up and would get it wrong. After initially dropping-up correctly, the menu would drop-down. The fix is to force it always up.

**Before**
![screen shot 2016-06-16 at 2 55 04 pm](https://cloud.githubusercontent.com/assets/39493/16134665/51c3f72c-33d3-11e6-87bc-23d31bde055a.png)

-----

**After**
![screen shot 2016-06-16 at 2 55 41 pm](https://cloud.githubusercontent.com/assets/39493/16134667/5769ad02-33d3-11e6-8716-4bb3b780fc12.png)


* Passing dropupAuto: false makes bs select keep dropup class if it is present on the element.
* Previously this code initialized the select then passed options that were ignored. This change removes code that did nothing.