### PR TITLE
timer_option_service - use _.flatten instead of $.map + identity

### DIFF
--- a/app/assets/javascripts/services/timer_option_service.js
+++ b/app/assets/javascripts/services/timer_option_service.js
@@ -21,15 +21,12 @@ ManageIQ.angular.app.service('timerOptionService', function() {
     return timeData;
   };
 
-  var hourlyTimeOptions = [
+  var hourlyTimeOptions = _.flatten([
     timeDataBuilder("Hours", 4),
     timeObject("Hours", 6),
     timeObject("Hours", 8),
     timeObject("Hours", 12)
-  ];
-  hourlyTimeOptions = $.map(hourlyTimeOptions, function(n){
-    return n;
-  });
+  ]);
 
   this.timerOptions = {
     "Once": [],


### PR DESCRIPTION
Fix a confusing use of using `map` with an identity function .. jQuery's `map` automatically flattens, and it was indeed introduced in d982fd3e to replace prototype's `flatten` .. but explicitly using `_.flatten` shows the intent more clearly..

(Discovered as part of #9019)