### PR TITLE
bottleneck ui form: remove unused hidden input field

### DIFF
--- a/app/views/miq_capacity/_bottlenecks_options.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_options.html.haml
@@ -37,5 +37,3 @@
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("tl_#{typ}_tz", "#{url}");
-  %form#hiddenForm
-    %input.filter1{:type => "hidden", :name => "filter1", :value => @sb[:bottlenecks][:tl_options][:fltr1]}


### PR DESCRIPTION
This perhaps came into existence by `copy_paste()` method from `_tl_options` layout.

@miq-bot add_label darga/no, ui, technical debt