### PR TITLE
When retiring resources, retire also nested resources

### DIFF
--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -14,6 +14,8 @@ module Service::RetirementManagement
   end
 
   def retire_service_resources
+    direct_service_children.each(&:retire_service_resources)
+
     service_resources.each do |sr|
       if sr.resource.respond_to?(:retire_now)
         $log.info("Retiring service resource for service: #{name} resource ID: #{sr.id}")


### PR DESCRIPTION
When retiring resources of a Service, retire also resources
of direct child services. So all resources will get cleaned
nicely.