### PR TITLE
VirtualTotals for group and user roles

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -16,7 +16,6 @@ class MiqGroup < ApplicationRecord
 
   virtual_column :miq_user_role_name, :type => :string,  :uses => :miq_user_role
   virtual_column :read_only,          :type => :boolean
-  virtual_column :user_count,         :type => :integer
 
   delegate :self_service?, :limited_self_service?, :to => :miq_user_role, :allow_nil => true
 
@@ -37,6 +36,7 @@ class MiqGroup < ApplicationRecord
   include ActiveVmAggregationMixin
   include TimezoneMixin
   include TenancyMixin
+  include VirtualTotalMixin
 
   alias_method :current_tenant, :tenant
 
@@ -167,9 +167,7 @@ class MiqGroup < ApplicationRecord
   end
   alias_method :read_only?, :read_only
 
-  def user_count
-    users.count
-  end
+  virtual_total :user_count, :users
 
   def description=(val)
     super(val.to_s.strip)

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -2,12 +2,12 @@ class MiqUserRole < ApplicationRecord
   SUPER_ADMIN_ROLE_NAME = "EvmRole-super_administrator"
   ADMIN_ROLE_NAME       = "EvmRole-administrator"
   DEFAULT_TENANT_ROLE_NAME = "EvmRole-tenant_administrator"
+  include VirtualTotalMixin
 
   has_many                :entitlements, :dependent => :restrict_with_exception
   has_many                :miq_groups, :through => :entitlements
   has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features
 
-  virtual_column :group_count,                      :type => :integer
   virtual_column :vm_restriction,                   :type => :string
 
   validates_presence_of   :name
@@ -139,9 +139,7 @@ class MiqUserRole < ApplicationRecord
     end
   end
 
-  def group_count
-    miq_groups.count
-  end
+  virtual_total :group_count, :miq_groups
 
   def vm_restriction
     vmr = settings && settings.fetch_path(:restrictions, :vms)

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -415,4 +415,17 @@ describe MiqGroup do
       expect(MiqGroup.where("description like 'want%'").next_sequence).to eq(1001)
     end
   end
+
+  describe "#user_count" do
+    it "counts none" do
+      group = FactoryGirl.create(:miq_group)
+      expect(group.user_count).to eq(0)
+    end
+
+    it "counts some" do
+      group = FactoryGirl.create(:miq_group)
+      FactoryGirl.create_list(:user, 2, :miq_groups =>[group])
+      expect(group.user_count).to eq(2)
+    end
+  end
 end

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -261,4 +261,17 @@ describe MiqUserRole do
       end
     end
   end
+
+  describe "#group_count" do
+    it "counts none in ruby" do
+      role = FactoryGirl.create(:miq_user_role)
+      expect(role.group_count).to eq(0)
+    end
+
+    it "counts some in ruby" do
+      role = FactoryGirl.create(:miq_user_role)
+      FactoryGirl.create_list(:miq_group, 2, :miq_user_role => role)
+      expect(role.group_count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
This is building on the momentum of `virtual_total` columns see #9263

This adds `virtual_total` columns for `miq_group` and `miq_user_roles`.

Currently, `virtual_total` does not provide performance benefits for `has_and_belongs_to_many` or `has_many :through`. But that is not a technical hurdle, just a resource/priority issue.

I would still like to convert these across to properly state the pattern and gauge how big the demand is for this improvement.