### PR TITLE
Fix markup to correctly display SNMP traps

### DIFF
--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -189,7 +189,7 @@
         - if @alert.options && @alert.options[:notifications] && !@alert.options[:notifications][:snmp].blank?
           %h3
             = _('Send SNMP Trap')
-          %label.control-label.col-md-2
+          .form-horizontal
             .form-group
               %label.control-label.col-md-2
                 = title_for_host


### PR DESCRIPTION
This addresses BZ 1348908: 
https://bugzilla.redhat.com/show_bug.cgi?id=1348908

The SNMP trap section of a custom alert was incorrectly wrapped in a label tag. This changes it to `div.form-horizontal` to make the lines within display correctly.

**Before**
![screen shot 2016-06-22 at 10 29 43 am](https://cloud.githubusercontent.com/assets/39493/16276991/c45cbb98-3865-11e6-901e-d1a8536254f9.png)

----------

**After**

![screen shot 2016-06-22 at 10 33 06 am](https://cloud.githubusercontent.com/assets/39493/16277003/ce054f3e-3865-11e6-8854-199170152a2b.png)


/cc @h-kataria 