### PR TITLE
Handle gracefully a missing tenant relationship

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -62,7 +62,7 @@ module EmsRefresh::SaveInventory
       h[:cloud_network_id]       = key_backup.fetch_path(:cloud_network, :id)
       h[:cloud_subnet_id]        = key_backup.fetch_path(:cloud_subnet, :id)
       h[:cloud_tenant_id]        = key_backup.fetch_path(:cloud_tenant, :id)
-      h[:cloud_tenants]          = key_backup.fetch_path(:cloud_tenants).map { |x| x[:_object] } if key_backup.fetch_path(:cloud_tenants, 0, :_object)
+      h[:cloud_tenants]          = key_backup.fetch_path(:cloud_tenants).compact.map { |x| x[:_object] } if key_backup.fetch_path(:cloud_tenants, 0, :_object)
       h[:orchestration_stack_id] = key_backup.fetch_path(:orchestration_stack, :id)
 
       begin


### PR DESCRIPTION
Handle gracefully a missing tenant relationship, missing
relationship can be caused by seeing tenant id on Image, while
not having rights to read the actual tenant.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1349310