### PR TITLE
Add Provider Name and Provider Guid to 'Chargeback for Vms' report

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -6,6 +6,8 @@ class ChargebackVm < Chargeback
     :display_range            => :string,
     :vm_name                  => :string,
     :owner_name               => :string,
+    :provider_name            => :string,
+    :provider_uid             => :string,
     :cpu_allocated_metric     => :float,
     :cpu_allocated_cost       => :float,
     :cpu_used_cost            => :float,
@@ -87,7 +89,10 @@ class ChargebackVm < Chargeback
     key = "#{perf.resource_id}_#{ts_key}"
     @vm_owners[perf.resource_id] ||= perf.resource.evm_owner_name
 
-    [key, {"vm_name" => perf.resource_name, "owner_name" => @vm_owners[perf.resource_id]}]
+    extra_fields = {"vm_name" => perf.resource_name, "owner_name" => @vm_owners[perf.resource_id],
+                    "provider_name" => perf.parent_ems.name, "provider_uid" => perf.parent_ems.guid}
+
+    [key, extra_fields]
   end
 
   def self.where_clause(records, options)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1346173

Add Provider Name and Provider Guid to 'Chargeback Vm' report. I also added giud as it is in 'Chargeback for Projects' report. Now these field are available in 'Available Fields' when report is defined

How it looks on report:
<img width="1434" alt="screen shot 2016-06-21 at 08 46 49" src="https://cloud.githubusercontent.com/assets/14937244/16220371/c4b32494-378c-11e6-8e38-e2df05fd1d1d.png">

@miq-bot add-label reporting
@miq-bot add-label chargeback
@miq-bot add-label ui

@miq-bot assign gtanzillo 
