### PR TITLE
CSRF ajaxSend code is dead - removed

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1216,20 +1216,6 @@ function miqSearchSpinner(status) {
   $('#searching_spinner_center').spin(status ? opts : false);
 }
 
-/*
- * Registers a callback which copies the csrf token into the
- * X-CSRF-Token header with each ajax request.  Necessary to
- * work with rails applications which have fixed
- * CVE-2011-0447
- */
-$(document).ajaxSend(function (event, request, settings) {
-  var csrf_meta_tag = $('#meta[name=csrf-token]')[0];
-  if (csrf_meta_tag) {
-    var header = 'X-CSRF-Token';
-    var token = csrf_meta_tag.readAttribute('content');
-  }
-});
-
 function miqProcessObserveQueue() {
   if (! ManageIQ.observe.queue.length) {
     return;


### PR DESCRIPTION
..and has been for more than a year ..

That functionality is now being handled by jquery-ujs...

(Discovered as part of #9019)