### PR TITLE
Use type column instead of a virtual one

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -466,7 +466,7 @@ class MiqRequestController < ApplicationController
       cond.push("or" => a_s.collect { |s| {"=" => {"value" => s, "field" => "MiqRequest-approval_state"}} })
     end
 
-    cond.push("or" => request_types_for_model.keys.collect { |k| {"=" => {"value" => k.to_s, "field" => "MiqRequest-resource_type"}} })
+    cond.push("or" => request_types_for_model.keys.collect { |k| {"=" => {"value" => k.to_s, "field" => "MiqRequest-type"}} })
 
     if opts[:type_choice] && opts[:type_choice] != "all"  # Add request_type filter, if selected
       cond.push("=" => {"value" => opts[:type_choice], "field" => "MiqRequest-request_type"})

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -101,9 +101,9 @@ describe MiqRequestController do
       controller.send(:prov_condition, :applied_states => ["state", "state 2"])
     end
 
-    it "MiqRequest-resource_type" do
+    it "MiqRequest-type" do
       content = %w(MiqProvisionRequest MiqProvisionConfiguredSystemRequest VmReconfigureRequest VmMigrateRequest ServiceTemplateProvisionRequest ServiceReconfigureRequest).collect do |type|
-        {"=" => {"value" => type, "field" => "MiqRequest-resource_type"}}
+        {"=" => {"value" => type, "field" => "MiqRequest-type"}}
       end
 
       expect(MiqExpression).to receive(:new) do |h|


### PR DESCRIPTION
Purpose or Intent
-----------------

tlr; From:many seconds, to: < 1 second depending on the size of your database, and number of miq_requests rows you have.

Previously, we were using the virtual column MiqRequest#resource_type in the
MiqExpression, see [1]. MiqExpression cannot process virtual columns in SQL, so
it was post-filtering by resource_type in ruby. By using a real column we
already have, type, we can filter by type in SQL instead.

Note, MiqRequest#resource_type calls self.class.name, which is the name of the
STI class also known the type column.

**200 days in pulldown**
**Before**:
```
 84196:3fbfdbd35efc]  INFO -- : Started POST "/miq_request/prov_button?button=apply" for 127.0.0.1 at 2016-06-24 15:38:43 -0400
 84196:3fbfdbd35efc]  INFO -- : Completed 200 OK in 5515ms (Views: 17.6ms | ActiveRecord: 0.0ms)
```

**After**:
```
 84286:3fdff0940b50]  INFO -- : Started POST "/miq_request/prov_button?button=apply" for 127.0.0.1 at 2016-06-24 15:40:56 -0400
 84286:3fdff0940b50]  INFO -- : Completed 200 OK in 281ms (Views: 20.4ms | ActiveRecord: 0.0ms)
```

**300 days in pulldown**:

**Before**:
```
 84196:3fbfdbd34ed0]  INFO -- : Started POST "/miq_request/prov_button?button=apply" for 127.0.0.1 at 2016-06-24 15:38:52 -0400
 84196:3fbfdbd34ed0]  INFO -- : Completed 200 OK in 11644ms (Views: 17.4ms | ActiveRecord: 0.0ms)
```

**After**:
```
 84286:3fdff0940600]  INFO -- : Started POST "/miq_request/prov_button?button=apply" for 127.0.0.1 at 2016-06-24 15:40:59 -0400
 84286:3fdff0940600]  INFO -- : Completed 200 OK in 229ms (Views: 16.6ms | ActiveRecord: 0.0ms)
```

[1]
```ruby
     {"or"=>
       [{"="=>
          {"value"=>"MiqProvisionRequest", "field"=>"MiqRequest-resource_type"}},
        {"="=>
          {"value"=>"MiqProvisionConfiguredSystemRequest",
           "field"=>"MiqRequest-resource_type"}},
        {"="=>
          {"value"=>"VmReconfigureRequest",
           "field"=>"MiqRequest-resource_type"}},
        {"="=>
          {"value"=>"VmMigrateRequest", "field"=>"MiqRequest-resource_type"}},
        {"="=>
          {"value"=>"ServiceTemplateProvisionRequest",
           "field"=>"MiqRequest-resource_type"}},
        {"="=>
          {"value"=>"ServiceReconfigureRequest",
           "field"=>"MiqRequest-resource_type"}}]}
```

Steps for Testing/QA
--------------------

Navigate to services -> requests, click the appropriate pulldowns and click apply
