### PR TITLE
Simplify x_tree and x_node handling in specs.

### DIFF
--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -25,6 +25,7 @@ module Sandbox
   end
 
   def x_active_tree
+    @sb ||= {}
     @sb[:active_tree]
   end
 
@@ -147,6 +148,7 @@ module Sandbox
   ).each_with_object({}) { |value, acc| acc[value] = value.to_sym }.freeze
 
   def x_active_tree=(tree)
+    @sb ||= {}
     @sb[:active_tree] = nil
     return if tree.nil?
 

--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -3,15 +3,19 @@ module Sandbox
   # Explorer shortcuts to the current tree and tree node
   #
 
+  def sandbox
+    @sb ||= {}
+  end
+
   # Return the current tree history array
   def x_tree_history
-    @sb[:history] ||= {}
-    @sb[:history][x_active_tree] ||= []
-    @sb[:history][x_active_tree]
+    sandbox[:history] ||= {}
+    sandbox[:history][x_active_tree] ||= []
+    sandbox[:history][x_active_tree]
   end
 
   def x_tree_init(name, type, leaf)
-    return if @sb.has_key_path?(:trees, name)
+    return if sandbox.has_key_path?(:trees, name)
 
     values = {
       :tree       => name,
@@ -21,12 +25,11 @@ module Sandbox
       :open_nodes => []
     }
 
-    @sb.store_path(:trees, name, values)
+    sandbox.store_path(:trees, name, values)
   end
 
   def x_active_tree
-    @sb ||= {}
-    @sb[:active_tree]
+    sandbox[:active_tree]
   end
 
   TREE_WHITELIST = %w(
@@ -148,33 +151,32 @@ module Sandbox
   ).each_with_object({}) { |value, acc| acc[value] = value.to_sym }.freeze
 
   def x_active_tree=(tree)
-    @sb ||= {}
-    @sb[:active_tree] = nil
+    sandbox[:active_tree] = nil
     return if tree.nil?
 
     raise ActionController::RoutingError, 'invalid tree' unless TREE_WHITELIST.key?(tree.to_s)
-    @sb[:active_tree] = TREE_WHITELIST[tree.to_s]
+    sandbox[:active_tree] = TREE_WHITELIST[tree.to_s]
   end
 
   def x_active_accord=(tree)
-    @sb[:active_accord] = nil
+    sandbox[:active_accord] = nil
 
     raise ActionController::RoutingError, 'invalid accordion' unless ACCORD_WHITELIST.key?(tree)
-    @sb[:active_accord] = ACCORD_WHITELIST[tree]
+    sandbox[:active_accord] = ACCORD_WHITELIST[tree]
   end
 
   def x_active_accord
-    @sb[:active_accord]
+    sandbox[:active_accord]
   end
 
   def x_tree(tree = nil)
     tree ||= x_active_tree
-    @sb.fetch_path(:trees, tree)
+    sandbox.fetch_path(:trees, tree)
   end
 
   def x_node(tree = nil)
     tree ||= x_active_tree
-    @sb.fetch_path(:trees, tree, :active_node)
+    sandbox.fetch_path(:trees, tree, :active_node)
   end
 
   def x_node=(node)
@@ -182,6 +184,6 @@ module Sandbox
   end
 
   def x_node_set(node, tree)
-    @sb.store_path(:trees, tree, :active_node, node)
+    sandbox.store_path(:trees, tree, :active_node, node)
   end
 end

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -16,11 +16,8 @@ describe ContainerController do
       set_user_privileges user
       allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      sandbox = {:active_tree => :containers_tree, :trees => {:containers_tree => {:active_node => "cnt_#{controller.to_cid(@ct.id)}"}}}
-      controller.instance_variable_set(:@sb, sandbox)
 
-      controller.x_active_tree = 'containers_tree'
-      allow(controller).to receive(:x_node).and_return("cnt_#{controller.to_cid(@ct.id)}")
+      seed_session_trees('container', :containers_tree, "cnt_#{controller.to_cid(@ct.id)}")
       @tag1 = FactoryGirl.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
@@ -28,10 +25,6 @@ describe ContainerController do
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
-      controller.instance_variable_set(:@sb,
-                                       :trees       => {:containers_tree => {:active_node => "root"}},
-                                       :active_tree => :containers_tree)
-      allow(controller).to receive(:get_node_info)
       session[:tag_db] = "Container"
       edit = {
         :key        => "Container_edit_tags__#{@ct.id}",

--- a/spec/controllers/miq_capacity_controller_spec.rb
+++ b/spec/controllers/miq_capacity_controller_spec.rb
@@ -84,11 +84,10 @@ describe MiqCapacityController do
       EvmSpecHelper.create_guid_miq_server_zone
       set_user_privileges
       FactoryGirl.create(:miq_enterprise)
+      FactoryGirl.create(:miq_region, :description => "My Region")
     end
     it 'it always sets breadcrumb' do
-      controller.instance_variable_set(:@sb, :planning => {:vms => {}, :options => {}}, :util => {:summary => {}})
-      controller.x_active_tree = 'bottlenecks_tree'
-      controller.x_node = 'I am not empty'
+      seed_session_trees('miq_capacity', :bottlenecks_tree, 'foobar')
       expect(controller).to receive(:bottleneck_get_node_info)
       # render fails but it's not needed for this test
       expect(controller).to receive(:render)

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -280,10 +280,8 @@ describe OpsController do
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
-      allow(controller).to receive(:x_active_tree).and_return(:diagnostics_tree)
-      allow(controller).to receive(:x_node).and_return("z-#{ApplicationRecord.compress_id(@zone.id)}")
+      seed_session_trees('ops', :diagnostics_tree, "z-#{ApplicationRecord.compress_id(@zone.id)}")
       post :change_tab, :params => { :tab_id => "diagnostics_collect_logs" }
-      allow(controller).to receive(:x_node).and_return("svr-#{ApplicationRecord.compress_id(@miq_server.id)}")
     end
     it "does not render toolbar buttons when edit is clicked" do
       post :x_button, :params => { :id => @miq_server.id, :pressed => 'log_depot_edit', :format => :js }
@@ -314,10 +312,7 @@ describe OpsController do
         _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
         allow(controller).to receive(:check_privileges).and_return(true)
         allow(controller).to receive(:assert_privileges).and_return(true)
-        controller.instance_variable_set(:@sb, {})
-        allow(controller).to receive(:x_active_tree).and_return(:settings_tree)
-        allow(controller).to receive(:x_node).and_return("root")
-        controller.x_active_tree = 'settings_tree'
+        seed_session_trees('ops', :settings_tree, 'root')
         expect(controller).to receive(:render_to_string).with(any_args).twice
         post :change_tab, :params => {:tab_id => tab}
       end

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -159,7 +159,7 @@ describe OpsController do
                          :ntp => {}}}
         controller.instance_variable_set(:@edit, edit)
         controller.instance_variable_set(:@_params, @params)
-        controller.instance_variable_set(:@sb, {:x_active_tree => :settings_tree, :active_tab =>"settings_evm_servers"})
+        seed_session_trees('ops', :settings_tree)
         allow(controller).to receive(:load_edit).and_return(true)
         controller.send(:zone_edit)
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1255,8 +1255,7 @@ describe ReportController do
 
         it "is allowed to see report created under Group1 for User 1(with current group Group2)" do
           controller.instance_variable_set(:@_params, :controller => "report", :action => "explorer")
-          controller.instance_variable_set(:@sb, :saved_reports => nil)
-          allow(controller).to receive(:x_active_tree).and_return("savedreports")
+          seed_session_trees('report', :saved_reports)
           allow(controller).to receive(:get_view_calculate_gtl_type).and_return("list")
           allow(controller).to receive(:get_view_pages_perpage).and_return(20)
 

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -170,11 +170,7 @@ describe StorageController do
       end
 
       it 'can Perform a datastore Smart State Analysis from the datastore list' do
-        allow(controller).to receive(:x_node).and_return("root")
-        allow(controller).to receive(:x_active_tree).and_return(:storage_tree)
-        allow(controller).to receive(:x_active_accord).and_return(:storage_accord)
         storage
-        session[:sb] = {:active_accord => :storage_accord}
         seed_session_trees('storage', :storage_tree, 'root')
         get :explorer
         post :x_button, :params => {:pressed => 'storage_scan', :miq_grid_checks => to_cid(storage.id), :format => :js}
@@ -184,12 +180,8 @@ describe StorageController do
       end
 
       it 'can Perform a datastore Smart State Analysis from the datastore cluster list' do
-        allow(controller).to receive(:x_active_tree).and_return(:storage_pod_tree)
-        allow(controller).to receive(:x_active_accord).and_return(:storage_pod_accord)
-        allow(controller).to receive(:x_node).and_return("xx-#{to_cid(storage_cluster.id)}")
         storage
         storage_cluster
-        session[:sb] = {:active_accord => :storage_pod_accord}
         seed_session_trees('storage', :storage_pod_tree, 'root')
         post :tree_select, :params => {:id => "xx-#{to_cid(storage_cluster.id)}", :format => :js}
         expect(response.status).to eq(200)
@@ -200,12 +192,8 @@ describe StorageController do
       end
 
       it 'can Perform a remove datastore from the datastore cluster list' do
-        allow(controller).to receive(:x_active_tree).and_return(:storage_pod_tree)
-        allow(controller).to receive(:x_active_accord).and_return(:storage_pod_accord)
-        allow(controller).to receive(:x_node).and_return("xx-#{to_cid(storage_cluster.id)}")
         storage
         storage_cluster
-        session[:sb] = {:active_accord => :storage_pod_accord}
         seed_session_trees('storage', :storage_pod_tree, 'root')
         post :tree_select, :params => {:id => "xx-#{to_cid(storage_cluster.id)}", :format => :js}
         expect(response.status).to eq(200)


### PR DESCRIPTION
Simplify testing and tests that deal with `x_(active_)tree` and `x_node`.