### PR TITLE
Azure provisioning - Floating IP support

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Azure::CloudManager::Provision < ManageIQ::Providers::CloudManager::Provision
   include_concern 'Cloning'
   include_concern 'OptionsHelper'
+  include_concern 'StateMachine'
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -47,7 +47,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
   end
 
   def prepare_for_clone_task
-    nic_id = create_nic
+    nic_id = invalid_or_nil_floating_ip? ? create_nic : associated_nic
     target_uri, source_uri, os = gather_storage_account_properties
 
     cloud_options =
@@ -98,6 +98,14 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
 
   def storage_account_name
     source.description.split("\\")[1]
+  end
+
+  def invalid_or_nil_floating_ip?
+    floating_ip.nil? || floating_ip.network_port.nil?
+  end
+
+  def associated_nic
+    floating_ip.network_port.ems_ref
   end
 
   def create_nic

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -47,7 +47,8 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
   end
 
   def prepare_for_clone_task
-    nic_id = invalid_or_nil_floating_ip? ? create_nic : associated_nic
+    nic_id = associated_nic || create_nic
+
     target_uri, source_uri, os = gather_storage_account_properties
 
     cloud_options =
@@ -100,12 +101,8 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
     source.description.split("\\")[1]
   end
 
-  def invalid_or_nil_floating_ip?
-    floating_ip.nil? || floating_ip.network_port.nil?
-  end
-
   def associated_nic
-    floating_ip.network_port.ems_ref
+    floating_ip.try(:network_port).try(:ems_ref)
   end
 
   def create_nic

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/state_machine.rb
@@ -1,0 +1,9 @@
+module ManageIQ::Providers::Azure::CloudManager::Provision::StateMachine
+  def customize_destination
+    message = "Customizing #{for_destination}"
+    _log.info("#{message} #{for_destination}")
+    update_and_notify_parent(:message => message)
+
+    signal :post_create_destination
+  end
+end

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -175,6 +175,15 @@
           :required: false
           :display: :edit
           :data_type: :integer
+        :floating_ip_address:
+          :values_from:
+            :method: :allowed_floating_ip_addresses
+          :description: Public IP Address
+          :auto_select_single: false
+          :default: nil
+          :required: false
+          :display: :edit
+          :data_type: :integer
       :display: :show
     :service:
       :description: Catalog

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -83,18 +83,18 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
       end
 
       context "nic settings" do
-        it "with floating_ip" do
+        it "use existing floating_ip and assign to network profile" do
           allow(subject).to receive(:floating_ip).and_return(floating_ip)
           floating_ip.network_port = network_port
           expect(subject.prepare_for_clone_task[:properties][:networkProfile][:networkInterfaces][0][:id]).to eq(network_port.ems_ref)
         end
 
-        it "without floating_ip" do
+        it "without floating_ip create new nic and assign to network profile" do
           allow(floating_ip).to receive(:floating_ip).and_return(nil)
           expect(subject.prepare_for_clone_task[:properties][:networkProfile][:networkInterfaces][0][:id]).to eq(nic_id)
         end
 
-        it "with floating_ip without network_port" do
+        it "with floating_ip without network_port create new nic and assign to network profile" do
           allow(subject).to receive(:floating_ip).and_return(floating_ip)
           floating_ip.network_port = nil
           expect(subject.prepare_for_clone_task[:properties][:networkProfile][:networkInterfaces][0][:id]).to eq(nic_id)

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -1,12 +1,15 @@
 require "spec_helper"
 
 describe ManageIQ::Providers::Azure::CloudManager::Provision do
-  let(:provider)  { FactoryGirl.create(:ems_azure_with_authentication) }
-  let(:template)  { FactoryGirl.create(:template_azure, :ext_management_system => provider) }
-  let(:flavor)    { FactoryGirl.create(:flavor_azure) }
-  let(:vm)        { FactoryGirl.create(:vm_azure, :ext_management_system => provider) }
-  let(:sec_group) { FactoryGirl.create(:security_group_azure) }
-  let(:subnet)    { FactoryGirl.create(:cloud_subnet_azure) }
+  let(:provider)     { FactoryGirl.create(:ems_azure_with_authentication) }
+  let(:template)     { FactoryGirl.create(:template_azure, :ext_management_system => provider) }
+  let(:flavor)       { FactoryGirl.create(:flavor_azure) }
+  let(:vm)           { FactoryGirl.create(:vm_azure, :ext_management_system => provider) }
+  let(:sec_group)    { FactoryGirl.create(:security_group_azure) }
+  let(:subnet)       { FactoryGirl.create(:cloud_subnet_azure) }
+  let(:network_port) { FactoryGirl.create(:network_port_azure) }
+  let(:floating_ip)  { FactoryGirl.create(:floating_ip_azure) }
+
 
   context "#create vm" do
     subscription_id = "01234567890"
@@ -80,8 +83,20 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
       end
 
       context "nic settings" do
-        it "with nic" do
-          subject.options[:vm_target_name] = name
+        it "with floating_ip" do
+          allow(subject).to receive(:floating_ip).and_return(floating_ip)
+          floating_ip.network_port = network_port
+          expect(subject.prepare_for_clone_task[:properties][:networkProfile][:networkInterfaces][0][:id]).to eq(network_port.ems_ref)
+        end
+
+        it "without floating_ip" do
+          allow(floating_ip).to receive(:floating_ip).and_return(nil)
+          expect(subject.prepare_for_clone_task[:properties][:networkProfile][:networkInterfaces][0][:id]).to eq(nic_id)
+        end
+
+        it "with floating_ip without network_port" do
+          allow(subject).to receive(:floating_ip).and_return(floating_ip)
+          floating_ip.network_port = nil
           expect(subject.prepare_for_clone_task[:properties][:networkProfile][:networkInterfaces][0][:id]).to eq(nic_id)
         end
       end


### PR DESCRIPTION
This PR includes support for assigning a floating IP during Azure instance provisioning.

There is a limit to the number of floating IP Addresses that can exist in Azure per region within a subscription. This limit is quickly met for 2 reasons:
1) A floating IP Address and its associated NIC are not deleted in Azure end when an instance is deleted, instead they hang around.
2) We **always** create a new floating IP and network interface during instance provisioning, see specific code:
https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb#L107

This PR includes changes to the Environment tab of the provisioning dialogs to provide users with the opportunity to re-use an existing floating IP that is:
1) Not already associated with an instance
2) Has a network interface associated with it. 

Selecting a floating IP is optional, if the user chooses **not** to select one a new floating IP and network interface will still be created automatically. This means we will still inch towards the maximum allowed number of floating IPs in a subscription and region, but this is an issue that exists across all cloud providers we support and should be addressed in a uniform way.

https://bugzilla.redhat.com/show_bug.cgi?id=1342640