### PR TITLE
Add support for metric collection in the Google provider

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -5,6 +5,8 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :Flavor
   require_nested :Provision
   require_nested :ProvisionWorkflow
+  require_nested :MetricsCapture
+  require_nested :MetricsCollectorWorker
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher

--- a/app/models/manageiq/providers/google/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/metrics_capture.rb
@@ -1,0 +1,200 @@
+class ManageIQ::Providers::Google::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  # List of counters we expose to the caller
+  VIM_STYLE_COUNTERS = {
+    "cpu_usage_rate_average"  => {
+      :counter_key           => "cpu_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "percent",
+      :capture_interval_name => "realtime"
+    },
+    "disk_usage_rate_average" => {
+      :counter_key           => "disk_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "kilobytespersecond",
+      :capture_interval_name => "realtime"
+    },
+    "net_usage_rate_average"  => {
+      :counter_key           => "net_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "kilobytespersecond",
+      :capture_interval_name => "realtime"
+    }
+  }.freeze
+
+  # Mapping from VIM counter name to our local descriptor. This describes how
+  # to translate a google metric into the corresponding ManageIQ metric.
+  #
+  # See the first schema for a description of each field.
+  VIM_COUNTER_SCHEMAS = [
+    {
+      # Name of the VIM_STYLE_COUNTER this schema describes
+      :vim_counter_name        => "cpu_usage_rate_average",
+
+      # List of metric names in GCP that should be retrieved to calculate the
+      # vim-style metric
+      :google_metric_names     => ["compute.googleapis.com/instance/cpu/utilization"],
+
+      # A function that maps a target to a list of google labels to be applied
+      # to the request. Only results matching the label are returned.
+      :target_to_google_labels => ->(target) { ["compute.googleapis.com/resource_id==#{target.ems_ref}"] },
+
+      # Function that maps a point returned by Google's monitoring api (which
+      # is a hash data structure; see
+      # https://cloud.google.com/monitoring/v2beta2/timeseries) to our counter
+      # value. Any unit transformations are applied as well.
+      :point_to_val            => ->(point) { point["doubleValue"].to_f * 100 },
+
+      # Function that takes two points and reduces them to one. This is used
+      # when multiple points are found for the same data point in the same
+      # query (e.g. if we are querying disk usage and the host has multiple
+      # disks, this method is used to combine the points into a single metric)
+      :reducer                 => lambda do |x, _|
+        _log.warn("Received multiple values for cpu_usage; ignoring duplicates")
+        x
+      end
+    },
+    {
+      :vim_counter_name        => "disk_usage_rate_average",
+      :google_metric_names     => ["compute.googleapis.com/instance/disk/read_bytes_count",
+                                   "compute.googleapis.com/instance/disk/write_bytes_count"],
+      :target_to_google_labels => ->(target) { ["compute.googleapis.com/resource_id==#{target.ems_ref}"] },
+      :point_to_val            => ->(point) { point["int64Value"].to_i / (60.0 * 1024.0) }, # convert from b/m to Kb/s
+      :reducer                 => ->(x, y) { x + y },
+    },
+    {
+      :vim_counter_name        => "net_usage_rate_average",
+      :google_metric_names     => ["compute.googleapis.com/instance/network/received_bytes_count",
+                                   "compute.googleapis.com/instance/network/sent_bytes_count"],
+      :target_to_google_labels => ->(target) { ["compute.googleapis.com/resource_id==#{target.ems_ref}"] },
+      :point_to_val            => ->(point) { point["int64Value"].to_i / (60.0 * 1024.0) }, # convert from b/m to Kb/s
+      :reducer                 => ->(x, y) { x + y },
+    }
+  ].freeze
+
+  def perf_collect_metrics(_interval_name, start_time = nil, end_time = nil)
+    raise "No EMS defined" if target.ext_management_system.nil?
+
+    # Currently we only know how to capture VMs
+    return [{}, {}] unless target.type == ManageIQ::Providers::Google::CloudManager::Vm.name
+
+    end_time   ||= Time.now.utc
+    end_time     = end_time.utc
+    start_time ||= end_time - 4.hours # 4 hours for symmetry with VIM (still needed?)
+    start_time   = start_time.utc
+
+    counter_values_by_ts = {}
+    target.ext_management_system.with_provider_connection(:service => 'monitoring') do |google|
+      VIM_COUNTER_SCHEMAS.each do |schema|
+        collect_metrics(google, start_time, end_time, schema, counter_values_by_ts)
+      end
+    end
+
+    # Now that we've collected the data, transform it into 20-second metrics
+    # by interpolation. For now we just set the interpolated value to the
+    # value at the closest minute rounded-down.
+    #
+    # Note that we can do this because all three VM metrics are "gauge" style
+    # metrics - a delta metric would require further transformation.
+    add_20_second_interpolated_points(counter_values_by_ts, end_time)
+
+    counters_by_id              = {target.ems_ref => VIM_STYLE_COUNTERS}
+    counter_values_by_id_and_ts = {target.ems_ref => counter_values_by_ts}
+
+    return counters_by_id, counter_values_by_id_and_ts
+  end
+
+  # Lookup and retrieve a metric from Google Cloud, storing it in the
+  # 'counter_values_by_ts' hash. Note that this method retrieves, transforms
+  # and collects a metric according to a metric schema (see
+  # VIM_COUNTER_SCHEMAS for examples).
+  #
+  # @param google [Fog::Google::Monitoring] monitoring client instance to use
+  #   for retrieving metrics
+  # @param start_time [Time] the earliest point to query
+  # @param end_time [Time] the latest point to query
+  # @param schema [Hash] schema describing metric to query (see
+  #   VIM_STYLE_COUNTERS definition for a description)
+  # @param counter_values_by_ts [Hash{Time => Hash{String => Number}}] hash to
+  #   aggregate metrics onto (will be modified by method)
+  # @return nil
+  def collect_metrics(google, start_time, end_time, schema, counter_values_by_ts)
+    schema[:google_metric_names].each do |google_metric_name|
+      options = {
+        :labels => schema[:target_to_google_labels].call(target),
+        :oldest => start_time.to_datetime.rfc3339,
+      }
+      # Make our service call for metrics; Note that we might get multiple
+      # time series back (for example, if the host has multiple disks/network
+      # cards)
+      tss = google.timeseries_collection.all(google_metric_name, end_time.to_datetime.rfc3339, options)
+
+      tss.each do |ts|
+        collect_time_series_metrics(ts, schema, counter_values_by_ts)
+      end
+    end
+  end
+
+  # Collect the metrics from a time series returned by Google cloud into the
+  # provided 'counter_values_by_ts' hash, using the provided schema.
+  #
+  # @param time_series [Hash] resource returned by GCP describing a metric
+  #   lookup result (see https://cloud.google.com/monitoring/v2beta2/timeseries)
+  # @param schema [Hash] schema describing the metric to query (see
+  #   VIM_STYLE_COUNTERS definition for a description)
+  # @param counter_values_by_ts [Hash{Time => Hash{String => Number}}] hash to
+  #   aggregate metrics onto (will be modified by method)
+  # @return nil
+  def collect_time_series_metrics(time_series, schema, counter_values_by_ts)
+    time_series.points.each do |point|
+      # Parse out the time object and set it to the beginning of the
+      # minute; this allows us to sum up points across time series that may
+      # have landed on different seconds. Note this only holds true for
+      # 1-minute metrics.
+      timestamp = Time.zone.parse(point["start"]).beginning_of_minute
+      val = schema[:point_to_val].call(point)
+
+      # If we already have a value, reduce using our reduction function
+      prev_val = counter_values_by_ts.fetch_path(timestamp, schema[:vim_counter_name])
+      unless prev_val.nil?
+        val = schema[:reducer].call(prev_val, val)
+      end
+
+      counter_values_by_ts.store_path(timestamp, schema[:vim_counter_name], val)
+    end
+  end
+
+  # Transform a provided counter_values_by_ts struct by interpolating values
+  # for the :20 and :40 suffixes. Note that this method assumes the value for
+  # interpolation lies on the :00 suffix. Also note this is only correct for a
+  # gauge-style metric.
+  #
+  # @param counter_values_by_ts [Hash{Time => Hash{String => Number}}] hash to
+  #   interpolate metrics onto (will be modified by method)
+  # @param end_time [Time] time that points will not be interpolated beyond
+  # @return nil
+  def add_20_second_interpolated_points(counter_values_by_ts, end_time)
+    counter_values_by_ts.keys.each do |ts|
+      # Skip any already interpolated values
+      next if ts.sec != 0
+
+      # Create a :20 and a :40 entry for every counter name
+      counter_values_by_ts[ts].each do |counter_name, counter_val|
+        [ts + 20.seconds, ts + 40.seconds].each do |interpolated_ts|
+          # Make sure we don't interpolate past our requested range
+          next if interpolated_ts > end_time
+
+          counter_values_by_ts.store_path(interpolated_ts, counter_name, counter_val)
+        end
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/metrics_collector_worker.rb
@@ -1,0 +1,10 @@
+class ManageIQ::Providers::Google::CloudManager::MetricsCollectorWorker <
+  ManageIQ::Providers::BaseManager::MetricsCollectorWorker
+  require_nested :Runner
+
+  self.default_queue_name = "google"
+
+  def friendly_name
+    @friendly_name ||= "C&U Metrics Collector for Google"
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Google::CloudManager::MetricsCollectorWorker::Runner <
+  ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
+end

--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -51,6 +51,8 @@ module ManageIQ::Providers::Google::ManagerMixin
         ::Fog::Compute.new(config)
       when 'pubsub'
         ::Fog::Google::Pubsub.new(config.except(:provider))
+      when 'monitoring'
+        ::Fog::Google::Monitoring.new(config.except(:provider))
       else
         raise ArgumentError, "Unknown service: #{options[:service]}"
       end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -7,6 +7,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Redhat::InfraManager::MetricsCollectorWorker
     ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
     ManageIQ::Providers::Openshift::ContainerManager::MetricsCollectorWorker
+    ManageIQ::Providers::Google::CloudManager::MetricsCollectorWorker
     ManageIQ::Providers::Atomic::ContainerManager::MetricsCollectorWorker
     ManageIQ::Providers::OpenshiftEnterprise::ContainerManager::MetricsCollectorWorker
     ManageIQ::Providers::AtomicEnterprise::ContainerManager::MetricsCollectorWorker
@@ -75,6 +76,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Redhat::InfraManager::MetricsCollectorWorker
     ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
     ManageIQ::Providers::Openshift::ContainerManager::MetricsCollectorWorker
+    ManageIQ::Providers::Google::CloudManager::MetricsCollectorWorker
     ManageIQ::Providers::Atomic::ContainerManager::MetricsCollectorWorker
     ManageIQ::Providers::OpenshiftEnterprise::ContainerManager::MetricsCollectorWorker
     ManageIQ::Providers::AtomicEnterprise::ContainerManager::MetricsCollectorWorker

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1193,6 +1193,7 @@
         :ems_metrics_collector_worker_amazon: {}
         :ems_metrics_collector_worker_atomic: {}
         :ems_metrics_collector_worker_atomic_enterprise: {}
+        :ems_metrics_collector_worker_google: {}
         :ems_metrics_collector_worker_kubernetes:
           :metrics_port: 5000
           :metrics_path: "/hawkular/metrics"

--- a/spec/models/manageiq/providers/google/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/metrics_capture_spec.rb
@@ -1,0 +1,205 @@
+require 'fog/google'
+
+describe ManageIQ::Providers::Google::CloudManager::MetricsCapture do
+  let(:ems) { FactoryGirl.create(:ems_google) }
+  let(:vm) { FactoryGirl.build(:vm_google, :ext_management_system => ems, :ems_ref => "my_ems_ref") }
+
+  context "#perf_collect_metrics" do
+    it "raises an error when no EMS is defined" do
+      vm = FactoryGirl.build(:vm_google, :ext_management_system => nil)
+      expect { vm.perf_collect_metrics('interval_name') }.to raise_error(RuntimeError, /No EMS defined/)
+    end
+
+    it "returns [{},{}] when target is not a vm" do
+      template = FactoryGirl.build(:template_google, :ext_management_system => ems)
+      expect(template.perf_collect_metrics('interval_name')).to eq([{}, {}])
+    end
+
+    it "has definitions for cpu, network and disk metrics" do
+      # Don't stage any metrics
+      stage_metrics({})
+
+      counters_by_id, = vm.perf_collect_metrics('interval_name')
+
+      expect(counters_by_id).to have_key("my_ems_ref")
+      expect(counters_by_id["my_ems_ref"]).to have_key("cpu_usage_rate_average")
+      expect(counters_by_id["my_ems_ref"]).to have_key("disk_usage_rate_average")
+      expect(counters_by_id["my_ems_ref"]).to have_key("net_usage_rate_average")
+    end
+
+    it "parses and handles cpu metrics" do
+      # Stage a single cpu metric
+      stage_metrics(
+        "compute.googleapis.com/instance/cpu/utilization" => [
+          {
+            "points" => [
+              {
+                "start"       => "2016-06-23T00:00:00.000Z",
+                "doubleValue" => "0.42"
+              }
+            ]
+          }
+        ]
+      )
+
+      _, counter_values_by_id_and_ts = vm.perf_collect_metrics('interval_name')
+
+      expect(counter_values_by_id_and_ts).to eq(
+        "my_ems_ref" => {
+          Time.zone.parse("2016-06-23T00:00:00.000Z") => {
+            "cpu_usage_rate_average" => 42.0
+          },
+          Time.zone.parse("2016-06-23T00:00:20.000Z") => {
+            "cpu_usage_rate_average" => 42.0
+          },
+          Time.zone.parse("2016-06-23T00:00:40.000Z") => {
+            "cpu_usage_rate_average" => 42.0
+          }
+        }
+      )
+    end
+
+    it "parses and aggregates multiple disks" do
+      stage_metrics(
+        "compute.googleapis.com/instance/disk/read_bytes_count" => [
+          { # Disk 1
+            "points" => [
+              {
+                "start"      => "2016-06-23T00:00:00.000Z",
+                "int64Value" => "7864020"
+              }
+            ]
+          },
+          { # Disk 2
+            "points" => [
+              {
+                "start"      => "2016-06-23T00:00:00.000Z",
+                "int64Value" => "300"
+              }
+            ]
+          }
+        ]
+      )
+
+      _, counter_values_by_id_and_ts = vm.perf_collect_metrics('interval_name')
+
+      expect(counter_values_by_id_and_ts).to eq(
+        "my_ems_ref" => {
+          Time.zone.parse("2016-06-23T00:00:00.000Z") => {
+            "disk_usage_rate_average" => 128.0 # 7864320 bytes/min = 128 kb/s
+          },
+          Time.zone.parse("2016-06-23T00:00:20.000Z") => {
+            "disk_usage_rate_average" => 128.0
+          },
+          Time.zone.parse("2016-06-23T00:00:40.000Z") => {
+            "disk_usage_rate_average" => 128.0
+          }
+        }
+      )
+    end
+
+    it "parses and aggregates read and write on disk" do
+      stage_metrics(
+        "compute.googleapis.com/instance/disk/read_bytes_count"  => [
+          {
+            "points" => [
+              {
+                "start"      => "2016-06-23T00:00:00.000Z",
+                "int64Value" => "982252"
+              }
+            ]
+          },
+        ],
+        "compute.googleapis.com/instance/disk/write_bytes_count" => [
+          {
+            "points" => [
+              {
+                "start"      => "2016-06-23T00:00:00.000Z",
+                "int64Value" => "788"
+              }
+            ]
+          },
+        ]
+      )
+
+      _, counter_values_by_id_and_ts = vm.perf_collect_metrics('interval_name')
+
+      expect(counter_values_by_id_and_ts).to eq(
+        "my_ems_ref" => {
+          Time.zone.parse("2016-06-23T00:00:00.000Z") => {
+            "disk_usage_rate_average" => 16.0 # 983040 bytes/min = 16 kb/s
+          },
+          Time.zone.parse("2016-06-23T00:00:20.000Z") => {
+            "disk_usage_rate_average" => 16.0
+          },
+          Time.zone.parse("2016-06-23T00:00:40.000Z") => {
+            "disk_usage_rate_average" => 16.0
+          }
+        }
+      )
+    end
+
+    it "parses and aggregates read and write on network" do
+      stage_metrics(
+        "compute.googleapis.com/instance/network/received_bytes_count" => [
+          {
+            "points" => [
+              {
+                "start"      => "2016-06-23T00:00:00.000Z",
+                "int64Value" => "982252"
+              }
+            ]
+          },
+        ],
+        "compute.googleapis.com/instance/network/sent_bytes_count"     => [
+          {
+            "points" => [
+              {
+                "start"      => "2016-06-23T00:00:00.000Z",
+                "int64Value" => "788"
+              }
+            ]
+          },
+        ]
+      )
+
+      _, counter_values_by_id_and_ts = vm.perf_collect_metrics('interval_name')
+
+      expect(counter_values_by_id_and_ts).to eq(
+        "my_ems_ref" => {
+          Time.zone.parse("2016-06-23T00:00:00.000Z") => {
+            "net_usage_rate_average" => 16.0  # 983040 bytes/min = 16 kb/s
+          },
+          Time.zone.parse("2016-06-23T00:00:20.000Z") => {
+            "net_usage_rate_average" => 16.0
+          },
+          Time.zone.parse("2016-06-23T00:00:40.000Z") => {
+            "net_usage_rate_average" => 16.0
+          }
+        }
+      )
+    end
+  end
+
+  def stage_metrics(metrics)
+    timeseries_collection = double("timeseries_collection")
+    # By default, missing metrics return empty lists
+    allow(timeseries_collection).to receive(:all) { [] }
+
+    # Annoyingly fog returns an object for each time series rather than a hash
+    # so we're forced to use test doubles here
+    metrics.each do |metric_name, tss|
+      time_series_list = []
+      tss.each do |ts|
+        time_series = double(:points => ts["points"])
+        time_series_list << time_series
+      end
+      allow(timeseries_collection).to receive(:all).with(metric_name, anything, anything) { time_series_list }
+    end
+
+    # Create a monitoring double and ensure it gets used instead of the real client
+    monitoring = double("::Fog::Google::Monitoring")
+    allow(monitoring).to receive(:timeseries_collection) { timeseries_collection }
+    allow(::Fog::Google::Monitoring).to receive(:new) { monitoring }
+  end
+end


### PR DESCRIPTION
This adds support for metric collection in the GCP provider. The metrics collected are cpu, network and disk.

Note that the tests are currently pretty weak; I'm working on that now to hopefully provide more coverage, so this PR might get updated. Also, while I'm able to force metrics to get collected via the UI by pressing the C&U refresh button, I haven't yet figured out how to make ManageIQ collect metrics in the background automatically.  Any tips?
