### PR TITLE
Fix MiqExpression#to_sql date format

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1606,7 +1606,7 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil)
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil).to_date
               when field.datetime?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil).utc
               else
@@ -1617,7 +1617,7 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end").to_date
               when field.datetime?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end").utc
               else
@@ -1628,7 +1628,7 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning").to_date
               when field.datetime?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning").utc
               else
@@ -1639,7 +1639,7 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning").to_date
               when field.datetime?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning").utc
               else
@@ -1650,7 +1650,7 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end").to_date
               when field.datetime?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end").utc
               else
@@ -1661,7 +1661,7 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil)
+                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil).to_date
               when field.datetime?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil).utc
               else

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1608,7 +1608,7 @@ class MiqExpression
               when field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil)
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil)
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil).utc
               else
                 exp[operator]["value"]
               end
@@ -1619,7 +1619,7 @@ class MiqExpression
               when field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end")
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end").utc
               else
                 exp[operator]["value"]
               end
@@ -1630,7 +1630,7 @@ class MiqExpression
               when field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning")
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning").utc
               else
                 exp[operator]["value"]
               end
@@ -1641,7 +1641,7 @@ class MiqExpression
               when field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning")
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning")
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning").utc
               else
                 exp[operator]["value"]
               end
@@ -1652,7 +1652,7 @@ class MiqExpression
               when field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end")
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end")
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end").utc
               else
                 exp[operator]["value"]
               end
@@ -1663,7 +1663,7 @@ class MiqExpression
               when field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil)
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil)
+                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil).utc
               else
                 exp[operator]["value"]
               end

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -192,37 +192,37 @@ describe MiqExpression do
       it "generates the SQL for an AFTER expression" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10 23:59:59.999999'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10'")
       end
 
       it "generates the SQL for a > expression" do
         exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10 23:59:59.999999'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10'")
       end
 
       it "generates the SQL for a BEFORE expression" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10 00:00:00'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10'")
       end
 
       it "generates the SQL for a < expression" do
         exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10 00:00:00'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10'")
       end
 
       it "generates the SQL for a >= expression" do
         exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" >= '2011-01-10 00:00:00'")
+        expect(sql).to eq("\"vms\".\"retires_on\" >= '2011-01-10'")
       end
 
       it "generates the SQL for a <= expression" do
         exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" <= '2011-01-10 23:59:59.999999'")
+        expect(sql).to eq("\"vms\".\"retires_on\" <= '2011-01-10'")
       end
 
       it "generates the SQL for an AFTER expression with date/time" do
@@ -278,7 +278,7 @@ describe MiqExpression do
       it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a date field" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-09 23:59:59.999999'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-09'")
       end
 
       it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a datetime field" do
@@ -290,7 +290,7 @@ describe MiqExpression do
       it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a date field" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-09 00:00:00'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-09'")
       end
 
       it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a datetime field" do


### PR DESCRIPTION
@gtanzillo this takes care of an issue we noticed of times creeping into date queries. I don't know if this is a fix because I don't think anything was actually broken. But it does at least make it a bit clearer.
@miq-bot assign @gtanzillo 
@miq-bot add-label core