### PR TITLE
net-ssh final bump to final version 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem "inifile",                        "~>3.0",     :require => false
 gem "logging",                        "~>1.8",     :require => false  # Ziya depends on this
 gem "net_app_manageability",          ">=0.1.0",   :require => false
 gem "net-ping",                       "~>1.7.4",   :require => false
-gem "net-ssh",                        "~>3.2.0.rc2",   :require => false
+gem "net-ssh",                        "=3.2.0",    :require => false
 gem "omniauth",                       "~>1.3.1",   :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",   :require => false


### PR DESCRIPTION
@jrafanie @simon3z  3.2 final version was released sooner then expected :).
This would be the final bump needed for the container-deployment feature.