### PR TITLE
Missing cascade delete, leaves zombie subnets in the db

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private < Ma
   include CloudNetworkPrivateMixin
 
   has_many :cloud_subnets, :class_name  => "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet",
-                           :foreign_key => :cloud_network_id
+                           :foreign_key => :cloud_network_id, :dependent => :destroy
   has_many :network_routers, -> { distinct }, :through => :cloud_subnets
   has_many :public_networks, -> { distinct }, :through => :cloud_subnets
 end


### PR DESCRIPTION
Missing cascade delete, leaves zombie subnets in the db