### PR TITLE
JS - toggle_expansion - fix shadowed param

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1644,7 +1644,7 @@ function miqHideSearchClearButton() {
 }
 
 function toggle_expansion(link) {
-  var link = $(link);
+  link = $(link);
   link.find("i").toggleClass("fa-angle-right fa-angle-down");
   link.closest('td').children(0).toggleClass("expanded");
 }


### PR DESCRIPTION
`toggle_expansion(link)` would always ignore it's `link` argument, because of a stray `var` - so the whole function does nothing.

(Because `function(foo) { var foo = foo; return foo; }` is always `undefined`)

(Discovered as part of #9019)