### PR TITLE
js - rename credentialsController -> CredentialsController

### DIFF
--- a/app/assets/javascripts/controllers/credentials/credentials_controller.js
+++ b/app/assets/javascripts/controllers/credentials/credentials_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('credentialsController', ['$scope', function($scope) {
+ManageIQ.angular.app.controller('CredentialsController', ['$scope', function($scope) {
   var init = function() {
     $scope.bChangeStoredPassword = undefined;
     $scope.bCancelPasswordChange = undefined;

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -16,7 +16,7 @@
 - verify_title_off       ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - ng_show_userid         ||= true
 
-%div{"ng-controller" => "credentialsController"}
+%div{"ng-controller" => "CredentialsController"}
   %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_userid.$invalid}"}
       %label.col-md-2.control-label{"for" => "#{prefix}_userid"}

--- a/app/views/layouts/angular/_auth_service_account_angular.html.haml
+++ b/app/views/layouts/angular/_auth_service_account_angular.html.haml
@@ -2,7 +2,7 @@
 - validate_url ||= 'log_depot_edit'
 - prefix ||= 'log'
 
-%div{"ng-controller" => "credentialsController"}
+%div{"ng-controller" => "CredentialsController"}
   %div{"ng-show" => ng_show}
     .form-group
       %label.col-md-2.control-label{"for" => "service_account"}

--- a/spec/javascripts/controllers/credentials/credentials_controller_spec.js
+++ b/spec/javascripts/controllers/credentials/credentials_controller_spec.js
@@ -1,4 +1,4 @@
-describe('credentialsController', function() {
+describe('CredentialsController', function() {
   var $scope, $controller, $httpBackend, miqService;
 
   beforeEach(module('ManageIQ'));
@@ -8,7 +8,7 @@ describe('credentialsController', function() {
     $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
     $scope.model = "hostModel";
-    $controller = _$controller_('credentialsController',
+    $controller = _$controller_('CredentialsController',
       {$http: $httpBackend, $scope: $scope, miqService: miqService});
   }));
 
@@ -20,7 +20,7 @@ describe('credentialsController', function() {
   describe('when formId is new', function() {
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
       $scope.formId = 'new';
-      $controller = _$controller_('credentialsController',
+      $controller = _$controller_('CredentialsController',
         {$http: $httpBackend, $scope: $scope, miqService: miqService});
     }));
     it('initializes stored password state flags for new records', function() {
@@ -33,7 +33,7 @@ describe('credentialsController', function() {
   describe('when formId is not new', function() {
     beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_) {
       $scope.formId = '12345';
-      $controller = _$controller_('credentialsController',
+      $controller = _$controller_('CredentialsController',
         {$http: $httpBackend, $scope: $scope, miqService: miqService});
     }));
     it('initializes stored password state flags for existing records', function() {


### PR DESCRIPTION
Angular controllers should be named with a starting capital letter.. renaming `credentialsController` to `CredentialsController` - for consistency with the rest...

(Discovered as part of #9019)