### PR TITLE
Reinitialize accordions when editing a dialog

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1602,8 +1602,8 @@ function miqWidgetToolbarClick(e) {
 function miqInitAccordions() {
   var height = $('#left_div').height() - $('#toolbar').outerHeight();
   var panel = $('.panel-heading').outerHeight();
-  var count = $('#accordion > .panel .panel-body').length;
-  $('#accordion > .panel .panel-body').each(function (k, v) {
+  var count = $('#accordion:visible > .panel .panel-body').length;
+  $('#accordion:visible > .panel .panel-body').each(function (k, v) {
     $(v).css('max-height', (height - count * panel) + 'px');
     $(v).css('overflow-y', 'auto')
     $(v).css('overflow-x', 'hidden')

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -413,6 +413,7 @@ class MiqAeCustomizationController < ApplicationController
     # url to be used in url in miqDropComplete method
     presenter[:miq_widget_dd_url] = 'miq_ae_customization/dialog_res_reorder'
     presenter[:init_dashboard] = true
+    presenter[:init_accords] = true
     presenter.update(:custom_left_cell, render_proc[:partial => "dialog_edit_tree"])
     presenter.show(:custom_left_cell).hide(:default_left_cell)
   end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -19,6 +19,7 @@ class ExplorerPresenter
   #   delete_node                      -- key of node to be deleted from the active tree
   #   build_calendar                   -- call miqBuildCalendar, true/false or Hash (:date_from, :date_to, :skip_days)
   #   init_dashboard
+  #   init_accords                     -- initialize accordion autoresize
   #   ajax_action                      -- Hash of options for AJAX action to fire
   #   clear_gtl_list_grid              -- Clear ManageIQ.grids.gtl_list_grid
   #   right_cell_text
@@ -239,6 +240,8 @@ class ExplorerPresenter
     # always replace content partial to adjust height of content div
     @out << "miqInitMainContent();"
     @out << "$('#quicksearchbox').modal('hide');" if @options[:hide_modal]
+
+    @out << "miqInitAccordions();" if @options[:init_accords]
 
     # Don't turn off spinner for charts/timelines
     @out << set_spinner_off unless @options[:ajax_action]


### PR DESCRIPTION
In the accordion editor, the `#left_div` is being replaced by the `#custom_left_div` and the accordions initialized in that div are not initialized with height. This PR changes the behavior of the `miqInitAccordions()` JS function to provide auto-height for this `#custom_left_div` and sends this function to the presenter when it's needed.

**Before:**
![screenshot from 2016-06-20 10-06-33](https://cloud.githubusercontent.com/assets/649130/16187590/807e2294-36d1-11e6-8446-1e3039d750ea.png)

**After:**
![screenshot from 2016-06-20 10-06-02](https://cloud.githubusercontent.com/assets/649130/16187605/8c7d9c50-36d1-11e6-85dd-45f583634d07.png)


FIXME: The `#accordion` is still duplicated and should be fixed in a separate PR!

https://bugzilla.redhat.com/show_bug.cgi?id=1339323

