### PR TITLE
Do not bail out of the refresh parser if no machineId is present

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
@@ -43,6 +43,7 @@ module ManageIQ::Providers
       end
 
       def alternate_machine_id(machine_id)
+        return if machine_id.nil?
         # See the BZ #1294461 [1] for a more complete background.
         # Here, we'll try to adjust the machine ID to the format from that bug. We expect to get a string like
         # this: 2f68d133a4bc4c4bb19ecb47d344746c . For such string, we should return
@@ -68,6 +69,7 @@ module ManageIQ::Providers
       end
 
       def find_host_by_bios_uuid(machine_id)
+        return if machine_id.nil?
         identity_system = machine_id.downcase
         Vm.find_by(:uid_ems => identity_system,
                    :type    => uuid_provider_types) if identity_system

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -95,4 +95,14 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
       expect(parser.swap_part(part)).to eq(expected)
     end
   end
+
+  describe 'handle_no_machine_id' do
+    it 'should_find_nil_for_nil' do
+      expect(parser.find_host_by_bios_uuid(nil)).to be_nil
+    end
+
+    it 'should_alternate_nil_for_nil' do
+      expect(parser.alternate_machine_id(nil)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Without this patch, the `refresh_parser` would bail out if the machine id could not be obtained for whatever reason.
```
[----] E, [2016-06-24T10:57:58.513279 #78548:3ff40dc5e1bc] ERROR -- : [NoMethodError]: undefined method `[]' for nil:NilClass  Method:[re
scue in block in refresh]
[----] E, [2016-06-24T10:57:58.513441 #78548:3ff40dc5e1bc] ERROR -- : /miq/manageiq/app/models/manageiq/providers/hawkular/middleware_man
ager/refresh_parser.rb:54:in `alternate_machine_id'
```

@miq-bot add_label providers/hawkular, bug, darga/no
cc @abonas 