### PR TITLE
Handle URI::InvalidComponentError in the File.path_to_uri method

### DIFF
--- a/gems/pending/spec/util/miq-file_spec.rb
+++ b/gems/pending/spec/util/miq-file_spec.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'util/extensions/miq-file'
 
 describe 'MIQFile' do
@@ -29,6 +30,17 @@ describe 'MIQFile' do
     it 'handles an IPv6 hostname as expected' do
       hostname = '::1'
       expect(File.path_to_uri('foo', hostname)).to eql("file://[#{hostname}]/foo")
+    end
+
+    it 'handles a UNC path as expected' do
+      file = "//foo/bar/baz"
+      expect(File.path_to_uri(file, hostname)).to eql("file://#{hostname}/#{file}")
+    end
+
+    it 'handles a volume name as expected' do
+      file = "///?/Volume{xxx-yyy-42zzz-1111-222233334444}/"
+      encoded_file = URI.encode(file)
+      expect(File.path_to_uri(file, hostname)).to eql("file://#{hostname}/#{encoded_file}")
     end
 
     it 'requires at least one argument' do

--- a/gems/pending/util/extensions/miq-file.rb
+++ b/gems/pending/util/extensions/miq-file.rb
@@ -53,12 +53,17 @@ class File
 
   def self.path_to_uri(file, hostname = nil)
     hostname ||= MiqSockUtil.getFullyQualifiedDomainName
+    file = Addressable::URI.encode(file.tr('\\', '/'))
 
-    URI::Generic.build(
-      :scheme => 'file',
-      :host   => hostname,
-      :path   => "/#{Addressable::URI.encode(file.tr('\\', '/'))}"
-    ).to_s
+    begin
+      URI::Generic.build(
+        :scheme => 'file',
+        :host   => hostname,
+        :path   => "/#{file}"
+      ).to_s
+    rescue URI::InvalidComponentError # Punt on Windows volume names, etc
+      "file://#{hostname}/#{file}"
+    end
   end
 
   def self.uri_to_local_path(uri_path)


### PR DESCRIPTION
This updates the File.path_to_uri method so that it punts on invalid component errors and defaults to a simpler string generation approach.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1347406.

Primarily this is to deal with Windows volume names as paths. I've also added specs for sample volumes and UNC paths.