### PR TITLE
[WIP] Moving Settings from Nav to Banner

### DIFF
--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -9,7 +9,6 @@
       %li.disabled
         %a{:href => "#"}
           = _('Server: %s') % appliance_name
-
       - if current_user.miq_groups.length > 1
         %li.dropdown-submenu.pull-left
           %a{:href => "#"}
@@ -32,6 +31,19 @@
         %li.disabled
           %a{:href => "#"}
             = current_group.try(:description)
+      %li.divider
+      %li
+        %a
+          = _('My Settings')
+      %li
+        %a
+          = _('Tasks')
+      %li
+        %a
+          = _('Configuration')
+      %li
+        %a
+          = _('About')
       %li.divider
       %li
         %a{:href => "/dashboard/logout", :onclick => 'return miqCheckForChanges()', :title => _("Click to Logout")}


### PR DESCRIPTION
Sample code for initial move of Settings to the banner. "About" and "Tasks" will shortly move to the 'About Modal' and 'Notification Drawer', respectively.

https://trello.com/c/FLvu7RQ8
<img width="273" alt="screen shot 2016-06-20 at 12 57 44 pm" src="https://cloud.githubusercontent.com/assets/1287144/16203121/ba4bb3f0-36e6-11e6-8a8f-1289d0e35b59.png">
