### PR TITLE
Use a default connection object in EvmDatabase.ping

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -96,7 +96,7 @@ class EvmDatabase
   end
 
   # Determines the average time to the database in milliseconds
-  def self.ping(connection)
+  def self.ping(connection = ApplicationRecord.connection)
     query = "SELECT 1"
     Benchmark.realtime { 10.times { connection.select_value(query) } } / 10 * 1000
   end


### PR DESCRIPTION
2705059811f5d8030914c23f9d5f3353219c0817 changed `db_ping.rb` to use `EvmDatabase` instead of `MiqServer`.

Previously `EvmDatabase.ping` did not default the connection parameter which was causing `db_ping.rb` to fail.