### PR TITLE
NetworkTopologyController - fix dead case for FloatingIp

### DIFF
--- a/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/network_topology/network_topology_controller.js
@@ -251,7 +251,8 @@ function NetworkTopologyCtrl($scope, $http, $interval, $location, topologyServic
     switch (d.item.kind) {
       case "NetworkManager":
         return { x: -20, y: -20, r: 28 };
-      case "FloatingIp", "Tag":
+      case "FloatingIp":
+      case "Tag":
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: 13 };
       case "NetworkRouter":
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: defaultDimensions.r };


### PR DESCRIPTION
`case "FloatingIp", "Tag"` *looks* like it should handle both things, but that's a rubyism, in JS, it's evaluated as a comma expression, which always returns the last value, thus, `"FloatingIp"` was ignored.

FYI @Ladas (a265e769) ;)

(Discovered as part of #9019)