### PR TITLE
Refactor #update_field_visibility in MiqProvisionVirtWorkflow

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -166,8 +166,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     options_hash = setup_parameters_for_visibility_sevice(options)
     visibility_hash = dialog_field_visibility_service.determine_visibility(options_hash)
 
-    update_field_visibility_linked_clone(options, visibility_hash)
-
     update_field_display_values(visibility_hash)
 
     # Show/Hide Notes
@@ -183,18 +181,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     f.each { |k, v| show_fields(k, v, :notes_display) }
 
     update_field_read_only(options)
-  end
-
-  def update_field_visibility_linked_clone(_options = {}, f)
-    if get_value(@values[:provision_type]).to_s == 'vmware'
-      show_flag = @vm_snapshot_count.zero? ? :show : :edit
-      f[show_flag] += [:linked_clone]
-
-      show_flag = get_value(@values[:linked_clone]) == true ? :edit : :hide
-      f[show_flag] += [:snapshot]
-    else
-      f[:hide] += [:linked_clone, :snapshot]
-    end
   end
 
   def update_field_read_only(options = {})

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -200,8 +200,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
     update_field_visibility_linked_clone(options, f)
 
-    update_field_visibility_pxe_iso(f)
-
     # Update field :display value
     all_fields = []
     fields do |field_name, field, _dialog_name, _dialog|
@@ -235,14 +233,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     else
       f[:hide] += [:linked_clone, :snapshot]
     end
-  end
-
-  def update_field_visibility_pxe_iso(f)
-    show_flag = self.supports_pxe? ? :edit : :hide
-    f[show_flag] += [:pxe_image_id, :pxe_server_id]
-
-    show_flag = self.supports_iso? ? :edit : :hide
-    f[show_flag] += [:iso_image_id]
   end
 
   def show_customize_fields_pxe(fields)

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -963,12 +963,12 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def update_field_display_values(options = {})
-    options_hash = setup_parameters_for_visibility_sevice(options)
+    options_hash = setup_parameters_for_visibility_service(options)
     visibility_hash = dialog_field_visibility_service.determine_visibility(options_hash)
 
     all_fields = []
     fields do |field_name, field, _dialog_name, _dialog|
-      all_fields << field.merge({:name => field_name})
+      all_fields << field.merge(:name => field_name)
     end
     dialog_field_visibility_service.set_shown_fields(visibility_hash[:edit], all_fields)
     dialog_field_visibility_service.set_hidden_fields(visibility_hash[:hide], all_fields)
@@ -986,14 +986,14 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     field_note_visibility.each { |display_flag, field_names| show_fields(display_flag, field_names, :notes_display) }
   end
 
-  def setup_parameters_for_visibility_sevice(options)
+  def setup_parameters_for_visibility_service(options)
     vm = get_source_vm
     platform = options[:force_platform] || vm.try(:platform)
 
     number_of_vms = get_value(@values[:number_of_vms]).to_i
 
     customize_fields_list = []
-    self.fields(:customize) do |field_name, _, _, _|
+    fields(:customize) do |field_name, _, _, _|
       customize_fields_list << field_name.to_sym
     end
 
@@ -1006,9 +1006,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       :request_type                    => request_type,
       :retirement                      => get_value(@values[:retirement]).to_i,
       :service_template_request        => get_value(@values[:service_template_request]),
-      :supports_customization_template => self.supports_customization_template?,
-      :supports_iso                    => self.supports_iso?,
-      :supports_pxe                    => self.supports_pxe?,
+      :supports_customization_template => supports_customization_template?,
+      :supports_iso                    => supports_iso?,
+      :supports_pxe                    => supports_pxe?,
       :sysprep_auto_logon              => get_value(@values[:sysprep_auto_logon]),
       :sysprep_custom_spec             => get_value(@values[:sysprep_custom_spec]),
       :sysprep_enabled                 => get_value(@values[:sysprep_enabled])

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -181,6 +181,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       :customize_fields_list           => customize_fields_list,
       :number_of_vms                   => number_of_vms,
       :platform                        => platform,
+      :request_type                    => request_type,
       :retirement                      => get_value(@values[:retirement]).to_i,
       :service_template_request        => get_value(@values[:service_template_request]),
       :supports_customization_template => self.supports_customization_template?,
@@ -193,13 +194,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
     f = dialog_field_visibility_service.determine_visibility(options)
 
-    # Hide VM filter if we are using a pre-selected VM
-    if [:clone_to_vm, :clone_to_template].include?(request_type)
-      f[:hide] += [:vm_filter]
-      if request_type == :clone_to_template
-        show_dialog(:customize, :hide, "disabled")
-        f[:hide] += [:vm_auto_start]
-      end
+    if request_type == :clone_to_template
+      show_dialog(:customize, :hide, "disabled")
     end
 
     update_field_visibility_linked_clone(options, f)
@@ -225,7 +221,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
     # Update field :notes_display value
     f.each { |k, v| show_fields(k, v, :notes_display) }
-
 
     update_field_read_only(options)
   end

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -235,41 +235,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
   end
 
-  def show_customize_fields_pxe(fields)
-    pxe_customization_fields = [
-      :root_password,
-      :addr_mode,
-      :hostname,
-      :ip_addr,
-      :subnet_mask,
-      :gateway,
-      :dns_servers,
-      :dns_suffixes,
-      :customization_template_id,
-      :customization_template_script,
-    ]
-
-    pxe_customization_fields.each do |f|
-      fields[:edit].push(f) unless fields[:edit].include?(f)
-      fields[:hide].delete(f)
-    end
-  end
-
-  def show_customize_fields(fields, platform)
-    # ISO and cloud-init prov. needs to show same fields on customize tab as Pxe prov.
-    return show_customize_fields_pxe(fields) if self.supports_customization_template?
-
-    exclude_list = [:sysprep_spec_override, :sysprep_custom_spec, :sysprep_enabled, :sysprep_upload_file, :sysprep_upload_text,
-                    :linux_host_name, :sysprep_computer_name, :ip_addr, :subnet_mask, :gateway, :dns_servers, :dns_suffixes]
-    linux_fields = [:linux_domain_name]
-    show_options = [:edit, :hide]
-    show_options.reverse! if platform == 'linux'
-    self.fields(:customize) do |fn, _f, _dn, _d|
-      next if exclude_list.include?(fn)
-      linux_fields.include?(fn) ? fields[show_options[1]] += [fn] : fields[show_options[0]] += [fn]
-    end
-  end
-
   def update_field_read_only(options = {})
     read_only = get_value(@values[:sysprep_custom_spec]).blank? ? false : !(get_value(@values[:sysprep_spec_override]) == true)
     exclude_list = [:sysprep_spec_override, :sysprep_custom_spec, :sysprep_enabled, :sysprep_upload_file, :sysprep_upload_text]

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -187,13 +187,11 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       :supports_iso                    => self.supports_iso?,
       :supports_pxe                    => self.supports_pxe?,
       :sysprep_auto_logon              => get_value(@values[:sysprep_auto_logon]),
+      :sysprep_custom_spec             => get_value(@values[:sysprep_custom_spec]),
       :sysprep_enabled                 => get_value(@values[:sysprep_enabled])
     }
 
     f = dialog_field_visibility_service.determine_visibility(options)
-
-    show_flag = get_value(@values[:sysprep_custom_spec]).blank? ? :hide : :edit
-    f[show_flag] += [:sysprep_spec_override]
 
     # Hide VM filter if we are using a pre-selected VM
     if [:clone_to_vm, :clone_to_template].include?(request_type)

--- a/app/services/auto_placement_visibility_service.rb
+++ b/app/services/auto_placement_visibility_service.rb
@@ -11,7 +11,8 @@ class AutoPlacementVisibilityService
       :cluster_filter,
       :placement_cluster_name,
       :rp_filter,
-      :placement_rp_name
+      :placement_rp_name,
+      :placement_dc_name
     ]
 
     if auto_placement_enabled

--- a/app/services/auto_placement_visibility_service.rb
+++ b/app/services/auto_placement_visibility_service.rb
@@ -1,0 +1,25 @@
+class AutoPlacementVisibilityService
+  def determine_visibility(auto_placement_enabled)
+    field_names_to_hide = []
+    field_names_to_show = []
+
+    auto_placement_values = [
+      :placement_host_name,
+      :placement_ds_name,
+      :host_filter,
+      :ds_filter,
+      :cluster_filter,
+      :placement_cluster_name,
+      :rp_filter,
+      :placement_rp_name
+    ]
+
+    if auto_placement_enabled
+      field_names_to_hide += auto_placement_values
+    else
+      field_names_to_show += auto_placement_values
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+end

--- a/app/services/customize_fields_visibility_service.rb
+++ b/app/services/customize_fields_visibility_service.rb
@@ -34,13 +34,12 @@ class CustomizeFieldsVisibilityService
 
       customize_fields_list.each do |field_name|
         next if exclude_list.include?(field_name)
+        next unless platform == "linux"
 
-        if platform == "linux"
-          if field_name == :linux_domain_name
-            field_names_to_show << field_name
-          else
-            field_names_to_hide << field_name
-          end
+        if field_name == :linux_domain_name
+          field_names_to_show << field_name
+        else
+          field_names_to_hide << field_name
         end
       end
     end

--- a/app/services/customize_fields_visibility_service.rb
+++ b/app/services/customize_fields_visibility_service.rb
@@ -1,0 +1,50 @@
+class CustomizeFieldsVisibilityService
+  def determine_visibility(platform, supports_customization_template, customize_fields_list)
+    field_names_to_show = []
+    field_names_to_hide = []
+
+    if supports_customization_template
+      field_names_to_show += [
+        :addr_mode,
+        :customization_template_id,
+        :customization_template_script,
+        :dns_servers,
+        :dns_suffixes,
+        :gateway,
+        :hostname,
+        :ip_addr,
+        :root_password,
+        :subnet_mask
+      ]
+    else
+      exclude_list = [
+        :sysprep_spec_override,
+        :sysprep_custom_spec,
+        :sysprep_enabled,
+        :sysprep_upload_file,
+        :sysprep_upload_text,
+        :linux_host_name,
+        :sysprep_computer_name,
+        :ip_addr,
+        :subnet_mask,
+        :gateway,
+        :dns_servers,
+        :dns_suffixes
+      ]
+
+      customize_fields_list.each do |field_name|
+        next if exclude_list.include?(field_name)
+
+        if platform == "linux"
+          if field_name == :linux_domain_name
+            field_names_to_show << field_name
+          else
+            field_names_to_hide << field_name
+          end
+        end
+      end
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+end

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -2,14 +2,19 @@ class DialogFieldVisibilityService
   def initialize(
     auto_placement_visibility_service = AutoPlacementVisibilityService.new,
     number_of_vms_visibility_service = NumberOfVmsVisibilityService.new,
+    service_template_fields_visibility_service = ServiceTemplateFieldsVisibilityService.new,
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
+    @service_template_fields_visibility_service = service_template_fields_visibility_service
   end
 
   def determine_visibility(options)
     field_names_to_hide = []
     field_names_to_show = []
+
+    visibility_hash = @service_template_fields_visibility_service.determine_visibility(options[:service_template_request])
+    field_names_to_hide += visibility_hash[:hide]
 
     visibility_hash = @auto_placement_visibility_service.determine_visibility(options[:auto_placement_enabled])
     field_names_to_hide += visibility_hash[:hide]

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -8,7 +8,8 @@ class DialogFieldVisibilityService
     retirement_visibility_service = RetirementVisibilityService.new,
     customize_fields_visibility_service = CustomizeFieldsVisibilityService.new,
     sysprep_custom_spec_visibility_service = SysprepCustomSpecVisibilityService.new,
-    request_type_visibility_service = RequestTypeVisibilityService.new
+    request_type_visibility_service = RequestTypeVisibilityService.new,
+    pxe_iso_visibility_service = PxeIsoVisibilityService.new
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
@@ -19,6 +20,7 @@ class DialogFieldVisibilityService
     @customize_fields_visibility_service = customize_fields_visibility_service
     @sysprep_custom_spec_visibility_service = sysprep_custom_spec_visibility_service
     @request_type_visibility_service = request_type_visibility_service
+    @pxe_iso_visibility_service = pxe_iso_visibility_service
   end
 
   def set_hidden_fields(field_names_to_hide, fields)
@@ -66,6 +68,10 @@ class DialogFieldVisibilityService
 
     visibility_hash = @request_type_visibility_service.determine_visibility(options[:request_type])
     field_names_to_hide += visibility_hash[:hide]
+
+    visibility_hash = @pxe_iso_visibility_service.determine_visibility(options[:supports_iso], options[:supports_pxe])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
 
     field_names_to_hide -= field_names_to_hide & field_names_to_show
     field_names_to_hide.uniq!

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -4,13 +4,15 @@ class DialogFieldVisibilityService
     number_of_vms_visibility_service = NumberOfVmsVisibilityService.new,
     service_template_fields_visibility_service = ServiceTemplateFieldsVisibilityService.new,
     network_visibility_service = NetworkVisibilityService.new,
-    sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new
+    sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new,
+    retirement_visibility_service = RetirementVisibilityService.new
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
     @service_template_fields_visibility_service = service_template_fields_visibility_service
     @network_visibility_service = network_visibility_service
     @sysprep_auto_logon_visibility_service = sysprep_auto_logon_visibility_service
+    @retirement_visibility_service = retirement_visibility_service
   end
 
   def determine_visibility(options)
@@ -35,6 +37,11 @@ class DialogFieldVisibilityService
     visibility_hash = @sysprep_auto_logon_visibility_service.determine_visibility(options[:sysprep_auto_logon])
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
+
+    visibility_hash = @retirement_visibility_service.determine_visibility(options[:retirement])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
+
     {:hide => field_names_to_hide.flatten, :edit => field_names_to_show.flatten}
   end
 end

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -3,10 +3,12 @@ class DialogFieldVisibilityService
     auto_placement_visibility_service = AutoPlacementVisibilityService.new,
     number_of_vms_visibility_service = NumberOfVmsVisibilityService.new,
     service_template_fields_visibility_service = ServiceTemplateFieldsVisibilityService.new,
+    network_visibility_service = NetworkVisibilityService.new,
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
     @service_template_fields_visibility_service = service_template_fields_visibility_service
+    @network_visibility_service = network_visibility_service
   end
 
   def determine_visibility(options)
@@ -21,6 +23,10 @@ class DialogFieldVisibilityService
     field_names_to_show += visibility_hash[:show]
 
     visibility_hash = @number_of_vms_visibility_service.determine_visibility(options[:number_of_vms], options[:platform])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
+
+    visibility_hash = @network_visibility_service.determine_visibility(options[:sysprep_enabled], options[:supports_pxe], options[:supports_iso], options[:addr_mode])
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
     {:hide => field_names_to_hide.flatten, :edit => field_names_to_show.flatten}

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -6,7 +6,8 @@ class DialogFieldVisibilityService
     network_visibility_service = NetworkVisibilityService.new,
     sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new,
     retirement_visibility_service = RetirementVisibilityService.new,
-    customize_fields_visibility_service = CustomizeFieldsVisibilityService.new
+    customize_fields_visibility_service = CustomizeFieldsVisibilityService.new,
+    sysprep_custom_spec_visibility_service = SysprepCustomSpecVisibilityService.new
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
@@ -15,6 +16,7 @@ class DialogFieldVisibilityService
     @sysprep_auto_logon_visibility_service = sysprep_auto_logon_visibility_service
     @retirement_visibility_service = retirement_visibility_service
     @customize_fields_visibility_service = customize_fields_visibility_service
+    @sysprep_custom_spec_visibility_service = sysprep_custom_spec_visibility_service
   end
 
   def set_hidden_fields(field_names_to_hide, fields)
@@ -53,6 +55,10 @@ class DialogFieldVisibilityService
     field_names_to_show += visibility_hash[:show]
 
     visibility_hash = @customize_fields_visibility_service.determine_visibility(options[:platform], options[:supports_customization_template], options[:customize_fields_list])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
+
+    visibility_hash = @sysprep_custom_spec_visibility_service.determine_visibility(options[:sysprep_custom_spec])
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -1,8 +1,10 @@
 class DialogFieldVisibilityService
   def initialize(
-    auto_placement_visibility_service = AutoPlacementVisibilityService.new
+    auto_placement_visibility_service = AutoPlacementVisibilityService.new,
+    number_of_vms_visibility_service = NumberOfVmsVisibilityService.new,
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
+    @number_of_vms_visibility_service = number_of_vms_visibility_service
   end
 
   def determine_visibility(options)
@@ -13,6 +15,9 @@ class DialogFieldVisibilityService
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 
+    visibility_hash = @number_of_vms_visibility_service.determine_visibility(options[:number_of_vms], options[:platform])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
     {:hide => field_names_to_hide.flatten, :edit => field_names_to_show.flatten}
   end
 end

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -1,0 +1,18 @@
+class DialogFieldVisibilityService
+  def initialize(
+    auto_placement_visibility_service = AutoPlacementVisibilityService.new
+  )
+    @auto_placement_visibility_service = auto_placement_visibility_service
+  end
+
+  def determine_visibility(options)
+    field_names_to_hide = []
+    field_names_to_show = []
+
+    visibility_hash = @auto_placement_visibility_service.determine_visibility(options[:auto_placement_enabled])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
+
+    {:hide => field_names_to_hide.flatten, :edit => field_names_to_show.flatten}
+  end
+end

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -9,7 +9,8 @@ class DialogFieldVisibilityService
     customize_fields_visibility_service = CustomizeFieldsVisibilityService.new,
     sysprep_custom_spec_visibility_service = SysprepCustomSpecVisibilityService.new,
     request_type_visibility_service = RequestTypeVisibilityService.new,
-    pxe_iso_visibility_service = PxeIsoVisibilityService.new
+    pxe_iso_visibility_service = PxeIsoVisibilityService.new,
+    linked_clone_visibility_service = LinkedCloneVisibilityService.new
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
@@ -21,6 +22,7 @@ class DialogFieldVisibilityService
     @sysprep_custom_spec_visibility_service = sysprep_custom_spec_visibility_service
     @request_type_visibility_service = request_type_visibility_service
     @pxe_iso_visibility_service = pxe_iso_visibility_service
+    @linked_clone_visibility_service = linked_clone_visibility_service
   end
 
   def set_hidden_fields(field_names_to_hide, fields)
@@ -35,18 +37,28 @@ class DialogFieldVisibilityService
     field_names_to_hide = []
     field_names_to_show = []
 
-    visibility_hash = @service_template_fields_visibility_service.determine_visibility(options[:service_template_request])
+    visibility_hash = @service_template_fields_visibility_service.determine_visibility(
+      options[:service_template_request]
+    )
     field_names_to_hide += visibility_hash[:hide]
 
     visibility_hash = @auto_placement_visibility_service.determine_visibility(options[:auto_placement_enabled])
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 
-    visibility_hash = @number_of_vms_visibility_service.determine_visibility(options[:number_of_vms], options[:platform])
+    visibility_hash = @number_of_vms_visibility_service.determine_visibility(
+      options[:number_of_vms],
+      options[:platform]
+    )
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 
-    visibility_hash = @network_visibility_service.determine_visibility(options[:sysprep_enabled], options[:supports_pxe], options[:supports_iso], options[:addr_mode])
+    visibility_hash = @network_visibility_service.determine_visibility(
+      options[:sysprep_enabled],
+      options[:supports_pxe],
+      options[:supports_iso],
+      options[:addr_mode]
+    )
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 
@@ -58,7 +70,11 @@ class DialogFieldVisibilityService
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 
-    visibility_hash = @customize_fields_visibility_service.determine_visibility(options[:platform], options[:supports_customization_template], options[:customize_fields_list])
+    visibility_hash = @customize_fields_visibility_service.determine_visibility(
+      options[:platform],
+      options[:supports_customization_template],
+      options[:customize_fields_list]
+    )
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 
@@ -70,6 +86,13 @@ class DialogFieldVisibilityService
     field_names_to_hide += visibility_hash[:hide]
 
     visibility_hash = @pxe_iso_visibility_service.determine_visibility(options[:supports_iso], options[:supports_pxe])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
+
+    visibility_hash = @linked_clone_visibility_service.determine_visibility(
+      options[:provision_type],
+      options[:linked_clone]
+    )
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -4,11 +4,13 @@ class DialogFieldVisibilityService
     number_of_vms_visibility_service = NumberOfVmsVisibilityService.new,
     service_template_fields_visibility_service = ServiceTemplateFieldsVisibilityService.new,
     network_visibility_service = NetworkVisibilityService.new,
+    sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
     @service_template_fields_visibility_service = service_template_fields_visibility_service
     @network_visibility_service = network_visibility_service
+    @sysprep_auto_logon_visibility_service = sysprep_auto_logon_visibility_service
   end
 
   def determine_visibility(options)
@@ -27,6 +29,10 @@ class DialogFieldVisibilityService
     field_names_to_show += visibility_hash[:show]
 
     visibility_hash = @network_visibility_service.determine_visibility(options[:sysprep_enabled], options[:supports_pxe], options[:supports_iso], options[:addr_mode])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
+
+    visibility_hash = @sysprep_auto_logon_visibility_service.determine_visibility(options[:sysprep_auto_logon])
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
     {:hide => field_names_to_hide.flatten, :edit => field_names_to_show.flatten}

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -5,7 +5,8 @@ class DialogFieldVisibilityService
     service_template_fields_visibility_service = ServiceTemplateFieldsVisibilityService.new,
     network_visibility_service = NetworkVisibilityService.new,
     sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new,
-    retirement_visibility_service = RetirementVisibilityService.new
+    retirement_visibility_service = RetirementVisibilityService.new,
+    customize_fields_visibility_service = CustomizeFieldsVisibilityService.new
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
@@ -13,6 +14,7 @@ class DialogFieldVisibilityService
     @network_visibility_service = network_visibility_service
     @sysprep_auto_logon_visibility_service = sysprep_auto_logon_visibility_service
     @retirement_visibility_service = retirement_visibility_service
+    @customize_fields_visibility_service = customize_fields_visibility_service
   end
 
   def determine_visibility(options)
@@ -42,6 +44,13 @@ class DialogFieldVisibilityService
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
 
+    visibility_hash = @customize_fields_visibility_service.determine_visibility(options[:platform], options[:supports_customization_template], options[:customize_fields_list])
+    field_names_to_hide += visibility_hash[:hide]
+    field_names_to_show += visibility_hash[:show]
+
+    field_names_to_hide -= field_names_to_hide & field_names_to_show
+    field_names_to_hide.uniq!
+    field_names_to_show.uniq!
     {:hide => field_names_to_hide.flatten, :edit => field_names_to_show.flatten}
   end
 end

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -7,7 +7,8 @@ class DialogFieldVisibilityService
     sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new,
     retirement_visibility_service = RetirementVisibilityService.new,
     customize_fields_visibility_service = CustomizeFieldsVisibilityService.new,
-    sysprep_custom_spec_visibility_service = SysprepCustomSpecVisibilityService.new
+    sysprep_custom_spec_visibility_service = SysprepCustomSpecVisibilityService.new,
+    request_type_visibility_service = RequestTypeVisibilityService.new
   )
     @auto_placement_visibility_service = auto_placement_visibility_service
     @number_of_vms_visibility_service = number_of_vms_visibility_service
@@ -17,6 +18,7 @@ class DialogFieldVisibilityService
     @retirement_visibility_service = retirement_visibility_service
     @customize_fields_visibility_service = customize_fields_visibility_service
     @sysprep_custom_spec_visibility_service = sysprep_custom_spec_visibility_service
+    @request_type_visibility_service = request_type_visibility_service
   end
 
   def set_hidden_fields(field_names_to_hide, fields)
@@ -61,6 +63,9 @@ class DialogFieldVisibilityService
     visibility_hash = @sysprep_custom_spec_visibility_service.determine_visibility(options[:sysprep_custom_spec])
     field_names_to_hide += visibility_hash[:hide]
     field_names_to_show += visibility_hash[:show]
+
+    visibility_hash = @request_type_visibility_service.determine_visibility(options[:request_type])
+    field_names_to_hide += visibility_hash[:hide]
 
     field_names_to_hide -= field_names_to_hide & field_names_to_show
     field_names_to_hide.uniq!

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -49,8 +49,8 @@ class DialogFieldVisibilityService
       options[:addr_mode]
     )
 
-    add_to_visiblity_arrays(@sysprep_auto_logon_visibility_service,options[:sysprep_auto_logon])
-    add_to_visiblity_arrays(@retirement_visibility_service,options[:retirement])
+    add_to_visiblity_arrays(@sysprep_auto_logon_visibility_service, options[:sysprep_auto_logon])
+    add_to_visiblity_arrays(@retirement_visibility_service, options[:retirement])
 
     add_to_visiblity_arrays(
       @customize_fields_visibility_service,
@@ -59,9 +59,9 @@ class DialogFieldVisibilityService
       options[:customize_fields_list]
     )
 
-    add_to_visiblity_arrays(@sysprep_custom_spec_visibility_service,options[:sysprep_custom_spec])
-    add_to_visiblity_arrays(@request_type_visibility_service,options[:request_type])
-    add_to_visiblity_arrays(@pxe_iso_visibility_service,options[:supports_iso], options[:supports_pxe])
+    add_to_visiblity_arrays(@sysprep_custom_spec_visibility_service, options[:sysprep_custom_spec])
+    add_to_visiblity_arrays(@request_type_visibility_service, options[:request_type])
+    add_to_visiblity_arrays(@pxe_iso_visibility_service, options[:supports_iso], options[:supports_pxe])
     add_to_visiblity_arrays(@linked_clone_visibility_service, options[:provision_type], options[:linked_clone])
 
     @field_names_to_hide -= @field_names_to_hide & @field_names_to_show

--- a/app/services/dialog_field_visibility_service.rb
+++ b/app/services/dialog_field_visibility_service.rb
@@ -17,6 +17,14 @@ class DialogFieldVisibilityService
     @customize_fields_visibility_service = customize_fields_visibility_service
   end
 
+  def set_hidden_fields(field_names_to_hide, fields)
+    set_fields_display_status(fields, field_names_to_hide, :hide)
+  end
+
+  def set_shown_fields(field_names_to_show, fields)
+    set_fields_display_status(fields, field_names_to_show, :edit)
+  end
+
   def determine_visibility(options)
     field_names_to_hide = []
     field_names_to_show = []
@@ -52,5 +60,15 @@ class DialogFieldVisibilityService
     field_names_to_hide.uniq!
     field_names_to_show.uniq!
     {:hide => field_names_to_hide.flatten, :edit => field_names_to_show.flatten}
+  end
+
+  private
+
+  def set_fields_display_status(fields, field_name_list, status)
+    fields.each do |field|
+      if field_name_list.include?(field[:name])
+        field[:display] = field[:display_override].presence || status
+      end
+    end
   end
 end

--- a/app/services/linked_clone_visibility_service.rb
+++ b/app/services/linked_clone_visibility_service.rb
@@ -1,0 +1,19 @@
+class LinkedCloneVisibilityService
+  def determine_visibility(provision_type, linked_clone)
+    field_names_to_show = []
+    field_names_to_hide = []
+
+    if provision_type.to_s == 'vmware'
+      field_names_to_show += [:linked_clone]
+      if linked_clone == true
+        field_names_to_show += [:snapshot]
+      else
+        field_names_to_hide += [:snapshot]
+      end
+    else
+      field_names_to_hide += [:linked_clone, :snapshot]
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+end

--- a/app/services/network_visibility_service.rb
+++ b/app/services/network_visibility_service.rb
@@ -1,0 +1,30 @@
+class NetworkVisibilityService
+  def determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)
+    field_names_to_hide = []
+    field_names_to_show = []
+
+    if show_dns_settings?(sysprep_enabled, supports_pxe, supports_iso)
+      field_names_to_show += [:addr_mode, :dns_suffixes, :dns_servers]
+
+      if show_ip_settings?(addr_mode, supports_pxe, supports_iso)
+        field_names_to_show += [:ip_addr, :subnet_mask, :gateway]
+      else
+        field_names_to_hide += [:ip_addr, :subnet_mask, :gateway]
+      end
+    else
+      field_names_to_hide += [:addr_mode, :ip_addr, :subnet_mask, :gateway, :dns_servers, :dns_suffixes]
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+
+  private
+
+  def show_dns_settings?(sysprep_enabled, supports_pxe, supports_iso)
+    sysprep_enabled.in?(%w(fields file)) || supports_pxe || supports_iso
+  end
+
+  def show_ip_settings?(addr_mode, supports_pxe, supports_iso)
+    addr_mode == "static" || supports_pxe || supports_iso
+  end
+end

--- a/app/services/number_of_vms_visibility_service.rb
+++ b/app/services/number_of_vms_visibility_service.rb
@@ -1,0 +1,23 @@
+class NumberOfVmsVisibilityService
+  def determine_visibility(number_of_vms, platform)
+    field_names_to_hide = []
+    field_names_to_show = []
+
+    if number_of_vms > 1
+      field_names_to_hide += [:sysprep_computer_name, :linux_host_name]
+      field_names_to_show += [:ip_addr]
+    else
+      field_names_to_hide += [:ip_addr]
+
+      if platform == "linux"
+        field_names_to_show += [:linux_host_name]
+        field_names_to_hide += [:sysprep_computer_name]
+      else
+        field_names_to_show += [:sysprep_computer_name]
+        field_names_to_hide += [:linux_host_name]
+      end
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+end

--- a/app/services/pxe_iso_visibility_service.rb
+++ b/app/services/pxe_iso_visibility_service.rb
@@ -1,0 +1,20 @@
+class PxeIsoVisibilityService
+  def determine_visibility(supports_iso, supports_pxe)
+    field_names_to_show = []
+    field_names_to_hide = []
+
+    if supports_pxe
+      field_names_to_show += [:pxe_image_id, :pxe_server_id]
+    else
+      field_names_to_hide += [:pxe_image_id, :pxe_server_id]
+    end
+
+    if supports_iso
+      field_names_to_show += [:iso_image_id]
+    else
+      field_names_to_hide += [:iso_image_id]
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+end

--- a/app/services/request_type_visibility_service.rb
+++ b/app/services/request_type_visibility_service.rb
@@ -1,0 +1,14 @@
+class RequestTypeVisibilityService
+  def determine_visibility(request_type)
+    field_names_to_hide = []
+
+    if [:clone_to_vm, :clone_to_template].include?(request_type)
+      field_names_to_hide += [:vm_filter]
+      if request_type == :clone_to_template
+        field_names_to_hide += [:vm_auto_start]
+      end
+    end
+
+    {:hide => field_names_to_hide}
+  end
+end

--- a/app/services/retirement_visibility_service.rb
+++ b/app/services/retirement_visibility_service.rb
@@ -1,0 +1,14 @@
+class RetirementVisibilityService
+  def determine_visibility(retirement)
+    fields_to_show = []
+    fields_to_hide = []
+
+    if retirement > 0
+      fields_to_show += [:retirement_warn]
+    else
+      fields_to_hide += [:retirement_warn]
+    end
+
+    {:hide => fields_to_hide, :show => fields_to_show}
+  end
+end

--- a/app/services/service_template_fields_visibility_service.rb
+++ b/app/services/service_template_fields_visibility_service.rb
@@ -1,0 +1,10 @@
+class ServiceTemplateFieldsVisibilityService
+  def determine_visibility(service_template_request)
+    field_names_to_hide = []
+    if service_template_request
+      field_names_to_hide += [:number_of_vms, :vm_description, :schedule_type, :schedule_time]
+    end
+
+    {:hide => field_names_to_hide}
+  end
+end

--- a/app/services/sysprep_auto_logon_visibility_service.rb
+++ b/app/services/sysprep_auto_logon_visibility_service.rb
@@ -1,0 +1,14 @@
+class SysprepAutoLogonVisibilityService
+  def determine_visibility(sysprep_auto_logon)
+    field_names_to_hide = []
+    field_names_to_show = []
+
+    if sysprep_auto_logon == false
+      field_names_to_hide += [:sysprep_auto_logon_count]
+    else
+      field_names_to_show += [:sysprep_auto_logon_count]
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+end

--- a/app/services/sysprep_custom_spec_visibility_service.rb
+++ b/app/services/sysprep_custom_spec_visibility_service.rb
@@ -1,0 +1,14 @@
+class SysprepCustomSpecVisibilityService
+  def determine_visibility(sysprep_custom_spec)
+    field_names_to_hide = []
+    field_names_to_show = []
+
+    if sysprep_custom_spec
+      field_names_to_hide += [:sysprep_spec_override]
+    else
+      field_names_to_show += [:sysprep_spec_override]
+    end
+
+    {:hide => field_names_to_hide, :show => field_names_to_show}
+  end
+end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -206,17 +206,17 @@ describe MiqProvisionVirtWorkflow do
     let(:workflow) do
       described_class.new(
         {
-          :addr_mode => "addr_mode",
-          :number_of_vms => "123",
-          :placement_auto => true,
-          :retirement => "321",
+          :addr_mode                => "addr_mode",
+          :number_of_vms            => "123",
+          :placement_auto           => true,
+          :retirement               => "321",
           :service_template_request => "service_template_request",
-          :sysprep_auto_logon => "sysprep_auto_logon",
-          :sysprep_custom_spec => "sysprep_custom_spec",
-          :sysprep_enabled => "sysprep_enabled"
+          :sysprep_auto_logon       => "sysprep_auto_logon",
+          :sysprep_custom_spec      => "sysprep_custom_spec",
+          :sysprep_enabled          => "sysprep_enabled"
         },
         requester,
-        {:skip_dialog_load => true}
+        :skip_dialog_load => true
       )
     end
 
@@ -255,10 +255,10 @@ describe MiqProvisionVirtWorkflow do
     before do
       allow(requester).to receive(:kind_of?).with(User).and_return(true)
       allow(DialogFieldVisibilityService).to receive(:new).and_return(dialog_field_visibility_service)
-      allow(dialog_field_visibility_service).to receive(:determine_visibility).with(options_hash).and_return({
+      allow(dialog_field_visibility_service).to receive(:determine_visibility).with(options_hash).and_return(
         :edit => "shown_visibility_hash",
         :hide => "hidden_visibility_hash"
-      })
+      )
       allow(dialog_field_visibility_service).to receive(:set_shown_fields).with(
         "shown_visibility_hash", [{:name => :field_name}]
       )

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -201,4 +201,90 @@ describe MiqProvisionVirtWorkflow do
       expect(workflow.ws_find_template_or_vm("", "VMWARE", "asdf-adsf", "asdfadfasdf")).to be_nil
     end
   end
+
+  describe "#update_field_visibility" do
+    let(:workflow) do
+      described_class.new(
+        {
+          :addr_mode => "addr_mode",
+          :number_of_vms => "123",
+          :placement_auto => true,
+          :retirement => "321",
+          :service_template_request => "service_template_request",
+          :sysprep_auto_logon => "sysprep_auto_logon",
+          :sysprep_custom_spec => "sysprep_custom_spec",
+          :sysprep_enabled => "sysprep_enabled"
+        },
+        requester,
+        {:skip_dialog_load => true}
+      )
+    end
+
+    let(:requester) { double("User") }
+
+    let(:dialog_field_visibility_service) { double("DialogFieldVisibilityService") }
+
+    let(:options_hash) do
+      {
+        :addr_mode                       => "addr_mode",
+        :auto_placement_enabled          => true,
+        :customize_fields_list           => [],
+        :number_of_vms                   => 123,
+        :platform                        => nil,
+        :request_type                    => "template",
+        :retirement                      => 321,
+        :service_template_request        => "service_template_request",
+        :supports_customization_template => false,
+        :supports_iso                    => false,
+        :supports_pxe                    => false,
+        :sysprep_auto_logon              => "sysprep_auto_logon",
+        :sysprep_custom_spec             => "sysprep_custom_spec",
+        :sysprep_enabled                 => "sysprep_enabled"
+      }
+    end
+    let(:dialogs) do
+      {
+        :dialogs => {
+          :dialog_name => {
+            :fields => {:field_name => {}}
+          }
+        }
+      }
+    end
+
+    before do
+      allow(requester).to receive(:kind_of?).with(User).and_return(true)
+      allow(DialogFieldVisibilityService).to receive(:new).and_return(dialog_field_visibility_service)
+      allow(dialog_field_visibility_service).to receive(:determine_visibility).with(options_hash).and_return({
+        :edit => "shown_visibility_hash",
+        :hide => "hidden_visibility_hash"
+      })
+      allow(dialog_field_visibility_service).to receive(:set_shown_fields).with(
+        "shown_visibility_hash", [{:name => :field_name}]
+      )
+      allow(dialog_field_visibility_service).to receive(:set_hidden_fields).with(
+        "hidden_visibility_hash", [{:name => :field_name}]
+      )
+      workflow.instance_variable_set(:@dialogs, dialogs)
+    end
+
+    it "delegates to the dialog_field_visibility_service with the correct options" do
+      expect(dialog_field_visibility_service).to receive(:determine_visibility).with(options_hash)
+      workflow.update_field_visibility
+    end
+
+    it "sets the shown fields via the dialog_field_visibility_service" do
+      expect(dialog_field_visibility_service).to receive(:set_shown_fields).with(
+        "shown_visibility_hash", [{:name => :field_name}]
+      )
+      workflow.update_field_visibility
+    end
+
+    it "sets the hidden fields via the dialog_field_visibility_service" do
+      expect(dialog_field_visibility_service).to receive(:set_hidden_fields).with(
+        "hidden_visibility_hash", [{:name => :field_name}]
+      )
+      workflow.update_field_visibility
+    end
+  end
 end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -149,39 +149,6 @@ describe MiqProvisionVirtWorkflow do
     end
   end
 
-  context "#update_field_visibility_pxe_iso" do
-    let(:show_hide_iso_pxe) { {:hide => [], :edit => []} }
-    describe "supports iso" do
-      before do
-        allow(workflow).to receive(:supports_iso?).and_return(true)
-        allow(workflow).to receive(:supports_pxe?).and_return(false)
-      end
-
-      it "sets iso_image_id as a validated key" do
-        workflow.update_field_visibility_pxe_iso(show_hide_iso_pxe)
-        expect(show_hide_iso_pxe[:edit]).to eq [:iso_image_id]
-        expect(show_hide_iso_pxe[:edit]).to_not eq [:pxe_image_id, :pxe_server_id]
-        expect(show_hide_iso_pxe[:hide]).to_not eq [:iso_image_id]
-        expect(show_hide_iso_pxe[:hide]).to eq [:pxe_image_id, :pxe_server_id]
-      end
-    end
-
-    describe "supports pxe" do
-      before do
-        allow(workflow).to receive(:supports_iso?).and_return(false)
-        allow(workflow).to receive(:supports_pxe?).and_return(true)
-      end
-
-      it "sets pxe_server_id and pxe_image_id as validated keys" do
-        workflow.update_field_visibility_pxe_iso(show_hide_iso_pxe)
-        expect(show_hide_iso_pxe[:edit]).to_not eq [:iso_image_id]
-        expect(show_hide_iso_pxe[:edit]).to eq [:pxe_image_id, :pxe_server_id]
-        expect(show_hide_iso_pxe[:hide]).to eq [:iso_image_id]
-        expect(show_hide_iso_pxe[:hide]).to_not eq [:pxe_image_id, :pxe_server_id]
-      end
-    end
-  end
-
   context "#validate_memory_reservation" do
     let(:values) { {:vm_memory => %w(1024 1024)} }
 

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -95,16 +95,6 @@ describe MiqProvisionWorkflow do
           end
         end
       end
-
-      context "#show_customize_fields" do
-        it "should show PXE fields when customization supported" do
-          fields = {'key' => 'value'}
-          wf = MiqProvisionVirtWorkflow.new({}, admin)
-          expect(wf).to receive(:supports_customization_template?).and_return(true)
-          expect(wf).to receive(:show_customize_fields_pxe).with(fields)
-          wf.show_customize_fields(fields, 'linux')
-        end
-      end
     end
   end
 

--- a/spec/services/auto_placement_visibility_service_spec.rb
+++ b/spec/services/auto_placement_visibility_service_spec.rb
@@ -7,20 +7,18 @@ describe AutoPlacementVisibilityService do
 
       it "adds values to the field names to hide" do
         expect(subject.determine_visibility(auto_placement)).to eq(
-          {
-            :hide => [
-              :placement_host_name,
-              :placement_ds_name,
-              :host_filter,
-              :ds_filter,
-              :cluster_filter,
-              :placement_cluster_name,
-              :rp_filter,
-              :placement_rp_name,
-              :placement_dc_name
-            ],
-            :show => []
-          }
+          :hide => [
+            :placement_host_name,
+            :placement_ds_name,
+            :host_filter,
+            :ds_filter,
+            :cluster_filter,
+            :placement_cluster_name,
+            :rp_filter,
+            :placement_rp_name,
+            :placement_dc_name
+          ],
+          :show => []
         )
       end
     end
@@ -30,20 +28,18 @@ describe AutoPlacementVisibilityService do
 
       it "adds values to the field names to show" do
         expect(subject.determine_visibility(auto_placement)).to eq(
-          {
-            :hide => [],
-            :show => [
-              :placement_host_name,
-              :placement_ds_name,
-              :host_filter,
-              :ds_filter,
-              :cluster_filter,
-              :placement_cluster_name,
-              :rp_filter,
-              :placement_rp_name,
-              :placement_dc_name
-            ]
-          }
+          :hide => [],
+          :show => [
+            :placement_host_name,
+            :placement_ds_name,
+            :host_filter,
+            :ds_filter,
+            :cluster_filter,
+            :placement_cluster_name,
+            :rp_filter,
+            :placement_rp_name,
+            :placement_dc_name
+          ]
         )
       end
     end

--- a/spec/services/auto_placement_visibility_service_spec.rb
+++ b/spec/services/auto_placement_visibility_service_spec.rb
@@ -16,7 +16,8 @@ describe AutoPlacementVisibilityService do
               :cluster_filter,
               :placement_cluster_name,
               :rp_filter,
-              :placement_rp_name
+              :placement_rp_name,
+              :placement_dc_name
             ],
             :show => []
           }
@@ -39,7 +40,8 @@ describe AutoPlacementVisibilityService do
               :cluster_filter,
               :placement_cluster_name,
               :rp_filter,
-              :placement_rp_name
+              :placement_rp_name,
+              :placement_dc_name
             ]
           }
         )

--- a/spec/services/auto_placement_visibility_service_spec.rb
+++ b/spec/services/auto_placement_visibility_service_spec.rb
@@ -1,0 +1,49 @@
+describe AutoPlacementVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when auto placement is enabled" do
+      let(:auto_placement) { true }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(auto_placement)).to eq(
+          {
+            :hide => [
+              :placement_host_name,
+              :placement_ds_name,
+              :host_filter,
+              :ds_filter,
+              :cluster_filter,
+              :placement_cluster_name,
+              :rp_filter,
+              :placement_rp_name
+            ],
+            :show => []
+          }
+        )
+      end
+    end
+
+    context "when auto placement is not enabled" do
+      let(:auto_placement) { false }
+
+      it "adds values to the field names to show" do
+        expect(subject.determine_visibility(auto_placement)).to eq(
+          {
+            :hide => [],
+            :show => [
+              :placement_host_name,
+              :placement_ds_name,
+              :host_filter,
+              :ds_filter,
+              :cluster_filter,
+              :placement_cluster_name,
+              :rp_filter,
+              :placement_rp_name
+            ]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/customize_fields_visibility_service_spec.rb
+++ b/spec/services/customize_fields_visibility_service_spec.rb
@@ -8,7 +8,7 @@ describe CustomizeFieldsVisibilityService do
       let(:customize_fields_list) { "potato" }
 
       it "returns a list of pxe customization fields to show" do
-        expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
+        expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq(
           :hide => [],
           :show => [
             :addr_mode,
@@ -22,7 +22,7 @@ describe CustomizeFieldsVisibilityService do
             :root_password,
             :subnet_mask
           ]
-        })
+        )
       end
     end
 
@@ -30,26 +30,28 @@ describe CustomizeFieldsVisibilityService do
       let(:supports_customization_template) { false }
 
       context "when the customize_fields_list contains only items from exclude list" do
-        let(:customize_fields_list) {[
-          :sysprep_spec_override,
-          :sysprep_custom_spec,
-          :sysprep_enabled,
-          :sysprep_upload_file,
-          :sysprep_upload_text,
-          :linux_host_name,
-          :sysprep_computer_name,
-          :ip_addr,
-          :subnet_mask,
-          :gateway,
-          :dns_servers,
-          :dns_suffixes
-        ]}
+        let(:customize_fields_list) do
+          [
+            :sysprep_spec_override,
+            :sysprep_custom_spec,
+            :sysprep_enabled,
+            :sysprep_upload_file,
+            :sysprep_upload_text,
+            :linux_host_name,
+            :sysprep_computer_name,
+            :ip_addr,
+            :subnet_mask,
+            :gateway,
+            :dns_servers,
+            :dns_suffixes
+          ]
+        end
         let(:platform) { "linux" }
 
         it "returns an empty hide/show hash" do
-          expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
+          expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq(
             :hide => [], :show => []
-          })
+          )
         end
       end
 
@@ -60,9 +62,12 @@ describe CustomizeFieldsVisibilityService do
           let(:platform) { "linux" }
 
           it "returns the correct list of things to show/hide" do
-            expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
-              :hide => [:potato], :show => [:linux_domain_name]
-            })
+            expect(subject.determine_visibility(
+              platform,
+              supports_customization_template,
+              customize_fields_list)).to eq(
+                :hide => [:potato], :show => [:linux_domain_name]
+              )
           end
         end
 
@@ -70,9 +75,12 @@ describe CustomizeFieldsVisibilityService do
           let(:platform) { "potato" }
 
           it "returns an empty hide/show hash" do
-            expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
-              :hide => [], :show => []
-            })
+            expect(subject.determine_visibility(
+              platform,
+              supports_customization_template,
+              customize_fields_list)).to eq(
+                :hide => [], :show => []
+              )
           end
         end
       end

--- a/spec/services/customize_fields_visibility_service_spec.rb
+++ b/spec/services/customize_fields_visibility_service_spec.rb
@@ -1,0 +1,81 @@
+describe CustomizeFieldsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the customization template is supported" do
+      let(:supports_customization_template) { true }
+      let(:platform) { "potato" }
+      let(:customize_fields_list) { "potato" }
+
+      it "returns a list of pxe customization fields to show" do
+        expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
+          :hide => [],
+          :show => [
+            :addr_mode,
+            :customization_template_id,
+            :customization_template_script,
+            :dns_servers,
+            :dns_suffixes,
+            :gateway,
+            :hostname,
+            :ip_addr,
+            :root_password,
+            :subnet_mask
+          ]
+        })
+      end
+    end
+
+    context "when the customization template is not supported" do
+      let(:supports_customization_template) { false }
+
+      context "when the customize_fields_list contains only items from exclude list" do
+        let(:customize_fields_list) {[
+          :sysprep_spec_override,
+          :sysprep_custom_spec,
+          :sysprep_enabled,
+          :sysprep_upload_file,
+          :sysprep_upload_text,
+          :linux_host_name,
+          :sysprep_computer_name,
+          :ip_addr,
+          :subnet_mask,
+          :gateway,
+          :dns_servers,
+          :dns_suffixes
+        ]}
+        let(:platform) { "linux" }
+
+        it "returns an empty hide/show hash" do
+          expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
+            :hide => [], :show => []
+          })
+        end
+      end
+
+      context "when the customize_fields_list contains linux_domain_name" do
+        let(:customize_fields_list) { [:linux_domain_name, :potato] }
+
+        context "when the platform is linux" do
+          let(:platform) { "linux" }
+
+          it "returns the correct list of things to show/hide" do
+            expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
+              :hide => [:potato], :show => [:linux_domain_name]
+            })
+          end
+        end
+
+        context "when the platform is not linux" do
+          let(:platform) { "potato" }
+
+          it "returns an empty hide/show hash" do
+            expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq({
+              :hide => [], :show => []
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -114,4 +114,80 @@ describe DialogFieldVisibilityService do
       })
     end
   end
+
+  describe "#set_hidden_fields" do
+    let(:fields) { [field] }
+    let(:field) { {:name => field_name, :display => :unchanged, :display_override => display_override} }
+    let(:field_names_to_hide) { ["hide_me"] }
+
+    context "when the field name is contained in the field names to hide" do
+      let(:field_name) { "hide_me" }
+
+      context "when the field has a display override" do
+        let(:display_override) { :potato }
+
+        it "sets the field's display property to :hide" do
+          subject.set_hidden_fields(field_names_to_hide, fields)
+          expect(field[:display]).to eq(:potato)
+        end
+      end
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the field's display property to :hide" do
+          subject.set_hidden_fields(field_names_to_hide, fields)
+          expect(field[:display]).to eq(:hide)
+        end
+      end
+    end
+
+    context "when the field name is not contained in the field names to hide" do
+      let(:field_name) { "test" }
+      let(:display_override) { "" }
+
+      it "does not change the field's display property" do
+        subject.set_hidden_fields(field_names_to_hide, fields)
+        expect(field[:display]).to eq(:unchanged)
+      end
+    end
+  end
+
+  describe "#set_shown_fields" do
+    let(:fields) { [field] }
+    let(:field) { {:name => field_name, :display => :unchanged, :display_override => display_override} }
+    let(:field_names_to_show) { ["show_me"] }
+
+    context "when the field name is contained in the field names to hide" do
+      let(:field_name) { "show_me" }
+
+      context "when the field has a display override" do
+        let(:display_override) { :potato }
+
+        it "sets the field's display property to the override" do
+          subject.set_shown_fields(field_names_to_show, fields)
+          expect(field[:display]).to eq(:potato)
+        end
+      end
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the field's display property to :edit" do
+          subject.set_shown_fields(field_names_to_show, fields)
+          expect(field[:display]).to eq(:edit)
+        end
+      end
+    end
+
+    context "when the field name is not contained in the field names to show" do
+      let(:field_name) { "test" }
+      let(:display_override) { nil }
+
+      it "does not change the field's display property" do
+        subject.set_shown_fields(field_names_to_show, fields)
+        expect(field[:display]).to eq(:unchanged)
+      end
+    end
+  end
 end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -7,15 +7,20 @@ describe DialogFieldVisibilityService do
         auto_placement_visibility_service,
         number_of_vms_visibility_service,
         service_template_fields_visibility_service,
+        network_visibility_service,
       )
     end
 
     let(:options) do
       {
+        :addr_mode                       => addr_mode,
         :auto_placement_enabled          => auto_placement_enabled,
         :number_of_vms                   => number_of_vms,
         :platform                        => platform,
         :service_template_request        => service_template_request,
+        :supports_iso                    => supports_iso,
+        :supports_pxe                    => supports_pxe,
+        :sysprep_enabled                 => sysprep_enabled
       }
     end
 
@@ -29,6 +34,12 @@ describe DialogFieldVisibilityService do
     let(:number_of_vms) { "number_of_vms" }
     let(:platform) { "platform" }
 
+    let(:network_visibility_service) { double("NetworkVisibilityService") }
+    let(:sysprep_enabled) { "sysprep_enabled" }
+    let(:supports_pxe) { "supports_pxe" }
+    let(:supports_iso) { "supports_iso" }
+    let(:addr_mode) { "addr_mode" }
+
     before do
       allow(service_template_fields_visibility_service).
         to receive(:determine_visibility).with(service_template_request).and_return(
@@ -41,6 +52,10 @@ describe DialogFieldVisibilityService do
       allow(number_of_vms_visibility_service).
         to receive(:determine_visibility).with(number_of_vms, platform).and_return(
           {:hide => [:number_hide], :show => [:number_show]}
+        )
+      allow(network_visibility_service).
+        to receive(:determine_visibility).with(sysprep_enabled, supports_pxe, supports_iso, addr_mode).and_return(
+          {:hide => [:network_hide], :show => [:network_show]}
         )
     end
 

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -13,7 +13,8 @@ describe DialogFieldVisibilityService do
         customize_fields_visibility_service,
         sysprep_custom_spec_visibility_service,
         request_type_visibility_service,
-        pxe_iso_visibility_service
+        pxe_iso_visibility_service,
+        linked_clone_visibility_service
       )
     end
 
@@ -22,8 +23,10 @@ describe DialogFieldVisibilityService do
         :addr_mode                       => addr_mode,
         :auto_placement_enabled          => auto_placement_enabled,
         :customize_fields_list           => customize_fields_list,
+        :linked_clone                    => linked_clone,
         :number_of_vms                   => number_of_vms,
         :platform                        => platform,
+        :provision_type                  => provision_type,
         :request_type                    => request_type,
         :retirement                      => retirement,
         :service_template_request        => service_template_request,
@@ -69,6 +72,10 @@ describe DialogFieldVisibilityService do
     let(:request_type) { "request_type" }
 
     let(:pxe_iso_visibility_service) { double("PxeIsoVisibilityService") }
+
+    let(:linked_clone_visibility_service) { double("LinkedCloneVisibilityService") }
+    let(:provision_type) { "provision_type" }
+    let(:linked_clone) { "linked_clone" }
 
     before do
       allow(service_template_fields_visibility_service).
@@ -123,6 +130,12 @@ describe DialogFieldVisibilityService do
           :hide => [:pxe_iso_hide],
           :show => [:pxe_iso_show]
       })
+
+      allow(linked_clone_visibility_service).
+        to receive(:determine_visibility).with(provision_type, linked_clone).and_return({
+          :hide => [:linked_clone_hide],
+          :show => [:linked_clone_show]
+      })
     end
 
     it "adds the values to the field names to hide and show without duplicates or intersections" do
@@ -136,7 +149,8 @@ describe DialogFieldVisibilityService do
           :customize_fields_hide,
           :sysprep_custom_spec_hide,
           :request_type_hide,
-          :pxe_iso_hide
+          :pxe_iso_hide,
+          :linked_clone_hide
         ],
         :edit => [
           :auto_show,
@@ -147,7 +161,8 @@ describe DialogFieldVisibilityService do
           :customize_fields_show,
           :retirement_hide,
           :sysprep_custom_spec_show,
-          :pxe_iso_show
+          :pxe_iso_show,
+          :linked_clone_show
         ]
       })
     end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -139,32 +139,31 @@ describe DialogFieldVisibilityService do
     end
 
     it "adds the values to the field names to hide and show without duplicates or intersections" do
-      expect(subject.determine_visibility(options)).to eq({
-        :hide => [
-          :service_template_request_hide,
-          :auto_hide,
-          :number_hide,
-          :network_hide,
-          :sysprep_auto_logon_hide,
-          :customize_fields_hide,
-          :sysprep_custom_spec_hide,
-          :request_type_hide,
-          :pxe_iso_hide,
-          :linked_clone_hide
-        ],
-        :edit => [
-          :auto_show,
-          :number_show,
-          :network_show,
-          :sysprep_auto_logon_show,
-          :retirement_show,
-          :customize_fields_show,
-          :retirement_hide,
-          :sysprep_custom_spec_show,
-          :pxe_iso_show,
-          :linked_clone_show
-        ]
-      })
+      result = subject.determine_visibility(options)
+      expect(result[:hide]).to match_array([
+        :auto_hide,
+        :customize_fields_hide,
+        :linked_clone_hide,
+        :network_hide,
+        :number_hide,
+        :pxe_iso_hide,
+        :request_type_hide,
+        :service_template_request_hide,
+        :sysprep_auto_logon_hide,
+        :sysprep_custom_spec_hide
+      ])
+      expect(result[:edit]).to match_array([
+        :auto_show,
+        :customize_fields_show,
+        :linked_clone_show,
+        :network_show,
+        :number_show,
+        :pxe_iso_show,
+        :retirement_hide,
+        :retirement_show,
+        :sysprep_auto_logon_show,
+        :sysprep_custom_spec_show
+      ])
     end
   end
 

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -12,7 +12,8 @@ describe DialogFieldVisibilityService do
         retirement_visibility_service,
         customize_fields_visibility_service,
         sysprep_custom_spec_visibility_service,
-        request_type_visibility_service
+        request_type_visibility_service,
+        pxe_iso_visibility_service
       )
     end
 
@@ -67,6 +68,8 @@ describe DialogFieldVisibilityService do
     let(:request_type_visibility_service) { double("RequestTypeVisibilityService") }
     let(:request_type) { "request_type" }
 
+    let(:pxe_iso_visibility_service) { double("PxeIsoVisibilityService") }
+
     before do
       allow(service_template_fields_visibility_service).
         to receive(:determine_visibility).with(service_template_request).and_return(
@@ -114,6 +117,12 @@ describe DialogFieldVisibilityService do
 
       allow(request_type_visibility_service).
         to receive(:determine_visibility).with(request_type).and_return({:hide => [:request_type_hide]})
+
+      allow(pxe_iso_visibility_service).
+        to receive(:determine_visibility).with(supports_iso, supports_pxe).and_return({
+          :hide => [:pxe_iso_hide],
+          :show => [:pxe_iso_show]
+      })
     end
 
     it "adds the values to the field names to hide and show without duplicates or intersections" do
@@ -126,7 +135,8 @@ describe DialogFieldVisibilityService do
           :sysprep_auto_logon_hide,
           :customize_fields_hide,
           :sysprep_custom_spec_hide,
-          :request_type_hide
+          :request_type_hide,
+          :pxe_iso_hide
         ],
         :edit => [
           :auto_show,
@@ -137,6 +147,7 @@ describe DialogFieldVisibilityService do
           :customize_fields_show,
           :retirement_hide,
           :sysprep_custom_spec_show,
+          :pxe_iso_show
         ]
       })
     end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -8,7 +8,8 @@ describe DialogFieldVisibilityService do
         number_of_vms_visibility_service,
         service_template_fields_visibility_service,
         network_visibility_service,
-        sysprep_auto_logon_visibility_service
+        sysprep_auto_logon_visibility_service,
+        retirement_visibility_service
       )
     end
 
@@ -18,6 +19,7 @@ describe DialogFieldVisibilityService do
         :auto_placement_enabled          => auto_placement_enabled,
         :number_of_vms                   => number_of_vms,
         :platform                        => platform,
+        :retirement                      => retirement,
         :service_template_request        => service_template_request,
         :supports_iso                    => supports_iso,
         :supports_pxe                    => supports_pxe,
@@ -45,6 +47,9 @@ describe DialogFieldVisibilityService do
     let(:sysprep_auto_logon_visibility_service) { double("SysprepAutoLogonVisibilityService") }
     let(:sysprep_auto_logon) { "sysprep_auto_logon" }
 
+    let(:retirement_visibility_service) { double("RetirementVisibilityService") }
+    let(:retirement) { "retirement" }
+
     before do
       allow(service_template_fields_visibility_service).
         to receive(:determine_visibility).with(service_template_request).and_return(
@@ -65,6 +70,10 @@ describe DialogFieldVisibilityService do
       allow(sysprep_auto_logon_visibility_service).
         to receive(:determine_visibility).with(sysprep_auto_logon).and_return(
           {:hide => [:sysprep_auto_logon_hide], :show => [:sysprep_auto_logon_show]}
+        )
+      allow(retirement_visibility_service).
+        to receive(:determine_visibility).with(retirement).and_return(
+          {:hide => [:retirement_hide], :show => [:retirement_show]}
         )
     end
 

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -9,18 +9,22 @@ describe DialogFieldVisibilityService do
         service_template_fields_visibility_service,
         network_visibility_service,
         sysprep_auto_logon_visibility_service,
-        retirement_visibility_service
+        retirement_visibility_service,
+        customize_fields_visibility_service
       )
     end
 
     let(:options) do
       {
         :addr_mode                       => addr_mode,
+
         :auto_placement_enabled          => auto_placement_enabled,
+        :customize_fields_list           => customize_fields_list,
         :number_of_vms                   => number_of_vms,
         :platform                        => platform,
         :retirement                      => retirement,
         :service_template_request        => service_template_request,
+        :supports_customization_template => supports_customization_template,
         :supports_iso                    => supports_iso,
         :supports_pxe                    => supports_pxe,
         :sysprep_auto_logon              => sysprep_auto_logon,
@@ -50,6 +54,10 @@ describe DialogFieldVisibilityService do
     let(:retirement_visibility_service) { double("RetirementVisibilityService") }
     let(:retirement) { "retirement" }
 
+    let(:customize_fields_visibility_service) { double("CustomizeFieldsVisibilityService") }
+    let(:supports_customization_template) { "supports_customization_template" }
+    let(:customize_fields_list) { "customize_fields_list" }
+
     before do
       allow(service_template_fields_visibility_service).
         to receive(:determine_visibility).with(service_template_request).and_return(
@@ -75,6 +83,13 @@ describe DialogFieldVisibilityService do
         to receive(:determine_visibility).with(retirement).and_return(
           {:hide => [:retirement_hide], :show => [:retirement_show]}
         )
+      allow(customize_fields_visibility_service).
+        to receive(:determine_visibility).with(
+          platform, supports_customization_template, customize_fields_list
+        ).and_return({
+          :hide => [:customize_fields_hide, :number_hide], # Forces uniq
+          :show => [:customize_fields_show, :number_show, :retirement_hide] # Forces uniq and removal of intersection
+        })
     end
 
     it "adds the values to the field names to hide and show without duplicates or intersections" do
@@ -82,11 +97,19 @@ describe DialogFieldVisibilityService do
         :hide => [
           :service_template_request_hide,
           :auto_hide,
-          :number_hide
+          :number_hide,
+          :network_hide,
+          :sysprep_auto_logon_hide,
+          :customize_fields_hide
         ],
         :edit => [
           :auto_show,
-          :number_show
+          :number_show,
+          :network_show,
+          :sysprep_auto_logon_show,
+          :retirement_show,
+          :customize_fields_show,
+          :retirement_hide
         ]
       })
     end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -6,6 +6,7 @@ describe DialogFieldVisibilityService do
       described_class.new(
         auto_placement_visibility_service,
         number_of_vms_visibility_service,
+        service_template_fields_visibility_service,
       )
     end
 
@@ -14,8 +15,12 @@ describe DialogFieldVisibilityService do
         :auto_placement_enabled          => auto_placement_enabled,
         :number_of_vms                   => number_of_vms,
         :platform                        => platform,
+        :service_template_request        => service_template_request,
       }
     end
+
+    let(:service_template_fields_visibility_service) { double("ServiceTemplateFieldsVisibilityService") }
+    let(:service_template_request) { "service_template_request" }
 
     let(:auto_placement_visibility_service) { double("AutoPlacementVisibilityService") }
     let(:auto_placement_enabled) { "auto_placement_enabled" }
@@ -25,6 +30,10 @@ describe DialogFieldVisibilityService do
     let(:platform) { "platform" }
 
     before do
+      allow(service_template_fields_visibility_service).
+        to receive(:determine_visibility).with(service_template_request).and_return(
+          {:hide => [:service_template_request_hide]}
+        )
       allow(auto_placement_visibility_service).
         to receive(:determine_visibility).with(auto_placement_enabled).and_return(
           {:hide => [:auto_hide], :show => [:auto_show]}
@@ -38,6 +47,7 @@ describe DialogFieldVisibilityService do
     it "adds the values to the field names to hide and show without duplicates or intersections" do
       expect(subject.determine_visibility(options)).to eq({
         :hide => [
+          :service_template_request_hide,
           :auto_hide,
           :number_hide
         ],

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -11,7 +11,8 @@ describe DialogFieldVisibilityService do
         sysprep_auto_logon_visibility_service,
         retirement_visibility_service,
         customize_fields_visibility_service,
-        sysprep_custom_spec_visibility_service
+        sysprep_custom_spec_visibility_service,
+        request_type_visibility_service
       )
     end
 
@@ -22,6 +23,7 @@ describe DialogFieldVisibilityService do
         :customize_fields_list           => customize_fields_list,
         :number_of_vms                   => number_of_vms,
         :platform                        => platform,
+        :request_type                    => request_type,
         :retirement                      => retirement,
         :service_template_request        => service_template_request,
         :supports_customization_template => supports_customization_template,
@@ -61,6 +63,9 @@ describe DialogFieldVisibilityService do
 
     let(:sysprep_custom_spec_visibility_service) { double("SysprepCustomSpecVisibilityService") }
     let(:sysprep_custom_spec) { "sysprep_custom_spec" }
+
+    let(:request_type_visibility_service) { double("RequestTypeVisibilityService") }
+    let(:request_type) { "request_type" }
 
     before do
       allow(service_template_fields_visibility_service).
@@ -106,6 +111,9 @@ describe DialogFieldVisibilityService do
           :hide => [:sysprep_custom_spec_hide],
           :show => [:sysprep_custom_spec_show]
       })
+
+      allow(request_type_visibility_service).
+        to receive(:determine_visibility).with(request_type).and_return({:hide => [:request_type_hide]})
     end
 
     it "adds the values to the field names to hide and show without duplicates or intersections" do
@@ -117,7 +125,8 @@ describe DialogFieldVisibilityService do
           :network_hide,
           :sysprep_auto_logon_hide,
           :customize_fields_hide,
-          :sysprep_custom_spec_hide
+          :sysprep_custom_spec_hide,
+          :request_type_hide
         ],
         :edit => [
           :auto_show,
@@ -127,7 +136,7 @@ describe DialogFieldVisibilityService do
           :retirement_show,
           :customize_fields_show,
           :retirement_hide,
-          :sysprep_custom_spec_show
+          :sysprep_custom_spec_show,
         ]
       })
     end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -1,0 +1,38 @@
+describe DialogFieldVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    let(:subject) do
+      described_class.new(
+        auto_placement_visibility_service,
+      )
+    end
+
+    let(:options) do
+      {
+        :auto_placement_enabled          => auto_placement_enabled,
+      }
+    end
+
+    let(:auto_placement_visibility_service) { double("AutoPlacementVisibilityService") }
+    let(:auto_placement_enabled) { "auto_placement_enabled" }
+
+    before do
+      allow(auto_placement_visibility_service).
+        to receive(:determine_visibility).with(auto_placement_enabled).and_return(
+          {:hide => [:auto_hide], :show => [:auto_show]}
+        )
+    end
+
+    it "adds the values to the field names to hide and show without duplicates or intersections" do
+      expect(subject.determine_visibility(options)).to eq({
+        :hide => [
+          :auto_hide,
+        ],
+        :edit => [
+          :auto_show,
+        ]
+      })
+    end
+  end
+end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -8,6 +8,7 @@ describe DialogFieldVisibilityService do
         number_of_vms_visibility_service,
         service_template_fields_visibility_service,
         network_visibility_service,
+        sysprep_auto_logon_visibility_service
       )
     end
 
@@ -20,6 +21,7 @@ describe DialogFieldVisibilityService do
         :service_template_request        => service_template_request,
         :supports_iso                    => supports_iso,
         :supports_pxe                    => supports_pxe,
+        :sysprep_auto_logon              => sysprep_auto_logon,
         :sysprep_enabled                 => sysprep_enabled
       }
     end
@@ -40,6 +42,9 @@ describe DialogFieldVisibilityService do
     let(:supports_iso) { "supports_iso" }
     let(:addr_mode) { "addr_mode" }
 
+    let(:sysprep_auto_logon_visibility_service) { double("SysprepAutoLogonVisibilityService") }
+    let(:sysprep_auto_logon) { "sysprep_auto_logon" }
+
     before do
       allow(service_template_fields_visibility_service).
         to receive(:determine_visibility).with(service_template_request).and_return(
@@ -56,6 +61,10 @@ describe DialogFieldVisibilityService do
       allow(network_visibility_service).
         to receive(:determine_visibility).with(sysprep_enabled, supports_pxe, supports_iso, addr_mode).and_return(
           {:hide => [:network_hide], :show => [:network_show]}
+        )
+      allow(sysprep_auto_logon_visibility_service).
+        to receive(:determine_visibility).with(sysprep_auto_logon).and_return(
+          {:hide => [:sysprep_auto_logon_hide], :show => [:sysprep_auto_logon_show]}
         )
     end
 

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -10,14 +10,14 @@ describe DialogFieldVisibilityService do
         network_visibility_service,
         sysprep_auto_logon_visibility_service,
         retirement_visibility_service,
-        customize_fields_visibility_service
+        customize_fields_visibility_service,
+        sysprep_custom_spec_visibility_service
       )
     end
 
     let(:options) do
       {
         :addr_mode                       => addr_mode,
-
         :auto_placement_enabled          => auto_placement_enabled,
         :customize_fields_list           => customize_fields_list,
         :number_of_vms                   => number_of_vms,
@@ -28,6 +28,7 @@ describe DialogFieldVisibilityService do
         :supports_iso                    => supports_iso,
         :supports_pxe                    => supports_pxe,
         :sysprep_auto_logon              => sysprep_auto_logon,
+        :sysprep_custom_spec             => sysprep_custom_spec,
         :sysprep_enabled                 => sysprep_enabled
       }
     end
@@ -58,31 +59,40 @@ describe DialogFieldVisibilityService do
     let(:supports_customization_template) { "supports_customization_template" }
     let(:customize_fields_list) { "customize_fields_list" }
 
+    let(:sysprep_custom_spec_visibility_service) { double("SysprepCustomSpecVisibilityService") }
+    let(:sysprep_custom_spec) { "sysprep_custom_spec" }
+
     before do
       allow(service_template_fields_visibility_service).
         to receive(:determine_visibility).with(service_template_request).and_return(
           {:hide => [:service_template_request_hide]}
         )
+
       allow(auto_placement_visibility_service).
         to receive(:determine_visibility).with(auto_placement_enabled).and_return(
           {:hide => [:auto_hide], :show => [:auto_show]}
         )
+
       allow(number_of_vms_visibility_service).
         to receive(:determine_visibility).with(number_of_vms, platform).and_return(
           {:hide => [:number_hide], :show => [:number_show]}
         )
+
       allow(network_visibility_service).
         to receive(:determine_visibility).with(sysprep_enabled, supports_pxe, supports_iso, addr_mode).and_return(
           {:hide => [:network_hide], :show => [:network_show]}
         )
+
       allow(sysprep_auto_logon_visibility_service).
         to receive(:determine_visibility).with(sysprep_auto_logon).and_return(
           {:hide => [:sysprep_auto_logon_hide], :show => [:sysprep_auto_logon_show]}
         )
+
       allow(retirement_visibility_service).
         to receive(:determine_visibility).with(retirement).and_return(
           {:hide => [:retirement_hide], :show => [:retirement_show]}
         )
+
       allow(customize_fields_visibility_service).
         to receive(:determine_visibility).with(
           platform, supports_customization_template, customize_fields_list
@@ -90,6 +100,12 @@ describe DialogFieldVisibilityService do
           :hide => [:customize_fields_hide, :number_hide], # Forces uniq
           :show => [:customize_fields_show, :number_show, :retirement_hide] # Forces uniq and removal of intersection
         })
+
+      allow(sysprep_custom_spec_visibility_service).
+        to receive(:determine_visibility).with(sysprep_custom_spec).and_return({
+          :hide => [:sysprep_custom_spec_hide],
+          :show => [:sysprep_custom_spec_show]
+      })
     end
 
     it "adds the values to the field names to hide and show without duplicates or intersections" do
@@ -100,7 +116,8 @@ describe DialogFieldVisibilityService do
           :number_hide,
           :network_hide,
           :sysprep_auto_logon_hide,
-          :customize_fields_hide
+          :customize_fields_hide,
+          :sysprep_custom_spec_hide
         ],
         :edit => [
           :auto_show,
@@ -109,7 +126,8 @@ describe DialogFieldVisibilityService do
           :sysprep_auto_logon_show,
           :retirement_show,
           :customize_fields_show,
-          :retirement_hide
+          :retirement_hide,
+          :sysprep_custom_spec_show
         ]
       })
     end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -5,22 +5,33 @@ describe DialogFieldVisibilityService do
     let(:subject) do
       described_class.new(
         auto_placement_visibility_service,
+        number_of_vms_visibility_service,
       )
     end
 
     let(:options) do
       {
         :auto_placement_enabled          => auto_placement_enabled,
+        :number_of_vms                   => number_of_vms,
+        :platform                        => platform,
       }
     end
 
     let(:auto_placement_visibility_service) { double("AutoPlacementVisibilityService") }
     let(:auto_placement_enabled) { "auto_placement_enabled" }
 
+    let(:number_of_vms_visibility_service) { double("NumberOfVmsVisibilityService") }
+    let(:number_of_vms) { "number_of_vms" }
+    let(:platform) { "platform" }
+
     before do
       allow(auto_placement_visibility_service).
         to receive(:determine_visibility).with(auto_placement_enabled).and_return(
           {:hide => [:auto_hide], :show => [:auto_show]}
+        )
+      allow(number_of_vms_visibility_service).
+        to receive(:determine_visibility).with(number_of_vms, platform).and_return(
+          {:hide => [:number_hide], :show => [:number_show]}
         )
     end
 
@@ -28,9 +39,11 @@ describe DialogFieldVisibilityService do
       expect(subject.determine_visibility(options)).to eq({
         :hide => [
           :auto_hide,
+          :number_hide
         ],
         :edit => [
           :auto_show,
+          :number_show
         ]
       })
     end

--- a/spec/services/dialog_field_visibility_service_spec.rb
+++ b/spec/services/dialog_field_visibility_service_spec.rb
@@ -78,64 +78,64 @@ describe DialogFieldVisibilityService do
     let(:linked_clone) { "linked_clone" }
 
     before do
-      allow(service_template_fields_visibility_service).
-        to receive(:determine_visibility).with(service_template_request).and_return(
-          {:hide => [:service_template_request_hide]}
+      allow(service_template_fields_visibility_service)
+        .to receive(:determine_visibility).with(service_template_request).and_return(
+          :hide => [:service_template_request_hide]
         )
 
-      allow(auto_placement_visibility_service).
-        to receive(:determine_visibility).with(auto_placement_enabled).and_return(
-          {:hide => [:auto_hide], :show => [:auto_show]}
+      allow(auto_placement_visibility_service)
+        .to receive(:determine_visibility).with(auto_placement_enabled).and_return(
+          :hide => [:auto_hide], :show => [:auto_show]
         )
 
-      allow(number_of_vms_visibility_service).
-        to receive(:determine_visibility).with(number_of_vms, platform).and_return(
-          {:hide => [:number_hide], :show => [:number_show]}
+      allow(number_of_vms_visibility_service)
+        .to receive(:determine_visibility).with(number_of_vms, platform).and_return(
+          :hide => [:number_hide], :show => [:number_show]
         )
 
-      allow(network_visibility_service).
-        to receive(:determine_visibility).with(sysprep_enabled, supports_pxe, supports_iso, addr_mode).and_return(
-          {:hide => [:network_hide], :show => [:network_show]}
+      allow(network_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_enabled, supports_pxe, supports_iso, addr_mode).and_return(
+          :hide => [:network_hide], :show => [:network_show]
         )
 
-      allow(sysprep_auto_logon_visibility_service).
-        to receive(:determine_visibility).with(sysprep_auto_logon).and_return(
-          {:hide => [:sysprep_auto_logon_hide], :show => [:sysprep_auto_logon_show]}
+      allow(sysprep_auto_logon_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_auto_logon).and_return(
+          :hide => [:sysprep_auto_logon_hide], :show => [:sysprep_auto_logon_show]
         )
 
-      allow(retirement_visibility_service).
-        to receive(:determine_visibility).with(retirement).and_return(
-          {:hide => [:retirement_hide], :show => [:retirement_show]}
+      allow(retirement_visibility_service)
+        .to receive(:determine_visibility).with(retirement).and_return(
+          :hide => [:retirement_hide], :show => [:retirement_show]
         )
 
-      allow(customize_fields_visibility_service).
-        to receive(:determine_visibility).with(
+      allow(customize_fields_visibility_service)
+        .to receive(:determine_visibility).with(
           platform, supports_customization_template, customize_fields_list
-        ).and_return({
+        ).and_return(
           :hide => [:customize_fields_hide, :number_hide], # Forces uniq
           :show => [:customize_fields_show, :number_show, :retirement_hide] # Forces uniq and removal of intersection
-        })
+        )
 
-      allow(sysprep_custom_spec_visibility_service).
-        to receive(:determine_visibility).with(sysprep_custom_spec).and_return({
+      allow(sysprep_custom_spec_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_custom_spec).and_return(
           :hide => [:sysprep_custom_spec_hide],
           :show => [:sysprep_custom_spec_show]
-      })
+        )
 
-      allow(request_type_visibility_service).
-        to receive(:determine_visibility).with(request_type).and_return({:hide => [:request_type_hide]})
+      allow(request_type_visibility_service)
+        .to receive(:determine_visibility).with(request_type).and_return(:hide => [:request_type_hide])
 
-      allow(pxe_iso_visibility_service).
-        to receive(:determine_visibility).with(supports_iso, supports_pxe).and_return({
+      allow(pxe_iso_visibility_service)
+        .to receive(:determine_visibility).with(supports_iso, supports_pxe).and_return(
           :hide => [:pxe_iso_hide],
           :show => [:pxe_iso_show]
-      })
+        )
 
-      allow(linked_clone_visibility_service).
-        to receive(:determine_visibility).with(provision_type, linked_clone).and_return({
+      allow(linked_clone_visibility_service)
+        .to receive(:determine_visibility).with(provision_type, linked_clone).and_return(
           :hide => [:linked_clone_hide],
           :show => [:linked_clone_show]
-      })
+        )
     end
 
     it "adds the values to the field names to hide and show without duplicates or intersections" do

--- a/spec/services/linked_clone_visibility_service_spec.rb
+++ b/spec/services/linked_clone_visibility_service_spec.rb
@@ -1,0 +1,49 @@
+describe LinkedCloneVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when provision type is vmware" do
+      let(:provision_type) { "vmware" }
+
+      context "when linked clone is true" do
+        let(:linked_clone) { true }
+
+        it "adds values to the field names to show" do
+          expect(subject.determine_visibility(provision_type, linked_clone)).to eq(
+            {
+              :hide => [],
+              :show => [:linked_clone, :snapshot]
+            }
+          )
+        end
+      end
+
+      context "when linked clone is not true" do
+        let(:linked_clone) { false }
+
+        it "adds values to the field names to hide" do
+          expect(subject.determine_visibility(provision_type, linked_clone)).to eq(
+            {
+              :hide => [:snapshot],
+              :show => [:linked_clone]
+            }
+          )
+        end
+      end
+    end
+
+    context "when provision type is not vmware" do
+      let(:provision_type) { nil }
+      let(:linked_clone) { nil }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(provision_type, linked_clone)).to eq(
+          {
+            :hide => [:linked_clone, :snapshot],
+            :show => []
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/linked_clone_visibility_service_spec.rb
+++ b/spec/services/linked_clone_visibility_service_spec.rb
@@ -10,10 +10,8 @@ describe LinkedCloneVisibilityService do
 
         it "adds values to the field names to show" do
           expect(subject.determine_visibility(provision_type, linked_clone)).to eq(
-            {
-              :hide => [],
-              :show => [:linked_clone, :snapshot]
-            }
+            :hide => [],
+            :show => [:linked_clone, :snapshot]
           )
         end
       end
@@ -23,10 +21,8 @@ describe LinkedCloneVisibilityService do
 
         it "adds values to the field names to hide" do
           expect(subject.determine_visibility(provision_type, linked_clone)).to eq(
-            {
-              :hide => [:snapshot],
-              :show => [:linked_clone]
-            }
+            :hide => [:snapshot],
+            :show => [:linked_clone]
           )
         end
       end
@@ -38,10 +34,8 @@ describe LinkedCloneVisibilityService do
 
       it "adds values to the field names to hide" do
         expect(subject.determine_visibility(provision_type, linked_clone)).to eq(
-          {
-            :hide => [:linked_clone, :snapshot],
-            :show => []
-          }
+          :hide => [:linked_clone, :snapshot],
+          :show => []
         )
       end
     end

--- a/spec/services/network_visibility_service_spec.rb
+++ b/spec/services/network_visibility_service_spec.rb
@@ -1,0 +1,130 @@
+describe NetworkVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    let(:supports_pxe) { nil }
+    let(:supports_iso) { nil }
+    let(:addr_mode) { nil }
+
+    shared_examples_for "NetworkVisibilityService#determine_visibility that shows everything" do
+      it "adds the network values to the show values" do
+        expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq({
+          :hide => [],
+          :show => [:addr_mode, :dns_suffixes, :dns_servers, :ip_addr, :subnet_mask, :gateway]
+        })
+      end
+    end
+
+    shared_examples_for "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'" do
+      context "when addr_mode is static" do
+        let(:addr_mode) { "static" }
+
+        it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+      end
+
+      context "when addr_mode is not static" do
+        let(:addr_mode) { "not static" }
+
+        context "when supports_pxe is true" do
+          let(:supports_pxe) { true }
+
+          it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+        end
+
+        context "when supports_pxe is false" do
+          let(:supports_pxe) { false }
+
+          context "when supports_iso is true" do
+            let(:supports_iso) { true }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when supports_iso is false" do
+            let(:supports_iso) { false }
+
+            it "adds the correct values to the show and hide values" do
+              expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq({
+                :hide => [:ip_addr, :subnet_mask, :gateway],
+                :show => [:addr_mode, :dns_suffixes, :dns_servers]
+              })
+            end
+          end
+        end
+      end
+    end
+
+    context "when sysprep_enabled is 'fields'" do
+      let(:sysprep_enabled) { "fields" }
+
+      it_behaves_like "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'"
+    end
+
+    context "when sysprep_enabled is 'file'" do
+      let(:sysprep_enabled) { "file" }
+
+      it_behaves_like "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'"
+    end
+
+    context "when sysprep_enabled is something else" do
+      let(:sysprep_enabled) { "potato" }
+
+      context "when supports_pxe is true" do
+        let(:supports_pxe) { true }
+
+        context "when addr_mode is static" do
+          let(:addr_mode) { "static" }
+
+          it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+        end
+
+        context "when addr_mode is not static" do
+          let(:addr_mode) { "not static" }
+
+          context "when supports_iso is true" do
+            let(:supports_iso) { true }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when supports_iso is false" do
+            let(:supports_iso) { false }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+        end
+      end
+
+      context "when supports_pxe is false" do
+        let(:supports_pxe) { false }
+
+        context "when supports_iso is true" do
+          let(:supports_iso) { true }
+
+          context "when addr_mode is static" do
+            let(:addr_mode) { "static" }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when addr_mode is not static" do
+            let(:addr_mode) { "not static" }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+        end
+
+        context "when supports_iso is false" do
+          let(:supports_iso) { false }
+
+          it "adds the correct values to the hide values" do
+            expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq({
+              :hide => [:addr_mode, :ip_addr, :subnet_mask, :gateway, :dns_servers, :dns_suffixes],
+              :show => []
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/network_visibility_service_spec.rb
+++ b/spec/services/network_visibility_service_spec.rb
@@ -8,10 +8,10 @@ describe NetworkVisibilityService do
 
     shared_examples_for "NetworkVisibilityService#determine_visibility that shows everything" do
       it "adds the network values to the show values" do
-        expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq({
+        expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
           :hide => [],
           :show => [:addr_mode, :dns_suffixes, :dns_servers, :ip_addr, :subnet_mask, :gateway]
-        })
+        )
       end
     end
 
@@ -44,10 +44,10 @@ describe NetworkVisibilityService do
             let(:supports_iso) { false }
 
             it "adds the correct values to the show and hide values" do
-              expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq({
+              expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
                 :hide => [:ip_addr, :subnet_mask, :gateway],
                 :show => [:addr_mode, :dns_suffixes, :dns_servers]
-              })
+              )
             end
           end
         end
@@ -118,10 +118,10 @@ describe NetworkVisibilityService do
           let(:supports_iso) { false }
 
           it "adds the correct values to the hide values" do
-            expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq({
+            expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
               :hide => [:addr_mode, :ip_addr, :subnet_mask, :gateway, :dns_servers, :dns_suffixes],
               :show => []
-            })
+            )
           end
         end
       end

--- a/spec/services/number_of_vms_visibility_service_spec.rb
+++ b/spec/services/number_of_vms_visibility_service_spec.rb
@@ -1,0 +1,57 @@
+describe NumberOfVmsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the number of vms is greater than 1" do
+      let(:number_of_vms) { 2 }
+
+      context "when the platform is linux" do
+        let(:platform) { "linux" }
+
+        it "adds values to field names to hide and show" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:sysprep_computer_name, :linux_host_name],
+            :show => [:ip_addr]
+          )
+        end
+      end
+
+      context "when the platform is not linux" do
+        let(:platform) { "not linux" }
+
+        it "adds values to field names to hide and show" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:sysprep_computer_name, :linux_host_name],
+            :show => [:ip_addr]
+          )
+        end
+      end
+    end
+
+    context "when the number of vms is not greater than 1" do
+      let(:number_of_vms) { 1 }
+
+      context "when the platform is linux" do
+        let(:platform) { "linux" }
+
+        it "adds values to field names to hide and show" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:ip_addr, :sysprep_computer_name],
+            :show => [:linux_host_name]
+          )
+        end
+      end
+
+      context "when the platform is not linux" do
+        let(:platform) { "not linux" }
+
+        it "adds values to field names to hide and show" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => [:ip_addr, :linux_host_name],
+            :show => [:sysprep_computer_name]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/pxe_iso_visibility_service_spec.rb
+++ b/spec/services/pxe_iso_visibility_service_spec.rb
@@ -1,0 +1,57 @@
+describe PxeIsoVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when pxe is supported" do
+      let(:supports_pxe) { true }
+
+      context "when iso is supported" do
+        let(:supports_iso) { true }
+
+        it "returns the values to be shown and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+            :hide => [],
+            :show => [:pxe_image_id, :pxe_server_id, :iso_image_id]
+          })
+        end
+      end
+
+      context "when iso is not supported" do
+        let(:supports_iso) { false }
+
+        it "returns the values to be shown and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+            :hide => [:iso_image_id],
+            :show => [:pxe_image_id, :pxe_server_id]
+          })
+        end
+      end
+    end
+
+    context "when pxe is not supported" do
+      let(:supports_pxe) { false }
+
+      context "when iso is supported" do
+        let(:supports_iso) { true }
+
+        it "returns the values to be shown and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+            :hide => [:pxe_image_id, :pxe_server_id],
+            :show => [:iso_image_id]
+          })
+        end
+      end
+
+      context "when iso is not supported" do
+        let(:supports_iso) { false }
+
+        it "returns the values to be shown and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+            :hide => [:pxe_image_id, :pxe_server_id, :iso_image_id],
+            :show => []
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/services/pxe_iso_visibility_service_spec.rb
+++ b/spec/services/pxe_iso_visibility_service_spec.rb
@@ -9,10 +9,10 @@ describe PxeIsoVisibilityService do
         let(:supports_iso) { true }
 
         it "returns the values to be shown and hidden" do
-          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
             :hide => [],
             :show => [:pxe_image_id, :pxe_server_id, :iso_image_id]
-          })
+          )
         end
       end
 
@@ -20,10 +20,10 @@ describe PxeIsoVisibilityService do
         let(:supports_iso) { false }
 
         it "returns the values to be shown and hidden" do
-          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
             :hide => [:iso_image_id],
             :show => [:pxe_image_id, :pxe_server_id]
-          })
+          )
         end
       end
     end
@@ -35,10 +35,10 @@ describe PxeIsoVisibilityService do
         let(:supports_iso) { true }
 
         it "returns the values to be shown and hidden" do
-          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
             :hide => [:pxe_image_id, :pxe_server_id],
             :show => [:iso_image_id]
-          })
+          )
         end
       end
 
@@ -46,10 +46,10 @@ describe PxeIsoVisibilityService do
         let(:supports_iso) { false }
 
         it "returns the values to be shown and hidden" do
-          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq({
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
             :hide => [:pxe_image_id, :pxe_server_id, :iso_image_id],
             :show => []
-          })
+          )
         end
       end
     end

--- a/spec/services/request_type_visibility_service_spec.rb
+++ b/spec/services/request_type_visibility_service_spec.rb
@@ -1,0 +1,29 @@
+describe RequestTypeVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the request type is 'clone_to_template'" do
+      let(:request_type) { :clone_to_template }
+
+      it "returns the values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq({:hide => [:vm_filter, :vm_auto_start]})
+      end
+    end
+
+    context "when the request type is 'clone_to_vm'" do
+      let(:request_type) { :clone_to_vm }
+
+      it "returns the values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq({:hide => [:vm_filter]})
+      end
+    end
+
+    context "when the request type is anything else" do
+      let(:request_type) { :potato }
+
+      it "returns an empty list of values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq({:hide => []})
+      end
+    end
+  end
+end

--- a/spec/services/request_type_visibility_service_spec.rb
+++ b/spec/services/request_type_visibility_service_spec.rb
@@ -6,7 +6,7 @@ describe RequestTypeVisibilityService do
       let(:request_type) { :clone_to_template }
 
       it "returns the values to be hidden" do
-        expect(subject.determine_visibility(request_type)).to eq({:hide => [:vm_filter, :vm_auto_start]})
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [:vm_filter, :vm_auto_start])
       end
     end
 
@@ -14,7 +14,7 @@ describe RequestTypeVisibilityService do
       let(:request_type) { :clone_to_vm }
 
       it "returns the values to be hidden" do
-        expect(subject.determine_visibility(request_type)).to eq({:hide => [:vm_filter]})
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [:vm_filter])
       end
     end
 
@@ -22,7 +22,7 @@ describe RequestTypeVisibilityService do
       let(:request_type) { :potato }
 
       it "returns an empty list of values to be hidden" do
-        expect(subject.determine_visibility(request_type)).to eq({:hide => []})
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [])
       end
     end
   end

--- a/spec/services/retirement_visibility_service_spec.rb
+++ b/spec/services/retirement_visibility_service_spec.rb
@@ -1,0 +1,27 @@
+describe RetirementVisibilityService do
+  let (:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when retirement to_i is greater than 0" do
+      let(:retirement) { 123 }
+
+      it "adds the retirement warn to the show fields" do
+        expect(subject.determine_visibility(retirement)).to eq({
+          :hide => [],
+          :show => [:retirement_warn]
+        })
+      end
+    end
+
+    context "when retirement to_i is not greater than 0" do
+      let(:retirement) { 0 }
+
+      it "adds the retirement warn to the hide fields" do
+        expect(subject.determine_visibility(retirement)).to eq({
+          :hide => [:retirement_warn],
+          :show => []
+        })
+      end
+    end
+  end
+end

--- a/spec/services/retirement_visibility_service_spec.rb
+++ b/spec/services/retirement_visibility_service_spec.rb
@@ -1,15 +1,15 @@
 describe RetirementVisibilityService do
-  let (:subject) { described_class.new }
+  let(:subject) { described_class.new }
 
   describe "#determine_visibility" do
     context "when retirement to_i is greater than 0" do
       let(:retirement) { 123 }
 
       it "adds the retirement warn to the show fields" do
-        expect(subject.determine_visibility(retirement)).to eq({
+        expect(subject.determine_visibility(retirement)).to eq(
           :hide => [],
           :show => [:retirement_warn]
-        })
+        )
       end
     end
 
@@ -17,10 +17,10 @@ describe RetirementVisibilityService do
       let(:retirement) { 0 }
 
       it "adds the retirement warn to the hide fields" do
-        expect(subject.determine_visibility(retirement)).to eq({
+        expect(subject.determine_visibility(retirement)).to eq(
           :hide => [:retirement_warn],
           :show => []
-        })
+        )
       end
     end
   end

--- a/spec/services/service_template_fields_visibility_service_spec.rb
+++ b/spec/services/service_template_fields_visibility_service_spec.rb
@@ -7,7 +7,7 @@ describe ServiceTemplateFieldsVisibilityService do
 
       it "adds values to field names to hide" do
         expect(subject.determine_visibility(service_template_request)).to eq(
-          {:hide => [:number_of_vms, :vm_description, :schedule_type, :schedule_time]}
+          :hide => [:number_of_vms, :vm_description, :schedule_type, :schedule_time]
         )
       end
     end
@@ -17,7 +17,7 @@ describe ServiceTemplateFieldsVisibilityService do
 
       it "returns an empty hide/show hash" do
         expect(subject.determine_visibility(service_template_request)).to eq(
-          {:hide => []}
+          :hide => []
         )
       end
     end

--- a/spec/services/service_template_fields_visibility_service_spec.rb
+++ b/spec/services/service_template_fields_visibility_service_spec.rb
@@ -1,0 +1,25 @@
+describe ServiceTemplateFieldsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when service_template_request exists" do
+      let(:service_template_request) { "a service template request" }
+
+      it "adds values to field names to hide" do
+        expect(subject.determine_visibility(service_template_request)).to eq(
+          {:hide => [:number_of_vms, :vm_description, :schedule_type, :schedule_time]}
+        )
+      end
+    end
+
+    context "when service_template_request does not exist" do
+      let(:service_template_request) { nil }
+
+      it "returns an empty hide/show hash" do
+        expect(subject.determine_visibility(service_template_request)).to eq(
+          {:hide => []}
+        )
+      end
+    end
+  end
+end

--- a/spec/services/sysprep_auto_logon_visibility_service_spec.rb
+++ b/spec/services/sysprep_auto_logon_visibility_service_spec.rb
@@ -1,0 +1,31 @@
+describe SysprepAutoLogonVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when sysprep_auto_logon is false" do
+      let(:sysprep_auto_logon) { false }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
+          {
+            :hide => [:sysprep_auto_logon_count],
+            :show => []
+          }
+        )
+      end
+    end
+
+    context "when sysprep auto logon is true" do
+      let(:sysprep_auto_logon) { true }
+
+      it "adds values to the field names to show" do
+        expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
+          {
+            :hide => [],
+            :show => [:sysprep_auto_logon_count]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/sysprep_auto_logon_visibility_service_spec.rb
+++ b/spec/services/sysprep_auto_logon_visibility_service_spec.rb
@@ -7,10 +7,8 @@ describe SysprepAutoLogonVisibilityService do
 
       it "adds values to the field names to hide" do
         expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
-          {
-            :hide => [:sysprep_auto_logon_count],
-            :show => []
-          }
+          :hide => [:sysprep_auto_logon_count],
+          :show => []
         )
       end
     end
@@ -20,10 +18,8 @@ describe SysprepAutoLogonVisibilityService do
 
       it "adds values to the field names to show" do
         expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
-          {
-            :hide => [],
-            :show => [:sysprep_auto_logon_count]
-          }
+          :hide => [],
+          :show => [:sysprep_auto_logon_count]
         )
       end
     end

--- a/spec/services/sysprep_custom_spec_visibility_service_spec.rb
+++ b/spec/services/sysprep_custom_spec_visibility_service_spec.rb
@@ -7,10 +7,8 @@ describe SysprepCustomSpecVisibilityService do
 
       it "adds values to the field names to hide" do
         expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
-          {
-            :hide => [:sysprep_spec_override],
-            :show => []
-          }
+          :hide => [:sysprep_spec_override],
+          :show => []
         )
       end
     end
@@ -20,10 +18,8 @@ describe SysprepCustomSpecVisibilityService do
 
       it "adds values to the field names to show" do
         expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
-          {
-            :hide => [],
-            :show => [:sysprep_spec_override]
-          }
+          :hide => [],
+          :show => [:sysprep_spec_override]
         )
       end
     end

--- a/spec/services/sysprep_custom_spec_visibility_service_spec.rb
+++ b/spec/services/sysprep_custom_spec_visibility_service_spec.rb
@@ -1,0 +1,31 @@
+describe SysprepCustomSpecVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when sysprep custom spec is not blank" do
+      let(:sysprep_custom_spec) { "foo" }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
+          {
+            :hide => [:sysprep_spec_override],
+            :show => []
+          }
+        )
+      end
+    end
+
+    context "when sysprep custom spec is blank" do
+      let(:sysprep_custom_spec) { nil }
+
+      it "adds values to the field names to show" do
+        expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
+          {
+            :hide => [],
+            :show => [:sysprep_spec_override]
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first step into breaking out functionality of the workflow that may need to be used elsewhere outside of the workflow and without knowledge of the workflow. Each visibility service contains the related dialog field names to show or hide.

Currently only the field display is broken out into these services, but ideally the notes display and the read only would become separate so that they can be used outside of the workflow as well.

The changes as a whole seem large, but should hopefully be easier to follow if you go commit by commit.

Paired with @d-m-u for all of this, not sure how to attribute!

@gmcculloug Please Review or tag someone else to review 😄 