### PR TITLE
Render correct partial for policy simulation detail page

### DIFF
--- a/app/views/vm/show.html.haml
+++ b/app/views/vm/show.html.haml
@@ -11,3 +11,5 @@
     = render :partial => "vm_common/live_migrate"
   - elsif @evacuate
     = render :partial => "vm_common/evacuate"
+  - else
+    = render :partial => "vm_common/#{@showtype}", :locals => {:controller => "vm"}

--- a/spec/views/vm/_show.html.haml_spec.rb
+++ b/spec/views/vm/_show.html.haml_spec.rb
@@ -1,0 +1,30 @@
+describe "vm/show.html.haml" do
+  shared_examples_for "miq_before_onload JS is needed" do
+    it "renders proper JS" do
+      js_string = "var miq_after_onload = \"miqAsyncAjax('/vm/#{action}/#{vm.id}');\""
+      render
+      expect(rendered).to include(js_string)
+    end
+  end
+
+  let(:vm) { FactoryGirl.create(:vm, :name => 'vm', :description => 'vm description') }
+  let(:action) { 'show' }
+
+  before do
+    assign(:record, vm)
+    assign(:ajax_action, action)
+    assign(:showtype, showtype)
+  end
+
+  context "when showtype is 'policies'" do
+    let(:showtype) { 'policies' }
+    let(:display) { 'main' }
+
+    it 'should render policies view' do
+      assign(:lastaction, 'policy_sim')
+      stub_template "vm_common/_policies.html.haml" => "Stubbed Content"
+      render
+      expect(rendered).to render_template(:partial => 'vm_common/policies', :locals => {:controller => 'vm'})
+    end
+  end
+end


### PR DESCRIPTION
Renders the correct partial instead of a blank content area.

Fixes #9283 
https://bugzilla.redhat.com/show_bug.cgi?id=1348341