### PR TITLE
Drop unused window-width from session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1968,8 +1968,7 @@ class ApplicationController < ActionController::Base
     # Get performance hash, if it is in the sandbox for the running controller
     @perf_options = @sb[:perf_options] ? copy_hash(@sb[:perf_options]) : {}
 
-    # Set window width/height for views to use
-    @winW = session[:winW] ? session[:winW].to_i : 1330
+    # Set window height for views to use
     @winH = session[:winH] ? session[:winH].to_i : 805
 
     # Set @edit key default for the expression editor to use

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -52,7 +52,6 @@ class DashboardController < ApplicationController
   # Accept window sizes from the client
   def window_sizes
     session[:winH] = params[:height] if params[:height]
-    session[:winW] = params[:width] if params[:width]
     if params[:exp_left] && params[:exp_controller]
       # Set the left divider position in the controller's sandbox
       session[:sandboxes][params[:exp_controller]][:exp_left] = params[:exp_left]
@@ -640,7 +639,7 @@ class DashboardController < ApplicationController
 
   def session_reset
     # save some fields to recover back into session hash after session is cleared
-    keys_to_restore = [:winH, :winW, :browser, :user_TZO]
+    keys_to_restore = [:winH, :browser, :user_TZO]
     data_to_restore = keys_to_restore.each_with_object({}) { |k, v| v[k] = session[k] }
 
     session.clear

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -20,7 +20,6 @@
                                     :row_url_ajax    => ajax_url}})
   - else
     -# TODO: is this still even relevant? haven't seen it yet (--mhradil)
-    -# substracting leftcol 219 from @winW to calculate width of div
     #list_grid
       = render(:partial => 'layouts/list_grid',
         :locals  => {:options    => grid_options,

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -372,20 +372,17 @@ describe DashboardController do
   context "#session_reset" do
     it "verify certain keys are restored after session is cleared" do
       winH               = '600'
-      winW               = '800'
       user_TZO           = '5'
       browser_info       = {:name => 'firefox', :version => '32'}
       session[:browser]  = browser_info
       session[:user_TZO] = user_TZO
       session[:winH]     = winH
-      session[:winW]     = winW
       session[:foo]      = 'foo_bar'
 
       controller.send(:session_reset)
 
       expect(session[:browser]).to eq(browser_info)
       expect(session[:winH]).to eq(winH)
-      expect(session[:winW]).to eq(winW)
       expect(session[:user_TZO]).to eq(user_TZO)
       expect(session[:foo]).to eq(nil)
       expect(browser_info(:version)).to eq(browser_info[:version])


### PR DESCRIPTION
Unused since e9349f8b8ee2e43d24ac39908120eeb90d914c97. Unfortunately, the window height is still used to get size of log viewer (see both `_log_viewer.html.haml` files).

@miq-bot add_label ui, technical debt