### PR TITLE
Rescue RecordNorFound in MiqQueue#destroy_potentially_stale_record

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -504,6 +504,10 @@ class MiqQueue < ApplicationRecord
   def destroy_potentially_stale_record
     destroy
   rescue ActiveRecord::StaleObjectError
-    reload.destroy
+    begin
+      reload.destroy
+    rescue ActiveRecord::RecordNotFound
+      # ignore
+    end
   end
 end # Class MiqQueue


### PR DESCRIPTION
Issue: Attempt to execute reload.destroy on stale object sporadicly throws RecordNotFound exception. When it happens in rails console -  simulate_queue_worker process terminated, which is very annoying when running metrics aggregation

Fix: rescue attempt to reload.destroy in MiqQueue#destroy_potentially_stale_record

/cc @gtanzillo 