### PR TITLE
Add vertical scrollbar to Optimize/Planning left div

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -513,3 +513,8 @@ body#dashboard {
     max-width:1200px;
   }
 }
+
+/* scrollable */
+.scrollable {
+  overflow: auto;
+}


### PR DESCRIPTION
Redefined the `.scrollable` CSS class for auto-toggling the scrollbar when it's needed.

**Before:**
![screenshot from 2016-06-20 10-41-32](https://cloud.githubusercontent.com/assets/649130/16188082/03f6ec12-36d4-11e6-997a-731ebaf3c5c3.png)

**After:**
![screenshot from 2016-06-20 10-41-12](https://cloud.githubusercontent.com/assets/649130/16188083/07a4811c-36d4-11e6-9343-b2c98212e0de.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1341074