### PR TITLE
dynatree - remove unused cfme_changes_check

### DIFF
--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -31,8 +31,7 @@
                              :no_base_exp         => true,
                              :exp_tree            => false,
                              :highlighting        => true,
-                             :autoload            => true,
-                             :cfme_changes_check  => true})
+                             :autoload            => true})
       .modal-footer
         %div{:id => "include_domain_prefix_div"}
           %input#include_domain_prefix_chk{:onclick  => "miqOnClickIncludeDomainPrefix()",

--- a/app/views/layouts/_dynatree.html.haml
+++ b/app/views/layouts/_dynatree.html.haml
@@ -1,4 +1,3 @@
-- cfme_changes_check          ||= false
 - cfme_no_click               ||= false
 - click_url                   ||= false
 - cookie_id_prefix            ||= "treeOpenStatex"
@@ -26,7 +25,6 @@
     check_url = "#{check_url}"
   - if click_url
     ManageIQ.clickUrl = "#{click_url}";
-  cfme_changes_check = #{cfme_changes_check}
   - if session[:group_changed]
     miqDeleteDynatreeCookies();
     - session[:group_changed] = false

--- a/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
+++ b/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
@@ -21,5 +21,4 @@
               :no_tree_lines              =>  false,
               :tree_state                 =>  true,
               :cookie_id_prefix           => "edit_treeOpenStatex",
-              :multi_lines                =>  true,
-              :cfme_changes_check         =>  true})
+              :multi_lines                =>  true})

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -76,7 +76,6 @@
               :onclick                     => "miqOnClickTagCat",
               :enable_tree_images          => false,
               :exp_tree                    => false,
-              :cfme_changes_check          => true,
               :open_close_all_on_dbl_click => true})
   - when "create_snapshot"
     %h3

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -197,7 +197,6 @@
                                 :json_tree          => @ldap_ous_tree,
                                 :onclick            => "miqOnClickProvLdapOus",
                                 :click_url          => "/miq_request/prov_field_changed/#{click}",
-                                :cfme_changes_check => true,
                                 :cookie_id_prefix   => "prov_trees",
                                 :tree_state         => true})
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?


### PR DESCRIPTION
`cfme_changes_check` used to be a thing that meant something for dynatree .. now it's just dead code .. removing.

(Discovered as part of #9019)