### PR TITLE
Extract Api::Settings

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -127,7 +127,7 @@ class ApiController < ApplicationController
   delegate :base_config, :version_config, :collection_config, :to => self
 
   def initialize
-    @config          = self.class.load_config
+    @config          = Api::Settings.data
     @module          = base_config[:module]
     @name            = base_config[:name]
     @description     = base_config[:description]

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -124,7 +124,17 @@ class ApiController < ApplicationController
     skip_before_action :verify_authenticity_token, :only => [:show, :update, :destroy, :handle_options_request]
   end
 
-  delegate :base_config, :version_config, :collection_config, :to => self
+  def base_config
+    Api::Settings.base
+  end
+
+  def version_config
+    Api::Settings.version
+  end
+
+  def collection_config
+    Api::Settings.collections
+  end
 
   def initialize
     @config          = Api::Settings.data

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -3,7 +3,6 @@ class ApiController
     extend ActiveSupport::Concern
 
     included do
-      @config = load_config
       init_env
       gen_attr_type_hash
     end
@@ -20,20 +19,16 @@ class ApiController
       # in the :base section which must also exist in the :version
       # definition section.
       #
-      def load_config
-        @config = YAML.load_file(Rails.root.join("config/api.yml"))
-      end
-
       def base_config
-        @config[:base]
+        Api::Settings.base
       end
 
       def version_config
-        @config[:version]
+        Api::Settings.version
       end
 
       def collection_config
-        @config[:collections]
+        Api::Settings.collections
       end
 
       #
@@ -58,7 +53,7 @@ class ApiController
       #
       def init_env
         $api_log.info("Initializing Environment for #{base_config[:name]}")
-        @api_user_token_service ||= ApiUserTokenService.new(@config, :log_init => true)
+        @api_user_token_service ||= ApiUserTokenService.new(Api::Settings.data, :log_init => true)
         log_config
       end
 

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -9,29 +9,6 @@ class ApiController
 
     module ClassMethods
       #
-      # Load REST API Config, Versioning, Methods, Collections and Actions
-      # from the api.tmpl.yml file.
-      #
-      # For API Versioning - no ident in the version definitions means that
-      # version is not be advertised by the entrypoint.
-      #
-      # URLs without the v#.# versioning default to :version listed
-      # in the :base section which must also exist in the :version
-      # definition section.
-      #
-      def base_config
-        Api::Settings.base
-      end
-
-      def version_config
-        Api::Settings.version
-      end
-
-      def collection_config
-        Api::Settings.collections
-      end
-
-      #
       # Let's fetch encrypted attribute names of objects being rendered if not already done
       #
       def fetch_encrypted_attribute_names(obj)
@@ -52,7 +29,7 @@ class ApiController
       # Initializing REST API environment, called once @ startup
       #
       def init_env
-        $api_log.info("Initializing Environment for #{base_config[:name]}")
+        $api_log.info("Initializing Environment for #{Api::Settings.base[:name]}")
         @api_user_token_service ||= ApiUserTokenService.new(Api::Settings.data, :log_init => true)
         log_config
       end
@@ -60,7 +37,7 @@ class ApiController
       def log_config
         $api_log.info("")
         $api_log.info("Static Configuration")
-        base_config.each { |key, val| log_kv(key, val) }
+        Api::Settings.base.each { |key, val| log_kv(key, val) }
 
         $api_log.info("")
         $api_log.info("Dynamic Configuration")
@@ -89,7 +66,7 @@ class ApiController
       # Let's dynamically get the :date and :datetime attributes from the Classes we care about.
       #
       def gen_time_attr_type_hash
-        collection_config.values.each do |cspec|
+        Api::Settings.collections.each_value do |cspec|
           next if cspec[:klass].blank?
           klass = cspec[:klass].constantize
           klass.columns_hash.collect  do |name, typeobj|

--- a/app/services/api_user_token_service.rb
+++ b/app/services/api_user_token_service.rb
@@ -1,5 +1,5 @@
 class ApiUserTokenService
-  def initialize(config = YAML.load_file(Rails.root.join("config/api.yml")), args = {})
+  def initialize(config = Api::Settings.data, args = {})
     @config = config
     @svc_options = args
     @token_mgr = new_token_mgr(base_config[:module], base_config[:name], api_config)

--- a/lib/api/settings.rb
+++ b/lib/api/settings.rb
@@ -1,0 +1,17 @@
+class Api::Settings
+  def self.data
+    @data ||= YAML.load_file(Rails.root.join("config/api.yml"))
+  end
+
+  def self.base
+    data[:base]
+  end
+
+  def self.version
+    data[:version]
+  end
+
+  def self.collections
+    data[:collections]
+  end
+end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -9,7 +9,7 @@ describe ApiController do
   end
 
   def test_collection_query(collection, collection_url, klass, attr = :id)
-    if collection_config.fetch_path(collection, :collection_actions, :get)
+    if Api::Settings.collections.fetch_path(collection, :collection_actions, :get)
       api_basic_authorize collection_action_identifier(collection, :read, :get)
     else
       api_basic_authorize

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -145,16 +145,8 @@ module ApiSpecHelper
     @miq_server_guid ||= MiqUUID.new_guid
   end
 
-  def api_server_config
-    @api_server_config ||= YAML.load_file(Rails.root.join("config/api.yml"))
-  end
-
-  def collection_config
-    api_server_config[:collections]
-  end
-
   def action_identifier(type, action, selection = :resource_actions, method = :post)
-    collection_config.fetch_path(type, selection, method)
+    Api::Settings.collections.fetch_path(type, selection, method)
       .detect { |spec| spec[:name] == action.to_s }[:identifier]
   end
 
@@ -164,7 +156,7 @@ module ApiSpecHelper
 
   def subcollection_action_identifier(type, subtype, action, method = :post)
     subtype_actions = "#{subtype}_subcollection_actions".to_sym
-    if collection_config.fetch_path(type, subtype_actions).present?
+    if Api::Settings.collections.fetch_path(type, subtype_actions).present?
       action_identifier(type, action, subtype_actions, method)
     else
       action_identifier(subtype, action, :subcollection_actions, method)


### PR DESCRIPTION
This moves the central place where we parse and store the API configuration out of the API Controller, and into a dedicated object. I can see a number of benefits from doing this:

* It can be tested independently
* It can be used as a collaborator of objects that live outside of the API controller
* It reduces the indirection in the API controller (e.g. `base_config` => `self.base_config` => parsed yaml file)
* We can dry up the API specs by not parsing the api.yml file over again
* I am noticing a ~20 second improvement on running the API specs. This is because even though the parsed api.yml file is memoized in the spec helper, that value is only stored for the running of one spec, so we are currently reading from disk and parsing that configuration on the running of every spec.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 