### PR TITLE
MiqApache::Conf - update SSUI redirects to allow bower_components/ and gettext/

### DIFF
--- a/gems/pending/spec/util/miq_apache/conf_spec.rb
+++ b/gems/pending/spec/util/miq_apache/conf_spec.rb
@@ -40,7 +40,7 @@ describe MiqApache::Conf do
     it "sets root balancer correctly" do
       default_options = {:cluster => 'evmcluster_ui', :redirects => %w(/)}
       output = MiqApache::Conf.create_redirects_config(default_options).lines.to_a
-      expect(output).to include("RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts)) /self_service/index.html [L]\n")
+      expect(output).to include("RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts|bower_components|gettext)) /self_service/index.html [L]\n")
       expect(output).to include("RewriteCond \%{REQUEST_URI} !^/proxy_pages\n")
       expect(output).to include("RewriteCond \%{REQUEST_URI} !^/saml2\n")
       expect(output).to include("RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n")

--- a/gems/pending/util/miq_apache/miq_apache.rb
+++ b/gems/pending/util/miq_apache/miq_apache.rb
@@ -206,7 +206,7 @@ module MiqApache
     def self.create_redirects_config(opts = {})
       opts[:redirects].to_miq_a.each_with_object("") do |redirect, content|
         if redirect == "/"
-          content << "RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts)) /self_service/index.html [L]\n"
+          content << "RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts|bower_components|gettext)) /self_service/index.html [L]\n"
           content << "RewriteCond \%{REQUEST_URI} !^/ws\n"
           content << "RewriteCond \%{REQUEST_URI} !^/proxy_pages\n"
           content << "RewriteCond \%{REQUEST_URI} !^/saml2\n"


### PR DESCRIPTION
SSUI needs html files under `bower_components` for the consoles to work, and json translations under `gettext/` for translations to work.

These files are there since https://github.com/ManageIQ/manageiq-ui-self_service/pull/65 , but the `RewriteRule` in `/etc/httpd/conf.d/manageiq-redirects-ui` always rewrites those URLs to `/self_service/index.html` => this PR makes `bower_components/` and `gettext/` *not* get redirected to `index.html`

https://bugzilla.redhat.com/show_bug.cgi?id=1347319
https://bugzilla.redhat.com/show_bug.cgi?id=1347312