### PR TITLE
Require Dialog Type when creating a new Dialog

### DIFF
--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -250,7 +250,7 @@ module MiqAeCustomizationController::OldDialogs
       if @edit[:new][:name].blank?
         add_flash(_("Name is required"), :error)
       end
-      unless @edit[:new][:dialog_type]
+      if @edit[:new][:dialog_type].blank?
         add_flash(_("Dialog Type must be selected"), :error)
       end
       begin

--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -253,10 +253,12 @@ module MiqAeCustomizationController::OldDialogs
       if @edit[:new][:dialog_type].blank?
         add_flash(_("Dialog Type must be selected"), :error)
       end
-      begin
-        YAML.parse(@edit[:new][:content])
-      rescue YAML::SyntaxError => ex
-        add_flash(_("Syntax error in YAML file: %{error_message}") % {:error_message => ex.message}, :error)
+      unless @flash_array
+        begin
+          YAML.parse(@edit[:new][:content])
+        rescue YAML::SyntaxError => ex
+          add_flash(_("Syntax error in YAML file: %{error_message}") % {:error_message => ex.message}, :error)
+        end
       end
       if @flash_array
         render :update do |page|

--- a/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -52,5 +52,27 @@ describe MiqAeCustomizationController do
         expect(controller.send(:flash_errors?)).to be_truthy
       end
     end
+
+    context 'Adding a new Dialog' do
+      render_views
+
+      it 'will show a flash error without Dialog Type' do
+        allow(controller).to receive(:load_edit).and_return(true)
+        controller.instance_variable_set(:@_params, :button => 'add',
+                                                    :id     => 'new')
+        controller.instance_variable_set(:@edit, {:new    => {:name        => 'name',
+                                                              :description => 'description',
+                                                              :dialog_type => '',
+                                                              :content     => '',},
+                                                  :dialog => MiqDialog.new})
+        allow(controller).to receive(:render)
+        controller.send(:old_dialogs_update)
+
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first[:message]).to include('Dialog Type must be selected')
+        expect(controller.send(:flash_errors?)).to be_truthy
+      end
+    end
+
   end
 end

--- a/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -60,11 +60,11 @@ describe MiqAeCustomizationController do
         allow(controller).to receive(:load_edit).and_return(true)
         controller.instance_variable_set(:@_params, :button => 'add',
                                                     :id     => 'new')
-        controller.instance_variable_set(:@edit, {:new    => {:name        => 'name',
-                                                              :description => 'description',
-                                                              :dialog_type => '',
-                                                              :content     => '',},
-                                                  :dialog => MiqDialog.new})
+        controller.instance_variable_set(:@edit, :new    => {:name        => 'name',
+                                                             :description => 'description',
+                                                             :dialog_type => '',
+                                                             :content     => '',},
+                                                 :dialog => MiqDialog.new)
         allow(controller).to receive(:render)
         controller.send(:old_dialogs_update)
 
@@ -73,6 +73,5 @@ describe MiqAeCustomizationController do
         expect(controller.send(:flash_errors?)).to be_truthy
       end
     end
-
   end
 end


### PR DESCRIPTION
Fixes a situation in Automate - Customization - Add New Dialog where the user was allowed to create a new Dialog without a dialog type.  This created multiple issues (summarized in the linked BZ), all of which were corrected when requiring the dialog type be selected prior to form submission.

https://bugzilla.redhat.com/show_bug.cgi?id=1344080