### PR TITLE
Align haml correctly in chargeback assigments

### DIFF
--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -10,7 +10,7 @@
         = _('Assign To')
       .col-md-8
         - options = ASSIGN_TOS[x_node.split('-').last == "Compute" ? "chargeback_compute".to_sym : "chargeback_storage".to_sym].map do |k, v|
-          [v.kind_of?(PostponedTranslation) ? v.translate : _(v), k]
+          - [v.kind_of?(PostponedTranslation) ? v.translate : _(v), k]
         = select_tag("cbshow_typ", options_for_select([[nothing, "nil"]] + options, @edit[:new][:cbshow_typ]),
                     "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker")
       :javascript


### PR DESCRIPTION
after https://github.com/ManageIQ/manageiq/pull/9086


before
![screen shot 2016-06-17 at 11 31 27](https://cloud.githubusercontent.com/assets/14937244/16146593/3b197b6c-347f-11e6-83d1-f04b4311c6a9.png)
after
![screen shot 2016-06-17 at 11 33 50](https://cloud.githubusercontent.com/assets/14937244/16146627/65285dc4-347f-11e6-8eb3-52d309698b27.png)
cc @martinpovolny @mzazrivec 

I skimmed through the PR and other similar cases have not found
