### PR TITLE
Service should load all_vms from nested stacks

### DIFF
--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -59,7 +59,11 @@ class ServiceOrchestration < Service
   end
 
   def direct_vms
-    orchestration_stack.try(:direct_vms) || []
+    # Loading all VMs, to make listing of the VMs under Service work, when we deal with nested stacks. A proper fix
+    # would be to use something like closure_tree, where we can build tree from the multiple classes. Then Service level
+    # MiqPreloader.preload_and_map(subtree, :direct_vms) will work also for nested stacks. Because in that case, nested
+    # stacks will be a part of the subtree.
+    orchestration_stack.try(:vms) || []
   end
 
   def all_vms

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -170,7 +170,7 @@ describe ServiceOrchestration do
       child_stack.direct_vms << vm2
 
       expect(service_with_deployed_stack.all_vms.map(&:id)).to match_array([vm1, vm2].map(&:id))
-      expect(service_with_deployed_stack.direct_vms.map(&:id)).to match_array([vm1].map(&:id))
+      expect(service_with_deployed_stack.direct_vms.map(&:id)).to match_array([vm1, vm2].map(&:id))
       expect(service_with_deployed_stack.indirect_vms.map(&:id)).to match_array([vm2].map(&:id))
       expect(service_with_deployed_stack.vms.map(&:id)).to match_array([vm1, vm2].map(&:id))
     end


### PR DESCRIPTION
Service should load all_vms from nested stacks
    
If service orchestration contains nested orchestration stacks,
we will not see the list of VMs in the service. Cause we
call direct_vms only on the root stack. We need to call all_vms
on the root stack.
