### PR TITLE
Validate Azure subscription ID's if provided.

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -11,12 +11,24 @@ module ManageIQ::Providers::Azure::ManagerMixin
 
   def verify_credentials(_auth_type = nil, options = {})
     require 'azure-armrest'
-    connect(options)
-  rescue Azure::Armrest::UnauthorizedException
-    raise MiqException::MiqHostError, _("Incorrect credentials - check your Azure Client ID and Client Key")
+    conf = connect(options)
+
+    unless subscription.blank?
+      vms = ::Azure::Armrest::VirtualMachineService.new(conf)
+      subscriptions = vms.subscriptions.map(&:subscription_id)
+      unless subscriptions.include?(subscription)
+        raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - check your Azure Subscription ID")
+      end
+    end
+  rescue Azure::Armrest::UnauthorizedException, Azure::Armrest::BadRequestException
+    raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - check your Azure Client ID and Client Key")
+  rescue MiqException::MiqInvalidCredentialsError
+    raise # Raise before falling into catch-all block below
   rescue StandardError => err
     _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
-    raise MiqException::MiqHostError, _("Unexpected response returned from system, see log for details")
+    raise MiqException::MiqInvalidCredentialsError, _("Unexpected response returned from system, see log for details")
+  else
+    conf
   end
 
   module ClassMethods

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -50,13 +50,13 @@ describe ManageIQ::Providers::Azure::CloudManager do
     context "#validation" do
       it "handles unknown error" do
         allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_raise(StandardError)
-        expect { @e.verify_credentials }.to raise_error(MiqException::MiqHostError, /Unexpected response returned*/)
+        expect { @e.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Unexpected response returned*/)
       end
 
       it "handles incorrect password" do
         allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_raise(
           Azure::Armrest::UnauthorizedException.new(nil, nil, nil))
-        expect { @e.verify_credentials }.to raise_error(MiqException::MiqHostError, /Incorrect credentials*/)
+        expect { @e.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Incorrect credentials*/)
       end
     end
   end
@@ -67,14 +67,14 @@ describe ManageIQ::Providers::Azure::CloudManager do
     before do
       EvmSpecHelper.local_miq_server(:zone => Zone.seed)
 
-      @client_id  = Rails.application.secrets.azure.try(:[], 'client_id') || 'AZURE_CLIENT_ID'
-      @client_key = Rails.application.secrets.azure.try(:[], 'client_secret') || 'AZURE_CLIENT_SECRET'
-      @tenant_id  = Rails.application.secrets.azure.try(:[], 'tenant_id') || 'AZURE_TENANT_ID'
+      @client_id    = Rails.application.secrets.azure.try(:[], 'client_id') || 'AZURE_CLIENT_ID'
+      @client_key   = Rails.application.secrets.azure.try(:[], 'client_secret') || 'AZURE_CLIENT_SECRET'
+      @tenant_id    = Rails.application.secrets.azure.try(:[], 'tenant_id') || 'AZURE_TENANT_ID'
       @subscription = Rails.application.secrets.azure.try(:[], 'subscription_id') || 'AZURE_SUBSCRIPTION_ID'
 
-      @alt_client_id       = 'testuser'
-      @alt_client_key      = 'secret'
-      @alt_tenant_id       = 'ABCDEFGHIJABCDEFGHIJ0123456789AB'
+      @alt_client_id    = 'testuser'
+      @alt_client_key   = 'secret'
+      @alt_tenant_id    = 'ABCDEFGHIJABCDEFGHIJ0123456789AB'
       @alt_subscription = '0123456789ABCDEFGHIJABCDEFGHIJKL'
 
       # A true thread may fail the test with VCR


### PR DESCRIPTION
This PR deals with an issue where credential validation did not work properly for Azure if a subscription ID text was provided.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1348594

In addition, I realized that the flash error message in the UI would always defer to the same default error message. This was caused by all StandardError's being rescued and re-raised without checking for the re-raised exception class first.

~~I believe this was a holdover from versions of Ruby prior to 2.x where RuntimeError (the parent class of MiqException classes) was not a subclass of StandardError, and could safely be used as a catch-all for things that weren't raised as MiqExceptions. However, since Ruby 2.x any MiqException classes will get picked up by a `rescue StandardError` clause because RuntimeError is now a subclass of StandardError.~~ (This turned out to be incorrect, RuntimeError has been a subclass of StandardError since 1.8)

Lastly, I changed MiqHostError to MiqCredentialsError, since that seemed more appropriate.

Steps for Testing/QA

Go to the "new provider" screen, and select Azure, and any region.

* Enter valid Tenant ID, Client ID and Client Key. Hit validate button. Should be green.
* Enter invalid Tenant ID, Client ID or Client Key. Hit validate button. Should fail with "Credential validation was not successful: Incorrect credentials - check your Azure Client ID and Client Key"
* Enter valid Tenant ID, Client ID and Client Key, but invalid Subscription ID. Hit validate button. Should fail with "Credential validation was not successful: Incorrect credentials - check your Azure Subscription ID"
* Enter valid Tenant ID, Client ID, Client Key and Subscriptin ID Hit validate button. Should be green.
