### PR TITLE
Consolidate api_settings with api.yml

### DIFF
--- a/app/controllers/api_controller/settings.rb
+++ b/app/controllers/api_controller/settings.rb
@@ -17,7 +17,7 @@ class ApiController
     private
 
     def exposed_settings
-      @exposed_settings ||= YAML.load_file(Rails.root.join("config/api_settings.yml"))[:settings]
+      Api::Settings.collections[:settings][:categories]
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1159,6 +1159,8 @@
     :options:
     - :collection
     :methods: *70174834086080
+    :categories:
+      - product
     :collection_actions:
       :get:
       - :name: read

--- a/config/api_settings.yml
+++ b/config/api_settings.yml
@@ -1,3 +1,0 @@
----
-:settings:
-  - product

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -2,8 +2,7 @@
 # REST API Request Tests - /api/settings
 #
 describe ApiController do
-  let(:api_settings_config_file) { Rails.root.join("config/api_settings.yml") }
-  let(:api_settings)             { YAML.load_file(api_settings_config_file)[:settings] }
+  let(:api_settings) { Api::Settings.collections[:settings][:categories] }
 
   context "Settings Queries" do
     it "tests queries of all exposed settings" do


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq/pull/9330. Having
Api::Settings and an unrelated api_settings.yml could be confusing.