### PR TITLE
Add MiddlewareServer into Alerts Profiles

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -492,6 +492,10 @@ module UiConstants
                       {:tables => ui_lookup(:tables => "miq_server")}
                     end,
   }
+  ASSIGN_TOS["MiddlewareServer"] = {
+    "enterprise"        => _("The Enterprise"),
+    "middleware_server" => _("Selected %{tables}") % {:tables => ui_lookup(:tables => "middleware_server")}
+  }
 
   # This set of assignments was created for chargeback_rates
   ASSIGN_TOS[:chargeback_storage] = ASSIGN_TOS["Storage"]

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -19,6 +19,7 @@ class MiqAlert < ApplicationRecord
     EmsCluster
     ExtManagementSystem
     MiqServer
+    MiddlewareServer
   )
 
   def self.base_tables

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -148,6 +148,10 @@ class Zone < ApplicationRecord
     ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::MiddlewareManager }
   end
 
+  def middleware_servers
+    ems_middlewares.flat_map(&:middleware_servers)
+  end
+
   def ems_clouds
     ext_management_systems.select { |e| e.kind_of? EmsCloud }
   end


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1662329/16332048/1d0cd8b0-39f4-11e6-9f30-57c549873a58.png)
![image](https://cloud.githubusercontent.com/assets/1662329/16332068/3dc4ea5c-39f4-11e6-8264-fd39ad869d7a.png)
This PR is the first of a series with the goal to add support for alerts based on Middleware models.
This one enables MiddlewareServer on alerts profile and lets to define a new alert based on MiddlewareServer models.
