### PR TITLE
Preload the root service picture, it's called in a loop

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -19,7 +19,7 @@ class Service < ApplicationRecord
   virtual_has_many   :vms
   virtual_has_many   :all_vms
   virtual_column     :v_total_vms,            :type => :integer,  :uses => :vms
-  virtual_has_one    :picture
+  virtual_has_one    :picture, :uses => :service_template
 
   virtual_has_one    :custom_actions
   virtual_has_one    :custom_action_buttons

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -24,7 +24,12 @@ class TreeBuilderServices < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, rbac_filtered_objects(Service.roots), "name")
+    roots = rbac_filtered_objects(Service.roots)
+
+    # Preload the root service picture since it's called by TreeNodeBuilder#build
+    MiqPreloader.preload(roots, :picture)
+
+    count_only_or_objects(count_only, roots, "name")
   end
 
   def x_get_tree_service_kids(object, count_only)


### PR DESCRIPTION
Purpose or Intent
-----------------

Services -> My Services was taking ~47 seconds in the UI with a large database with over 9000 services.
With this change, it's down to 26 seconds.

 Each root service picture is called by TreeNodeBuilder#build.

```ruby
Benchmark.ms { TreeBuilderServices.new(:svcs_tree, :svcs, {:trees=>{:svcs_tree=>{:tree=>:svcs_tree, :type=>:svcs, :klass_name=>"TreeBuilderServices", :leaf=>"Service", :add_root=>true, :open_nodes=>[], :lazy=>true, :full_ids=>true}}}, true) }
```
Note, there might be some model autoloading skewing the console/UI timings:

Before/after with a large database (9400+ services):
In the console: 55 -> 23 seconds
In the UI on /service/explorer: 47 -> 26 seconds

With help from @NickLaMuro @Fryguy 