### PR TITLE
Allow gtl view for Cloud Key Pairs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -173,14 +173,13 @@ module ApplicationHelper
 
   def url_for_record(record, action = "show") # Default action is show
     @id = to_cid(record.id)
-    db =
-      if record.kind_of?(VmOrTemplate)
-        controller_for_vm(model_for_vm(record))
-      elsif record.class.respond_to?(:db_name)
-        record.class.db_name
-      else
-        record.class.base_class.to_s
-      end
+    db  = if record.kind_of?(VmOrTemplate)
+            controller_for_vm(model_for_vm(record))
+          elsif record.class.respond_to?(:db_name)
+            record.class.db_name
+          else
+            record.class.base_class.to_s
+          end
     url_for_db(db, action, record)
   end
 
@@ -1057,7 +1056,8 @@ module ApplicationHelper
     "#{@options[:page_size] || "US-Legal"} #{@options[:page_layout]}"
   end
 
-  GTL_VIEW_LAYOUTS = %w(action availability_zone cim_base_storage_extent cloud_object_store_container
+  GTL_VIEW_LAYOUTS = %w(action availability_zone auth_key_pair_cloud
+                        cim_base_storage_extent cloud_object_store_container
                         cloud_object_store_object cloud_tenant cloud_volume cloud_volume_snapshot
                         condition container_group container_route container_project
                         container_replicator container_image container_image_registry

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -113,6 +113,9 @@ module QuadiconHelper
       elsif db == "FloatingIp"
         link_to(truncate_for_quad(item.address),
                 url_for_db(db, "show"), :title => h(item.address))
+      elsif db == "Authentication"
+        link_to(truncate_for_quad(row['name']),
+                url_for_db("auth_key_pair_cloud", "show"), :title => h(row['name']))
       else
         if @explorer
           column = case db

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -34,6 +34,11 @@ class Authentication < ApplicationRecord
     "invalid"     => 3,
   ).freeze
 
+  # To address problem with url resolution when displayed as a quadicon
+  def self.db_name
+    "auth_key_pair_cloud"
+  end
+
   def status_severity
     STATUS_SEVERITY[status.to_s.downcase]
   end

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -20,6 +20,8 @@
                                     :row_url_ajax    => ajax_url}})
   - else
     -# TODO: is this still even relevant? haven't seen it yet (--mhradil)
+    -# substracting leftcol 219 from @winW to calculate width of div
+    -# FYI: found a screen here: /auth_key_pair_cloud/show_list (--@hayesr)
     #list_grid
       = render(:partial => 'layouts/list_grid',
         :locals  => {:options    => grid_options,


### PR DESCRIPTION
Addresses this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1348796

The gtl options were missing on the Cloud Key Pairs screen, this adds them.

* Adds `auth_key_pair_cloud` to layout configuration constant
* Adds a class method to `Authentication` to help with determining url for quadicon
* Adds kludge in `quadicon_helper` for detecting Authentication class and setting correct controller. (I’m working on refactoring this.)
* Cleans up some style and adds a note for future refactoring

**Before**
![screen shot 2016-06-22 at 12 19 17 pm](https://cloud.githubusercontent.com/assets/39493/16280277/a37eaeaa-3873-11e6-85f7-e5a8e3ec63fb.png)

----------

**After**
![screen shot 2016-06-22 at 12 04 01 pm](https://cloud.githubusercontent.com/assets/39493/16280283/a95a9e24-3873-11e6-8d45-2e79ec8851f4.png)

