### PR TITLE
Automate - Enhanced messaging for vm and service provisioning.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
@@ -1,16 +1,21 @@
 #
-# Description: Update provision status.
+# Description: This method updates the provision status.
 # Required inputs: status
 #
 
-prov   = $evm.root['miq_provision']
+prov = $evm.root['miq_provision']
 unless prov
   $evm.log(:error, "miq_provision object not provided")
   exit(MIQ_STOP)
 end
 status = $evm.inputs['status']
 
-# Update Status for on_entry,on_exit
-if $evm.root['ae_result'] == 'ok' || $evm.root['ae_result'] == 'error'
-  prov.message = status
-end
+# Update Status Message
+updated_message  = "[#{$evm.root['miq_server'].name}] "
+updated_message += "VM [#{prov.get_option(:vm_target_name)}] "
+updated_message += "Step [#{$evm.root['ae_state']}] "
+updated_message += "Status [#{status}] "
+updated_message += "Message [#{prov.message}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+prov.miq_request.user_message = updated_message
+prov.message = status

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.rb
@@ -1,17 +1,21 @@
 #
-# Description: This method upates the provision status.
+# Description: This method updates the provision status.
 # Required inputs: status
 #
 
-prov   = $evm.root['miq_provision']
-unless prov 
+prov = $evm.root['miq_provision']
+unless prov
   $evm.log(:error, "miq_provision object not provided")
   exit(MIQ_STOP)
 end
-
 status = $evm.inputs['status']
 
-# Update Status for on_entry,on_exit
-if $evm.root['ae_result'] == 'ok' || $evm.root['ae_result'] == 'error'
-  prov.message = status
-end
+# Update Status Message
+updated_message  = "[#{$evm.root['miq_server'].name}] "
+updated_message += "VM [#{prov.get_option(:vm_target_name)}] "
+updated_message += "Step [#{$evm.root['ae_state']}] "
+updated_message += "Status [#{status}] "
+updated_message += "Message [#{prov.message}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+prov.miq_request.user_message = updated_message
+prov.message = status

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
@@ -1,17 +1,21 @@
 #
-# Description: This method upates the provision status.
+# Description: This method updates the provision status.
 # Required inputs: status
 #
 
-prov   = $evm.root['miq_provision']
-status = $evm.inputs['status']
-
+prov = $evm.root['miq_provision']
 unless prov
-  $evm.log(:error, "No miq_provision object provided")
+  $evm.log(:error, "miq_provision object not provided")
   exit(MIQ_STOP)
 end
+status = $evm.inputs['status']
 
-# Update Status for on_entry,on_exit
-if $evm.root['ae_result'] == 'ok' || $evm.root['ae_result'] == 'error'
-  prov.message = status
-end
+# Update Status Message
+updated_message  = "[#{$evm.root['miq_server'].name}] "
+updated_message += "VM [#{prov.get_option(:vm_target_name)}] "
+updated_message += "Step [#{$evm.root['ae_state']}] "
+updated_message += "Status [#{status}] "
+updated_message += "Message [#{prov.message}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+prov.miq_request.user_message = updated_message
+prov.message = status

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -1,14 +1,24 @@
 #
-# Description: This method updates the service provisioning status
+# Description: This method updates the service provision status.
 # Required inputs: status
 #
 
 prov = $evm.root['service_template_provision_task']
 
+unless prov
+  $evm.log(:error, "miq_provision object not provided")
+  exit(MIQ_STOP)
+end
+
 # Get status from input field status
 status = $evm.inputs['status']
 
-# Update Status for on_entry,on_exit
-if $evm.root['ae_result'] == 'ok' || $evm.root['ae_result'] == 'error'
-  prov.message = status
-end
+# Update Status Message
+updated_message  = "Server [#{$evm.root['miq_server'].name}] "
+updated_message += "Service [#{prov.destination.name}] "
+updated_message += "Step [#{$evm.root['ae_state']}] "
+updated_message += "Status [#{status}] "
+updated_message += "Message [#{prov.message}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+prov.miq_request.user_message = updated_message
+prov.message = status

--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
@@ -2,5 +2,19 @@
 # Description: Set finished message for provision object.
 #
 
-task = $evm.root[$evm.inputs['object']]
-task.finished($evm.inputs['message'])
+prov_obj_name = $evm.root['vmdb_object_type']
+@task = $evm.root[prov_obj_name]
+final_message = "[#{$evm.root['miq_server'].name}] "
+
+case $evm.root['vmdb_object_type']
+when 'service_template_provision_task'
+  final_message += "Service [#{@task.destination.name}] Provisioned Successfully"
+when 'miq_provision'
+  final_message += "VM [#{@task.get_option(:vm_target_name)}] "
+  final_message += "IP [#{@task.vm.ipaddresses.first}] " if @task.vm && !@task.vm.ipaddresses.blank?
+  final_message += "Provisioned Successfully"
+else
+  final_message += $evm.inputs['message']
+end
+@task.miq_request.user_message = final_message
+@task.finished(final_message)

--- a/spec/automation/unit/method_validation/task_finished_spec.rb
+++ b/spec/automation/unit/method_validation/task_finished_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+include AutomationSpecHelper
+
+describe "task_finished_status" do
+  def build_resolve_path
+    instance  = "/System/Request/Call_Method"
+    namespace = "namespace=/ManageIQ/System/CommonMethods"
+    klass     = "class=StateMachineMethods"
+    method    = "method=task_finished"
+    "#{instance}?#{namespace}&#{klass}&#{method}"
+  end
+
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:ws) { MiqAeEngine.instantiate("#{build_resolve_path}&#{@args}", user) }
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
+  let(:ems) { FactoryGirl.create(:ems_vmware_with_authentication) }
+  let(:vm_template) { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
+  let(:options) { {:src_vm_id => [vm_template.id, vm_template.name], :pass => 1} }
+  let(:miq_provision_request) do
+    FactoryGirl.create(:miq_provision_request,
+                       :provision_type => 'template',
+                       :state => 'pending', :status => 'Ok',
+                       :src_vm_id => vm_template.id,
+                       :requester => user)
+  end
+
+  let(:provision) do
+    FactoryGirl.create(:miq_provision_vmware, :provision_type => 'template',
+                       :state => 'pending', :status => 'Ok',
+                       :miq_request => miq_provision_request,
+                       :options => options, :userid => user.userid)
+  end
+
+  it "miq_provision method succeeds" do
+    @args = "status=fred&ae_result=ok&MiqProvision::miq_provision=#{provision.id}&" \
+            "MiqServer::miq_server=#{miq_server.id}&vmdb_object_type=miq_provision&" \
+            "object=miq_provision&message=not used"
+    add_call_method
+    ws
+    expect(provision.reload.status).to eq('Ok')
+    expect(provision.state).to eq('finished')
+    msg = "[#{miq_server.name}] VM [] Provisioned Successfully"
+    expect(miq_provision_request.reload.message).to eq(msg)
+  end
+
+  it "task_finished method input message" do
+    @args = "status=fred&ae_result=ok&MiqProvision::fred=#{provision.id}&" \
+            "MiqServer::miq_server=#{miq_server.id}&vmdb_object_type=fred&" \
+            "object=miq_provision&message=finished message here"
+    add_call_method
+    ws
+    msg = "[#{miq_server.name}] finished message here"
+    expect(miq_provision_request.reload.message).to eq(msg)
+  end
+end

--- a/spec/automation/unit/method_validation/update_provision_status_vm_cloud_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_cloud_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 include AutomationSpecHelper
 
 describe "update_provision_status" do
-  let(:user)      { FactoryGirl.create(:user_with_group) }
+  def build_resolve_path
+    instance  = "/System/Request/Call_Method"
+    namespace = "namespace=/ManageIQ/Cloud/VM/Provisioning/StateMachines"
+    klass     = "class=VMProvision_VM"
+    method    = "method=update_provision_status"
+    "#{instance}?#{namespace}&#{klass}&#{method}"
+  end
+
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:ws) { MiqAeEngine.instantiate("#{build_resolve_path}&#{@args}", user) }
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
 
   context "with a provision request object" do
     let(:ems)   { FactoryGirl.create(:ems_amazon_with_authentication) }
@@ -15,6 +25,7 @@ describe "update_provision_status" do
                          :src_vm_id => vm_template.id,
                          :requester => user)
     end
+
     let(:provision) do
       FactoryGirl.create(:miq_provision_amazon, :provision_type => 'template',
                          :state => 'pending', :status => 'Ok',
@@ -22,18 +33,30 @@ describe "update_provision_status" do
                          :options => options, :userid => user.userid)
     end
 
-    let(:ws) { MiqAeEngine.instantiate("/System/Request/Call_Method?namespace=/ManageIQ/Cloud/VM/Provisioning/StateMachines&status=fred&class=VMProvision_VM&method=update_provision_status&ae_result=ok&MiqProvision::miq_provision=#{provision.id}", user) }
     it "method succeeds" do
+      @args = "status=fred&ae_result=ok&MiqProvision::miq_provision=#{provision.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
       add_call_method
       ws
       expect(provision.reload.status).to eq('Ok')
     end
+
+    it "request message set properly" do
+      @args = "status=fred&ae_result=ok&MiqProvision::miq_provision=#{provision.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
+      add_call_method
+      ws
+      expect(provision.reload.status).to eq('Ok')
+      msg = "[#{miq_server.name}] VM [] Step [] Status [#{provision.message}] Message [] "
+      expect(miq_provision_request.reload.message).to eq(msg)
+    end
   end
 
   context "without a provision object" do
-    let(:ws) { MiqAeEngine.instantiate("/System/Request/Call_Method?namespace=/ManageIQ/Cloud/VM/Provisioning/StateMachines&status=fred&class=VMProvision_VM&method=update_provision_status&ae_result=ok", user) }
     it "method fails" do
+      @args = "status=fred&ae_result=ok&MiqServer::miq_server=#{miq_server.id}"
       add_call_method
+      ws
       expect(ws.root).to be_nil
     end
   end

--- a/spec/automation/unit/method_validation/update_provision_status_vm_infra_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_infra_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 include AutomationSpecHelper
 
 describe "update_provision_status" do
-  let(:user)      { FactoryGirl.create(:user_with_group) }
+  def build_resolve_path
+    instance  = "/System/Request/Call_Method"
+    namespace = "namespace=/ManageIQ/Infrastructure/VM/Provisioning/StateMachines"
+    klass     = "class=VMProvision_VM"
+    method    = "method=update_provision_status"
+    "#{instance}?#{namespace}&#{klass}&#{method}"
+  end
+
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:ws) { MiqAeEngine.instantiate("#{build_resolve_path}&#{@args}", user) }
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
 
   context "with a provision request object" do
     let(:ems)   { FactoryGirl.create(:ems_vmware_with_authentication) }
@@ -23,17 +33,28 @@ describe "update_provision_status" do
                          :options => options, :userid => user.userid)
     end
 
-    let(:ws) { MiqAeEngine.instantiate("/System/Request/Call_Method?namespace=/ManageIQ/Infrastructure/VM/Provisioning/StateMachines&status=fred&class=VMProvision_VM&method=update_provision_status&ae_result=ok&MiqProvision::miq_provision=#{provision.id}", user) }
     it "method succeeds" do
+      @args = "status=fred&ae_result=ok&MiqProvision::miq_provision=#{provision.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
       add_call_method
       ws
       expect(provision.reload.status).to eq('Ok')
     end
+
+    it "request message set properly" do
+      @args = "status=fred&ae_result=ok&MiqProvision::miq_provision=#{provision.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
+      add_call_method
+      ws
+      expect(provision.reload.status).to eq('Ok')
+      msg = "[#{miq_server.name}] VM [] Step [] Status [#{provision.message}] Message [] "
+      expect(miq_provision_request.reload.message).to eq(msg)
+    end
   end
 
   context "without a provision object" do
-    let(:ws) { MiqAeEngine.instantiate("/System/Request/Call_Method?namespace=/ManageIQ/Infrastructure/VM/Provisioning/StateMachines&status=fred&class=VMProvision_VM&method=update_provision_status&ae_result=ok", user) }
     it "method fails" do
+      @args = "status=fred&ae_result=ok&MiqServer::miq_server=#{miq_server.id}"
       add_call_method
       expect(ws.root).to be_nil
     end


### PR DESCRIPTION
Modified update_provision_status method in 3 places for vm provisioning messages;

/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/,

/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/ and

/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/.

Modified update_serviceprovision_status method in /Service/Provisioning/StateMachines/ServiceProvision_Template.class/

for service provisioning messages.

Sample old message:

Request completed with errors

Sample new messages:

[EVM] VM [test_billyb] Step [CheckProvisioned] Status [[Handsoap::Fault]: Handsoap::Fault { :code => ] Message [[Handsoap::Fault]: Handsoap::Fault { :code => 'ServerFaultCode', :reason => 'Permission to perform this operation was denied.' }]

[EVM] VM [test_billya] Step [CheckProvisioned] Status [State=<CheckProvisioned> running  raised exception: <number of retries <101> exceeded maximum of <100>>] Message [Validating New Vm]

[EVM] VM [test_billyb] Step [CheckProvisioned] Status [Creating VM] Message [Validating New Vm]Current Retry Number [94]