### PR TITLE
Properly group OR expressions

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1692,7 +1692,7 @@ class MiqExpression
         result << arel
       end
       first, *rest = operands
-      rest.inject(first) { |lhs, rhs| Arel::Nodes::Or.new(lhs, rhs) }
+      rest.inject(first) { |lhs, rhs| lhs.or(rhs) }
     when "not", "!"
       Arel::Nodes::Not.new(to_arel(exp[operator], tz))
     when "is null"


### PR DESCRIPTION
There was a regression in converting some of this code to Arel where OR
expressions were not being grouped properly. So an expression that was
previously expressing:

```
a AND (b OR c)
```

would now say:

```
a AND b OR c
```

Fortunately, since all the expressions are expressed in Arel now, the
fix can be made using Arel's DSL:

```ruby
node.or(other_node)
```

Fixes https://github.com/ManageIQ/manageiq/issues/9427

@miq-bot add-label core, bug
@miq-bot assign @gtanzillo 
/cc @jrafanie 