### PR TITLE
Use Ansible extra vars defined in options hash

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -29,9 +29,9 @@ class LaunchAnsibleJob
     @handle.root["miq_provision"].try(:destination)
   end
 
-  def ansible_vars(object, ext_vars)
+  def ansible_vars_from_objects(object, ext_vars)
     return ext_vars unless object
-    ansible_vars(object.parent, object_vars(object, ext_vars))
+    ansible_vars_from_objects(object.parent, object_vars(object, ext_vars))
   end
 
   def object_vars(object, ext_vars)
@@ -44,6 +44,16 @@ class LaunchAnsibleJob
         match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
         hash[match_data[1]] = object[key] if match_data
       end
+    end
+  end
+
+  def ansible_vars_from_options(ext_vars)
+    options = @handle.root["miq_provision"].try(:options) || {}
+    keys = options.keys.map(&:to_s)
+    key_list = keys.select { |k| k.start_with?('dialog_param') }
+    key_list.each_with_object(ext_vars) do |key, hash|
+      match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
+      hash[match_data[1]] = options[key.to_sym] if match_data
     end
   end
 
@@ -74,7 +84,8 @@ class LaunchAnsibleJob
   end
 
   def extra_variables
-    ansible_vars(@handle.object, {})
+    result = ansible_vars_from_objects(@handle.object, {})
+    ansible_vars_from_options(result)
   end
 
   def run(job_template, target)

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -35,25 +35,23 @@ class LaunchAnsibleJob
   end
 
   def object_vars(object, ext_vars)
-    key_list = object.attributes.keys.select { |k| k.start_with?('param', 'dialog_param') }
-    key_list.each_with_object(ext_vars) do |key, hash|
+    object.attributes.each_with_object(ext_vars) do |(key, value), hash|
       if key.start_with?('param')
-        match_data = ANSIBLE_VAR_REGEX.match(object[key])
+        match_data = ANSIBLE_VAR_REGEX.match(value)
         hash[match_data[1].strip] ||= match_data[2] if match_data
       else
         match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
-        hash[match_data[1]] = object[key] if match_data
+        hash[match_data[1]] = value if match_data
       end
     end
   end
 
   def ansible_vars_from_options(ext_vars)
     options = @handle.root["miq_provision"].try(:options) || {}
-    keys = options.keys.map(&:to_s)
-    key_list = keys.select { |k| k.start_with?('dialog_param') }
-    key_list.each_with_object(ext_vars) do |key, hash|
+    options.each_with_object(ext_vars) do |(k, v), hash|
+      key = k.to_s
       match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
-      hash[match_data[1]] = options[key.to_sym] if match_data
+      hash[match_data[1]] = v if match_data
     end
   end
 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -48,10 +48,9 @@ class LaunchAnsibleJob
 
   def ansible_vars_from_options(ext_vars)
     options = @handle.root["miq_provision"].try(:options) || {}
-    options.each_with_object(ext_vars) do |(k, v), hash|
-      key = k.to_s
-      match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
-      hash[match_data[1]] = v if match_data
+    options.each_with_object(ext_vars) do |(key, value), hash|
+      match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key.to_s)
+      hash[match_data[1]] = value if match_data
     end
   end
 

--- a/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
+++ b/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
@@ -17,7 +17,7 @@ describe LaunchAnsibleJob do
   let(:root_object) { MiqAeMockObject.new('param1' => "x=X", 'param2' => "y=Y") }
   let(:middle_object) { MiqAeMockObject.new('a' => 1, 'b' => 2) }
 
-  let(:ext_vars) { {'x' => 'X', 'y' => 'Y'} }
+  let(:ext_vars) { {} }
   let(:job_args) { {:extra_vars => ext_vars} }
 
   let(:service) { MiqAeMockService.new(root_object) }
@@ -47,6 +47,8 @@ describe LaunchAnsibleJob do
   let(:svc_provision) { MiqAeMethodService::MiqAeServiceMiqProvision.find(miq_provision.id) }
 
   it "run a job using job template name" do
+    ext_vars['x'] = 'X'
+    ext_vars['y'] = 'Y'
     root_object['vm'] = svc_vm
     current_object = MiqAeMockObject.new(:job_template_name => job_template.name)
     current_object.parent = root_object
@@ -58,6 +60,8 @@ describe LaunchAnsibleJob do
   end
 
   it "run a job using job template id" do
+    ext_vars['x'] = 'X'
+    ext_vars['y'] = 'Y'
     root_object['vm'] = svc_vm
     current_object = MiqAeMockObject.new(:job_template_id => job_template.id)
     current_object.parent = root_object
@@ -69,6 +73,8 @@ describe LaunchAnsibleJob do
   end
 
   it "run a job using job template object" do
+    ext_vars['x'] = 'X'
+    ext_vars['y'] = 'Y'
     root_object['vm'] = svc_vm
     current_object = MiqAeMockObject.new(:job_template => svc_job_template)
     current_object.parent = root_object
@@ -121,12 +127,11 @@ describe LaunchAnsibleJob do
 
   it "get dialog parameters" do
     prov_options[:dialog_param_name] = 'fred'
-    root_object[:job_template_name] = job_template.name
-    root_object[:miq_provision] = svc_provision
     ext_vars['name'] = 'fred'
-    current_object = MiqAeMockObject.new('param1' => 'x=X', 'param2' => 'y=Y')
-    current_object.parent = root_object
-    service.object = current_object
+    root = MiqAeMockObject.new(:job_template_name => job_template.name)
+    root[:miq_provision] = svc_provision
+    service = MiqAeMockService.new(root)
+    service.object = root
     expect(job_class).to receive(:create_job).once.with(anything, job_args).and_return(svc_job)
     LaunchAnsibleJob.new(service).main
     expect(service.get_state_var(:ansible_job_id)).to eq(job.id)


### PR DESCRIPTION
Purpose or Intent
-----------------
The options hash in a provision request can store the Ansible extra vars, the automate method was not looking at the options hash to collect the extra vars. The Automate method launch_ansible_job has been modified to honor the ansible extra vars stored in the options hash.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1348232

Steps for Testing/QA
--------------------
1. Create a Service Dialogs that collect information from the users about Ansible extra vars,
2. When the job runs on Ansible Tower these parameters have to be present.

https://bugzilla.redhat.com/show_bug.cgi?id=1348232

Users create service dialog to collect ansible extra vars these
get stored in the options hash by CatalogItemInitialization.
The Automate method wasn't looking at the options hash to get
the ansible extra vars.