### PR TITLE
Add new category and tag: lifecycle/retire_full.

### DIFF
--- a/db/fixtures/classifications.yml
+++ b/db/fixtures/classifications.yml
@@ -926,4 +926,21 @@
   :parent_id: 0
   :default: true
   :single_value: "1"
+- :description: LifeCycle
+  :entries: 
+  - :description: Fully retire VM and remove from Provider
+    :read_only: "0"
+    :syntax: string
+    :name: retire_full
+    :example_text: 
+    :default: true
+    :single_value: "1"
+  :read_only: "0"
+  :syntax: string
+  :show: true
+  :name: lifecycle
+  :example_text: LifeCycle Options
+  :parent_id: 0
+  :default: true
+  :single_value: "1"
 


### PR DESCRIPTION
The default retirement state machine will remove a VM from a provider if: a) the VM was provisioned by us, or b) the VM is tagged with the lifecycle/retire_full tag. This PR adds the category and tag for that purpose.  

https://trello.com/c/CAwcyFPO

