### PR TITLE
Store Resize explorer view state correctly

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -352,6 +352,7 @@ module ApplicationController::CiProcessing
     session[:edit] = @edit
     @in_a_form = true
     @resize = true
+    @sb[:explorer] = @explorer
     render :action => "show" unless @explorer
   end
 
@@ -405,7 +406,7 @@ module ApplicationController::CiProcessing
           add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {
             :instance => ui_lookup(:table => 'vm_cloud'),
             :name     => @record.name,
-            :details  => ex}, :error)
+            :details  => get_error_message_from_fog(ex.to_s)}, :error)
         end
       else
         add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {


### PR DESCRIPTION
Store the explorer state in `@sb` so that later steps in the resize
process can correctly identify if they are in an explorer view.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1348937
(Also took the opportunity to make the Resize error message print nicely like all the others)