### PR TITLE
toolbars - fix nonexistent fa-lg-assign and fa-lg-action with pficon-edit

### DIFF
--- a/app/helpers/application_helper/toolbar/custom_button_set_center.rb
+++ b/app/helpers/application_helper/toolbar/custom_button_set_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::CustomButtonSetCenter < ApplicationHelper::Too
           t),
         button(
           :ab_group_reorder,
-          'pficon pficon-edit fa-lg-assign',
+          'pficon pficon-edit fa-lg',
           N_('Reorder #{x_active_tree == :ab_tree ? "Buttons Groups" : "Buttons and Groups"}'),
           N_('Reorder')),
       ]

--- a/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::MiqAlertProfileCenter < ApplicationHelper::Too
           :url_parms => "main_div"),
         button(
           :alert_profile_assign,
-          'pficon pficon-edit fa-lg-assign',
+          'pficon pficon-edit fa-lg',
           t = N_('Edit assignments for this Alert Profile'),
           t,
           :url_parms => "main_div"),

--- a/app/helpers/application_helper/toolbar/miq_event_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_event_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::MiqEventCenter < ApplicationHelper::Toolbar::B
       :items => [
         button(
           :event_edit,
-          'pficon pficon-edit fa-lg-action',
+          'pficon pficon-edit fa-lg',
           t = N_('Edit Actions for this Policy Event'),
           t,
           :url_parms => "main_div",

--- a/app/helpers/application_helper/toolbar/miq_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_groups_center.rb
@@ -31,7 +31,7 @@ class ApplicationHelper::Toolbar::MiqGroupsCenter < ApplicationHelper::Toolbar::
         separator,
         button(
           :rbac_group_seq_edit,
-          'pficon pficon-edit fa-lg-assign',
+          'pficon pficon-edit fa-lg',
           t = N_('Edit Sequence of User Groups for LDAP Look Up'),
           t),
       ]


### PR DESCRIPTION
`pficon-edit` always goes with `fa-lg` in toolbars, but 4 toolbars have `fa-lg-action` or `fa-lg-assign` instead, neither of which exists..

Fixing for uniformity (and almost imperceptibly larger edit icons :)).

@martinpovolny can you..? :)