### PR TITLE
Expose missing network relations to automate

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_floating_ip.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_floating_ip.rb
@@ -3,5 +3,6 @@ module MiqAeMethodService
     expose :ext_management_system, :association => true
     expose :vm,                    :association => true
     expose :cloud_tenant,          :association => true
+    expose :network_port,          :association => true
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager-vm.rb
@@ -8,6 +8,7 @@ module MiqAeMethodService
     expose :network_routers,   :association => true
     expose :cloud_subnets,     :association => true
     expose :floating_ip,       :association => true
+    expose :floating_ips,      :association => true
     expose :security_groups,   :association => true
     expose :key_pairs,         :association => true
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_network_port.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_network_port.rb
@@ -3,6 +3,7 @@ module MiqAeMethodService
     expose :ext_management_system, :association => true
     expose :cloud_tenant,          :association => true
     expose :cloud_subnet,          :association => true
+    expose :cloud_subnets,         :association => true
     expose :device,                :association => true
   end
 end


### PR DESCRIPTION
This relations will allow us to identify a floating IP from a
certain subnet.