### PR TITLE
Set pending as the default state for MiqRequestTask.

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -415,8 +415,7 @@ class MiqRequest < ApplicationRecord
 
   def create_request_task(idx)
     req_task_attribs = attributes.dup
-    req_task_attribs['state'] = req_task_attribs.delete('request_state')
-    (req_task_attribs.keys - MiqRequestTask.column_names + %w(id created_on updated_on type)).each { |key| req_task_attribs.delete(key) }
+    (req_task_attribs.keys - MiqRequestTask.column_names + %w(id state created_on updated_on type)).each { |key| req_task_attribs.delete(key) }
     _log.debug("#{self.class.name} Attributes: [#{req_task_attribs.inspect}]...")
 
     customize_request_task_attributes(req_task_attribs, idx)

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -15,6 +15,7 @@ class MiqRequestTask < ApplicationRecord
 
   default_value_for :phase_context, {}
   default_value_for :options,       {}
+  default_value_for :state,         'pending'
 
   delegate :request_class, :task_description, :to => :class
 


### PR DESCRIPTION
The state of MiqRequest should not be used as the default state for tasks.

With multiple provisioning, the miq_request.state may have changed from pending to active before all tasks are created that would throw an RunTime error and kill the subsequent tasks.

https://bugzilla.redhat.com/show_bug.cgi?id=1337646