### PR TITLE
Add request_type to template_fields

### DIFF
--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -1,4 +1,5 @@
 require 'trollop'
+require 'rest-client'
 #
 # Helper Script to show the json / hash output of an
 # existing Automate request

--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -106,8 +106,9 @@ class Tab
 
   def parse_source
     src_id = @provision_options.delete(:src_vm_id)
+    request_type = @provision_options.delete(:request_type)
     source = VmOrTemplate.find_by(:id => src_id)
-    @output["template_fields"] = {'guid' => source.guid, 'name' => source.name}
+    @output["template_fields"] = {'guid' => source.guid, 'name' => source.name, 'request_type' => request_type.to_s}
   end
 
   def ws_only_files

--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -265,7 +265,7 @@ class AutomateHash
 
   def provision_options
     find_request_options
-    @provision_options.options.dup
+    @provision_options.options.dup.merge!(:request_type => @provision_options.request_type)
   end
 
   def dialog


### PR DESCRIPTION
For the Automate Tool: `tools/rebuild_provision_request.rb`

This adds the ability for `request_type` to be added as a key to the template_fields hash
We only add a request type when one exists.