### PR TITLE
Upgrade to jquery-rails 4.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ end
 gem "angular-ui-bootstrap-rails",     "~>0.13.0"
 gem "codemirror-rails",               "=4.2"
 gem "jquery-hotkeys-rails"
-gem "jquery-rails",                   "~>4.0.4"
+gem "jquery-rails",                   "~>4.1.1"
 gem "jquery-rjs",                     "=0.1.1",                       :git => "git://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"
 gem "lodash-rails",                   "~>3.10.0"
 # gem "patternfly-sass",                "~>3.4.0"


### PR DESCRIPTION
This solves a dependency conflict between jquery-rails and Rails 5.rc2:

```
Bundler could not find compatible versions for gem "rails-dom-testing":
  In Gemfile:
    rails (~> 5.0.x) was resolved to 5.0.0.rc2, which depends on
      actionmailer (= 5.0.0.rc2) was resolved to 5.0.0.rc2, which depends on
        rails-dom-testing (~> 2.0)

    jquery-rails (~> 4.0.4) was resolved to 4.0.4, which depends on
      rails-dom-testing (~> 1.0)
```