### PR TITLE
Fixed has_one associations to VmdbMetrics table

### DIFF
--- a/app/models/vmdb_index.rb
+++ b/app/models/vmdb_index.rb
@@ -2,7 +2,8 @@ class VmdbIndex < ApplicationRecord
   belongs_to :vmdb_table
 
   has_many :vmdb_metrics,          :as => :resource  # Destroy will be handled by purger
-  has_one  :latest_hourly_metric,  -> { where(:capture_interval_name => 'hourly').order "timestamp DESC" }, :as => :resource, :class_name => 'VmdbMetric'
+
+  has_one  :latest_hourly_metric,  -> { VmdbMetric.where(:capture_interval_name => 'hourly', :resource_type => 'VmdbIndex', :timestamp => VmdbMetric.maximum(:timestamp)) }, :as => :resource, :class_name => 'VmdbMetric'
 
   include VmdbDatabaseMetricsMixin
 

--- a/app/models/vmdb_table.rb
+++ b/app/models/vmdb_table.rb
@@ -3,7 +3,8 @@ class VmdbTable < ApplicationRecord
 
   has_many :vmdb_indexes,                            :dependent => :destroy
   has_many :vmdb_metrics,          :as => :resource  # Destroy will be handled by purger
-  has_one  :latest_hourly_metric,  -> { where(:capture_interval_name => 'hourly').order "timestamp DESC" }, :as => :resource, :class_name => 'VmdbMetric'
+
+  has_one  :latest_hourly_metric,  -> { VmdbMetric.where(:capture_interval_name => 'hourly', :resource_type => 'VmdbTable', :timestamp => VmdbMetric.maximum(:timestamp)) }, :as => :resource, :class_name => 'VmdbMetric'
 
   include VmdbDatabaseMetricsMixin
 

--- a/spec/models/vmdb_index_spec.rb
+++ b/spec/models/vmdb_index_spec.rb
@@ -108,5 +108,12 @@ describe VmdbIndex do
       expect(rollup_record.wasted_bytes).to   be_within(0.01).of(33.83)
       expect(rollup_record.percent_bloat).to  be_within(0.01).of(22.54)
     end
+
+    it "fetches latest metric record" do
+      expect(@evm_index.latest_hourly_metric.rows).to eq(500)
+      expect(@evm_index.latest_hourly_metric.size).to eq(5000)
+      expect(@evm_index.latest_hourly_metric.wasted_bytes).to eq(90)
+      expect(@evm_index.latest_hourly_metric.percent_bloat).to eq(50.7)
+    end
   end
 end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -42,5 +42,26 @@ describe VmdbTable do
       @vmdb_table.reload
       expect(@vmdb_table.vmdb_indexes.collect(&:name)).to eq(index_names)
     end
+
+    it "fetches latest metric record" do
+      ts = Time.gm(2012, 8, 15, 10, 00, 01)         # Need specific date in order to keep track of rollup data...
+
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 10.hours, :rows => 400, :size => 4000, :wasted_bytes => 44, :percent_bloat => 40.9)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 9.hours,  :rows => 410, :size => 4100, :wasted_bytes => 60, :percent_bloat => 41.1)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 8.hours,  :rows => 420, :size => 4200, :wasted_bytes => 62, :percent_bloat => 42.0)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 7.hours,  :rows => 420, :size => 4200, :wasted_bytes => 64, :percent_bloat => 42.0)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 6.hours,  :rows => 430, :size => 4300, :wasted_bytes => 70, :percent_bloat => 43.4)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 5.hours,  :rows => 440, :size => 4400, :wasted_bytes => 72, :percent_bloat => 44.7)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 4.hours,  :rows => 460, :size => 4600, :wasted_bytes => 74, :percent_bloat => 46.3)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 3.hours,  :rows => 470, :size => 4700, :wasted_bytes => 76, :percent_bloat => 47.0)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 2.hours,  :rows => 480, :size => 4800, :wasted_bytes => 80, :percent_bloat => 48.5)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts - 1.hour,   :rows => 490, :size => 4900, :wasted_bytes => 84, :percent_bloat => 49.0)
+      FactoryGirl.create(:vmdb_metric_hourly, :resource => @vmdb_table, :timestamp => ts,            :rows => 500, :size => 5000, :wasted_bytes => 90, :percent_bloat => 50.7)
+
+      expect(@vmdb_table.latest_hourly_metric.rows).to eq(500)
+      expect(@vmdb_table.latest_hourly_metric.size).to eq(5000)
+      expect(@vmdb_table.latest_hourly_metric.wasted_bytes).to eq(90)
+      expect(@vmdb_table.latest_hourly_metric.percent_bloat).to eq(50.7)
+    end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Applied fixes to has_one associations in VmdbTable and VmdbIndex models to fetch max(latest) performance metric from VmdbMetrics.  
Previously has_one associations to latest VmdbMetrics values in VmdbTable and VmdbIndex models were fetching random number of records to display in UI DB Configuration Tables and Indexes tabs. 

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1339638


Steps for Testing/QA
--------------------
Settings => Configuration => Database (accordion) =>  Select Tables or Index tab, proper number of entries should be displayed matching Per Page pagination controls' value. 
![db config indexes tab display](https://cloud.githubusercontent.com/assets/552686/16236548/96fde146-378d-11e6-9745-79900c3a8c2a.png)
![db config tables tab display](https://cloud.githubusercontent.com/assets/552686/16236547/96faceca-378d-11e6-9898-c341fb2f1482.png)

