### PR TITLE
Add ansible job and orchestration stack crosslink to service

### DIFF
--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module ServiceHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(catalog_item parent_service orchestration_stack)
+    %i(catalog_item parent_service orchestration_stack job)
   end
 
   def textual_group_tags
@@ -106,6 +106,10 @@ module ServiceHelper::TextualSummary
 
   def textual_orchestration_stack
     @record.try(:orchestration_stack)
+  end
+
+  def textual_job
+    @record.try(:job)
   end
 
   def textual_owner

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module ServiceHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(catalog_item parent_service)
+    %i(catalog_item parent_service orchestration_stack)
   end
 
   def textual_group_tags
@@ -102,6 +102,10 @@ module ServiceHelper::TextualSummary
       :title => _("Show this Service's Parent Service"),
       :link  => url_for(:controller => 'service', :action => 'show', :id => parent)
     } if parent
+  end
+
+  def textual_orchestration_stack
+    @record.try(:orchestration_stack)
   end
 
   def textual_owner


### PR DESCRIPTION
Service should have a link to orchestrations stack or ansible job it deployed

![image](https://cloud.githubusercontent.com/assets/1737058/16331137/6aabe9ae-39ee-11e6-8220-3a0a8579978e.png)

![image](https://cloud.githubusercontent.com/assets/1737058/16331147/7d4cff3a-39ee-11e6-9115-4d3b513f7c16.png)
