### PR TITLE
remove MiqExpression.merge_where_clauses_and_includes

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -709,10 +709,6 @@ class MiqExpression
     result.compact.uniq
   end
 
-  def self.merge_where_clauses_and_includes(where_clauses, includes)
-    [merge_where_clauses(*where_clauses), merge_includes(*includes)]
-  end
-
   def self.expand_conditional_clause(klass, cond)
     return klass.send(:sanitize_sql_for_conditions, cond) unless cond.is_a?(Hash)
 

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -442,7 +442,8 @@ module Rbac
     user_filters['match_via_descendants'] = to_class(options[:match_via_descendants])
 
     exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.try(:instances_are_derived?)
-    conditions, include_for_find = MiqExpression.merge_where_clauses_and_includes([conditions, sub_filter, where_clause, exp_sql, ids_clause], [include_for_find, exp_includes])
+    conditions = MiqExpression.merge_where_clauses(conditions, sub_filter, where_clause, exp_sql, ids_clause)
+    include_for_find = MiqExpression.merge_includes(include_for_find, exp_includes)
 
     attrs[:apply_limit_in_sql] = (exp_attrs.nil? || exp_attrs[:supported_by_sql]) && user_filters["belongsto"].blank?
 


### PR DESCRIPTION
High level:

We are getting out of the sql munging business. (part of my rbac scope work)
This removed a helper method.

Low level:

This convenience method is only calling once and there is an
equivalent version. When changing the code, the source code has a shorter line

/cc @imtayadeway yay