### PR TITLE
Pass the timezone when we have a date field

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -513,11 +513,11 @@ class MiqExpression
       value = exp[operator]["value"]
       if col_type == :date
         if RelativeDatetime.relative?(value)
-          start_val = quote(RelativeDatetime.normalize(value, "UTC", "beginning").to_date, :date)
-          end_val   = quote(RelativeDatetime.normalize(value, "UTC", "end").to_date, :date)
+          start_val = quote(RelativeDatetime.normalize(value, tz, "beginning").to_date, :date)
+          end_val   = quote(RelativeDatetime.normalize(value, tz, "end").to_date, :date)
           clause    = "val=#{col_ruby}; !val.nil? && val.to_date >= #{start_val} && val.to_date <= #{end_val}"
         else
-          value  = quote(RelativeDatetime.normalize(value, "UTC", "beginning").to_date, :date)
+          value  = quote(RelativeDatetime.normalize(value, tz, "beginning").to_date, :date)
           clause = "val=#{col_ruby}; !val.nil? && val.to_date == #{value}"
         end
       else
@@ -532,8 +532,8 @@ class MiqExpression
 
       start_val, end_val = exp[operator]["value"]
       if col_type == :date
-        start_val = quote(RelativeDatetime.normalize(start_val, "UTC", "beginning").to_date, :date)
-        end_val   = quote(RelativeDatetime.normalize(end_val, "UTC", "end").to_date, :date)
+        start_val = quote(RelativeDatetime.normalize(start_val, tz, "beginning").to_date, :date)
+        end_val   = quote(RelativeDatetime.normalize(end_val, tz, "end").to_date, :date)
 
         clause = "val=#{col_ruby}; !val.nil? && val.to_date >= #{start_val} && val.to_date <= #{end_val}"
       else
@@ -557,7 +557,7 @@ class MiqExpression
              end
 
       if col_type == :date
-        val = RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode)
+        val = RelativeDatetime.normalize(exp[operator]["value"], tz, mode)
 
         clause = "val=#{col_ruby}; !val.nil? && val.to_date #{normalized_operator} #{quote(val.to_date, :date)}"
       else
@@ -1605,9 +1605,9 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end").to_date
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").to_date
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end").utc
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").utc
               else
                 exp[operator]["value"]
               end
@@ -1616,9 +1616,9 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning").to_date
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").to_date
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning").utc
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").utc
               else
                 exp[operator]["value"]
               end
@@ -1627,9 +1627,9 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "beginning").to_date
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").to_date
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "beginning").utc
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").utc
               else
                 exp[operator]["value"]
               end
@@ -1638,9 +1638,9 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       value = case
               when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = "end").to_date
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").to_date
               when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = "end").utc
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").utc
               else
                 exp[operator]["value"]
               end
@@ -1709,11 +1709,11 @@ class MiqExpression
       value = exp[operator]["value"]
       if field.date?
         if RelativeDatetime.relative?(value)
-          start_val = RelativeDatetime.normalize(value, "UTC", "beginning").to_date
-          end_val = RelativeDatetime.normalize(value, "UTC", "end").to_date
+          start_val = RelativeDatetime.normalize(value, tz, "beginning").to_date
+          end_val = RelativeDatetime.normalize(value, tz, "end").to_date
           field.between(start_val..end_val)
         else
-          value  = RelativeDatetime.normalize(value, "UTC", "beginning").to_date
+          value = RelativeDatetime.normalize(value, tz, "beginning").to_date
           field.eq(value)
         end
       else
@@ -1725,8 +1725,8 @@ class MiqExpression
       field = Field.parse(exp[operator]["field"])
       start_val, end_val = exp[operator]["value"]
       if field.date?
-        start_val = RelativeDatetime.normalize(start_val, "UTC", "beginning").to_date
-        end_val   = RelativeDatetime.normalize(end_val, "UTC", "end").to_date
+        start_val = RelativeDatetime.normalize(start_val, tz, "beginning").to_date
+        end_val   = RelativeDatetime.normalize(end_val, tz, "end").to_date
       else
         start_val = RelativeDatetime.normalize(start_val, tz, "beginning").utc
         end_val   = RelativeDatetime.normalize(end_val, tz, "end").utc

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -293,6 +293,44 @@ describe MiqExpression do
     context "relative date/time support" do
       around { |example| Timecop.freeze("2011-01-11 17:30 UTC") { example.run } }
 
+      context "given a non-UTC timezone" do
+        it "generates the SQL for a > expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new(">" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          sql, * = exp.to_sql("Asia/Jakarta")
+          expect(sql).to eq(%q("vms"."retires_on" > '2011-01-10'))
+        end
+
+        it "generates the SQL for a >= expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new(">=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          sql, * = exp.to_sql("Asia/Jakarta")
+          expect(sql).to eq(%q("vms"."retires_on" >= '2011-01-10'))
+        end
+
+        it "generates the SQL for a < expression with a value of 'Yesterday' for a date field" do
+          exp =  described_class.new("<" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          sql, * = exp.to_sql("Asia/Jakarta")
+          expect(sql).to eq(%q("vms"."retires_on" < '2011-01-10'))
+        end
+
+        it "generates the SQL for a <= expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("<=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          sql, * = exp.to_sql("Asia/Jakarta")
+          expect(sql).to eq(%q("vms"."retires_on" <= '2011-01-10'))
+        end
+
+        it "generates the SQL for an IS expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          sql, * = exp.to_sql("Asia/Jakarta")
+          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-10' AND '2011-01-10'))
+        end
+
+        it "generates the SQL for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
+          exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w(Yesterday Today)})
+          sql, * = exp.to_sql("Asia/Jakarta")
+          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-10' AND '2011-01-11'))
+        end
+      end
+
       it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a date field" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
@@ -1112,6 +1150,44 @@ describe MiqExpression do
 
     context "relative date/time support" do
       around { |example| Timecop.freeze("2011-01-11 17:30 UTC") { example.run } }
+
+      context "given a non-UTC timezone" do
+        it "generates the SQL for a > expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new(">" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          ruby, * = exp.to_ruby("Asia/Jakarta")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
+        end
+
+        it "generates the RUBY for a >= expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new(">=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          ruby, * = exp.to_ruby("Asia/Jakarta")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date")
+        end
+
+        it "generates the RUBY for a < expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("<" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          ruby, * = exp.to_ruby("Asia/Jakarta")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
+        end
+
+        it "generates the RUBY for a <= expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("<=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          ruby, * = exp.to_ruby("Asia/Jakarta")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date")
+        end
+
+        it "generates the RUBY for an IS expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+          ruby, * = exp.to_ruby("Asia/Jakarta")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date && val.to_date <= '2011-01-10'.to_date")
+        end
+
+        it "generates the RUBY for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
+          exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w(Yesterday Today)})
+          ruby, * = exp.to_ruby("Asia/Jakarta")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date && val.to_date <= '2011-01-11'.to_date")
+        end
+      end
 
       context "relative dates with no time zone" do
         it "generates the ruby for an AFTER expression with date value of n Days Ago" do

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -297,37 +297,37 @@ describe MiqExpression do
         it "generates the SQL for a > expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new(">" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" > '2011-01-10'))
+          expect(sql).to eq(%q("vms"."retires_on" > '2011-01-11'))
         end
 
         it "generates the SQL for a >= expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new(">=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" >= '2011-01-10'))
+          expect(sql).to eq(%q("vms"."retires_on" >= '2011-01-11'))
         end
 
         it "generates the SQL for a < expression with a value of 'Yesterday' for a date field" do
           exp =  described_class.new("<" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" < '2011-01-10'))
+          expect(sql).to eq(%q("vms"."retires_on" < '2011-01-11'))
         end
 
         it "generates the SQL for a <= expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("<=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" <= '2011-01-10'))
+          expect(sql).to eq(%q("vms"."retires_on" <= '2011-01-11'))
         end
 
         it "generates the SQL for an IS expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-10' AND '2011-01-10'))
+          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-11' AND '2011-01-11'))
         end
 
         it "generates the SQL for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
           exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w(Yesterday Today)})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-10' AND '2011-01-11'))
+          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-11' AND '2011-01-12'))
         end
       end
 
@@ -1155,37 +1155,37 @@ describe MiqExpression do
         it "generates the SQL for a > expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new(">" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for a >= expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new(">=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for a < expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("<" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for a <= expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("<=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for an IS expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date && val.to_date <= '2011-01-10'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
           exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w(Yesterday Today)})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-12'.to_date")
         end
       end
 


### PR DESCRIPTION
For datetimes we pass the timezone when normalizing because a concept
like "yesterday" is dependent on the user's timezone - i.e. it will
correlate to two time boundaries which are not necessarily 00:00:00 -
23:59:59 UTC.

I don't understand why we are not doing the same for dates. My
"yesterday" may well be a day out in UTC. But we are currently treating
all such dates as if they were UTC.

This may result in a change in behavior to the end user - I don't know whether that change is desirable or if we want to preserve what it is doing now.

/cc @gtanzillo @dclarizio 