### PR TITLE
Fix sporadic failures in the replication test setup

### DIFF
--- a/lib/tasks/test_replication.rake
+++ b/lib/tasks/test_replication.rake
@@ -31,6 +31,8 @@ end
 end # ifdef
 
 class EvmTestSetupReplication
+  TEST_BRANCH = "evm_test_setup_replication_branch".freeze
+
   def initialize
     @db_yaml_file      = Rails.root.join("config", "database.yml")
     @db_yaml_file_orig = Rails.root.join("config", "database.evm_test_setup_replication.yml")
@@ -56,15 +58,21 @@ class EvmTestSetupReplication
   private
 
   def released_migrations
-    json = Net::HTTP.get(URI('https://api.github.com/repos/ManageIQ/manageiq/contents/db/migrate?ref=darga'))
+    unless system("git fetch --depth=1 http://github.com/ManageIQ/manageiq.git refs/heads/darga:#{TEST_BRANCH}")
+      return []
+    end
+    files = `git ls-tree -r --name-only #{TEST_BRANCH} db/migrate/`
+    return [] unless $CHILD_STATUS.success?
 
-    migrations = JSON.parse(json).map do |h|
-      filename = h["path"].split("/")[-1]
+    migrations = files.split.map do |path|
+      filename = path.split("/")[-1]
       filename.split('_')[0]
     end
 
     # eliminate any non-timestamp entries
     migrations.keep_if { |timestamp| timestamp =~ /\d+/ }
+  ensure
+    `git branch -D #{TEST_BRANCH}`
   end
 
   def prepare_slave_database


### PR DESCRIPTION
Fetching the list of migrations from the git API was subject to sporadic failures because of request limits.

This change fetches the darga branch locally and queries it to determine the migrations, removing the need for an API call.