### PR TITLE
[WIP] Move JS function definitions from partials to .js

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1712,6 +1712,41 @@ function cbHoverRow(row, state) {
   $("tr[id^='" + prefix + "']").toggleClass('active', state);
 }
 
+function provDialogVolumeFieldsetInit(counter) {
+  var button = $("#add-additional-volume-button");
+
+  button.click(function() {
+    var sourceNode = $("#add-volume-fieldset");
+    var node = duplicateNode(sourceNode, ["id", "name"]);
+
+    sourceNode.parent().append(node);
+  });
+
+  function duplicateNode(sourceNode, attributesToBump) {
+    var out = sourceNode.clone(true);
+    var nodes = out.find('*');
+
+    $.each(nodes, function (ix, node) {
+      $.each(attributesToBump, function (ix, attr) {
+        if (node.hasAttribute(attr)) {
+          $(node).prop(attr, increment_attr($(node).prop(attr)));
+        }
+      });
+      node.value = '';
+      node.checked = false;
+    });
+
+    function increment_attr(str) {
+      var str_pieces = str.split("_")
+      str_pieces[str_pieces.length - 1] = counter;
+      return str_pieces.join("_")
+    }
+
+    counter++;
+    return out;
+  }
+}
+
 function chartData(type, data, data2) {
   if (type == undefined) {
     return;

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1699,6 +1699,19 @@ function miqOpsAfterOnload(allowed, utilization_url, hide_toolbar) {
   }
 }
 
+function cbHoverEnable(selector) {
+  $(selector).hover(function() {
+    cbHoverRow(this, true);
+  }, function() {
+    cbHoverRow(this, false);
+  });
+}
+
+function cbHoverRow(row, state) {
+  var prefix = row.id.substr(0, row.id.lastIndexOf("_"));
+  $("tr[id^='" + prefix + "']").toggleClass('active', state);
+}
+
 function chartData(type, data, data2) {
   if (type == undefined) {
     return;

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1677,6 +1677,28 @@ function miqReportAfterOnload(node, active_tree, node_not_root, role_list, edito
   }
 }
 
+function miqOpsAfterOnload(allowed, utilization_url, hide_toolbar) {
+  if (allowed.ops_settings) {
+    miqDimDiv("#settings_tree_div", false);
+  }
+  if (allowed.ops_diagnostics) {
+    miqDimDiv("#diagnostics_tree_div", false);
+  }
+  if (allowed.ops_db) {
+    miqDimDiv("#vmdb_tree_div", false);
+  }
+  if (allowed.ops_rbac__any) {
+    miqDimDiv("#rbac_tree_div", false);
+  }
+
+  if (utilization_url) {
+    miqAsyncAjax(utilization_url);
+  }
+  if (hide_toolbar) {
+    $('#toolbar').hide();
+  }
+}
+
 function chartData(type, data, data2) {
   if (type == undefined) {
     return;

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1665,6 +1665,18 @@ function add_expanding_icon(element) {
   element.find('.pull-right').append("<a onclick='toggle_expansion(this)'> <i class='fa fa-angle-right'></i>");
 }
 
+function miqReportAfterOnload(node, active_tree, node_not_root, role_list, editor_allowed) {
+  if (role_list && !editor_allowed) {
+    return;
+  }
+
+  miqDynatreeActivateNode(role_list ? 'roles_tree' : active_tree, node);
+
+  if (role_list && node_not_root) {
+    $('#menu_div1, #menu_div3').hide();
+  }
+}
+
 function chartData(type, data, data2) {
   if (type == undefined) {
     return;

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -90,10 +90,4 @@
                                                                             :button => "remove")}');")
 
     :javascript
-      $('tbody tr.rdetail').hover( function(){hoverRowIn(this)}, function(row){hoverRowOut(this)});
-      function hoverRowIn(row) {
-        $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").addClass("active");
-      }
-      function hoverRowOut(row) {
-        $("tr[id ^= '"+row.id.substr(0, row.id.lastIndexOf("_"))+"']").removeClass("active");
-      }
+      cbHoverEnable('tbody tr.rdetail');

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -67,6 +67,7 @@
           %td{:colspan => "9"}
 
     :javascript
+      // FIXME unify with cbHoverEnable
       $('tbody tr.rdetail').hover(
         function () {
           $("tr[id = '"+this.id+"']").addClass("active");

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -27,8 +27,8 @@
                                                        :index  => i + "-#{n - 1}",
                                                        :button => "remove")}');")
   :javascript
-    $(document).ready(function () {
-        $('.new_tier').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();
-        $('.new_tier').addClass('new_tier_off').removeClass('new_tier');
+    $(document).ready(function() {
+      $('.new_tier').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();
+      $('.new_tier').addClass('new_tier_off').removeClass('new_tier');
     });
-    $('tbody tr.rdetail').hover( function(){hoverRowIn(this)}, function(row){hoverRowOut(this)});
+    cbHoverEnable('tbody tr.rdetail');

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -49,37 +49,4 @@
     - draw_fields = !options[:"volume_name_#{counter}"].blank? && !options[:"volume_size_#{counter}"].blank?
 
 :javascript
-  (function(){
-      var button = $("#add-additional-volume-button");
-
-      button.click(function() {
-        var sourceNode = $("#add-volume-fieldset");
-        var node = duplicateNode(sourceNode, ["id", "name"]);
-
-        sourceNode.parent().append(node);
-      });
-
-      var counter = #{counter};
-      function duplicateNode(sourceNode, attributesToBump) {
-        var out = sourceNode.clone(true);
-        var nodes = out.find('*');
-
-        $.each(nodes, function (ix, node) {
-          $.each(attributesToBump, function (ix, attr) {
-            if (node.hasAttribute(attr)) {
-              $(node).prop(attr, increment_attr($(node).prop(attr)));
-            }
-          });
-          node.value = '';
-          node.checked = false;
-        });
-
-        function increment_attr(str) {
-          str_pieces = str.split("_")
-          str_pieces[str_pieces.length - 1] = counter;
-          return str_pieces.join("_")
-        }
-        counter++;
-        return out;
-      }
-  })();
+  provDialogVolumeFieldsetInit(#{counter});

--- a/app/views/ops/explorer.html.haml
+++ b/app/views/ops/explorer.html.haml
@@ -10,20 +10,12 @@
                        :line_numbers => true,
                        :url          => url}
 
-%script{:type => "text/javascript"}
-  -# Create from/to date JS vars to limit calendar starting from
+:javascript
+  // Create from/to date JS vars to limit calendar starting from
   ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}");
-  ManageIQ.calendar.calDateTo = null
+  ManageIQ.calendar.calDateTo = null;
 
-  function miqOpsAfterOnload() {
-  = javascript_dim("settings_tree_div", false) if role_allows(:feature => "ops_settings")
-  = javascript_dim("diagnostics_tree_div", false) if role_allows(:feature => "ops_diagnostics")
-  = javascript_dim("vmdb_tree_div", false) if role_allows(:feature => "ops_db")
-  = javascript_dim("rbac_tree_div", false) if role_allows(:feature => "ops_rbac", :any => true)
-  - if @sb[:active_tab] == "db_utilization"
-    miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');
-  - if @sb[:center_tb_filename].nil? || @sb[:center_tb_filename] == "blank_view_tb"
-    $('#toolbar').hide();
-  };
-  var miq_after_onload = "miqOpsAfterOnload();"
-
+  var miq_after_onload = "miqOpsAfterOnload(#{{:ops_settings    => role_allows(:feature => "ops_settings"),
+                                               :ops_diagnostics => role_allows(:feature => "ops_diagnostics"),
+                                               :ops_db          => role_allows(:feature => "ops_db"),
+                                               :ops_rbac__any   => role_allows(:feature => "ops_rbac", :any => true)}.to_json, #{@sb[:active_tab] == "db_utilization" ? "'" + j_str(url_for(:action => @ajax_action, :id => @record)) + "'" : 'null'}, #{@sb[:center_tb_filename].nil? || @sb[:center_tb_filename] == "blank_view_tb"});";

--- a/app/views/report/explorer.html.haml
+++ b/app/views/report/explorer.html.haml
@@ -3,19 +3,8 @@
     = render :partial => list
     -# Include the center cell divs
 
-%script{:type => "text/javascript"}
-  function miqReportAfterOnload() {
-  - if @right_cell_div == "role_list"
-    - if role_allows(:feature => "miq_report_menu_editor")
-      miqDynatreeActivateNode('roles_tree','#{x_node}');
-      - if x_node.split('-').length > 1
-        = javascript_hide("menu_div1")
-        = javascript_show("menu_div3")
-  - else
-    miqDynatreeActivateNode('#{x_active_tree}', '#{x_node}')
-  };
-  var miq_after_onload = "miqReportAfterOnload();"
-
--# Create from/to date JS vars to limit calendar starting from
 :javascript
+  var miq_after_onload = "miqReportAfterOnload('#{j_str x_node}', '#{j_str x_active_tree}', #{x_node.split('-').length > 1}, #{@right_cell_div == "role_list"}, #{!! role_allows(:feature => "miq_report_menu_editor")});"
+
+  // Create from/to date JS vars to limit calendar starting from
   ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}").toDate();


### PR DESCRIPTION
Defining javascript functions in partials is a bit ..wrong, moving all these to `miq_application.js`..

Skipping `console_*` partials which are special, _and_ the timeline which should get rewritten soon anyway...

WIP because need to test it..
