### PR TITLE
Use proper pf-icons for warn and error notifications

### DIFF
--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -45,20 +45,10 @@ ManageIQ.angular.app.service('miqService', function() {
 
     if (type == "error") {
       var outerBox = $('<div class="alert alert-danger">');
-      var innerSpan = $('<span class="pficon-layered">');
-      var icon1 = $('<span class="pficon pficon-error-octagon">');
-      var icon2 = $('<span class="pficon pficon-warning-exclamation">');
-
-      $(innerSpan).append(icon1);
-      $(innerSpan).append(icon2);
+      var innerSpan = $('<span class="pficon pficon-error-circle-o">');
     } else if (type == "warn") {
       var outerBox = $('<div class="alert alert-warning">');
-      var innerSpan = $('<span class="pficon-layered">');
-      var icon1 = $('<span class="pficon pficon-warning-triangle">');
-      var icon2 = $('<span class="pficon pficon-warning-exclamation">');
-
-      $(innerSpan).append(icon1);
-      $(innerSpan).append(icon2);
+      var innerSpan = $('<span class="pficon pficon-warning-triangle-o">');
     } else if (type == "success") {
       var outerBox = $('<div class="alert alert-success">');
       var innerSpan = $('<span class="pficon pficon-ok">');


### PR DESCRIPTION
Fixes the missing icons when using miqFlash from miqService.

![image](https://cloud.githubusercontent.com/assets/1737954/16336343/73401110-3a04-11e6-9afd-fdfc3d35dd6c.png)

Fixes #9435 