### PR TITLE
miqOnMouseInHostNet - fix missing getAbsoluteTop

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -240,8 +240,9 @@ function miqOnMouseInHostNet(id) {
   if (nid) {
     // div id exists
     var node = $('#' + id); // Get html node
-    var top = getAbsoluteTop(node);
-    $("#" + nid).css({top: (top - 220) + "px"}); // Set quad top location
+    // FIXME: replace with a saner display method
+    var top  = node[0].getBoundingClientRect().top + node.scrollTop() - 220;
+    $("#" + nid).css({ top: top + "px" }); // Set quad top location
     $("#" + nid).show(); // Show the quad div
     return nid; // return current node id
   }


### PR DESCRIPTION
`getAbsoluteTop` is no longer available in our code, yet `miqOnMouseInHostNet` would still try to use it.. Replaced by an equivalent calculation, but it should eventually be replaced by some saner way of displaying quads at the right place though..

(Discovered as part of #9019.)