### PR TITLE
Move boot_with_cloudinit logic from provision to rhevm vm

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -45,14 +45,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
   end
 
   def autostart_destination
-    if get_option(:vm_auto_start)
-      message = "Starting"
-      _log.info("#{message} #{for_destination}")
-      update_and_notify_parent(:message => message)
-      get_provider_destination.start { |action| action.use_cloud_init(true) if phase_context[:boot_with_cloud_init] }
-    end
+    destination.custom_attributes.create!(:name => "miq_provision_boot_with_cloud_init") if phase_context[:boot_with_cloud_init]
 
-    signal :post_create_destination
+    super
   end
 
   private

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/power.rb
@@ -4,7 +4,11 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Power
   end
 
   def raw_start
-    with_provider_object(&:start)
+    start_with_cloud_init = custom_attributes.find_by(:name => "miq_provision_boot_with_cloud_init")
+    with_provider_object do |rhevm_vm|
+      rhevm_vm.start { |action| action.use_cloud_init(true) if start_with_cloud_init }
+    end
+    start_with_cloud_init.try(&:destroy)
   rescue Ovirt::VmAlreadyRunning
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -6,7 +6,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
   let(:rhevm_vm) { double("RHEVM VM") }
   let(:task)     { request.tap(&:create_request_tasks).miq_request_tasks.first }
   let(:template) { FactoryGirl.create(:template_redhat, :ext_management_system => ems) }
-  let(:vm)       { FactoryGirl.create(:vm_redhat, :ext_management_system => ems, :raw_power_state => "on").tap { |v| allow(v).to receive(:with_provider_object).and_return(rhevm_vm) } }
+  let(:vm)       { FactoryGirl.create(:vm_redhat, :ext_management_system => ems, :raw_power_state => "on").tap { |v| allow(v).to receive(:with_provider_object).and_yield(rhevm_vm) } }
 
   let(:options) do
     {
@@ -84,6 +84,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
   end
 
   def test_autostart_destination
+    expect(vm).to receive(:start).twice { vm.raw_start }
     test_autostart_destination_with_use_cloud_init
     test_autostart_destination_without_use_cloud_init
   end


### PR DESCRIPTION
In some cases during a provision, the provisioner does not want to use the
autostart destination logic of the provisioning state machine. Unfortunately
for rhevm vms, we need to set use_cloud_init = true when booting for the
cloud-init data to be attached. So we move this logic to the vm istelf by
setting a custom attribute on the vm, then modifying the raw_start method
to check for the custom attribute and conditionally set the flag and remove
the custom attribute.

https://bugzilla.redhat.com/show_bug.cgi?id=1348614