### PR TITLE
ManageIQ.dynatreeReplacement - fix nonexistent function call - cmfeAddNodeChildren

### DIFF
--- a/app/assets/javascripts/miq_dynatree_replacement.js
+++ b/app/assets/javascripts/miq_dynatree_replacement.js
@@ -155,7 +155,7 @@ ManageIQ.dynatreeReplacement = {
     }
 
     if (options.add_nodes && options.add_nodes[options.x_active_tree] && options.tree_name === options.x_active_tree) {
-      cmfeAddNodeChildren(
+      miqAddNodeChildren(
         options.x_active_tree,
         options.add_nodes_x_active_tree_key,
         options.select_node,


### PR DESCRIPTION
`cfmeAddNodeChildren` is now called `miqAddNodeChildren`, but `ManageIQ.dynatreeReplacement.replace` would still attempt to call the old method..

(Discovered as part of #9019)