### PR TITLE
Add good_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,7 @@ unless ENV['APPLIANCE']
   group :development, :test do
     gem "rspec-rails",      "~>3.5.x"
     gem "parallel_tests"
+    gem "good_migrations"
   end
 end
 

--- a/bin/setup
+++ b/bin/setup
@@ -39,7 +39,12 @@ Dir.chdir APP_ROOT do
   if options[:do_db]
     puts "\n== Preparing database =="
     system "bin/rake db:create"
-    system "bin/rake db:migrate db:seed"
+
+    puts "\n== Migrating database =="
+    system "bin/rake db:migrate"
+
+    puts "\n== Seeding database =="
+    system "bin/rake db:seed GOOD_MIGRATIONS=skip"
   end
 
   puts "\n== Removing old logs and tempfiles =="

--- a/bin/update
+++ b/bin/update
@@ -10,7 +10,11 @@ Dir.chdir APP_ROOT do
   system "bower update --allow-root -F --config.analytics=false"
 
   puts "\n== Migrating database =="
-  system "bin/rake db:migrate db:seed"
+  system "bin/rake db:migrate"
+
+  puts "\n== Seeding database =="
+  system "bin/rake db:seed GOOD_MIGRATIONS=skip"
+
 
   puts "\n== Resetting tests =="
   system "bin/rake test:vmdb:setup"


### PR DESCRIPTION
good_migrations gem detects loading classes from app folder here:
https://github.com/testdouble/good-migrations/blob/master/tasks/good_migrations.rake#L10

It prevents us to using models from application and It forces us to create stub models in migrations.

I am adding good_migrations gem for test and development environment.

as I mentioned you @jrafanie I had issues with `bin/update` and `bin/setup` and it was caused by included `rake db:seed` so I add `GOOD_MIGRATIONS=skip` to `bin/setup` and `bin/update` as initial solution. (Other solution can be require all loaded models in seed task.)

I am not sure why it is not throwing error when I run just  'bundle exec rake db:seed' 

 🎁 @jrafanie @Fryguy 






