### PR TITLE
Do not suppress openstack_handle log

### DIFF
--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -74,6 +74,10 @@ module OpenstackHandle
         Fog.const_get(service).new(opts)
       end
     rescue Fog::Errors::NotFound => err
+      $fog_log.warn("MIQ(#{self.class.name}##{__method__}) "\
+                    "Service #{service} not available for openstack provider #{auth_url}")
+      $fog_log.warn(err.message)
+      $fog_log.warn(err.backtrace.join("\n"))
       raise MiqException::ServiceNotAvailable if err.message.include?("Could not find service")
       raise
     end


### PR DESCRIPTION
With this exception all that is logged is ServiceNotAvailable,
and all details are lost. The message hold important info, like
you need to set a specific permissions.