### PR TITLE
Add warning to Policy Simulation when no policy is selected

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -709,7 +709,7 @@ module VmCommon
     @edit = session[:edit] if session[:edit]
     if @edit && @edit[:explorer]
       if session[:policies].empty?
-        add_flash(_("No policies were selected for Policy Simulation."), :error)
+        render_flash(_("No policies were selected for Policy Simulation."), :error)
         render :update do |page|
           page << javascript_prologue
           page.replace_html("flash_msg_div", :partial => "layouts/flash_msg")

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -709,7 +709,7 @@ module VmCommon
     @edit = session[:edit] if session[:edit]
     if @edit && @edit[:explorer]
       if session[:policies].empty?
-        add_flash(_("No policies were selected for Policy Simulation"), :error)
+        add_flash(_("No policies were selected for Policy Simulation."), :error)
         render :update do |page|
           page << javascript_prologue
           page.replace_html("flash_msg_div", :partial => "layouts/flash_msg")

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -708,8 +708,16 @@ module VmCommon
     build_policy_tree(@polArr)
     @edit = session[:edit] if session[:edit]
     if @edit && @edit[:explorer]
-      @in_a_form = true
-      replace_right_cell
+      if session[:policies].empty?
+        add_flash(_("No policies were selected for Policy Simulation"), :error)
+        render :update do |page|
+          page << javascript_prologue
+          page.replace_html("flash_msg_div", :partial => "layouts/flash_msg")
+        end
+      else
+        @in_a_form = true
+        replace_right_cell
+      end
     else
       render :template => 'vm/show'
     end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -708,15 +708,9 @@ module VmCommon
     build_policy_tree(@polArr)
     @edit = session[:edit] if session[:edit]
     if @edit && @edit[:explorer]
-      if session[:policies].empty?
-        render_flash(_("No policies were selected for Policy Simulation."), :error)
-        render :update do |page|
-          page << javascript_prologue
-          page.replace_html("flash_msg_div", :partial => "layouts/flash_msg")
-        end
-      else
-        @in_a_form = true
-        replace_right_cell
+      render_flash(_("No policies were selected for Policy Simulation."), :error) if session[:policies].empty?
+      @in_a_form = true
+      replace_right_cell
       end
     else
       render :template => 'vm/show'

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -711,7 +711,6 @@ module VmCommon
       render_flash(_("No policies were selected for Policy Simulation."), :error) if session[:policies].empty?
       @in_a_form = true
       replace_right_cell
-      end
     else
       render :template => 'vm/show'
     end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -566,7 +566,7 @@ module QuadiconHelper
             )
           end
         else
-          if @policy_sim && !session[:policies].empty?
+          if @policy_sim
             if @edit && @edit[:explorer]
               link_to(
                 image_tag(ActionController::Base.helpers.image_path("#{size}/reflection.png"),

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -1,6 +1,9 @@
 - url = url_for(:action => 'policy_sim_add')
 #main_div
-  = render :partial => "layouts/flash_msg"
+
+  #flash_msg_div
+    = render :partial => "layouts/flash_msg"
+
   %h3= _("Choose Policies")
   #tab_div
     %table.table.table-bordered.table-striped


### PR DESCRIPTION
Clicking quadicon in Policy Simulation with no policy selected resulted in an error. Now there is a flash message warning.

Before: 
`No route matches [GET] "/vm_infra/x_button/10000000001497"`

After:
![screen shot 2016-06-22 at 1 00 17 pm](https://cloud.githubusercontent.com/assets/9210860/16264437/f1720836-3879-11e6-90c5-04326aeec73d.png)