### PR TITLE
C&U charts interactivity fix

### DIFF
--- a/app/views/layouts/_perf_chart_js.html.haml
+++ b/app/views/layouts/_perf_chart_js.html.haml
@@ -30,6 +30,7 @@
                           "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}_2",
                           "style"           => "position: fixed;"}
         :javascript
+          $('body').addClass('cards-pf');
           $("#miq_chart_parent_#{chart_set}_#{chart_index}_2").on('hidden.bs.dropdown', function() {
             $("#miq_chartmenu_#{chart_set}_#{chart_index}_2").empty();
             $("#miq_chart_parent_#{chart_set}_#{chart_index}_2 .overlay").hide();
@@ -53,6 +54,7 @@
                         "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}",
                         "style"           => "position: fixed;"}
     :javascript
+      $('body').addClass('cards-pf');
       miqChartBindEvents("#{chart_set}", #{chart_index});
       $("#miq_chart_parent_#{chart_set}_#{chart_index}").on('hidden.bs.dropdown', function() {
         $("#miq_chartmenu_#{chart_set}_#{chart_index}").empty();

--- a/app/views/layouts/_perf_charts.html.haml
+++ b/app/views/layouts/_perf_charts.html.haml
@@ -49,12 +49,18 @@
           - if @html
             .row
               .col-md-6
-                %h3= _("VM \"%{name}\"") % {:name => @perf_record.name}
-                = @html.html_safe
+                .card-pf
+                  .card-pf-heading
+                    %h2.card-pf-title= _("VM \"%{name}\"") % {:name => @perf_record.name}
+                  .card-pf-body
+                    = @html.html_safe
               - if @p_html
                 .col-md-6
-                  %h3= "#{ui_lookup(:model => @perf_options[:parent])} #{@perf_record.send(@perf_options[:parent].underscore).name}"
-                  = @p_html.html_safe
+                  .card-pf
+                    .card-pf-heading
+                      %h2.card-pf-title= "#{ui_lookup(:model => @perf_options[:parent])} #{@perf_record.send(@perf_options[:parent].underscore).name}"
+                    .card-pf-body
+                      = @p_html.html_safe
         - else
           = render :partial => 'layouts/info_msg', :locals => {:message => _("No Capacity & Utilization data available.")}
       - elsif perf_compare_vm?


### PR DESCRIPTION
Fixing broken C&U charts interactivity from #8645. When menu shown after right click, it wont disappear until reload of page. It was caused by adding open class to wrong div.


Before:
![screenshot from 2016-05-18 15-29-39](https://cloud.githubusercontent.com/assets/9535558/16149791/63fcfc70-3493-11e6-9188-494738124283.png)
After:
![screenshot from 2016-06-21 13-20-06](https://cloud.githubusercontent.com/assets/9535558/16227768/02b52b18-37b3-11e6-9fb4-65c54d0af7de.png)
![screenshot from 2016-06-21 13-20-27](https://cloud.githubusercontent.com/assets/9535558/16227769/02bc8dd6-37b3-11e6-8750-8447bfe4b43e.png)

Compare screen with report table:
![screenshot from 2016-06-22 13-11-54](https://cloud.githubusercontent.com/assets/9535558/16264654/0be2f724-387b-11e6-8070-67fa9baf07e6.png)
![screenshot from 2016-06-22 13-11-43](https://cloud.githubusercontent.com/assets/9535558/16264657/0d933ade-387b-11e6-8da7-0265bd86eb33.png)


@martinpovolny @himdel  please review


