### PR TITLE
Add automated expressions for alerts based on MiddlewareServer model

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -432,6 +432,21 @@ class MiqAlert < ApplicationRecord
             :cpu_affinity => Dictionary.gettext("cpu_affinity", :type => "column")
           }},
           {:name => :operator, :description => _("Operator"), :values => ["Changed"]}
+        ]},
+      {:name => "mw_heap_used", :description => _("JVM Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "mw_event",
+        :options => [
+          {:name => :value_mw_greater_than, :description => _("> Heap Max (%)"), :numeric => true},
+          {:name => :value_mw_less_than, :description => _("< Heap Max (%)"), :numeric => true}
+        ]},
+      {:name => "mw_non_heap_used", :description => _("JVM Non Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "mw_event",
+        :options => [
+          {:name => :value_mw_greater_than, :description => _("> Non Heap Max (%)"), :numeric => true},
+          {:name => :value_mw_less_than, :description => _("< Non Heap Max (%)"), :numeric => true}
+        ]},
+      {:name => "mw_accumulated_gc_duration", :description => _("JVM Accumulated GC Duration"), :db => ["MiddlewareServer"], :responds_to_events => "mw_event",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<=", "="]},
+          {:name => :value_mw_garbage_collector, :description => _("Duration Per Minute (ms)"), :numeric => true}
         ]}
     ]
   end

--- a/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -221,6 +221,27 @@
             = _("Choose a %s first") % ui_lookup(:table => "ext_management_system")
         - else
           = h(@alert.expression[:options][:ems_alarm_name])
+  - when :mw_operator
+    -# Skip this, handled by value_mw_garbage_collector
+  - when :value_mw_garbage_collector
+    %label.control-label.col-md-2
+      = h(option[:description])
+    .col-md-8
+      - if @edit
+        = select_tag('select_mw_operator',
+          options_for_select(@edit[:operators], @edit[:new][:expression][:options][:mw_operator]),
+          :class => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('select_mw_operator', '#{url}', {beforeSend: true, complete: true})
+        = text_field_tag("value_mw_garbage_collector",
+          @edit[:new][:expression][:options][:value_mw_garbage_collector],
+          :maxlength         => MAX_NAME_LEN,
+          :class             => "form-control",
+          "data-miq_observe" => observe_with_interval)
+      - else
+        = h(@alert.expression[:options][:mw_operator])
+        = h(@alert.expression[:options][:value_mw_garbage_collector])
   - else
     -# Set up as a text input field
     %label.control-label.col-md-2


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1662329/16342937/e55acab2-3a34-11e6-9169-792e05928e0e.png)
![image](https://cloud.githubusercontent.com/assets/1662329/16342953/f1a2fec0-3a34-11e6-82f4-2d2ac285d028.png)
![image](https://cloud.githubusercontent.com/assets/1662329/16342961/f9c0c038-3a34-11e6-8930-becba2a4f9ca.png)
This PR adds on top of #9431 automated expressions for GC and JVM memory alerts on MiddlewareServer models.
@miq-bot add_label providers/hawkular, enhancement