### PR TITLE
Update azure-armrest to 0.2.7.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -15,7 +15,7 @@ gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails
 # Not locally modified and not required
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.3",            :require => false
-gem "azure-armrest",           "=0.2.6",            :require => false
+gem "azure-armrest",           "=0.2.7",            :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false


### PR DESCRIPTION
This PR updates the azure-armrest gem to 0.2.7. This includes a critical fix for URI encoding.

It is also part of the solution to https://bugzilla.redhat.com/show_bug.cgi?id=1345888 (the other part having already been fixed in azure-signature-0.2.2).

