### PR TITLE
Limit tiered rates "Per Time" to only hourly

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -4,7 +4,7 @@ class ChargebackController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  PER_TIME_TYPES = %w(hourly daily weekly monthly).freeze
+  PER_TIME_TYPES = %w(hourly).freeze
 
   def per_time_types_from
     PER_TIME_TYPES.map { |time_type| {time_type => time_type.capitalize} }.reduce(:merge)

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -9,7 +9,7 @@
   %td{:rowspan => n.to_s}
     = r[:description]
   %td{:rowspan => n.to_s}
-    - per_time_types = {"hourly"  => "Hourly", "daily"   => "Daily", "weekly"  => "Weekly", "monthly" => "Monthly"}
+    - per_time_types = {"hourly"  => "Hourly"}
     = select_tag("per_time_#{i}",
       options_for_select(per_time_types.invert, @edit[:new][:details][i.to_i][:per_time]),
       "data-miq_observe" => {:url => url}.to_json)


### PR DESCRIPTION
Chargeback reports are generated by pulling hourly metrics, selecting rates and converting the selected rate to hourly and applying the selected to the hourly metric value. This does not work very well with tiered rates that are not hourly because it will use the hourly metric to select a tier that may be daily, weekly or monthly.

This change mitigates the this by limiting to only hourly when adding or editing rate tiers.

https://bugzilla.redhat.com/show_bug.cgi?id=1337278

/cc @lpichler @sergio-ocon @tledesma @amaurygonzalez 