### PR TITLE
Remove atomic from form new container without harcoding subclasses in ContainerManager

### DIFF
--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -32,6 +32,11 @@ class EmsContainerController < ApplicationController
     ems_form_fields
   end
 
+  def new
+    super
+    @ems_types -= [["Atomic", "atomic"], ["Atomic Enterprise", "atomic_enterprise"]]
+  end
+
   private
 
   ############################

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -40,12 +40,6 @@ module ManageIQ::Providers
       define_method(:singular_route_key) { "ems_container" }
     end
 
-    def self.supported_subclasses
-      [ManageIQ::Providers::Kubernetes::ContainerManager,
-       ManageIQ::Providers::OpenshiftEnterprise::ContainerManager,
-       ManageIQ::Providers::Openshift::ContainerManager]
-    end
-
     # enables overide of ChartsLayoutService#find_chart_path
     def chart_layout_path
       "ManageIQ_Providers_ContainerManager"

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -19,6 +19,8 @@ describe ExtManagementSystem do
   let(:all_types_and_descriptions) do
     {
       "ansible_tower_configuration" => "Ansible Tower Configuration",
+      "atomic"                      => "Atomic",
+      "atomic_enterprise"           => "Atomic Enterprise",
       "azure"                       => "Azure",
       "azure_network"               => "Azure Network",
       "ec2"                         => "Amazon EC2",
@@ -40,8 +42,7 @@ describe ExtManagementSystem do
   end
 
   it ".types" do
-    # ['atomic', 'atomic_enterprise'] is a hack until atomic providers will be migrated to openshift
-    expect(described_class.types).to match_array(all_types_and_descriptions.keys + ['atomic', 'atomic_enterprise'])
+    expect(described_class.types).to match_array(all_types_and_descriptions.keys)
   end
 
   it ".supported_types" do
@@ -61,6 +62,10 @@ describe ExtManagementSystem do
 
     it "permissions.tmpl.yml should contain all EMS types" do
       types = YAML.load_file(Rails.root.join("config/permissions.tmpl.yml"))
+      # atomic is no longer in the list of permissions, because they should be faded out
+      # and new container managers should be openshift. Until they are fully removed from the
+      # codebase: https://github.com/ManageIQ/manageiq/issues/8612
+      types += %w(ems-type:atomic ems-type:atomic_enterprise)
       stub_vmdb_permission_store_with_types(types) do
         expect(described_class.supported_types_and_descriptions_hash).to eq(all_types_and_descriptions)
       end


### PR DESCRIPTION
the original intent was to remove Atomic from the dropdown
this is done by overriding #new in the controller