### PR TITLE
Adding cloud-init template that enables adding key to authorized hosts

### DIFF
--- a/db/fixtures/customization_templates.yml
+++ b/db/fixtures/customization_templates.yml
@@ -280,3 +280,9 @@
   :script: "#cloud-config\nchpasswd:\n  list: |\n    root:<%= MiqPassword.decrypt(evm[:root_password]) %>\n  expire: False"
   :type: CustomizationTemplateCloudInit
   :system: true
+
+- :name: SSH key addition template
+  :description: This template enables placing ssh public key in authorized keys
+  :script: "#cloud-config\nusers:\n  - name: root\n    ssh-authorized-keys:\n      - <%= evm[:ws_values][:ssh_public_key] %>"
+  :type: CustomizationTemplateCloudInit
+  :system: true


### PR DESCRIPTION
This template is required for the Openshift deployment using provisioning flow.