### PR TITLE
Allow for local middleware settings in intializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ config/apache
 config/database.yml*
 config/vmdb.yml.db
 
+config/initializers/*.local.rb
+
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml


### PR DESCRIPTION
Purpose or Intent
-----------------
For performance, debugging, and feature building setups, many developers working will have different setups and configurations that they prefer to use when working on a task.  Many of which require being hooked into the Rails Environment and customized through an initializer.  By including this, we can remove intitializers like `config/initializers/rack_ruby_prof.rb` and allow developers to include it themselves, if they so choose.

Example gems where this would be necessary:

- `pry`
- `ruby-prof`
- `stackprof`
- etc.

And other situations like being able to find the call-stack for a SQL query on a given page, you could do this for example:

```ruby
**config/intialitzers/sql_call_stack.local.rb**

if ENV['AR_CALL_STACK']
  ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, details|
    if details[:sql] =~ /services/
      puts caller.join("\n")
      puts "*" * 50
    end
  end
end
```

And it would display a stack trace in the rails server output for you.


**TODO**

- [ ] Documentaion/generators for common modifications
- [ ] Remove dev initializers that can be converted to `.local.rb` files


Links
-----
* https://github.com/ManageIQ/manageiq/blob/45a606b/config/initializers/rack_ruby_prof.rb


Steps for Testing/QA
--------------------
If you want to test this out because you don't trust me (honestly, I don't trust me), you can do:

* Checkout this branch
  
* Add a file like `config/initializers/my_init.local.rb` with something like:
  
  ```
  puts "\n\n\n\n"
  puts "Hello World!
  puts "\n\n\n\n"
  ```
  
* Run `bin/rails s` and confirm that the "Hello World" message is displayed
  
* Confirm that `git status` doesn't include the new file you added