### PR TITLE
Use the token service that we initialize with

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -136,6 +136,8 @@ class ApiController < ApplicationController
     Api::Settings.collections
   end
 
+  delegate :user_token_service, :to => self
+
   def initialize
     @config          = Api::Settings.data
     @module          = base_config[:module]
@@ -145,7 +147,6 @@ class ApiController < ApplicationController
     @prefix          = "/#{@module}"
     @req             = {}      # To store API request details by parse_api_request
     @api_config      = VMDB::Config.new("vmdb").config[@module.to_sym] || {}
-    @api_user_token_service = ApiUserTokenService.new(@config)
   end
 
   #

--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -6,7 +6,7 @@ class ApiController
 
     def show_auth
       requester_type = fetch_and_validate_requester_type
-      auth_token = @api_user_token_service.generate_token(@auth_user, requester_type)
+      auth_token = user_token_service.generate_token(@auth_user, requester_type)
       res = {
         :auth_token => auth_token,
         :token_ttl  => api_token_mgr.token_get_info(@module, auth_token, :token_ttl),
@@ -115,7 +115,7 @@ class ApiController
 
     def fetch_and_validate_requester_type
       requester_type = params['requester_type']
-      @api_user_token_service.validate_requester_type(requester_type)
+      user_token_service.validate_requester_type(requester_type)
       requester_type
     rescue => err
       raise BadRequestError, err.to_s
@@ -191,7 +191,7 @@ class ApiController
     end
 
     def api_token_mgr
-      @api_user_token_service.token_mgr
+      user_token_service.token_mgr
     end
   end
 end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -19,6 +19,10 @@ class ApiController
         @encrypted_objects_checked[klass].each { |attr| @attr_encrypted[attr] = true }
       end
 
+      def user_token_service
+        @api_user_token_service
+      end
+
       private
 
       def log_kv(key, val, pref = "")
@@ -41,7 +45,7 @@ class ApiController
 
         $api_log.info("")
         $api_log.info("Dynamic Configuration")
-        @api_user_token_service.api_config.each { |key, val| log_kv(key, val) }
+        user_token_service.api_config.each { |key, val| log_kv(key, val) }
       end
 
       #


### PR DESCRIPTION
The API initializer creates a new token service, but appears to only use
it to log some things about the environment. Each new request will
create another token service. This change allows ApiController instances
to use the class level token service instead.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 