### PR TITLE
Optimize Planning duplicate vm name not listed in dropdown

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -167,8 +167,7 @@ class MiqCapacityController < ApplicationController
   def planning_wizard_get_vms(filter_type, filter_value)
     vms = planning_wizard_get_vms_records(filter_type, filter_value)
     vms.each_with_object({}) do |v, h|
-      description = v.name.to_s
-      description.concat(_(" under provider #{v.ext_management_system.name}")) unless v.ext_management_system.nil?
+      description = v.ext_management_system ? _("#{v.ext_management_system.name}:#{v.name}") : v.name
       h[v.id.to_s] = description
     end
   end

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -166,7 +166,11 @@ class MiqCapacityController < ApplicationController
 
   def planning_wizard_get_vms(filter_type, filter_value)
     vms = planning_wizard_get_vms_records(filter_type, filter_value)
-    vms.each_with_object({}) { |v, h| h[v.id.to_s] = v.name }
+    vms.each_with_object({}) do |v, h|
+      description = v.name.to_s
+      description.concat(_(" under provider #{v.ext_management_system.name}")) unless v.ext_management_system.nil?
+      h[v.id.to_s] = description
+    end
   end
   private :planning_wizard_get_vms
 

--- a/spec/controllers/miq_capacity_controller_spec.rb
+++ b/spec/controllers/miq_capacity_controller_spec.rb
@@ -69,6 +69,21 @@ describe MiqCapacityController do
                                         @vm4.id.to_s => @vm4.name)
     end
 
+    it 'displays Vms with the same name' do
+      ems = FactoryGirl.create(:ems_vmware, :name => "ProviderName")
+      vm5 = FactoryGirl.create(:vm_vmware,  :name => 'Name1', :host => @host2, :ext_management_system => ems)
+      allow(controller).to receive(:render)
+      controller.instance_variable_set(:@sb, :planning => {:vms => {}, :options => {}})
+      controller.instance_variable_set(:@_params, :filter_typ => "all")
+      controller.send(:planning_option_changed)
+      sb = controller.instance_variable_get(:@sb)
+      expect(sb[:planning][:vms]).to eq(@vm1.id.to_s => @vm1.name,
+                                        vm5.id.to_s  => "#{vm5.name} under provider #{ems.name}",
+                                        @vm2.id.to_s => @vm2.name,
+                                        @vm3.id.to_s => @vm3.name,
+                                        @vm4.id.to_s => @vm4.name)
+    end
+
     it 'displays Vms filtered by host' do
       allow(controller).to receive(:render)
       controller.instance_variable_set(:@sb, :planning => {:vms => {}, :options => {}})

--- a/spec/controllers/miq_capacity_controller_spec.rb
+++ b/spec/controllers/miq_capacity_controller_spec.rb
@@ -78,7 +78,7 @@ describe MiqCapacityController do
       controller.send(:planning_option_changed)
       sb = controller.instance_variable_get(:@sb)
       expect(sb[:planning][:vms]).to eq(@vm1.id.to_s => @vm1.name,
-                                        vm5.id.to_s  => "#{vm5.name} under provider #{ems.name}",
+                                        vm5.id.to_s  => "#{ems.name}:#{vm5.name}",
                                         @vm2.id.to_s => @vm2.name,
                                         @vm3.id.to_s => @vm3.name,
                                         @vm4.id.to_s => @vm4.name)


### PR DESCRIPTION

Purpose or Intent
-----------------
VMs with duplicate names are not listed in the Optimize Planning dropdown list . This PR adds 'under provider <provider name> to the vm name in the dropdown.
Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1273404


Testing 

Steps to Reproduce:
1. create two providers e.g. RHEV and VMware
2. create a VM called "test1" in both providers
3. navigate to "Optimize, Planning"
4. select "All VMs"
5. the drop down list only shows "test1" once and does not indicate to which provider the VM belongs

![screenshot from 2016-06-24 14-22-56](https://cloud.githubusercontent.com/assets/12769982/16346808/4375b896-3a17-11e6-97bd-13598db5bdc9.png)

