### PR TITLE
Show VM relation to service through root orchestration stack

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -366,7 +366,7 @@ module VmHelper::TextualSummary
 
   def textual_service
     h = {:label => _("Service"), :image => "service"}
-    service = @record.service || @record.try(:orchestration_stack).try(:service)
+    service = @record.service || @record.try(:orchestration_stack).try(:service) || @record.try(:orchestration_stack).try(:root).try(:service)
     if service.nil?
       h[:value] = _("None")
     else


### PR DESCRIPTION
Show VM relation to service through root orchestration stack. Orchestration stacks make a tree, where only root is associated to service usually. Let's use that association to connect all nested stacks, but only if there is direct association to service missing.