### PR TITLE
Encapsulate code/data manipulating Timeline dialog [2/2]

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -315,11 +315,11 @@ module ApplicationController::Performance
       @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
       @perf_record = VmOrTemplate.find_by_id(@perf_options[:compare_vm]) unless @perf_options[:compare_vm].nil?
       new_opts = tl_session_data(request.parameters["controller"]) || ApplicationController::Timelines::Options.new
-      new_opts[:typ] = typ
       new_opts[:model] = @perf_record.class.base_class.to_s
       dt = typ == "Hourly" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
-      new_opts[:daily_date] = @perf_options[:daily_date] if typ == "Daily"
-      new_opts[:hourly_date] = [ts.month, ts.day, ts.year].join("/") if typ == "Hourly"
+      new_opts.date.typ = typ
+      new_opts.date.daily = @perf_options[:daily_date] if typ == "Daily"
+      new_opts.date.hourly = [ts.month, ts.day, ts.year].join("/") if typ == "Hourly"
       new_opts[:tl_show] = "timeline"
       set_tl_session_data(new_opts, request.parameters["controller"])
       f = @perf_record.first_event
@@ -355,11 +355,11 @@ module ApplicationController::Performance
       return unless @record = perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
       controller = data_row["resource_type"].underscore
       new_opts = tl_session_data(controller) || ApplicationController::Timelines::Options.new
-      new_opts[:typ] = typ
       new_opts[:model] = data_row["resource_type"]
       dt = typ == "Hourly" ? "on #{ts.to_date} at #{ts.strftime("%H:%M:%S %Z")}" : "on #{ts.to_date}"
-      new_opts[:daily_date] = @perf_options[:daily_date] if typ == "Daily"
-      new_opts[:hourly_date] = [ts.month, ts.day, ts.year].join("/") if typ == "Hourly"
+      new_opts.date.typ = typ
+      new_opts.date.daily = @perf_options[:daily_date] if typ == "Daily"
+      new_opts.date.hourly = [ts.month, ts.day, ts.year].join("/") if typ == "Hourly"
       new_opts[:tl_show] = "timeline"
       set_tl_session_data(new_opts, controller)
       f = @record.first_event

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -67,9 +67,7 @@ module ApplicationController::Timelines
       return unless @timeline
     end
 
-    if @tl_options.management_events?
-      @tl_options.mngmt_build_filters
-    else
+    unless @tl_options.management_events?
       @tl_options.policy_events.sort.each_with_index do |_e, i|
         @tl_options[:pol_fltr][i] = if !@tl_options.pol_filter[i].blank?
                                       tl_build_policy_filter(@tl_options[:pol_filter][i])
@@ -89,9 +87,9 @@ module ApplicationController::Timelines
       page << "ManageIQ.calendar.calDateTo = new Date(#{@tl_options[:edate]});" unless @tl_options[:edate].nil?
       page << 'miqBuildCalendar();'
       if @tl_options.management_events?
-        page << "$('#filter1').val('#{@tl_options[:fltr1]}');"
-        page << "$('#filter2').val('#{@tl_options[:fltr2]}');"
-        page << "$('#filter3').val('#{@tl_options[:fltr3]}');"
+        page << "$('#filter1').val('#{@tl_options.fltr1}');"
+        page << "$('#filter2').val('#{@tl_options.fltr2}');"
+        page << "$('#filter3').val('#{@tl_options.fltr3}');"
       else
         @tl_options.policy_events.sort.each_with_index do |_e, i|
           page << "$('#filter#{i}').val('#{@tl_options[:pol_fltr][i]}');"
@@ -241,7 +239,6 @@ module ApplicationController::Timelines
       @tl_options[:fl_typ] = "critical" if @tl_options[:fl_typ].nil?
       if @tl_options[:filter1].nil?
         @tl_options[:filter1] = "Power Activity"
-        @tl_options.mngmt_build_filters
       end
     end
   end

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -15,13 +15,13 @@ module ApplicationController::Timelines
     end
 
     if @tl_options.management_events?
-      @tl_options[:filter1] = params[:tl_fl_grp1] if params[:tl_fl_grp1]
-      @tl_options[:filter2] = params[:tl_fl_grp2] if params[:tl_fl_grp2]
-      @tl_options[:filter3] = params[:tl_fl_grp3] if params[:tl_fl_grp3]
+      @tl_options.mngt.filter1 = params[:tl_fl_grp1] if params[:tl_fl_grp1]
+      @tl_options.mngt.filter2 = params[:tl_fl_grp2] if params[:tl_fl_grp2]
+      @tl_options.mngt.filter3 = params[:tl_fl_grp3] if params[:tl_fl_grp3]
       # if pull down values have been switched
-      @tl_options[:filter1] = "" if (@tl_options[:filter1] == @tl_options[:filter2] || @tl_options[:filter1] == @tl_options[:filter3]) && !params[:tl_fl_grp1]
-      @tl_options[:filter2] = "" if (@tl_options[:filter2] == @tl_options[:filter3] || @tl_options[:filter2] == @tl_options[:filter1]) && !params[:tl_fl_grp2]
-      @tl_options[:filter3] = "" if (@tl_options[:filter3] == @tl_options[:filter2] || @tl_options[:filter3] == @tl_options[:filter1]) && !params[:tl_fl_grp3]
+      @tl_options.mngt.filter1 = "" if (@tl_options.mngt.filter1 == @tl_options.mngt.filter2 || @tl_options.mngt.filter1 == @tl_options.mngt.filter3) && !params[:tl_fl_grp1]
+      @tl_options.mngt.filter2 = "" if (@tl_options.mngt.filter2 == @tl_options.mngt.filter3 || @tl_options.mngt.filter2 == @tl_options.mngt.filter1) && !params[:tl_fl_grp2]
+      @tl_options.mngt.filter3 = "" if (@tl_options.mngt.filter3 == @tl_options.mngt.filter2 || @tl_options.mngt.filter3 == @tl_options.mngt.filter1) && !params[:tl_fl_grp3]
     else
       @tl_options[:tl_result] = params[:tl_result] if params[:tl_result]
       if params[:tl_fl_grp_all] == "1"
@@ -49,9 +49,9 @@ module ApplicationController::Timelines
       end
     end
 
-    @tl_options[:fl_typ] = params[:tl_fl_typ] if params[:tl_fl_typ]
+    @tl_options.mngt.level = params[:tl_fl_typ] if params[:tl_fl_typ]
     if @tl_options.management_events? &&
-       (@tl_options.filter1.blank? || @tl_options.filter2.blank? || @tl_options.filter3.blank?)
+       (@tl_options.mngt.filter1.blank? || @tl_options.mngt.filter2.blank? || @tl_options.mngt.filter3.blank?)
       add_flash(_("At least one filter must be selected"), :warning)
     elsif @tl_options.policy_events?
       if @tl_options.policy_event_filter_any?
@@ -84,9 +84,9 @@ module ApplicationController::Timelines
       page << "ManageIQ.calendar.calDateTo = new Date(#{@tl_options.date.end});" unless @tl_options.date.end.nil?
       page << 'miqBuildCalendar();'
       if @tl_options.management_events?
-        page << "$('#filter1').val('#{@tl_options.fltr1}');"
-        page << "$('#filter2').val('#{@tl_options.fltr2}');"
-        page << "$('#filter3').val('#{@tl_options.fltr3}');"
+        page << "$('#filter1').val('#{@tl_options.mngt.fltr1}');"
+        page << "$('#filter2').val('#{@tl_options.mngt.fltr2}');"
+        page << "$('#filter3').val('#{@tl_options.mngt.fltr3}');"
       else
         @tl_options.policy_events.sort.each_with_index do |_e, i|
           page << "$('#filter#{i}').val('#{@tl_options[:pol_fltr][i]}');"
@@ -225,9 +225,9 @@ module ApplicationController::Timelines
         end
       end
     else
-      @tl_options[:fl_typ] = "critical" if @tl_options[:fl_typ].nil?
-      if @tl_options[:filter1].nil?
-        @tl_options[:filter1] = "Power Activity"
+      @tl_options.mngt.level = "critical" if @tl_options.mngt.level.nil?
+      if @tl_options.mngt.filter1.nil?
+        @tl_options.mngt.filter1 = "Power Activity"
       end
     end
   end
@@ -296,21 +296,21 @@ module ApplicationController::Timelines
         end
       else
         event_groups = EmsEvent.event_groups
-        if !@tl_options.filter1.blank? || !@tl_options.filter2.blank? || !@tl_options.filter3.blank?
-          if !@tl_options.filter1.blank?
-            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter1]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_options.mngmt_events[@tl_options[:filter1]]
-            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter1]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+        if !@tl_options.mngt.filter1.blank? || !@tl_options.mngt.filter2.blank? || !@tl_options.mngt.filter3.blank?
+          if !@tl_options.mngt.filter1.blank?
+            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter1]][@tl_options.mngt.level.downcase.to_sym]) if @tl_options.mngt.events[@tl_options.mngt.filter1]
+            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter1]][:detail]) if @tl_options.mngt.level.downcase == "detail"
           end
-          if !@tl_options.filter2.blank?
-            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter2]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_options.mngmt_events[@tl_options[:filter2]]
-            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter2]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+          if !@tl_options.mngt.filter2.blank?
+            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter2]][@tl_options.mngt.level.downcase.to_sym]) if @tl_options.mngt.events[@tl_options.mngt.filter2]
+            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter2]][:detail]) if @tl_options.mngt.level.downcase == "detail"
           end
-          if !@tl_options.filter3.blank?
-            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter3]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_options.mngmt_events[@tl_options[:filter3]]
-            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter3]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+          if !@tl_options.mngt.filter3.blank?
+            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter3]][@tl_options.mngt.level.downcase.to_sym]) if @tl_options.mngt.events[@tl_options.mngt.filter3]
+            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter3]][:detail]) if @tl_options.mngt.level.downcase == "detail"
           end
         else
-          event_set.push(event_groups[:power][@tl_options[:fl_typ].to_sym])
+          event_set.push(event_groups[:power][@tl_options.mngt.level.to_sym])
         end
       end
 

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -229,12 +229,7 @@ module ApplicationController::Timelines
       cond = cond << temp_clause[0]
       params = temp_clause.slice(1, temp_clause.length)
 
-      if @tl_options.policy_events?
-        event_set = @tl_options.policy.event_set
-      else
-        event_set = @tl_options.mngt.event_set
-      end
-
+      event_set = @tl_options.event_set
       if !event_set.empty?
         if @tl_options.policy_events? && @tl_options.policy.result != "both"
           ftype = @tl_options.management_events? ? "event_type" : "miq_event_definition_id"

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -20,8 +20,7 @@ module ApplicationController::Timelines
       @tl_options.policy.update_from_params(params)
     end
 
-    if @tl_options.management_events? &&
-       (@tl_options.mngt.filter1.blank? || @tl_options.mngt.filter2.blank? || @tl_options.mngt.filter3.blank?)
+    if @tl_options.management_events? && !@tl_options.mngt.event_filter_any?
       add_flash(_("At least one filter must be selected"), :warning)
     elsif @tl_options.policy_events?
       if @tl_options.policy.event_filter_any?

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -1,10 +1,6 @@
 module ApplicationController::Timelines
   extend ActiveSupport::Concern
 
-  included do
-    helper_method :tl_groups_hash
-  end
-
   # Process changes to timeline selection
   def tl_chooser
     @record = identify_tl_or_perf_record
@@ -72,9 +68,9 @@ module ApplicationController::Timelines
     end
 
     if @tl_options.management_events?
-      @tl_options.fltr1 = @tl_options.filter1.blank? ? '' : tl_build_filter(tl_groups_hash[@tl_options.filter1])
-      @tl_options.fltr2 = @tl_options.filter2.blank? ? '' : tl_build_filter(tl_groups_hash[@tl_options.filter2])
-      @tl_options.fltr3 = @tl_options.filter3.blank? ? '' : tl_build_filter(tl_groups_hash[@tl_options.filter3])
+      @tl_options.fltr1 = @tl_options.filter1.blank? ? '' : tl_build_filter(@tl_options.mngmt_events[@tl_options.filter1])
+      @tl_options.fltr2 = @tl_options.filter2.blank? ? '' : tl_build_filter(@tl_options.mngmt_events[@tl_options.filter2])
+      @tl_options.fltr3 = @tl_options.filter3.blank? ? '' : tl_build_filter(@tl_options.mngmt_events[@tl_options.filter3])
     else
       @tl_options.policy_events.sort.each_with_index do |_e, i|
         @tl_options[:pol_fltr][i] = if !@tl_options.pol_filter[i].blank?
@@ -255,7 +251,7 @@ module ApplicationController::Timelines
       @tl_options[:fl_typ] = "critical" if @tl_options[:fl_typ].nil?
       if @tl_options[:filter1].nil?
         @tl_options[:filter1] = "Power Activity"
-        @tl_options[:fltr1] = tl_build_filter(tl_groups_hash[@tl_options[:filter1]])
+        @tl_options[:fltr1] = tl_build_filter(@tl_options.mngmt_events[@tl_options[:filter1]])
       end
     end
   end
@@ -326,16 +322,16 @@ module ApplicationController::Timelines
         event_groups = EmsEvent.event_groups
         if !@tl_options.filter1.blank? || !@tl_options.filter2.blank? || !@tl_options.filter3.blank?
           if !@tl_options.filter1.blank?
-            event_set.push(event_groups[tl_groups_hash[@tl_options[:filter1]]][@tl_options[:fl_typ].downcase.to_sym]) if tl_groups_hash[@tl_options[:filter1]]
-            event_set.push(event_groups[tl_groups_hash[@tl_options[:filter1]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter1]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_options.mngmt_events[@tl_options[:filter1]]
+            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter1]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
           end
           if !@tl_options.filter2.blank?
-            event_set.push(event_groups[tl_groups_hash[@tl_options[:filter2]]][@tl_options[:fl_typ].downcase.to_sym]) if tl_groups_hash[@tl_options[:filter2]]
-            event_set.push(event_groups[tl_groups_hash[@tl_options[:filter2]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter2]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_options.mngmt_events[@tl_options[:filter2]]
+            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter2]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
           end
           if !@tl_options.filter3.blank?
-            event_set.push(event_groups[tl_groups_hash[@tl_options[:filter3]]][@tl_options[:fl_typ].downcase.to_sym]) if tl_groups_hash[@tl_options[:filter3]]
-            event_set.push(event_groups[tl_groups_hash[@tl_options[:filter3]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
+            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter3]]][@tl_options[:fl_typ].downcase.to_sym]) if @tl_options.mngmt_events[@tl_options[:filter3]]
+            event_set.push(event_groups[@tl_options.mngmt_events[@tl_options[:filter3]]][:detail]) if @tl_options[:fl_typ].downcase == "detail"
           end
         else
           event_set.push(event_groups[:power][@tl_options[:fl_typ].to_sym])
@@ -411,13 +407,6 @@ module ApplicationController::Timelines
           #         END of TIMELINE TIMEZONE Code
         end
       end
-    end
-  end
-
-  def tl_groups_hash
-    @tl_groups_hash ||= EmsEvent.event_groups.each_with_object({}) do |egroup, hash|
-      gname, list = egroup
-      hash[list[:name].to_s] = gname
     end
   end
 

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -15,13 +15,7 @@ module ApplicationController::Timelines
     end
 
     if @tl_options.management_events?
-      @tl_options.mngt.filter1 = params[:tl_fl_grp1] if params[:tl_fl_grp1]
-      @tl_options.mngt.filter2 = params[:tl_fl_grp2] if params[:tl_fl_grp2]
-      @tl_options.mngt.filter3 = params[:tl_fl_grp3] if params[:tl_fl_grp3]
-      # if pull down values have been switched
-      @tl_options.mngt.filter1 = "" if (@tl_options.mngt.filter1 == @tl_options.mngt.filter2 || @tl_options.mngt.filter1 == @tl_options.mngt.filter3) && !params[:tl_fl_grp1]
-      @tl_options.mngt.filter2 = "" if (@tl_options.mngt.filter2 == @tl_options.mngt.filter3 || @tl_options.mngt.filter2 == @tl_options.mngt.filter1) && !params[:tl_fl_grp2]
-      @tl_options.mngt.filter3 = "" if (@tl_options.mngt.filter3 == @tl_options.mngt.filter2 || @tl_options.mngt.filter3 == @tl_options.mngt.filter1) && !params[:tl_fl_grp3]
+      @tl_options.mngt.update_from_params(params)
     else
       @tl_options[:tl_result] = params[:tl_result] if params[:tl_result]
       if params[:tl_fl_grp_all] == "1"
@@ -49,7 +43,6 @@ module ApplicationController::Timelines
       end
     end
 
-    @tl_options.mngt.level = params[:tl_fl_typ] if params[:tl_fl_typ]
     if @tl_options.management_events? &&
        (@tl_options.mngt.filter1.blank? || @tl_options.mngt.filter2.blank? || @tl_options.mngt.filter3.blank?)
       add_flash(_("At least one filter must be selected"), :warning)

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -229,14 +229,8 @@ module ApplicationController::Timelines
       cond = cond << temp_clause[0]
       params = temp_clause.slice(1, temp_clause.length)
 
-      event_set = []
-
       if @tl_options.policy_events?
-        unless @tl_options.policy.applied_filters.blank?
-          @tl_options.policy.applied_filters.each do |e|
-            event_set.push(@tl_options.policy.events[e])
-          end
-        end
+        event_set = @tl_options.policy.event_set
       else
         event_set = @tl_options.mngt.event_set
       end

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -5,10 +5,7 @@ module ApplicationController::Timelines
   def tl_chooser
     @record = identify_tl_or_perf_record
     @tl_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
-    @tl_options.date.typ = params[:tl_typ] if params[:tl_typ]
-    @tl_options.date.days = params[:tl_days] if params[:tl_days]
-    @tl_options.date.hourly = params[:miq_date_1] if params[:miq_date_1] && @tl_options.date.typ == 'Hourly'
-    @tl_options.date.daily = params[:miq_date_1] if params[:miq_date_1] && @tl_options.date.typ == 'Daily'
+    @tl_options.date.update_from_params(params)
 
     # set variables for type of timeline is selected
     if params[:tl_show]

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -33,17 +33,17 @@ module ApplicationController::Timelines
       @tl_options[:tl_result] = params[:tl_result] if params[:tl_result]
       if params[:tl_fl_grp_all] == "1"
         @tl_options[:tl_filter_all] = true
-        @tl_options.events.keys.sort.each do |e|
+        @tl_options.policy_events.keys.sort.each do |e|
           @tl_options[:applied_filters].push(e)
         end
       elsif params[:tl_fl_grp_all] == "null"
         @tl_options[:tl_filter_all] = false
         @tl_options[:applied_filters] = []
-        @tl_options[:pol_filter] = Array.new(@tl_options.events.length) { "" }
+        @tl_options[:pol_filter] = Array.new(@tl_options.policy_events.length) { "" }
         @tl_options[:pol_fltr] = @tl_options[:pol_filter].dup
       end
       # Look through the event type checkbox keys
-      @tl_options.events.keys.sort.each_with_index do |e, i|
+      @tl_options.policy_events.keys.sort.each_with_index do |e, i|
         ekey = "tl_fl_grp#{i + 1}__#{e.tr(" ", "_")}".to_sym
         if params[ekey] == "1" || (@tl_options[:tl_filter_all] && params[ekey] != "null")
           @tl_options[:pol_filter][i] = e
@@ -76,7 +76,7 @@ module ApplicationController::Timelines
       @tl_options.fltr2 = @tl_options.filter2.blank? ? '' : tl_build_filter(tl_groups_hash[@tl_options.filter2])
       @tl_options.fltr3 = @tl_options.filter3.blank? ? '' : tl_build_filter(tl_groups_hash[@tl_options.filter3])
     else
-      @tl_options.events.sort.each_with_index do |_e, i|
+      @tl_options.policy_events.sort.each_with_index do |_e, i|
         @tl_options[:pol_fltr][i] = if !@tl_options.pol_filter[i].blank?
                                       tl_build_policy_filter(@tl_options[:pol_filter][i])
                                     else
@@ -99,7 +99,7 @@ module ApplicationController::Timelines
         page << "$('#filter2').val('#{@tl_options[:fltr2]}');"
         page << "$('#filter3').val('#{@tl_options[:fltr3]}');"
       else
-        @tl_options.events.sort.each_with_index do |_e, i|
+        @tl_options.policy_events.sort.each_with_index do |_e, i|
           page << "$('#filter#{i}').val('#{@tl_options[:pol_fltr][i]}');"
         end
       end
@@ -200,7 +200,7 @@ module ApplicationController::Timelines
 
   def tl_build_policy_filter(grp_name)      # hidden fields to highlight bands in timeline
     arr = []
-    @tl_options.events[grp_name].each do |a|
+    @tl_options.policy_events[grp_name].each do |a|
       e = PolicyEvent.find_by_miq_event_definition_id(a.to_i)
       unless e.nil?
         arr.push(e.event_type)
@@ -244,7 +244,7 @@ module ApplicationController::Timelines
       if @tl_options[:applied_filters].blank?
         @tl_options[:applied_filters].push("VM Operation")
         # had to set this here because if it this is preselected in cboxes, it doesnt send the params back for this cb to tl_chooser
-        @tl_options.events.keys.sort.each_with_index do |e, i|
+        @tl_options.policy_events.keys.sort.each_with_index do |e, i|
           if e == "VM Operation"
             @tl_options[:pol_filter][i] = e
             @tl_options[:pol_fltr][i] = tl_build_policy_filter(e)
@@ -319,7 +319,7 @@ module ApplicationController::Timelines
       if @tl_options.policy_events?
         unless @tl_options[:applied_filters].blank?
           @tl_options[:applied_filters].each do |e|
-            event_set.push(@tl_options.events[e])
+            event_set.push(@tl_options.policy_events[e])
           end
         end
       else

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -68,9 +68,7 @@ module ApplicationController::Timelines
     end
 
     if @tl_options.management_events?
-      @tl_options.fltr1 = @tl_options.filter1.blank? ? '' : tl_build_filter(@tl_options.mngmt_events[@tl_options.filter1])
-      @tl_options.fltr2 = @tl_options.filter2.blank? ? '' : tl_build_filter(@tl_options.mngmt_events[@tl_options.filter2])
-      @tl_options.fltr3 = @tl_options.filter3.blank? ? '' : tl_build_filter(@tl_options.mngmt_events[@tl_options.filter3])
+      @tl_options.mngmt_build_filters
     else
       @tl_options.policy_events.sort.each_with_index do |_e, i|
         @tl_options[:pol_fltr][i] = if !@tl_options.pol_filter[i].blank?
@@ -186,14 +184,6 @@ module ApplicationController::Timelines
     MiqReport.new(YAML.load(File.open("#{TIMELINES_FOLDER}/miq_reports/#{timeline}.yaml")))
   end
 
-  def tl_build_filter(grp_name)             # hidden fields to highlight bands in timeline
-    event_groups = EmsEvent.event_groups
-    arr = event_groups[grp_name][@tl_options[:fl_typ].downcase.to_sym]
-    arr.push(event_groups[grp_name][:critical]) if @tl_options[:fl_typ].downcase == "detail"
-    filter = "(" << arr.join(")|(") << ")"
-    filter
-  end
-
   def tl_build_policy_filter(grp_name)      # hidden fields to highlight bands in timeline
     arr = []
     @tl_options.policy_events[grp_name].each do |a|
@@ -251,7 +241,7 @@ module ApplicationController::Timelines
       @tl_options[:fl_typ] = "critical" if @tl_options[:fl_typ].nil?
       if @tl_options[:filter1].nil?
         @tl_options[:filter1] = "Power Activity"
-        @tl_options[:fltr1] = tl_build_filter(@tl_options.mngmt_events[@tl_options[:filter1]])
+        @tl_options.mngmt_build_filters
       end
     end
   end

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -17,30 +17,7 @@ module ApplicationController::Timelines
     if @tl_options.management_events?
       @tl_options.mngt.update_from_params(params)
     else
-      @tl_options.policy.result = params[:tl_result] if params[:tl_result]
-      if params[:tl_fl_grp_all] == "1"
-        @tl_options.policy.filters_all = true
-        @tl_options.policy.events.keys.sort.each do |e|
-          @tl_options.policy.applied_filters.push(e)
-        end
-      elsif params[:tl_fl_grp_all] == "null"
-        @tl_options.policy.filters_all = false
-        @tl_options.policy.applied_filters = []
-        @tl_options.policy.filters = Array.new(@tl_options.policy.events.length) { "" }
-        @tl_options.policy.fltr = @tl_options.policy.filters.dup
-      end
-      # Look through the event type checkbox keys
-      @tl_options.policy.events.keys.sort.each_with_index do |e, i|
-        ekey = "tl_fl_grp#{i + 1}__#{e.tr(" ", "_")}".to_sym
-        if params[ekey] == "1" || (@tl_options.policy.filters_all && params[ekey] != "null")
-          @tl_options.policy.filters[i] = e
-          @tl_options.policy.applied_filters.push(e) unless @tl_options.policy.applied_filters.include?(e) || @tl_options.policy.filters_all = false
-        elsif params[ekey] == "null"
-          @tl_options.policy.filters_all = false
-          @tl_options.policy.filters[i] = nil
-          @tl_options.policy.applied_filters.delete(e)
-        end
-      end
+      @tl_options.policy.update_from_params(params)
     end
 
     if @tl_options.management_events? &&

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -61,15 +61,11 @@ module ApplicationController::Timelines
        (@tl_options.filter1.blank? || @tl_options.filter2.blank? || @tl_options.filter3.blank?)
       add_flash(_("At least one filter must be selected"), :warning)
     elsif @tl_options.policy_events?
-      flg = true
-      @tl_options.events.sort.each_with_index do |_e, i|
-        unless @tl_options.pol_filter[i].blank?
-          flg = false
-          tl_build_timeline(refresh = "n")
-          break
-        end
+      if @tl_options.policy_event_filter_any?
+        tl_build_timeline('n')
+      else
+        add_flash(_("At least one filter must be selected"), :warning)
       end
-      add_flash(_("At least one filter must be selected"), :warning) if flg
     else
       tl_gen_timeline_data(refresh = "n")
       return unless @timeline

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -288,23 +288,7 @@ module ApplicationController::Timelines
           end
         end
       else
-        event_groups = EmsEvent.event_groups
-        if !@tl_options.mngt.filter1.blank? || !@tl_options.mngt.filter2.blank? || !@tl_options.mngt.filter3.blank?
-          if !@tl_options.mngt.filter1.blank?
-            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter1]][@tl_options.mngt.level.downcase.to_sym]) if @tl_options.mngt.events[@tl_options.mngt.filter1]
-            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter1]][:detail]) if @tl_options.mngt.level.downcase == "detail"
-          end
-          if !@tl_options.mngt.filter2.blank?
-            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter2]][@tl_options.mngt.level.downcase.to_sym]) if @tl_options.mngt.events[@tl_options.mngt.filter2]
-            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter2]][:detail]) if @tl_options.mngt.level.downcase == "detail"
-          end
-          if !@tl_options.mngt.filter3.blank?
-            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter3]][@tl_options.mngt.level.downcase.to_sym]) if @tl_options.mngt.events[@tl_options.mngt.filter3]
-            event_set.push(event_groups[@tl_options.mngt.events[@tl_options.mngt.filter3]][:detail]) if @tl_options.mngt.level.downcase == "detail"
-          end
-        else
-          event_set.push(event_groups[:power][@tl_options.mngt.level.to_sym])
-        end
+        event_set = @tl_options.mngt.event_set
       end
 
       if !event_set.empty?

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -208,15 +208,7 @@ module ApplicationController::Timelines
       @tl_options[:pol_fltr] = []
     end
     sdate, edate = @tl_record.first_and_last_event(@tl_options.evt_type)
-    if !sdate.nil? && !edate.nil?
-      @tl_options.date.start = [sdate.year.to_s, (sdate.month - 1).to_s, sdate.day.to_s].join(", ")
-      @tl_options.date.end = [edate.year.to_s, (edate.month - 1).to_s, edate.day.to_s].join(", ")
-      @tl_options.date.hourly ||= [edate.month, edate.day, edate.year].join("/")
-      @tl_options.date.daily ||= [edate.month, edate.day, edate.year].join("/")
-    else
-      @tl_options.date.start = @tl_options.date.end = nil
-    end
-    @tl_options.date.days ||= "7"
+    @tl_options.date.update_start_end(sdate, edate)
 
     if @tl_options.policy_events?
       @tl_options[:tl_result] ||= "both"

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -199,6 +199,10 @@ module ApplicationController::Timelines
       management_events? ? :event_streams : :policy_events
     end
 
+    def event_set
+      (policy_events? ? policy : mngt).event_set
+    end
+
     def drop_cache
       [policy, mngt].each(&:drop_cache)
     end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -47,8 +47,15 @@ module ApplicationController::Timelines
       end
     end
 
+    def mngmt_events
+      @mngmt_events ||= EmsEvent.event_groups.each_with_object({}) do |egroup, hash|
+        gname, list = egroup
+        hash[list[:name].to_s] = gname
+      end
+    end
+
     def drop_cache
-      @policy_events = nil
+      @policy_events = @mngmt_events = nil
     end
   end
 end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -3,25 +3,33 @@ module ApplicationController::Timelines
   SELECT_RESULT_TYPE = {_('Both') => 'both', _('True') => 'success', _('False') => 'failure'}.freeze
   EVENT_COLORS = ['#CD051C', '#005C25', '#035CB1', '#FF3106', '#FF00FF', '#000000'].freeze
 
+  DateOptions = Struct.new(
+    :daily,
+    :days,
+    :end,
+    :hourly,
+    :start,
+    :typ
+  )
   Options = Struct.new(
     :applied_filters,
-    :daily_date,
-    :days,
-    :edate,
+    :date,
     :filter1,
     :filter2,
     :filter3,
     :fl_typ,
-    :hourly_date,
     :model,
     :pol_filter,
     :pol_fltr,
-    :sdate,
     :tl_filter_all,
     :tl_result,
     :tl_show,
-    :typ
   ) do
+    def initialize(*args)
+      super
+      self.date = DateOptions.new
+    end
+
     def management_events?
       tl_show == 'timeline'
     end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -10,7 +10,15 @@ module ApplicationController::Timelines
     :hourly,
     :start,
     :typ
-  )
+  ) do
+    def update_from_params(params)
+      self.typ = params[:tl_typ] if params[:tl_typ]
+      self.days = params[:tl_days] if params[:tl_days]
+      self.hourly = params[:miq_date_1] if params[:miq_date_1] && typ == 'Hourly'
+      self.daily = params[:miq_date_1] if params[:miq_date_1] && typ == 'Daily'
+    end
+  end
+
   Options = Struct.new(
     :applied_filters,
     :date,

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -54,8 +54,23 @@ module ApplicationController::Timelines
       end
     end
 
+    def mngmt_build_filters
+      self.fltr1 = filter1.blank? ? '' : mngmt_build_filter(mngmt_events[filter1])
+      self.fltr2 = filter2.blank? ? '' : mngmt_build_filter(mngmt_events[filter2])
+      self.fltr3 = filter3.blank? ? '' : mngmt_build_filter(mngmt_events[filter3])
+    end
+
     def drop_cache
       @policy_events = @mngmt_events = nil
+    end
+
+    private
+
+    def mngmt_build_filter(grp_name) # hidden fields to highlight bands in timeline
+      event_groups = EmsEvent.event_groups
+      arr = event_groups[grp_name][fl_typ.downcase.to_sym]
+      arr.push(event_groups[grp_name][:critical]) if fl_typ.downcase == 'detail'
+      "(" << arr.join(")|(") << ")"
     end
   end
 end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -67,6 +67,28 @@ module ApplicationController::Timelines
       end
     end
 
+    def event_set
+      event_set = []
+      event_groups = EmsEvent.event_groups
+      if !filter1.blank? || !filter2.blank? || !filter3.blank?
+        unless filter1.blank?
+          event_set.push(event_groups[events[filter1]][level.downcase.to_sym]) if events[filter1]
+          event_set.push(event_groups[events[filter1]][:detail]) if level.downcase == 'detail'
+        end
+        unless filter2.blank?
+          event_set.push(event_groups[events[filter2]][level.downcase.to_sym]) if events[filter2]
+          event_set.push(event_groups[events[filter2]][:detail]) if level.downcase == 'detail'
+        end
+        unless filter3.blank?
+          event_set.push(event_groups[events[filter3]][level.downcase.to_sym]) if events[filter3]
+          event_set.push(event_groups[events[filter3]][:detail]) if level.downcase == "detail"
+        end
+      else
+        event_set.push(event_groups[:power][level.to_sym])
+      end
+      event_set
+    end
+
     def drop_cache
       @events = nil
     end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -71,16 +71,16 @@ module ApplicationController::Timelines
       event_set = []
       if !filter1.blank? || !filter2.blank? || !filter3.blank?
         unless filter1.blank?
-          event_set.push(event_groups[events[filter1]][level.downcase.to_sym]) if events[filter1]
-          event_set.push(event_groups[events[filter1]][:detail]) if level.downcase == 'detail'
+          event_set.push(event_groups[events[filter1]][level.to_sym]) if events[filter1]
+          event_set.push(event_groups[events[filter1]][:detail]) if level == 'detail'
         end
         unless filter2.blank?
-          event_set.push(event_groups[events[filter2]][level.downcase.to_sym]) if events[filter2]
-          event_set.push(event_groups[events[filter2]][:detail]) if level.downcase == 'detail'
+          event_set.push(event_groups[events[filter2]][level.to_sym]) if events[filter2]
+          event_set.push(event_groups[events[filter2]][:detail]) if level == 'detail'
         end
         unless filter3.blank?
-          event_set.push(event_groups[events[filter3]][level.downcase.to_sym]) if events[filter3]
-          event_set.push(event_groups[events[filter3]][:detail]) if level.downcase == "detail"
+          event_set.push(event_groups[events[filter3]][level.to_sym]) if events[filter3]
+          event_set.push(event_groups[events[filter3]][:detail]) if level == 'detail'
         end
       else
         event_set.push(event_groups[:power][level.to_sym])
@@ -95,8 +95,8 @@ module ApplicationController::Timelines
     private
 
     def build_filter(grp_name) # hidden fields to highlight bands in timeline
-      arr = event_groups[grp_name][level.downcase.to_sym]
-      arr.push(event_groups[grp_name][:critical]) if level.downcase == 'detail'
+      arr = event_groups[grp_name][level.to_sym]
+      arr.push(event_groups[grp_name][:critical]) if level == 'detail'
       "(" << arr.join(")|(") << ")"
     end
 

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -60,6 +60,10 @@ module ApplicationController::Timelines
       filter3.blank? ? '' : build_filter(events[filter3])
     end
 
+    def event_filter_any?
+      [filter1, filter2, filter3].any? { |f| !f.blank? }
+    end
+
     def events
       @events ||= event_groups.each_with_object({}) do |egroup, hash|
         gname, list = egroup

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -17,6 +17,18 @@ module ApplicationController::Timelines
       self.hourly = params[:miq_date_1] if params[:miq_date_1] && typ == 'Hourly'
       self.daily = params[:miq_date_1] if params[:miq_date_1] && typ == 'Daily'
     end
+
+    def update_start_end(sdate, edate)
+      if !sdate.nil? && !edate.nil?
+        self.start = [sdate.year.to_s, (sdate.month - 1).to_s, sdate.day.to_s].join(", ")
+        self.end = [edate.year.to_s, (edate.month - 1).to_s, edate.day.to_s].join(", ")
+        self.hourly ||= [edate.month, edate.day, edate.year].join("/")
+        self.daily ||= [edate.month, edate.day, edate.year].join("/")
+      else
+        self.start = self.end = nil
+      end
+      self.days ||= "7"
+    end
   end
 
   Options = Struct.new(

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -37,6 +37,10 @@ module ApplicationController::Timelines
       management_events? ? :event_streams : :policy_events
     end
 
+    def policy_event_filter_any?
+      pol_filter.any? { |f| !f.blank? }
+    end
+
     def events
       @events ||= MiqEventDefinitionSet.all.each_with_object({}) do |event, hash|
         hash[event.description] = event.members.collect(&:id)

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -156,6 +156,10 @@ module ApplicationController::Timelines
       @fltr_cache[number] ||= build_filter(filters[number])
     end
 
+    def event_set
+      applied_filters.blank? ? [] : applied_filters.collect { |e| events[e] }
+    end
+
     private
 
     def build_filter(grp_name) # hidden fields to highlight bands in timeline

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -61,7 +61,7 @@ module ApplicationController::Timelines
     end
 
     def events
-      @events ||= EmsEvent.event_groups.each_with_object({}) do |egroup, hash|
+      @events ||= event_groups.each_with_object({}) do |egroup, hash|
         gname, list = egroup
         hash[list[:name].to_s] = gname
       end
@@ -69,7 +69,6 @@ module ApplicationController::Timelines
 
     def event_set
       event_set = []
-      event_groups = EmsEvent.event_groups
       if !filter1.blank? || !filter2.blank? || !filter3.blank?
         unless filter1.blank?
           event_set.push(event_groups[events[filter1]][level.downcase.to_sym]) if events[filter1]
@@ -90,16 +89,19 @@ module ApplicationController::Timelines
     end
 
     def drop_cache
-      @events = nil
+      @events = @event_groups = nil
     end
 
     private
 
     def build_filter(grp_name) # hidden fields to highlight bands in timeline
-      event_groups = EmsEvent.event_groups
       arr = event_groups[grp_name][level.downcase.to_sym]
       arr.push(event_groups[grp_name][:critical]) if level.downcase == 'detail'
       "(" << arr.join(")|(") << ")"
+    end
+
+    def event_groups
+      @event_groups ||= EmsEvent.event_groups
     end
   end
 

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -11,9 +11,6 @@ module ApplicationController::Timelines
     :filter1,
     :filter2,
     :filter3,
-    :fltr1,
-    :fltr2,
-    :fltr3,
     :fl_typ,
     :hourly_date,
     :model,
@@ -54,10 +51,16 @@ module ApplicationController::Timelines
       end
     end
 
-    def mngmt_build_filters
-      self.fltr1 = filter1.blank? ? '' : mngmt_build_filter(mngmt_events[filter1])
-      self.fltr2 = filter2.blank? ? '' : mngmt_build_filter(mngmt_events[filter2])
-      self.fltr3 = filter3.blank? ? '' : mngmt_build_filter(mngmt_events[filter3])
+    def fltr1
+      filter1.blank? ? '' : mngmt_build_filter(mngmt_events[filter1])
+    end
+
+    def fltr2
+      filter2.blank? ? '' : mngmt_build_filter(mngmt_events[filter2])
+    end
+
+    def fltr3
+      filter3.blank? ? '' : mngmt_build_filter(mngmt_events[filter3])
     end
 
     def drop_cache

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -112,6 +112,33 @@ module ApplicationController::Timelines
     :filters_all,
     :result
   ) do
+    def update_from_params(params)
+      self.result = params[:tl_result] if params[:tl_result]
+      if params[:tl_fl_grp_all] == '1'
+        self.filters_all = true
+        events.keys.sort.each do |e|
+          applied_filters.push(e)
+        end
+      elsif params[:tl_fl_grp_all] == 'null'
+        self.filters_all = false
+        self.applied_filters = []
+        self.filters = Array.new(events.length) { '' }
+        self.fltr = filters.dup
+      end
+      # Look through the event type checkbox keys
+      events.keys.sort.each_with_index do |e, i|
+        ekey = "tl_fl_grp#{i + 1}__#{e.tr(' ', '_')}".to_sym
+        if params[ekey] == '1' || (filters_all && params[ekey] != 'null')
+          filters[i] = e
+          applied_filters.push(e) unless applied_filters.include?(e) || self.filters_all = false
+        elsif params[ekey] == 'null'
+          self.filters_all = false
+          filters[i] = nil
+          applied_filters.delete(e)
+        end
+      end
+    end
+
     def event_filter_any?
       filters.any? { |f| !f.blank? }
     end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -41,14 +41,14 @@ module ApplicationController::Timelines
       pol_filter.any? { |f| !f.blank? }
     end
 
-    def events
-      @events ||= MiqEventDefinitionSet.all.each_with_object({}) do |event, hash|
+    def policy_events
+      @policy_events ||= MiqEventDefinitionSet.all.each_with_object({}) do |event, hash|
         hash[event.description] = event.members.collect(&:id)
       end
     end
 
     def drop_cache
-      @events = nil
+      @policy_events = nil
     end
   end
 end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -37,6 +37,17 @@ module ApplicationController::Timelines
     :filter2,
     :filter3
   ) do
+    def update_from_params(params)
+      self.filter1 = params[:tl_fl_grp1] if params[:tl_fl_grp1]
+      self.filter2 = params[:tl_fl_grp2] if params[:tl_fl_grp2]
+      self.filter3 = params[:tl_fl_grp3] if params[:tl_fl_grp3]
+      # if pull down values have been switched
+      self.filter1 = '' if (filter1 == filter2 || filter1 == filter3) && !params[:tl_fl_grp1]
+      self.filter2 = '' if (filter2 == filter3 || filter2 == filter1) && !params[:tl_fl_grp2]
+      self.filter3 = '' if (filter3 == filter2 || filter3 == filter1) && !params[:tl_fl_grp3]
+      self.level = params[:tl_fl_typ] if params[:tl_fl_typ]
+    end
+
     def fltr1
       filter1.blank? ? '' : build_filter(events[filter1])
     end

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -100,7 +100,7 @@
             = _("Level")
           .col-md-8
             = select_tag("tl_fl_typ",
-              options_for_select([[_("Summary"), "Critical"], [_("Detail"), "Detail"]], @tl_options[:fl_typ]),
+              options_for_select([[_("Summary"), "Critical"], [_("Detail"), "Detail"]], @tl_options.mngt.level),
               :class                => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -110,7 +110,7 @@
             = _("Event Groups")
           .col-md-8
             = select_tag("tl_fl_grp1",
-              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngmt_events.keys.sort, @tl_options[:filter1]),
+              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngt.events.keys.sort, @tl_options.mngt.filter1),
               :class                => "selectpicker")
             .bootstrap-select{:style => "border-bottom: 6px solid #CD051C;"}
             :javascript
@@ -120,7 +120,7 @@
           %label.control-label.col-md-2
           .col-md-8
             = select_tag("tl_fl_grp2",
-              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngmt_events.keys.sort, @tl_options[:filter2]),
+              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngt.events.keys.sort, @tl_options.mngt.filter2),
               :class                => "selectpicker")
             .bootstrap-select{:style => "border-bottom: 6px solid #005C25;"}
             :javascript
@@ -130,14 +130,14 @@
           %label.control-label.col-md-2
           .col-md-8
             = select_tag("tl_fl_grp3",
-              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngmt_events.keys.sort, @tl_options[:filter3]),
+              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngt.events.keys.sort, @tl_options.mngt.filter3),
               :class                => "selectpicker")
             .bootstrap-select{:style => "border-bottom: 6px solid #035CB1;"}
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent('tl_fl_grp3', '#{url}', {beforeSend: true})
       %form#hiddenForm
-        %input#filter1{:type => "hidden", :name => "filter1", :value => @tl_options.fltr1}
-        %input#filter2{:type => "hidden", :name => "filter2", :value => @tl_options.fltr2}
-        %input#filter3{:type => "hidden", :name => "filter3", :value => @tl_options.fltr3}
+        %input#filter1{:type => "hidden", :name => "filter1", :value => @tl_options.mngt.fltr1}
+        %input#filter2{:type => "hidden", :name => "filter2", :value => @tl_options.mngt.fltr2}
+        %input#filter3{:type => "hidden", :name => "filter3", :value => @tl_options.mngt.fltr3}
     = _("* Dates/Times on this page are based on time zone: %s.") % session[:user_tz]

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -76,7 +76,7 @@
         .form-group
           %label.control-label.col-md-2
           .col-md-8
-            - @tl_options.events.keys.sort.each_with_index do |e, i|
+            - @tl_options.policy_events.keys.sort.each_with_index do |e, i|
 
               %div{:style => "padding: 0px 5px 0px 0px; float: left; color: #{ApplicationController::Timelines::EVENT_COLORS[i]}"}
                 = check_box_tag("tl_fl_grp#{i + 1}__#{e}", "1", @tl_options[:applied_filters].include?(e),
@@ -90,7 +90,7 @@
           .col-md-8
           .col-md-8
       %form#hiddenForm
-        - @tl_options.events.length.times do |i|
+        - @tl_options.policy_events.length.times do |i|
           %input{:type => "hidden", :name => "filter#{i}", :id => "filter#{i}", :value => @tl_options[:pol_fltr][i]}
 
     - else

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -137,7 +137,7 @@
               miqInitSelectPicker();
               miqSelectPickerEvent('tl_fl_grp3', '#{url}', {beforeSend: true})
       %form#hiddenForm
-        %input#filter1{:type => "hidden", :name => "filter1", :value => @tl_options[:fltr1]}
-        %input#filter2{:type => "hidden", :name => "filter2", :value => @tl_options[:fltr2]}
-        %input#filter3{:type => "hidden", :name => "filter3", :value => @tl_options[:fltr3]}
+        %input#filter1{:type => "hidden", :name => "filter1", :value => @tl_options.fltr1}
+        %input#filter2{:type => "hidden", :name => "filter2", :value => @tl_options.fltr2}
+        %input#filter3{:type => "hidden", :name => "filter3", :value => @tl_options.fltr3}
     = _("* Dates/Times on this page are based on time zone: %s.") % session[:user_tz]

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -110,7 +110,7 @@
             = _("Event Groups")
           .col-md-8
             = select_tag("tl_fl_grp1",
-              options_for_select([["<#{_('NONE')}> ", ""]] + tl_groups_hash.keys.sort, @tl_options[:filter1]),
+              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngmt_events.keys.sort, @tl_options[:filter1]),
               :class                => "selectpicker")
             .bootstrap-select{:style => "border-bottom: 6px solid #CD051C;"}
             :javascript
@@ -120,7 +120,7 @@
           %label.control-label.col-md-2
           .col-md-8
             = select_tag("tl_fl_grp2",
-              options_for_select([["<#{_('NONE')}> ", ""]] + tl_groups_hash.keys.sort, @tl_options[:filter2]),
+              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngmt_events.keys.sort, @tl_options[:filter2]),
               :class                => "selectpicker")
             .bootstrap-select{:style => "border-bottom: 6px solid #005C25;"}
             :javascript
@@ -130,7 +130,7 @@
           %label.control-label.col-md-2
           .col-md-8
             = select_tag("tl_fl_grp3",
-              options_for_select([["<#{_('NONE')}> ", ""]] + tl_groups_hash.keys.sort, @tl_options[:filter3]),
+              options_for_select([["<#{_('NONE')}> ", ""]] + @tl_options.mngmt_events.keys.sort, @tl_options[:filter3]),
               :class                => "selectpicker")
             .bootstrap-select{:style => "border-bottom: 6px solid #035CB1;"}
             :javascript

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -91,7 +91,7 @@
           .col-md-8
       %form#hiddenForm
         - @tl_options.policy.events.length.times do |i|
-          %input{:type => "hidden", :name => "filter#{i}", :id => "filter#{i}", :value => @tl_options.policy.fltr[i]}
+          %input{:type => "hidden", :name => "filter#{i}", :id => "filter#{i}", :value => @tl_options.policy.fltr(i)}
 
     - else
       .form-horizontal

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -60,7 +60,7 @@
             = _("Result")
           .col-md-8
             = select_tag("tl_result",
-              options_for_select(ApplicationController::Timelines::SELECT_RESULT_TYPE, @tl_options[:tl_result]),
+              options_for_select(ApplicationController::Timelines::SELECT_RESULT_TYPE, @tl_options.policy.result),
               :class                => "selectpicker")
             :javascript
               miqInitSelectPicker();
@@ -69,17 +69,17 @@
           %label.control-label.col-md-2
             = _("Event Type")
           .col-md-8
-            = check_box_tag("tl_fl_grp_all", "1", @tl_options[:tl_filter_all],
+            = check_box_tag("tl_fl_grp_all", "1", @tl_options.policy.filters_all,
               "data-miq_sparkle_on"       => true,
               "data-miq_observe_checkbox" => {:url => url}.to_json)
             = _("(Check All)")
         .form-group
           %label.control-label.col-md-2
           .col-md-8
-            - @tl_options.policy_events.keys.sort.each_with_index do |e, i|
+            - @tl_options.policy.events.keys.sort.each_with_index do |e, i|
 
               %div{:style => "padding: 0px 5px 0px 0px; float: left; color: #{ApplicationController::Timelines::EVENT_COLORS[i]}"}
-                = check_box_tag("tl_fl_grp#{i + 1}__#{e}", "1", @tl_options[:applied_filters].include?(e),
+                = check_box_tag("tl_fl_grp#{i + 1}__#{e}", "1", @tl_options.policy.applied_filters.include?(e),
                   "data-miq_sparkle_on"       => true,
                   "data-miq_observe_checkbox" => {:url => url}.to_json)
                 = h(e)
@@ -90,8 +90,8 @@
           .col-md-8
           .col-md-8
       %form#hiddenForm
-        - @tl_options.policy_events.length.times do |i|
-          %input{:type => "hidden", :name => "filter#{i}", :id => "filter#{i}", :value => @tl_options[:pol_fltr][i]}
+        - @tl_options.policy.events.length.times do |i|
+          %input{:type => "hidden", :name => "filter#{i}", :id => "filter#{i}", :value => @tl_options.policy.fltr[i]}
 
     - else
       .form-horizontal

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -23,7 +23,7 @@
           = _("Interval")
         .col-md-8
           = select_tag("tl_typ",
-            options_for_select([[_("Hourly"), "Hourly"], [_("Daily"), "Daily"]], @tl_options[:typ]),
+            options_for_select([[_("Hourly"), "Hourly"], [_("Daily"), "Daily"]], @tl_options.date.typ),
             :class                => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -32,12 +32,12 @@
         %label.control-label.col-md-2
           = _("Date")
         .col-md-8
-          - v = h(@tl_options[:typ] == "Hourly" ? @tl_options[:hourly_date] : @tl_options[:daily_date])
+          - v = h(@tl_options.date.typ == 'Hourly' ? @tl_options.date.hourly : @tl_options.date.daily)
           = datepicker_input_tag("miq_date_1", v,
             :readonly               => "true",
             "data-miq_sparkle_on"   => true,
             "data-miq_observe_date" => {:url => url}.to_json)
-      - if @tl_options[:typ] == "Hourly"
+      - if @tl_options.date.typ == 'Hourly'
         %span#day_span{:style => "display: none;"}
       - else
         %span#day_span
@@ -46,7 +46,7 @@
               = _("Show")
             .col-md-8
               = select_tag("tl_days",
-                options_for_select((2..31).to_a, @tl_options[:days].to_i),
+                options_for_select((2..31).to_a, @tl_options.date.days.to_i),
                 :class                => "selectpicker")
               :javascript
                 miqInitSelectPicker();

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -100,7 +100,7 @@
             = _("Level")
           .col-md-8
             = select_tag("tl_fl_typ",
-              options_for_select([[_("Summary"), "Critical"], [_("Detail"), "Detail"]], @tl_options.mngt.level),
+              options_for_select([[_("Summary"), "critical"], [_("Detail"), "detail"]], @tl_options.mngt.level),
               :class                => "selectpicker")
             :javascript
               miqInitSelectPicker();

--- a/app/views/layouts/_tl_show.html.haml
+++ b/app/views/layouts/_tl_show.html.haml
@@ -1,7 +1,7 @@
 -# Create from/to date JS vars to limit calendar selection range
 :javascript
-  ManageIQ.calendar.calDateFrom = new Date(#{@tl_options[:sdate]});
-  ManageIQ.calendar.calDateTo = new Date(#{@tl_options[:edate]});
+  ManageIQ.calendar.calDateFrom = new Date(#{@tl_options.date.start});
+  ManageIQ.calendar.calDateTo = new Date(#{@tl_options.date.end});
 
 = render :partial => "layouts/flash_msg"
 = render :partial => "layouts/tl_options"


### PR DESCRIPTION
Previous part ([1/2]) was #9273.

This step attempts split `Timelines::Options` into smaller pieces that can be understood easily. `Timelines::DateOptions` can be perhaps re-used among multiple pages later on. This pr also slightly reduces data we keep in session as well as round-trips to database.

This is still wip, but mergable any time as you see fit, @martinpovolny.

@miq-bot assign @martinpovolny
@miq-bot add_label ui, refactoring, darga/no