### PR TITLE
Use PatternFly close button in flash messages

### DIFF
--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -7,24 +7,28 @@
   - if top_pad
     %div{:style => "padding-top: #{top_pad}px;"}
   - if @flash_array
-    %div{:id      => "flash_text_div#{div_num}",
-         :onclick => click_remove ? javascript_hide("flash_msg_div#{div_num}") : "",
-         :title   => click_remove ? _("Click to remove messages") : ""}
+    %div{:id      => "flash_text_div#{div_num}"}
       - @flash_array.each do |fl|
         - case fl[:level]
         - when :error
-          .alert.alert-danger
+          .alert.alert-danger.alert-dismissable
+            %button.close{:data => {:dismiss => "alert"}}
+              %span.pficon.pficon-close
             %span.pficon.pficon-error-circle-o
             %strong= h(fl[:message])
         - when :warning
-          .alert.alert-warning
+          .alert.alert-warning.alert-dismissable
+            %button.close{:data => {:dismiss => "alert"}}
+              %span.pficon.pficon-close
             %span.pficon-warning-triangle-o
             %strong= h(fl[:message])
         - when :info
           = render :partial => "layouts/info_msg",
                    :locals => {:message => h(fl[:message])}
         - else
-          .alert.alert-success
+          .alert.alert-success.alert-dismissable
+            %button.close{:data => {:dismiss => "alert"}}
+              %span.pficon.pficon-close
             %span.pficon.pficon-ok
             %strong= h(fl[:message])
   - if bottom_pad


### PR DESCRIPTION
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1330143

The bug happens on the login screen but this change could effect the entire UI. This partial is rendered from ~250 files.

Current behavior is that flash messages disappear if any part of the DOM element is clicked. This change moves closer to the PF pattern of having an explicit close button. 

**Before**
![screen shot 2016-06-20 at 9 44 11 am](https://cloud.githubusercontent.com/assets/39493/16202787/15fde404-36cc-11e6-867d-93effca52ada.png)

**After**
![screen shot 2016-06-20 at 9 40 02 am](https://cloud.githubusercontent.com/assets/39493/16202794/1bdd419e-36cc-11e6-9943-3816d58346c1.png)


/cc @epwinchell @dclarizio 


