### PR TITLE
Automate: Builtin entry and handling refactor

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -784,10 +784,13 @@ class MiqAeClassController < ApplicationController
     @edit[:new][:scope] = "instance"
     @edit[:new][:language] = "ruby"
     @edit[:new][:available_locations] = MiqAeMethod.available_locations
+    @edit[:new][:available_builtins] = MiqAeMethod.available_builtins
     @edit[:new][:location] = @ae_method.location.nil? ? "inline" : @ae_method.location
     @edit[:new][:data] = @ae_method.data.to_s
     if @edit[:new][:location] == "inline" && !@ae_method.data
       @edit[:new][:data] = MiqAeMethod.default_method_text
+    elsif @edit[:new][:location] == "builtin" && !@ae_method.data
+      @edit[:new][:data] = MiqAeMethod.available_builtins.sort.first
     end
     @edit[:default_verify_status] = @edit[:new][:location] == "inline" && @edit[:new][:data] && @edit[:new][:data] != ""
     @edit[:new][:fields] = @ae_method.inputs.collect do |input|

--- a/app/views/miq_ae_class/_method_data.html.haml
+++ b/app/views/miq_ae_class/_method_data.html.haml
@@ -7,13 +7,30 @@
     = text_area_tag("#{field_name}_data",
       @edit[:new][:data],
       :style => "display:none;")
-  - else
-    = text_field_tag("#{field_name}_data",
-      @edit[:new][:data],
-      :maxlength         => MAX_NAME_LEN,
-      "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  - if @edit[:new][:location] == 'builtin'
-    %em= _('Optional, if not specified, method name is used.')
+  - elsif @edit[:new][:location] == 'builtin'
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Builtin to call')
+        .col-md-8
+          = select_tag("#{field_name}_data",
+                       options_for_select(@edit[:new][:available_builtins].sort, @edit[:new][:data]),
+                       :class    => "selectpicker",
+                       "data-miq_observe" => {:url => url}.to_json)
+    :javascript
+      miqInitSelectPicker();
+      miqSelectPickerEvent("#{field_name}_data", "#{url}")
+  - elsif @edit[:new][:location] == 'uri'
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Method URI')
+        .col-md-8
+          = text_field_tag("#{field_name}_data",
+            @edit[:new][:data],
+            :maxlength         => MAX_NAME_LEN,
+            :class => "form-control",
+            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %tr
     %td
       %span#pwd_note{:style => "color: red;"}

--- a/app/views/miq_ae_class/_method_data.html.haml
+++ b/app/views/miq_ae_class/_method_data.html.haml
@@ -31,17 +31,18 @@
             :maxlength         => MAX_NAME_LEN,
             :class => "form-control",
             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  %tr
-    %td
-      %span#pwd_note{:style => "color: red;"}
-    %td
-      = render(:partial => "/layouts/form_buttons_verify",
-        :locals         => {:validate_url => "validate_method_data",
-          :valtype                        => "default",
-          :record                         => @ae_method,
-          :verify_title_off               => "Enter data to Validate",
-          :verify_title_on                => "Validate method data",
-          :serialize                      => true})
+  - unless @edit[:new][:location] == 'builtin'
+    %tr
+      %td
+        %span#pwd_note{:style => "color: red;"}
+      %td
+        = render(:partial => "/layouts/form_buttons_verify",
+          :locals         => {:validate_url => "validate_method_data",
+            :valtype                        => "default",
+            :record                         => @ae_method,
+            :verify_title_off               => "Enter data to Validate",
+            :verify_title_on                => "Validate method data",
+            :serialize                      => true})
 
 :javascript
   ManageIQ.oneTransition.oneTrans = 0;

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -50,7 +50,16 @@
           :line_numbers            => true,
           :read_only               => true}
     - else
-      = @ae_method.data
+      .form-horizontal.static
+        .form-group
+          %label.col-md-2.control-label
+            - if @ae_method.location == 'builtin'
+              = _('Builtin to call')
+            - elsif @ae_method.location == 'uri'
+              = _('Method URI')
+          .col-md-8
+            %p.form-control-static
+              = @ae_method.data
     -# show inputs parameters grid if there are any inputs
     #params_div{:style => @record.inputs.empty? ? "display: none;" : ""}
       %hr

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -227,6 +227,7 @@ module MiqAeEngine
 
     builtin :miq_event_action_refresh_sync do |obj, target|
       event_object_from_workspace(obj).refresh(inputs['target'], true)
+    end
 
     builtin :event_action_refresh do |obj, target|
       event_object_from_workspace(obj).refresh(target)

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -222,11 +222,11 @@ module MiqAeEngine
     end
 
     builtin :miq_event_action_refresh do |obj, target|
-      event_object_from_workspace(obj).refresh(inputs['target'], false)
+      event_object_from_workspace(obj).refresh(target, false)
     end
 
     builtin :miq_event_action_refresh_sync do |obj, target|
-      event_object_from_workspace(obj).refresh(inputs['target'], true)
+      event_object_from_workspace(obj).refresh(target, true)
     end
 
     builtin :event_action_refresh do |obj, target|

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -76,6 +76,11 @@ module MiqAeEngine
         instance_exec(*meth_params, &meth)
       end
 
+      def remove_builtin(name)
+        @builtins ||= {}
+        @builtins.delete(name.to_s)
+      end
+
       # Returns a list of all defined builtins
       def builtins
         @builtins ||= {}

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -180,7 +180,7 @@ module MiqAeEngine
       prepend_vendor(obj)
     end
 
-    builtin :miq_parse_automation_request do |obj|
+    builtin :parse_automation_request do |obj|
       obj['target_component'], obj['target_class'], obj['target_instance'] =
         case obj['request']
         when 'vm_provision'   then %w(VM   Lifecycle Provisioning)
@@ -221,11 +221,11 @@ module MiqAeEngine
       ["host", "storage"].each { |k| obj[k] = result[k] } unless result.empty?
     end
 
-    builtin :miq_event_action_refresh do |obj, target|
+    builtin :event_action_refresh do |obj, target|
       event_object_from_workspace(obj).refresh(target, false)
     end
 
-    builtin :miq_event_action_refresh_sync do |obj, target|
+    builtin :event_action_refresh_sync do |obj, target|
       event_object_from_workspace(obj).refresh(target, true)
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -53,9 +53,9 @@ module MiqAeEngine
       # * +obj+ - Object to invoke the builtin on.
       # * +inputs+ - Inputs to pass to the method. Hash
       def invoke_builtin(name, obj, inputs)
-        @builtins ||= {}
         meth = get_builtin(name).first
-        meth_params = meth.parameters.collect do |_, param_name|
+        # Taking only :opt, we do not care about :rest
+        meth_params = meth.parameters.select { |pt, _| pt == :opt } .collect do |_, param_name|
           if param_name == :obj
             obj
           elsif param_name == :inputs

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -3,7 +3,6 @@ module MiqAeEngine
   CLOUD          = 'cloud'.freeze
   UNKNOWN        = 'unknown'.freeze
 
-  # All Class Methods beginning with miq_ are callable from the engine
   class MiqAeBuiltinMethod
     ATTRIBUTE_LIST = %w(
       vm
@@ -15,7 +14,76 @@ module MiqAeEngine
       platform_category
     ).freeze
 
-    def self.miq_log_object(obj, _inputs)
+    class << self
+      # Define a new builtin for use in automate models
+      #
+      # Use it similarly like you would define a method. Required values are expressed using
+      # arguments. Argument "obj" is considered to be the $evm.object. Any other argument is
+      # considered an input, where it will pull out the value from inputs hash based on the name.
+      # For backwards compatibility, argument "inputs" will receive all inputs.
+      #
+      # ==== Attributes
+      #
+      # * +name+ - Name of the builtin. Symbol.
+      # * +metadata+ - Metadata (TODO - future use for reflection). Hash.
+      #
+      # ==== Examples
+      #
+      #   # This one takes the $evm.object and pulls "foo" out of inputs
+      #   builtin :mybuiltin do |obj, foo|
+      #     do_something
+      #   end
+      def builtin(name, metadata = {}, &block)
+        @builtins ||= {}
+        $miq_ae_logger.warn("Overwriting builtin method #{name}") if @builtins.include?(name)
+        @builtins[name] = [block, metadata]
+      end
+
+      # Invokes a builtin on obj with inputs.
+      #
+      # Raises MiqAeException::MethodNotFound if the builtin was not found.
+      #
+      # ==== Attributes
+      #
+      # * +name+ - Name of the builtin to invoke. Symbol.
+      # * +obj+ - Object to invoke the builtin on.
+      # * +inputs+ - Inputs to pass to the method. Hash
+      def invoke_builtin(name, obj, inputs)
+        @builtins ||= {}
+        raise MiqAeException::MethodNotFound, "Built-In Method [#{name}] does not exist" unless builtin?(name)
+        meth = @builtins[name].first
+        meth_params = meth.parameters.collect do |_, param_name|
+          if param_name == :obj
+            obj
+          elsif param_name == :inputs
+            # Backwards compatibility
+            inputs
+          else
+            inputs[param_name.to_s]
+          end # Otherwise nil as
+        end
+        instance_exec(*meth_params, &meth)
+      end
+
+      # Returns a list of all defined builtins
+      def builtins
+        @builtins ||= {}
+        @builtins.keys
+      end
+
+      # Checks whether any builtin with such name exists.
+      #
+      # ==== Attributes
+      #
+      # * +name+ - Name of the builtin to check. Symbol
+      def builtin?(name)
+        builtins.include?(name)
+      end
+    end
+
+    # Here you can define your builtins and also helper classmethods to support them
+
+    builtin :log_object do |obj|
       $miq_ae_logger.info("===========================================")
       $miq_ae_logger.info("Dumping Object")
 
@@ -24,38 +92,40 @@ module MiqAeEngine
       $miq_ae_logger.info("===========================================")
     end
 
-    def self.miq_log_workspace(obj, _inputs)
+    builtin :log_workspace do |obj|
       $miq_ae_logger.info("===========================================")
       $miq_ae_logger.info("Dumping Workspace")
       $miq_ae_logger.info(obj.workspace.to_expanded_xml)
       $miq_ae_logger.info("===========================================")
     end
 
-    def self.miq_send_email(_obj, inputs)
-      MiqAeMethodService::MiqAeServiceMethods.send_email(inputs["to"], inputs["from"], inputs["subject"], inputs["body"])
+    builtin :send_email do |to, from, subject, body|
+      MiqAeMethodService::MiqAeServiceMethods.send_email(to, from, subject, body)
     end
 
-    def self.miq_snmp_trap_v1(_obj, inputs)
+    builtin :snmp_trap_v1 do |inputs|
       MiqAeMethodService::MiqAeServiceMethods.snmp_trap_v1(inputs)
     end
 
-    def self.miq_snmp_trap_v2(_obj, inputs)
+    builtin :snmp_trap_v2 do |inputs|
       MiqAeMethodService::MiqAeServiceMethods.snmp_trap_v2(inputs)
     end
 
-    def self.miq_service_now_eccq_insert(_obj, inputs)
-      if inputs['payload'].nil?
-        MiqAeMethodService::MiqAeServiceMethods.service_now_eccq_insert(inputs['server'], inputs['username'], inputs['password'], inputs['agent'], inputs['queue'], inputs['topic'], inputs['name'], inputs['source'])
+    builtin :service_now_eccq_insert do |server, username, password, agent, queue, topic, name, source, payload|
+      if payload.nil?
+        MiqAeMethodService::MiqAeServiceMethods.service_now_eccq_insert(
+          server, username, password, agent, queue, topic, name, source)
       else
-        MiqAeMethodService::MiqAeServiceMethods.service_now_eccq_insert(inputs['server'], inputs['username'], inputs['password'], inputs['agent'], inputs['queue'], inputs['topic'], inputs['name'], inputs['source'], *(inputs['payload']))
+        MiqAeMethodService::MiqAeServiceMethods.service_now_eccq_insert(
+          server, username, password, agent, queue, topic, name, source, *payload)
       end
     end
 
-    def self.powershell(_obj, inputs)
-      MiqAeMethodService::MiqAeServiceMethods.powershell(inputs['script'], inputs['returns'])
+    builtin :powershell do |script, returns|
+      MiqAeMethodService::MiqAeServiceMethods.powershell(script, returns)
     end
 
-    def self.miq_parse_provider_category(obj, _inputs)
+    builtin :parse_provider_category do |obj|
       provider_category = nil
       ATTRIBUTE_LIST.detect { |attr| provider_category = category_for_key(obj, attr) }
       $miq_ae_logger.info("Setting provider_category to: #{provider_category}")
@@ -65,7 +135,7 @@ module MiqAeEngine
       prepend_vendor(obj)
     end
 
-    def self.miq_parse_automation_request(obj, _inputs)
+    builtin :miq_parse_automation_request do |obj|
       obj['target_component'], obj['target_class'], obj['target_instance'] =
         case obj['request']
         when 'vm_provision'   then %w(VM   Lifecycle Provisioning)
@@ -80,7 +150,7 @@ module MiqAeEngine
       $miq_ae_logger.info("Target Class:<#{obj['target_class']}> Target Instance:<#{obj['target_instance']}>")
     end
 
-    def self.miq_host_and_storage_least_utilized(obj, _inputs)
+    builtin :host_and_storage_least_utilized do |obj|
       prov = obj.workspace.get_obj_from_path("/")['miq_provision']
       raise MiqAeException::MethodParmMissing, "Provision not specified" if prov.nil?
 
@@ -106,43 +176,46 @@ module MiqAeEngine
       ["host", "storage"].each { |k| obj[k] = result[k] } unless result.empty?
     end
 
-    def self.miq_event_action_refresh(obj, inputs)
+    builtin :miq_event_action_refresh do |obj, target|
       event_object_from_workspace(obj).refresh(inputs['target'], false)
     end
 
-    def self.miq_event_action_refresh_sync(obj, inputs)
+    builtin :miq_event_action_refresh_sync do |obj, target|
       event_object_from_workspace(obj).refresh(inputs['target'], true)
+
+    builtin :event_action_refresh do |obj, target|
+      event_object_from_workspace(obj).refresh(target)
     end
 
-    def self.miq_event_action_policy(obj, inputs)
-      event_object_from_workspace(obj).policy(inputs['target'], inputs['policy_event'], inputs['param'])
+    builtin :event_action_policy do |obj, target, policy_event, param|
+      event_object_from_workspace(obj).policy(target, policy_event, param)
     end
 
-    def self.miq_event_action_scan(obj, inputs)
-      event_object_from_workspace(obj).scan(inputs['target'])
+    builtin :event_action_scan do |obj, target|
+      event_object_from_workspace(obj).scan(target)
     end
 
-    def self.miq_src_vm_as_template(obj, inputs)
-      event_object_from_workspace(obj).src_vm_as_template(inputs['flag'])
+    builtin :src_vm_as_template do |obj, flag|
+      event_object_from_workspace(obj).src_vm_as_template(flag)
     end
 
-    def self.miq_change_event_target_state(obj, inputs)
-      event_object_from_workspace(obj).change_event_target_state(inputs['target'], inputs['param'])
+    builtin :change_event_target_state do |obj, target, param|
+      event_object_from_workspace(obj).change_event_target_state(target, param)
     end
 
-    def self.miq_src_vm_destroy_all_snapshots(obj, _inputs)
+    builtin :src_vm_destroy_all_snapshots do |obj|
       event_object_from_workspace(obj).src_vm_destroy_all_snapshots
     end
 
-    def self.miq_src_vm_disconnect_storage(obj, _inputs)
+    builtin :src_vm_disconnect_storage do |obj|
       event_object_from_workspace(obj).src_vm_disconnect_storage
     end
 
-    def self.miq_src_vm_refresh_on_reconfig(obj, _inputs)
+    builtin :src_vm_refresh_on_reconfig do |obj|
       event_object_from_workspace(obj).src_vm_refresh_on_reconfig
     end
 
-    def self.miq_event_enforce_policy(obj, _inputs)
+    builtin :event_enforce_policy do |obj|
       event_object_from_workspace(obj).process_evm_event
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -28,9 +28,9 @@ module MiqAeEngine
       svc = MiqAeMethodService::MiqAeService.new(obj.workspace)
 
       begin
-        return MiqAeBuiltinMethod.invoke_builtin(mname.to_sym, obj, inputs)
+        return MiqAeBuiltinMethod.invoke_builtin(mname, obj, inputs)
       rescue MiqAeException::MethodNotFound
-        # In order for MethodNotFound to not become AbortInstantiation
+        # In order for MethodNotFound to not become AbortInstantiation so the engine can handle it
         raise
       rescue => err
         raise MiqAeException::AbortInstantiation, err.message

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -22,14 +22,16 @@ module MiqAeEngine
     end
 
     def self.invoke_builtin(aem, obj, inputs)
-      mname = "miq_#{aem.data.blank? ? aem.name.downcase : aem.data.downcase}"
-      raise  MiqAeException::MethodNotFound, "Built-In Method [#{mname}] does not exist" unless MiqAeBuiltinMethod.public_methods.collect(&:to_s).include?(mname)
+      mname = aem.data.blank? ? aem.name.downcase : aem.data.downcase
 
       # Create service, since built-in method may be calling things that assume there is one
       svc = MiqAeMethodService::MiqAeService.new(obj.workspace)
 
       begin
-        return MiqAeBuiltinMethod.send(mname, obj, inputs)
+        return MiqAeBuiltinMethod.invoke_builtin(mname, obj, inputs)
+      rescue MiqAeException::MethodNotFound
+        # In order for MethodNotFound to not become AbortInstantiation
+        raise
       rescue => err
         raise MiqAeException::AbortInstantiation, err.message
       ensure

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -28,7 +28,7 @@ module MiqAeEngine
       svc = MiqAeMethodService::MiqAeService.new(obj.workspace)
 
       begin
-        return MiqAeBuiltinMethod.invoke_builtin(mname, obj, inputs)
+        return MiqAeBuiltinMethod.invoke_builtin(mname.to_sym, obj, inputs)
       rescue MiqAeException::MethodNotFound
         # In order for MethodNotFound to not become AbortInstantiation
         raise

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -32,6 +32,10 @@ class MiqAeMethod < ApplicationRecord
     AVAILABLE_SCOPES
   end
 
+  def self.available_builtins
+    MiqAeEngine::MiqAeBuiltinMethod.builtins
+  end
+
   # Validate the syntax of the passed in inline ruby code
   def self.validate_syntax(code_text)
     result = MiqSyntaxChecker.check(code_text)

--- a/spec/lib/miq_automation_engine/miq_ae_builtin_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_builtin_method_spec.rb
@@ -1,0 +1,95 @@
+module MiqAeBuiltinMethodSpec
+  include MiqAeEngine
+
+  describe MiqAeBuiltinMethod do
+    context 'on stock class' do
+      it 'corresponds when comparing builtins and builtin?' do
+        described_class.builtins.each do |builtin|
+          expect(described_class.builtin?(builtin)).to be_truthy
+          expect(described_class.builtins.size).not_to be(0)
+        end
+      end
+    end
+
+    context 'on fresh class' do
+      before(:each) do
+        # Wipe builtins so the class is fresh to be used
+        described_class.instance_exec { @builtins = nil }
+      end
+
+      after(:each) do
+        # Wipe builtins so the class is fresh to be used
+        described_class.instance_exec { @builtins = nil }
+      end
+
+      it 'is present when defined' do
+        described_class.builtin :foo do
+        end
+
+        expect(described_class.builtin?(:foo)).to be_truthy
+        expect(described_class.builtins.size).to eq(1)
+      end
+
+      it 'raises an exception when unknown builtin invoked' do
+        described_class.builtin :foo do
+        end
+
+        expect { described_class.invoke_builtin(:oops, nil, nil) }.to raise_error(MiqAeException::MethodNotFound)
+      end
+
+      it 'invokes builtin with no params' do
+        described_class.builtin :foo do
+          true
+        end
+
+        expect(described_class.invoke_builtin(:foo, nil, nil)).to be_truthy
+      end
+
+      it 'invokes builtin with only obj param' do
+        described_class.builtin :foo do |obj|
+          obj
+        end
+
+        expect(described_class.invoke_builtin(:foo, 1, nil)).to be(1)
+      end
+
+      it 'invokes builtin with only legacy inputs param' do
+        described_class.builtin :foo do |inputs|
+          inputs
+        end
+
+        test_inputs = {:a => 1, :b => 2}
+        expect(described_class.invoke_builtin(:foo, nil, test_inputs)).to be(test_inputs)
+      end
+
+      it 'invokes builtin with only input params' do
+        described_class.builtin :foo do |x, y, z|
+          [x, y, z]
+        end
+
+        test_inputs = {"x" => 1, "y" => 2, "z" => 3}
+        test_values = [1, 2, 3]
+        expect(described_class.invoke_builtin(:foo, nil, test_inputs)).to eq(test_values)
+      end
+
+      it 'input params not present replaced by nil' do
+        described_class.builtin :foo do |x, y, z|
+          [x, y, z]
+        end
+
+        test_inputs = {"x" => 1, "y" => 2}
+        test_values = [1, 2, nil]
+        expect(described_class.invoke_builtin(:foo, nil, test_inputs)).to eq(test_values)
+      end
+
+      it 'invokes builtin with all possible parameters' do
+        described_class.builtin :foo do |obj, inputs, x, y, z|
+          [obj, inputs, x, y, z]
+        end
+        test_inputs = {"x" => 1, "y" => 2}
+        test_values = [10, test_inputs, 1, 2, nil]
+        expect(described_class.invoke_builtin(:foo, 10, test_inputs)).to eq(test_values)
+      end
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_builtin_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_builtin_method_spec.rb
@@ -11,15 +11,9 @@ module MiqAeBuiltinMethodSpec
       end
     end
 
-    context 'on fresh class' do
-      before(:each) do
-        # Wipe builtins so the class is fresh to be used
-        described_class.instance_exec { @builtins = nil }
-      end
-
+    context 'with adding a custom method' do
       after(:each) do
-        # Wipe builtins so the class is fresh to be used
-        described_class.instance_exec { @builtins = nil }
+        described_class.remove_builtin(:foo)
       end
 
       it 'is present when defined' do
@@ -31,10 +25,7 @@ module MiqAeBuiltinMethodSpec
       end
 
       it 'raises an exception when unknown builtin invoked' do
-        described_class.builtin :foo do
-        end
-
-        expect { described_class.invoke_builtin(:oops, nil, nil) }.to raise_error(MiqAeException::MethodNotFound)
+        expect { described_class.invoke_builtin(:foo, nil, nil) }.to raise_error(MiqAeException::MethodNotFound)
       end
 
       it 'invokes builtin with no params' do


### PR DESCRIPTION
Once I was discussing with AE guys how exactly the builtin methods are handled, then I saw the code and I saw an opportunity to make it better.
# Things done:
- **Explicit definition of builtins**. Before it was just sending a message to a class that contains all the methods.
- **Builtin definition implies inputs** - uses the method parameters to know what inputs are required. Since pulling a nonexisting value from hash is nil, the current behaviour is exactly the same. There is a yet unused hash with metadata that can be used to refine the builtin definition - required inputs, input types ...
- **Some specs** (not sure if they are written "the-way-it-should-be(TM)")
- **UI cleanup** - got rid of the ugly input under data and now both builtin and uri method type are properly styled and aligned with their corresponding labels added
- **Builtin method selector** - Now you can only select the builtin, you are no longer allowed to type whatever you like in

![image](https://cloud.githubusercontent.com/assets/2163040/16186106/e6256232-36c8-11e6-9d23-31960e24c7f0.png)
![image](https://cloud.githubusercontent.com/assets/2163040/16186114/f5819688-36c8-11e6-9efa-ed39f74f6753.png)
![image](https://cloud.githubusercontent.com/assets/2163040/16186118/f9bd17ea-36c8-11e6-83cf-7ebe004e9604.png)
![image](https://cloud.githubusercontent.com/assets/2163040/16186119/fcf212da-36c8-11e6-92f0-4cf95f5cb386.png)

For comparison, this is how it looked before:
![image](https://cloud.githubusercontent.com/assets/2163040/16186132/16128e20-36c9-11e6-9985-6b3ec8cb0f9b.png)
# Things I am unsure of:
- **the `.to_sym` on the `builtin_invoke`** - Can I use HashWithIndifferentAccess in the automate engine? If yes, then I will use it and remove the `.to_sym` which may be a candidate to memory leak, though I guess Ruby can handle that :)
# Things not done:
- **UI that automatically pre-generates inputs** - I played with it, I was able to modify the inputs to spawn them based on the method parameters and with the name editing disabled and modifying the rows disabled, but it: 1) did not "refresh" with the change of the method type and 2) saving it second time, it was probably trying to save the same fields again. 1) I am not a strong JS/HTML guy so I did not decipher the way how could I do it and for 2) the controller is a bit messy so leaving that out for now. Nevertheless, the supporting backend code is in place :)

Possibly supersedes #9011 
