### PR TITLE
Use column values for virtual total values

### DIFF
--- a/app/models/mixins/virtual_total_mixin.rb
+++ b/app/models/mixins/virtual_total_mixin.rb
@@ -16,7 +16,7 @@ module VirtualTotalMixin
     #
     def virtual_total(name, relation, options = {})
       define_method(name) do
-        send(relation).try(:size) || 0
+        (attribute_present?(name) ? self[name] : nil) || send(relation).try(:size) || 0
       end
 
       # allow this attribute to be sorted in the database

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -15,6 +15,18 @@ describe VirtualTotalMixin do
       expect(model_with_children(2).total_vms).to eq(2)
     end
 
+    it "can bring back totals in primary query" do
+      m3 = model_with_children(3)
+      m1 = model_with_children(1)
+      m2 = model_with_children(2)
+      mc = m1.class
+      expect {
+        ms = mc.select(:id, mc.arel_attribute(:total_vms).as("total_vms"))
+        expect(ms).to match_array([m3, m2, m1])
+        expect(ms.map(&:total_vms)).to match_array([3, 2, 1])
+      }.to match_query_limit_of(1)
+    end
+
     def model_with_children(count)
       FactoryGirl.create(:ext_management_system).tap do |ems|
         FactoryGirl.create_list(:vm, count, :ext_management_system => ems) if count > 0


### PR DESCRIPTION
Purpose or Intent
-----------------
@Fryguy asked if we could bring back totals as part of a primary query instead of going through each row and calculating them.

We need to get counts for most of the views, along with other ares of our code like the tree builder. So avoiding this N+1 situation is good. (Doing it while using up less memory is a bonus)

This could provide benefit on any screen where we have counts. (e.g.: `host_count` or `vm_count`) I'm thinking this may be 1/3 of all screens.

What is happening?
-------

**before:**

run primary query to fetch result set. for every row, run query to fetch `count(*)`

**after:**

run primary query that includes `count(*)` as a subquery. Do not run other queries.

The primary query is 1 column more, and no more rows, but this avoids the subsequent N queries to fetch the count.

Implementation details
-------

I'm working on getting a few fixes into rails, but in the meantime, the interface is a little less elegant than I would like. Since most of this is generated from reporting, our code base should not notice too much of a change.

```ruby
EmsCluster.select(:id, EmsCluster.arel_attribute(:total_vms).as("total_vms"))
          .map(&:total_vms)
```

Unfortunately I was not able to get the simple syntax working:

```ruby
EmsCluster.select(:id, :total_vms).map(&:total_vms)
```

The first example asks for `:total_vms` to have an alias `as("total_vms")`, so we can pull the value out of the query. Without that, we are not able to stick with the short syntax. I am looking into solutions that rails core would be willing to merge.


Numbers
------

Using the sql example provided above:

model|count
---|---
`EmsCluster`|10
`Vm`|1,000


**before:**

|       ms |   bytes | objects |queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|     49.8 | 1,417,114 |  17,850 |   11 |     6.8 |       10 |`before`

**after:**

|       ms |   bytes | objects |queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|     24.9 |  47,781 |     547 |    1 |     3.8 |       10 |`after`
