### PR TITLE
Finding the middleware servers by ems_ref that is unique rather than using ambiguous nativeid

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
@@ -37,7 +37,7 @@ module ManageIQ::Providers
             end
 
             @data[:middleware_servers] << server
-            @data_index.store_path(:middleware_servers, :by_nativeid, server[:nativeid], server)
+            @data_index.store_path(:middleware_servers, :by_ems_ref, server[:ems_ref], server)
           end
         end.flatten
       end
@@ -86,7 +86,7 @@ module ManageIQ::Providers
         @eaps.map do |eap|
           @ems.child_resources(eap.path).map do |child|
             next unless child.type_path.end_with?('Deployment', 'Datasource')
-            server = @data_index.fetch_path(:middleware_servers, :by_nativeid, eap.id)
+            server = @data_index.fetch_path(:middleware_servers, :by_ems_ref, eap.path)
             process_server_entity(server, child)
           end
         end


### PR DESCRIPTION
Fixes issue #9101

When using the `nativeid` and there were more servers with the same `nativeid` ('Local~~' by default), everything (datasources, deployments) were assigned to the firstly added server. Using the `ems_ref` is better, because it contains also the `feedId` and it's guaranteed (by the Hawkular inventory graph db model) that there can't be 2 servers under the same feed with the same id (~`nativeId` in MiQ).

cc @abonas, @theute 
@miq-bot add_label providers/hawkular, bug