### PR TITLE
Display cross link middleware

### DIFF
--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module MiddlewareServerHelper::TextualSummary
 
   def textual_group_relationships
     # Order of items should be from parent to child
-    %i(ems middleware_deployments middleware_datasources)
+    %i(ems middleware_deployments middleware_datasources lives_on)
   end
 
   def textual_group_smart_management
@@ -43,5 +43,21 @@ module MiddlewareServerHelper::TextualSummary
 
   def textual_version
     @record.properties['Version']
+  end
+
+  def textual_lives_on
+    lives_on_ems = @record.try(:lives_on).try(:ext_management_system)
+    return nil if lives_on_ems.nil?
+    lives_on_entity_name = _("Virtual Machine")
+     {
+         :label      => "Underlying #{lives_on_entity_name}",
+         :image      => "vendor-#{lives_on_ems.image_name}",
+         :value      => "#{@record.lives_on.name}",
+         :link       => url_for(
+           :action     => 'show',
+           :controller => 'vm_or_template',
+           :id         => @record.lives_on.id
+          )
+     }
   end
 end


### PR DESCRIPTION
Display a link to vm that is linked to a middleware server in case such relationship exists.

![crosslink_vm](https://cloud.githubusercontent.com/assets/6277245/16263345/9b43c816-387c-11e6-8682-201250fd85dc.png)
currently depends on #9296 that should be merged first. hence wip.
@miq-bot add_label ui, enhancement, providers/hawkular, wip