### PR TITLE
Add spec for column migration to shared examples

### DIFF
--- a/spec/migrations/20150630100251_namespace_ems_amazon_spec.rb
+++ b/spec/migrations/20150630100251_namespace_ems_amazon_spec.rb
@@ -4,25 +4,12 @@ describe NamespaceEmsAmazon do
   class NamespaceEmsAmazon::ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "EmsAmazon")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Amazon::CloudManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "EmsAmazon")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/migrations/20150714053019_namespace_ems_redhat_spec.rb
+++ b/spec/migrations/20150714053019_namespace_ems_redhat_spec.rb
@@ -4,25 +4,12 @@ describe NamespaceEmsRedhat do
   class NamespaceEmsRedhat::ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "EmsRedhat")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Redhat::CloudManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Redhat::CloudManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "EmsRedhat")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/migrations/20150716021334_fix_redhat_namespace_spec.rb
+++ b/spec/migrations/20150716021334_fix_redhat_namespace_spec.rb
@@ -4,25 +4,12 @@ describe FixRedhatNamespace do
   class FixRedhatNamespace::ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Redhat::CloudManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Redhat::InfraManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Redhat::InfraManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Redhat::CloudManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/migrations/20150724030353_namespace_ems_foreman_spec.rb
+++ b/spec/migrations/20150724030353_namespace_ems_foreman_spec.rb
@@ -4,25 +4,12 @@ describe NamespaceEmsForeman do
   class NamespaceEmsForeman::ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ConfigurationManagerForeman")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Foreman::ConfigurationManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Foreman::ConfigurationManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ConfigurationManagerForeman")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/migrations/20150731025210_namespace_ems_openstack_spec.rb
+++ b/spec/migrations/20150731025210_namespace_ems_openstack_spec.rb
@@ -4,25 +4,12 @@ describe NamespaceEmsOpenstack do
   class NamespaceEmsOpenstack::ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "EmsOpenstack")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Openstack::CloudManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "EmsOpenstack")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/migrations/20150807165254_namespace_ems_container_spec.rb
+++ b/spec/migrations/20150807165254_namespace_ems_container_spec.rb
@@ -4,25 +4,12 @@ describe NamespaceEmsContainer do
   class NamespaceEmsContainer::ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "EmsKubernetes")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Kubernetes::ContainerManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Kubernetes::ContainerManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "EmsKubernetes")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/migrations/20150815051916_namespace_ems_microsoft_spec.rb
+++ b/spec/migrations/20150815051916_namespace_ems_microsoft_spec.rb
@@ -4,25 +4,12 @@ describe NamespaceEmsMicrosoft do
   class NamespaceEmsMicrosoft::ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "EmsMicrosoft")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Microsoft::InfraManager")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Microsoft::InfraManager")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "EmsMicrosoft")
-    end
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/migrations/20150815052719_fix_foreman_provider_type_spec.rb
+++ b/spec/migrations/20150815052719_fix_foreman_provider_type_spec.rb
@@ -4,25 +4,12 @@ describe FixForemanProviderType do
   class FixForemanProviderType::Provider < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end
-  let(:ems_stub) { migration_stub(:Provider) }
 
   migration_context :up do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ProviderForeman")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ManageIQ::Providers::Foreman::Provider")
-    end
+    include_examples "column migration", :type, :Provider, described_class::NAME_MAP.first
   end
 
   migration_context :down do
-    it "migrates a representative row" do
-      ems = ems_stub.create!(:type => "ManageIQ::Providers::Foreman::Provider")
-
-      migrate
-
-      expect(ems.reload).to have_attributes(:type => "ProviderForeman")
-    end
+    include_examples "column migration", :type, :Provider, described_class::NAME_MAP.invert.first
   end
 end

--- a/spec/support/examples_group/shared_examples_for_column_migration.rb
+++ b/spec/support/examples_group/shared_examples_for_column_migration.rb
@@ -1,0 +1,17 @@
+# it tests data migration for one column
+# Example:
+# include_examples "column migration", :type, :ExtManagementSystem, ["Old Data Field", "New Data Field"]
+shared_examples_for "column migration" do |column, klass, data_to_convert|
+  let(:stub)           { migration_stub(klass) }
+  let(:old_data_field) { data_to_convert.first }
+  let(:new_data_field) { data_to_convert.second }
+
+  it "migrates column #{column} of #{klass}" do
+    rec = stub.create!(column => old_data_field)
+
+    migrate
+
+    column_value = rec.reload.send(column)
+    expect(column_value).to eq(new_data_field)
+  end
+end


### PR DESCRIPTION
There is couple of specs where we are doing same thing: we are testing data migration for one column

So I am moving this to the one common place; to the shared examples.

cc @jrafanie @Fryguy 

@miq-bot add_label refactoring
@miq-bot add_label sql migration
@miq-bot add_label test

