### PR TITLE
Add missing specs for migrations

### DIFF
--- a/spec/migrations/20150822102141_fix_more_foreman_types_spec.rb
+++ b/spec/migrations/20150822102141_fix_more_foreman_types_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe FixMoreForemanTypes do
+  class FixMoreForemanTypes::ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  migration_context :up do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
+  end
+
+  migration_context :down do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
+  end
+end

--- a/spec/migrations/20150823120001_namespace_ems_openstack_availability_zones_null_spec.rb
+++ b/spec/migrations/20150823120001_namespace_ems_openstack_availability_zones_null_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe NamespaceEmsOpenstackAvailabilityZonesNull do
+  class NamespaceEmsOpenstackAvailabilityZonesNull::ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  migration_context :up do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
+  end
+
+  migration_context :down do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
+  end
+end

--- a/spec/migrations/20150907163347_confirm_all_class_renames_spec.rb
+++ b/spec/migrations/20150907163347_confirm_all_class_renames_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe ConfirmAllClassRenames do
+  class ConfirmAllClassRenames::ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  migration_context :up do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
+  end
+
+  migration_context :down do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
+  end
+end

--- a/spec/migrations/20150909023532_namespace_ems_azure_spec.rb
+++ b/spec/migrations/20150909023532_namespace_ems_azure_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe NamespaceEmsAzure do
+  class NamespaceEmsAzure::ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  migration_context :up do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.first
+  end
+
+  migration_context :down do
+    include_examples "column migration", :type, :ExtManagementSystem, described_class::NAME_MAP.invert.first
+  end
+end


### PR DESCRIPTION
issue: https://github.com/ManageIQ/manageiq/issues/6739
added specs for migrations:
https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20150822102141_fix_more_foreman_types.rb
https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20150823120001_namespace_ems_openstack_availability_zones_null.rb
https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20150907163347_confirm_all_class_renames.rb
https://github.com/ManageIQ/manageiq/blob/master/spec/migrations/20150909023532_namespace_ems_azure_spec.rb


this PR https://github.com/ManageIQ/manageiq/pull/9340 needs to be merged first,  Commits	https://github.com/ManageIQ/manageiq/commit/2df79b80874522f099cffbbd3fe643bee64ba404 and https://github.com/ManageIQ/manageiq/commit/6bd0d0406f6d035d0e8d1e8e8fb20c4e5cb4240d are already here

These are probably last ones 👍 

cc @jrafanie @Fryguy 