### PR TITLE
Fix redirect when an unauthorized user clicks on a VM on a dashboard

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1379,11 +1379,9 @@ module ApplicationController::CiProcessing
       record = find_by_id_filtered(klass, from_cid(id))
     rescue ActiveRecord::RecordNotFound
     rescue => @bang
-      if @explorer
-        self.x_node = "root"
-        add_flash(@bang.message, :error, true)
-        session[:flash_msgs] = @flash_array.dup
-      end
+      self.x_node = "root" if @explorer
+      add_flash(@bang.message, :error, true)
+      session[:flash_msgs] = @flash_array.dup
     end
     record
   end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -183,6 +183,11 @@ module VmCommon
     @lastaction = "show"
     @showtype = "config"
     @record = identify_record(id || params[:id], VmOrTemplate)
+    if @record.nil?
+      referrer = Rails.application.routes.recognize_path(request.referrer)
+      redirect_to :controller => referrer[:controller], :action => referrer[:action]
+      return
+    end
     return if record_no_longer_exists?(@record)
 
     @explorer = true if request.xml_http_request? # Ajax request means in explorer

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -77,6 +77,22 @@ describe VmOrTemplateController do
       expect(response).to redirect_to(:controller => "dashboard", :action => 'show')
       expect(assigns(:flash_array).first[:message]).to include("is not authorized to access")
     end
+
+    it "Redirects user with privileges to vm_infra/explorer" do
+      set_user_privileges
+      get :show, :params => {:id => @vm.id}
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')
+    end
+
+    it "Redirects user to the referrer controller/action" do
+      login_as FactoryGirl.create(:user)
+      request.env["HTTP_REFERER"] = "http://localhost:3000/dashboard/show"
+      allow(controller).to receive(:find_by_id_filtered).and_return(nil)
+      get :show, :params => {:id => @vm.id}
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(:controller => "dashboard", :action => 'show')
+    end
   end
 
   describe '#console_after_task' do


### PR DESCRIPTION
When an unauthorized user clicks on a Recently discovered VM on a dashboard widget, redirect appropriately to the referrer controller (dashboard, in this case) and display a flash message that the user is not authorized to view the VM.

https://bugzilla.redhat.com/show_bug.cgi?id=1347645

<img width="1405" alt="screen shot 2016-06-21 at 5 50 21 pm" src="https://cloud.githubusercontent.com/assets/1538216/16251169/b7466d88-37d8-11e6-88fe-95d898912dac.png">
