### PR TITLE
Resolve missing buttons from refactorings #9179 & #9171

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
-  def included(included_class)
-    button_group('instance_operations', [
-      select(
+  def self.included(included_class)
+    included_class.button_group('instance_operations', [
+      included_class.select(
         :instance_power_choice,
         'fa fa-power-off fa-lg',
         N_('Instance Power Functions'),
@@ -56,7 +56,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Resume'),
             :image   => "power_resume",
             :confirm => N_("Resume this Instance?")),
-          separator,
+          included_class.separator,
           included_class.button(
             :instance_guest_restart,
             nil,

--- a/app/helpers/application_helper/toolbar/configured_system/lifecycle_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/lifecycle_mixin.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper::Toolbar::ConfiguredSystem::LifecycleMixin
-  def included(included_class)
-    button_group('provider_foreman_lifecycle', [
-      select(
+  def self.included(included_class)
+    included_class.button_group('provider_foreman_lifecycle', [
+      included_class.select(
         :provider_foreman_lifecycle_choice,
         'fa fa-recycle fa-lg',
         t = N_('Lifecycle'),

--- a/app/helpers/application_helper/toolbar/configured_system/policy_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/policy_mixin.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper::Toolbar::ConfiguredSystem::PolicyMixin
-  def included(included_class)
-    button_group('provider_foreman_policy', [
-      select(
+  def self.included(included_class)
+    included_class.button_group('provider_foreman_policy', [
+      included_class.select(
         :provider_foreman_policy_choice,
         'fa fa-shield fa-lg',
         t = N_('Policy'),


### PR DESCRIPTION
The `included` hook is on the module itself.  This caused the module to be loaded, but the `included` method was never run because it was in the wrong scope.