### PR TITLE
Fix image paths for policy VM simulation

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -745,7 +745,7 @@ module VmCommon
       profile_node = TreeNodeBuilder.generic_tree_node(
         "policy_profile_#{profile['id']}",
         profile['description'],
-        ActionController::Base.helpers.image_path("100/#{icon}"),
+        icon,
         nil,
         :style_class => "cfme-no-cursor-node"
       )
@@ -786,7 +786,7 @@ module VmCommon
       policy_node = TreeNodeBuilder.generic_tree_node(
         "policy_#{policy["id"]}",
         policy['description'],
-        ActionController::Base.helpers.image_path("100/#{icon}"),
+        icon,
         nil,
         :style_class => "cfme-no-cursor-node"
       )
@@ -827,7 +827,7 @@ module VmCommon
       condition_node = TreeNodeBuilder.generic_tree_node(
         "condition_#{condition["id"]}_#{condition["name"]}_#{policy["name"]}",
         condition["description"],
-        ActionController::Base.helpers.image_path("100/#{icon}"),
+        icon,
         nil,
         :style_class => "cfme-no-cursor-node"
       )
@@ -855,7 +855,7 @@ module VmCommon
     node = TreeNodeBuilder.generic_tree_node(
       node_key,
       exp_string.html_safe,
-      ActionController::Base.helpers.image_path("100/#{icon}"),
+      icon,
       exp_tooltip.html_safe,
       :style_class => "cfme-no-cursor-node"
     )


### PR DESCRIPTION
The way we generated the path of tree node images [has been moved](https://github.com/ManageIQ/manageiq/blob/master/app/presenters/tree_node_builder.rb#L11) and this piece of code was not updated. 

**Before:**
![screenshot from 2016-06-21 16-33-34](https://cloud.githubusercontent.com/assets/649130/16233241/fcaa4382-37cd-11e6-96fb-b3c63d721a06.png)

**After:**
![screenshot from 2016-06-21 16-32-56](https://cloud.githubusercontent.com/assets/649130/16233248/0251ada2-37ce-11e6-9e4b-56b77193d4c6.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1347873