### PR TITLE
Show PNG icons for Middleware in list view

### DIFF
--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -20,6 +20,5 @@ class EmsMiddlewareController < ApplicationController
 
   def listicon_image(item, _view)
     icon = item.decorate.try(:listicon_image)
-    "svg/#{icon}.svg"
   end
 end

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -37,7 +37,6 @@ class MiddlewareServerController < ApplicationController
 
   def listicon_image(item, _view)
     icon = item.decorate.try(:listicon_image)
-    "svg/#{icon}.svg"
   end
 
   def button

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -17,8 +17,7 @@ module MiddlewareCommonMixin
   end
 
   def listicon_image(item, _view)
-    icon = item.decorate.try(:listicon_image)
-    "100/#{icon}.png"
+    item.decorate.try(:listicon_image)
   end
 
   def clear_topology_breadcrumb

--- a/app/decorators/manageiq/providers/amazon/cloud_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/amazon/cloud_manager/auth_key_pair_decorator.rb
@@ -6,13 +6,13 @@ class ManageIQ::Providers::Amazon::CloudManager::AuthKeyPairDecorator < Draper::
   end
 
   def listicon_image
-    item_image
+    "100/#{item_image}.png"
   end
 
   private
 
   # Determine the icon
   def item_image
-    '100/auth_key_pair'
+    'auth_key_pair'
   end
 end

--- a/app/decorators/manageiq/providers/ansible_tower/configuration_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/configuration_manager/configuration_script_decorator.rb
@@ -6,6 +6,6 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScri
   end
 
   def listicon_image
-    "100/configuration_script.png"
+    '100/configuration_script.png'
   end
 end

--- a/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/hawkular/middleware_manager_decorator.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Hawkular
     end
 
     def listicon_image
-      item_image
+      "svg/#{item_image}.svg"
     end
 
     def item_image

--- a/app/decorators/middleware_decorator_mixin.rb
+++ b/app/decorators/middleware_decorator_mixin.rb
@@ -1,7 +1,5 @@
 module MiddlewareDecoratorMixin
   def listicon_image
-    prefix = "100/"
-    suffix = ".png"
-    prefix + item_image + suffix
+    "100/#{item_image}.png"
   end
 end

--- a/app/decorators/middleware_deployment_decorator.rb
+++ b/app/decorators/middleware_deployment_decorator.rb
@@ -3,7 +3,13 @@ class MiddlewareDeploymentDecorator < Draper::Decorator
   include MiddlewareDecoratorMixin
 
   def fonticon
-    nil
+    if name.end_with? '.ear'
+      'product-file-ear-o'
+    elsif name.end_with? '.war'
+      'product-file-war-o'
+    else
+      'product-report'
+    end
   end
 
   # Determine the icon

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -6,6 +6,6 @@ class ResourcePoolDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/#{vapp ? "vapp" : "resource_pool"}.png"
+    "100/#{vapp ? 'vapp' : 'resource_pool'}.png"
   end
 end

--- a/app/decorators/service_resource_decorator.rb
+++ b/app/decorators/service_resource_decorator.rb
@@ -6,6 +6,6 @@ class ServiceResourceDecorator < Draper::Decorator
   end
 
   def listicon_image
-    "100/#{resource_type.to_s == "VmOrTemplate" ? "vm" : "service_template"}.png"
+    "100/#{resource_type.to_s == 'VmOrTemplate' ? 'vm' : 'service_template'}.png"
   end
 end

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -376,7 +376,7 @@ module QuadiconHelper
                      "100/#{item.class.to_s.underscore}.png"
                    end
                  elsif item.decorator_class?
-                   item.decorate.try(:fonticon) || item.decorate.try(:listicon_image)
+                   item.decorate.try(:listicon_image)
                  else
                    "100/#{item.class.base_class.to_s.underscore}.png"
                  end


### PR DESCRIPTION
Purpose or Intent
-----------------

Show PNG icons for Middleware in list view, because of changes in #8734.

Before:
![screencapture-localhost-3000-ems_middleware-show-10000000000013-1466603031337](https://cloud.githubusercontent.com/assets/1187051/16268867/54fa47d6-3890-11e6-923f-60bc6fecbf47.png)

After:
![screencapture-localhost-3000-ems_middleware-show-10000000000013-1466600772650](https://cloud.githubusercontent.com/assets/1187051/16268870/57b0d828-3890-11e6-88bf-de3684e0c18d.png)

___

Before:
![screencapture-localhost-3000-middleware_datasource-show-10r2-1466672085909](https://cloud.githubusercontent.com/assets/1187051/16297398/01038790-3931-11e6-85ea-93292c417c16.png)

After:
![screencapture-localhost-3000-middleware_datasource-show-10r2-1466672179228](https://cloud.githubusercontent.com/assets/1187051/16297431/2a710738-3931-11e6-859e-2bfd52cf2934.png)



Links
-----
Fixes: #9143
Fixes: #8780

Steps for Testing/QA
--------------------
> [Optional] If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.

