### PR TITLE
Refactor ifs in middleware and container topology controllers

### DIFF
--- a/app/controllers/container_topology_controller.rb
+++ b/app/controllers/container_topology_controller.rb
@@ -8,9 +8,7 @@ class ContainerTopologyController < ApplicationController
     # When navigated here without id, it means this is a general view for all providers (not for a specific provider)
     # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
     # any other page in the application.
-    if params[:id].nil?
-      @breadcrumbs.clear
-    end
+    @breadcrumbs.clear if params[:id].nil?
     drop_breadcrumb(:name => _('Topology'), :url => '')
   end
 

--- a/app/controllers/middleware_topology_controller.rb
+++ b/app/controllers/middleware_topology_controller.rb
@@ -8,9 +8,7 @@ class MiddlewareTopologyController < ApplicationController
     # When navigated here without id, it means this is a general view for all providers (not for a specific provider)
     # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
     # any other page in the application.
-    if params[:id].nil?
-      @breadcrumbs.clear
-    end
+    @breadcrumbs.clear if params[:id].nil?
     drop_breadcrumb(:name => _('Topology'), :url => '')
   end
 


### PR DESCRIPTION
Refactor `if` methods in `show` actions in 
`container_topology_controller.rb` and `middleware_topology_controller.rb`. 
Turn 3-line method into 1-line as same as in `network_topology_controller.rb`
Now that methods in topology controllers are all the same.