### PR TITLE
Fix provision dialogs copying

### DIFF
--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -193,8 +193,12 @@ module MiqAeCustomizationController::OldDialogs
 
   def old_dialogs_edit
     assert_privileges("old_dialogs_edit")
-    obj = find_checked_items
-    @_params[:id] = obj[0] unless obj.empty?
+
+    # copy called on checkbox-checked item
+    unless params[:id]
+      obj = find_checked_items
+      @_params[:id] = obj[0]
+    end
 
     if params[:typ] == "copy"
       dialog = MiqDialog.find_by_id(from_cid(params[:id]))


### PR DESCRIPTION
When user checked the provision dialog in the list view (All Dialogs) and then selected other one
in the tree and called the copy of the dialog from explorer screen,
it copied wrong one (1st checked checkbox from list view).

It was caused by overriding the ID of the selected item by checked item's ID in the list view.

https://bugzilla.redhat.com/show_bug.cgi?id=1342260