### PR TITLE
[WIP] Allow pre-release bundler so we can try 1.13.0.pre1

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -1,7 +1,7 @@
 set -v
 
 echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
-travis_retry gem install bundler -v ">= 1.11.1"
+travis_retry gem install --prerelease bundler -v ">= 1.11.1"
 
 if [[ -n "${GEM}" ]] ; then
   cd gems/${GEM}


### PR DESCRIPTION
Purpose or Intent
-----------------

Don't merge.

Bundler resolution with 1.13.0.pre1 should be significantly faster and we should no longer be re-resolving constantly with our path gems.  This release changed the internals of bundler so we should test the pre-release...
