### PR TITLE
Fix SSA user logon time on RHEL7

### DIFF
--- a/gems/pending/metadata/linux/LinuxUsers.rb
+++ b/gems/pending/metadata/linux/LinuxUsers.rb
@@ -192,7 +192,7 @@ module MiqLinux
       @contents = nil
       @records  = nil
       begin
-        fs.fileOpen(path) { |fo| @contents = fo.read }
+        fs.fileOpen(path, "rb") { |fo| @contents = fo.read }
       rescue
       end
     end


### PR DESCRIPTION
Smart state analysis failed to read user logon time after
certain amount of logged actions. Reading /var/log/wtmp file
in binary mode fixes it.

https://bugzilla.redhat.com/show_bug.cgi?id=1289699
https://bugzilla.redhat.com/show_bug.cgi?id=1278003