### PR TITLE
Ansible extra variables missing when called from button

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -35,6 +35,9 @@ class LaunchAnsibleJob
   end
 
   def object_vars(object, ext_vars)
+    # We are traversing the list twice because the object.attributes is a DrbObject
+    # and when we use each_with_object on a DrbObject, it doesn't seem to update the
+    # hash. We are investigating that
     key_list = object.attributes.keys.select { |k| k.start_with?('param', 'dialog_param') }
     key_list.each_with_object(ext_vars) do |key, hash|
       if key.start_with?('param')

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -35,13 +35,14 @@ class LaunchAnsibleJob
   end
 
   def object_vars(object, ext_vars)
-    object.attributes.each_with_object(ext_vars) do |(key, value), hash|
+    key_list = object.attributes.keys.select { |k| k.start_with?('param', 'dialog_param') }
+    key_list.each_with_object(ext_vars) do |key, hash|
       if key.start_with?('param')
-        match_data = ANSIBLE_VAR_REGEX.match(value)
+        match_data = ANSIBLE_VAR_REGEX.match(object[key])
         hash[match_data[1].strip] ||= match_data[2] if match_data
       else
         match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
-        hash[match_data[1]] = value if match_data
+        hash[match_data[1]] = object[key] if match_data
       end
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
When called from a button the Ansible extra variables were not being passed to the job.

This PR is undoing some of the changes done in a earlier PR #9306 

This is a temporary solution to workaround hash not getting updated when we call each_with_object on a  DRb::DRbObject
e.g.
object.attributes.each_with_object({}) do |(key,value), hash|
  hash[key] = value if key.starts_with?('param')
end

In the above case object.attributes is a DRb::DrbObject

Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1348232
> * This was broken after PR #9306 

