### PR TITLE
Pass cols into Rbac.search() options to improve AAARM performance

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -192,6 +192,7 @@ module MiqReport::Generator
     ext_options = {:tz => tz, :time_profile => time_profile}
     # TODO: these columns need to be converted to real SQL columns
     # only_cols = cols
+    ext_options[:only_cols] = cols
     self.extras ||= {}
 
     if custom_results_method
@@ -279,6 +280,7 @@ module MiqReport::Generator
           :include_for_find => includes,
           :where_clause     => where_clause,
           :results_format   => :objects,
+          :ext_options      => ext_options
         )
       )
       results = Metric::Helper.remove_duplicate_timestamps(results)


### PR DESCRIPTION
The purpose of this PR is to pass again the ext_options[:only_cols] into the Rbac.search() call.
On this way, classes based on ActsAsArModel will benefit of knowing which cols are fetched on the query.
This is very beneficial for LiveMetrics as an example, without only_cols parameters, for a model it needs to fetch all available cols, with only_cols, this query can be improved and only make the calls necessary for the report which means a significant performance improvement.
@kbrock this is the suggestion we were discussing yesterday, I guess it is more clear to have it on a PR for review things.
I guess this change is harmless to others models, but it can mean a good improvement in our model for the middleware provider.
Please could you review it ?
Or perhaps there is an easy way to accomplish the same goal, I am afraid that my knowledge of the rbac design is limited and perhaps I may miss something.
Thanks.