### PR TITLE
Fix multiple ui_lookup(:model => nonCamelized) in MiqPolicyController*

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -574,33 +574,40 @@ class MiqPolicyController < ApplicationController
         if @profiles
           r[:partial => 'profile_list']
         elsif @policies || (@view && @sb[:tree_typ] == 'policies')
-          right_cell_text = _("All %{typ} %{model}") % {:typ => "#{ui_lookup(:model => @sb[:nodeid])} #{@sb[:mode] ? @sb[:mode].capitalize : ""}", :model => ui_lookup(:models => "MiqPolicy")}
+          right_cell_text = _("All %{typ} %{model}") % {
+            :typ   => "#{ui_lookup(:model => @sb[:nodeid].try(:camelize))} #{@sb[:mode] ? @sb[:mode].capitalize : ""}",
+            :model => ui_lookup(:models => "MiqPolicy")
+          }
           r[:partial => 'policy_list']
         elsif @conditions
-          right_cell_text = _("All %{typ} %{model}") % {:typ => ui_lookup(:model => @sb[:folder].titleize), :model => ui_lookup(:models => 'Condition')}
+          right_cell_text = _("All %{typ} %{model}") % {:typ   => ui_lookup(:model => @sb[:folder].try(:camelize)),
+                                                        :model => ui_lookup(:models => 'Condition')}
           r[:partial => 'condition_list']
         elsif @folders
-          right_cell_text = _("%{typ} %{model}") % {:typ => ui_lookup(:model => @sb[:folder]), :model => ui_lookup(:models => 'MiqPolicy')}
+          mode = @sb[:folder]
+          right_cell_text = _("%{typ} %{model}") % {:typ   => mode.capitalize,
+                                                    :model => ui_lookup(:models => 'MiqPolicy')}
           r[:partial => 'policy_folders']
         elsif @alert_profiles
-          right_cell_text = _("All %{typ} %{model}") % {:typ   => ui_lookup(:model => @sb[:folder]),
+          right_cell_text = _("All %{typ} %{model}") % {:typ   => ui_lookup(:model => @sb[:folder].try(:camelize)),
                                                         :model => ui_lookup(:models => 'MiqAlertSet')}
           r[:partial => 'alert_profile_list']
         end
       )
     when 'p'
       presenter.update(:main_div, r[:partial => 'policy_details', :locals => {:read_only => true}])
+      model_name = ui_lookup(:model => @sb[:nodeid].try(:camelize))
       if @policy.id.blank?
         right_cell_text = if @sb[:mode]
                             _("Adding a new %{model_name} %{mode} Policy") %
-                            {:model_name => ui_lookup(:model => @sb[:nodeid]), :mode => @sb[:mode].capitalize}
+                              {:model_name => model_name, :mode => @sb[:mode].capitalize}
                           else
-                            _("Adding a new %{model_name} Policy") % {:model_name => ui_lookup(:model => @sb[:nodeid])}
+                            _("Adding a new %{model_name} Policy") % {:model_name => model_name}
                           end
       else
-        right_cell_text = @edit ?
-            _("Editing %{model} \"%{name}\"") % {:model => "#{ui_lookup(:model => @sb[:nodeid])} #{@sb[:mode] ? @sb[:mode].capitalize : ""} Policy", :name => @policy.description.gsub(/'/, "\\'")} :
-            _("%{model} \"%{name}\"") % {:model => "#{ui_lookup(:model => @sb[:nodeid])} #{@sb[:mode] ? @sb[:mode].capitalize : ""} Policy", :name => @policy.description.gsub(/'/, "\\'")}
+        options = {:model => "#{model_name} #{@sb[:mode] ? @sb[:mode].capitalize : ""} Policy",
+                   :name  => @policy.description.gsub(/'/, "\\'")}
+        right_cell_text = @edit ? _("Editing %{model} \"%{name}\"") % options : _("%{model} \"%{name}\"") % options
         if @edit && @edit[:typ] == 'conditions'
           right_cell_text += _(" %{model} Assignments") % {:model => ui_lookup(:model => 'Condition')}
         end
@@ -922,20 +929,21 @@ class MiqPolicyController < ApplicationController
         @sb[:folder] = "#{nodeid.split("-")[1]}-#{nodeid.split("-")[2]}"
         set_search_text
         policy_get_all if folder_node.split("_").length <= 2
-        @right_cell_text = _("All %{typ} %{model}") % {:typ => ui_lookup(:model => @sb[:nodeid]), :model => ui_lookup(:models => "MiqPolicy")}
+        @right_cell_text = _("All %{typ} %{model}") % {:typ   => ui_lookup(:model => @sb[:nodeid].try(:camelize)),
+                                                       :model => ui_lookup(:models => "MiqPolicy")}
         @right_cell_div = "policy_list"
       end
     elsif x_active_tree == :condition_tree
       @conditions = Condition.where(:towhat => @sb[:folder].camelize).sort_by { |c| c.description.downcase }
       set_search_text
       @conditions = apply_search_filter(@search_text, @conditions) unless @search_text.blank?
-      @right_cell_text = _("All %{typ} Conditions") % {:typ => ui_lookup(:model => @sb[:folder])}
+      @right_cell_text = _("All %{typ} Conditions") % {:typ => ui_lookup(:model => @sb[:folder].try(:camelize))}
       @right_cell_div = "condition_list"
     elsif x_active_tree == :alert_profile_tree
       @alert_profiles = MiqAlertSet.where(:mode => @sb[:folder]).sort_by { |as| as.description.downcase }
       set_search_text
       @alert_profiles = apply_search_filter(@search_text, @alert_profiles) unless @search_text.blank?
-      @right_cell_text = _("All %{typ} Alert Profiles") % {:typ => ui_lookup(:model => @sb[:folder])}
+      @right_cell_text = _("All %{typ} Alert Profiles") % {:typ => ui_lookup(:model => @sb[:folder].try(:camelize))}
       @right_cell_div = "alert_profile_list"
     end
   end

--- a/app/helpers/application_helper/toolbar/conditions_center.rb
+++ b/app/helpers/application_helper/toolbar/conditions_center.rb
@@ -13,7 +13,9 @@ class ApplicationHelper::Toolbar::ConditionsCenter < ApplicationHelper::Toolbar:
             if @sb[:folder].upcase == "VM"
               _('Add a New VM Condition')
             else
-              _('Add a New %{condition_type} Condition') % {:condition_type => ui_lookup(:model => @sb[:folder])}
+              _('Add a New %{condition_type} Condition') % {
+                :condition_type => ui_lookup(:model => @sb[:folder].camelize)
+              }
             end
           end,
           t),

--- a/app/helpers/application_helper/toolbar/miq_policies_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policies_center.rb
@@ -11,7 +11,7 @@ class ApplicationHelper::Toolbar::MiqPoliciesCenter < ApplicationHelper::Toolbar
           'pficon pficon-add-circle-o fa-lg',
           t = proc do
               _('Add a New %{model} %{mode} Policy') % {
-                :model => ui_lookup(:model => @sb[:nodeid]),
+                :model => ui_lookup(:model => @sb[:nodeid].camelize),
                 :mode  => @sb[:mode].capitalize
               }
           end,

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -38,7 +38,8 @@ describe MiqPolicyController do
       it "Renders the control policy creation form correctly" do
         session[:sandboxes] = {"miq_policy" => {:trees       => {:policy_tree => {:active_node => "xx-compliance_xx-compliance-host"}},
                                                 :active_tree => :policy_tree,
-                                                :folder      => "compliance-host"}}
+                                                :folder      => "compliance-host",
+                                                :nodeid      => "host"}}
         session[:edit] = {:new => {:mode => "compliance", :towhat => "Host"}}
         post :x_button, :pressed => "policy_new", :typ => "basic"
         expect(response).to render_template("layouts/exp_atom/_editor")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1359909 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1360772 (darga)

Multiple ui_lookup calls in MiqPolicyController and children were failing due to incorrect capitaliztion (and in one case a titleize-inflicted space).
This wasn't highly visible **in English** because the fallback `titleize` behavior looked reasonable.

### implementation
I could pepper `.camelize` calls but IMO that doesn't convey the intent clearly.  It's impossible to look at such code and notice "Here titleize should be camelize"...
Instead I extracted `ui_model[s]_from_id` method (better naming welcome).

- Arguably this doesn't belong in MiqPolicyController but in/near GlobalMethods#ui_lookup.
  However I'm unsure we want to camelize *all* model lookups, and anyway, I'm too scared to affect all UI in one change.
  (This PR took me almost a week to do, test, discard half, re-do, test...)

#### Why nil check?
Old code occasionally performs `ui_lookup(:model => nil)`, it quietly returns nil, expanding into a missing word.
New code would do `nil.camelize` and crash — with the nil check, it stays a missing word.

I initially tried fixing all such callers in this PR.
In one test I've established it's not nil in reality & fixed that test.
But I see it's happening on master in at least 3 places, perhaps more.
=> Will report / address separately.  UPDATE: #9401 is one case.

### Impact
I [instrumented][i] the new code to compare lookup results to old behaviour.

Test coverage is low for this aspect, only one lookup changed:
```
#LOOKUP model 'host' -> 'Host' RETURNS 'Host' -> 'Host / Node'
```
Clicking all around the Control UI (obviously not exhaustively):

> ~~2 #LOOKUP model 'compliance' -> 'Compliance' RETURNS 'Compliance' -> '»Compliance History«'~~
> 42 #LOOKUP model 'containerImage' -> 'ContainerImage' RETURNS 'Container Image' -> '»Image«'
> 6 #LOOKUP model 'host' -> 'Host' RETURNS 'Host' -> '»Host / Node«'
> 1 #LOOKUP model 'host' -> 'Host' RETURNS 'Host' -> 'Host / Node'
> 6 #LOOKUP model 'vm' -> 'Vm' RETURNS 'Vm' -> '»VM and Instance«'

And clicking around again in Japanese (without mark_translated_strings):

> ~~1 #LOOKUP model 'compliance' -> 'Compliance' RETURNS 'Compliance' -> 'コンプライアンス履歴'~~
> 48 #LOOKUP model 'containerImage' -> 'ContainerImage' RETURNS 'Container Image' -> 'イメージ'
> 11 #LOOKUP model 'host' -> 'Host' RETURNS 'Host' -> 'ホスト / ノード'
> 6 #LOOKUP model 'vm' -> 'Vm' RETURNS 'Vm' -> 'VM およびインスタンス'

- The above is just the ui_lookup half of the picture.
  These resulting strings are then [interpolated into a *translated* template string](https://gist.github.com/cben/40ada6166852710fdc18fcbcd04b08c4), which made my head hurt but is generally the right thing, 
  and means the lookup diff will be part of the user-visible string diff, and won't affect the rest of the string.  Good!

The bottom line is that translations did increase, but less places than I hoped.
**The changes are mostly in right_cell_text — the title of the right side.**

#### Before (sample)
![screenshot-localhost 3001 2016-06-22 13-18-05 host compliance pre](https://cloud.githubusercontent.com/assets/273688/16265415/e0787e62-3887-11e6-9d69-a8d5d695a022.png)
![screenshot-localhost 3001 2016-06-22 14-41-33 cond pre](https://cloud.githubusercontent.com/assets/273688/16265416/e4dff4d0-3887-11e6-92bb-904ed5a4be02.png)
![screenshot-localhost 3000 2016-08-08 11-25-48 add container group policy](https://cloud.githubusercontent.com/assets/273688/17474112/ff7ab628-5d5c-11e6-8890-000af7a9adf0.png)

#### After (sample)
![screenshot-localhost 3000 2016-06-22 13-18-41 host compliance post](https://cloud.githubusercontent.com/assets/273688/16265426/f5b88aec-3887-11e6-905f-322bb372c4b8.png)
![screenshot-localhost 3000 2016-06-22 14-42-15 cond post](https://cloud.githubusercontent.com/assets/273688/16265428/f9924ec8-3887-11e6-96d6-1ce24d1f65f9.png)
![screenshot-localhost 3000 2016-08-08 11-29-08 add pod policy](https://cloud.githubusercontent.com/assets/273688/17474119/07021d00-5d5d-11e6-968f-1759bc6684b0.png)

P.S. Both these images show how there are still tons of incomplete translations / inconsistent strings — compare left side labels to right side titles.

#### P.S. some failing lookups still happen:

> 26 #MISSING dictionary.model.Ap-20
> 10 #MISSING dictionary.model.Co-1
> 2 #MISSING dictionary.model.compliance-host
> 2 #MISSING dictionary.model.compliance-vm
> 2 #MISSING dictionary.model.control-host
> 2 #MISSING dictionary.model.control-vm
> 4 #MISSING dictionary.model.Xx-Storage

I debugged a few of these, they are in `folder_get_info` IIRC, the bad results are later overridden by another method eg. alert_profile_get_info.  Ugly but works(?).

[i]: https://github.com/ManageIQ/manageiq/commit/6c40d761ebbe0d51aca4c58d0becac3e74573f57

----

@miq-bot add_label control, ui, bug, darga/yes

I want this backported for #8654 — this will help #8815 correctly use "Pod" instead of "Container Group", "Replicator" instead of "Container Replicator" etc.