### PR TITLE
MiqDisk Disk Cache Module

### DIFF
--- a/gems/pending/disk/modules/miq_disk_cache.rb
+++ b/gems/pending/disk/modules/miq_disk_cache.rb
@@ -1,0 +1,111 @@
+require 'rufus/lru'
+require_relative "../MiqDisk"
+require 'ostruct'
+
+module MiqDiskCache
+  MIN_SECTORS_PER_ENTRY = 32
+  DEF_LRU_HASH_ENTRIES  = 100
+  DEBUG_CACHE_STATS     = false
+
+  attr_reader :d_size, :blockSize, :lru_hash_entries, :min_sectors_per_entry, :cache_hits, :cache_misses
+
+  def self.new(down_stream, lru_hash_entries = DEF_LRU_HASH_ENTRIES, min_sectors_per_entry = MIN_SECTORS_PER_ENTRY)
+    raise "MiqDiskCache: Downstream Disk Module is nil" if down_stream.nil?
+    @dInfo                       = OpenStruct.new
+    @dInfo.lru_hash_entries      = lru_hash_entries
+    @dInfo.min_sectors_per_entry = min_sectors_per_entry
+    @dInfo.block_size            = down_stream.blockSize
+    @dInfo.down_stream           = down_stream
+
+    MiqDisk.new(self, @dInfo, 0)
+  end
+
+  def d_init
+    @block_cache           = LruHash.new(@dInfo.lru_hash_entries)
+    @cache_hits            = Hash.new(0)
+    @cache_misses          = Hash.new(0)
+    @blockSize             = @dInfo.block_size
+    @down_stream           = @dInfo.down_stream
+    @min_sectors_per_entry = @dInfo.min_sectors_per_entry
+  end
+
+  def d_size
+    @d_size ||= @down_stream.d_size
+  end
+
+  def d_read(pos, len)
+    $log.debug "MiqDiskCache.d_read(#{pos}, #{len})"
+    return nil if pos >= @endByteAddr
+    len = @endByteAddr - pos if (pos + len) > @endByteAddr
+    start_sector, start_offset = pos.divmod(@blockSize)
+    end_sector                 = (pos + len - 1) / @blockSize
+    number_sectors             = end_sector - start_sector + 1
+    d_read_cached(start_sector, number_sectors)[start_offset, len]
+  end
+
+  def d_read_cached(start_sector, number_sectors)
+    $log.debug "MiqDiskCache.d_read_cached(#{start_sector}, #{number_sectors})"
+    @block_cache.keys.each do |block_range|
+      sector_offset = start_sector - block_range.first
+      buffer_offset = sector_offset * @blockSize
+      if block_range.include?(start_sector) && block_range.include?(start_sector + number_sectors - 1)
+        length = number_sectors * @blockSize
+        @cache_hits[start_sector] += 1
+        return @block_cache[block_range][buffer_offset, length]
+      elsif block_range.include?(start_sector)
+        sectors_in_range = block_range.last - start_sector
+        length           = sectors_in_range * @blockSize
+        remaining_blocks = number_sectors - sectors_in_range
+        @cache_hits[start_sector] += 1
+        return @block_cache[block_range][buffer_offset, length] + d_read_cached(block_range.last + 1, remaining_blocks)
+      elsif block_range.include?(start_sector + number_sectors - 1)
+        sectors_in_range = (start_sector + number_sectors) - block_range.first
+        length           = sectors_in_range * @blockSize
+        remaining_blocks = number_sectors - sectors_in_range
+        @cache_hits[start_sector] += 1
+        return d_read_cached(start_sector, remaining_blocks) + @block_cache[block_range][block_range.first, length]
+      end
+    end
+    block_range               = entry_range(start_sector, number_sectors)
+    range_length              = (block_range.last - block_range.first + 1) * @blockSize
+    @block_cache[block_range] = @down_stream.d_read(block_range.first * @blockSize, range_length)
+    @cache_misses[start_sector] += 1
+
+    sector_offset = start_sector - block_range.first
+    buffer_offset = sector_offset * @blockSize
+    length        = number_sectors * @blockSize
+
+    @block_cache[block_range][buffer_offset, length]
+  end
+
+  def d_close
+    hit_or_miss if DEBUG_CACHE_STATS
+    @down_stream.d_close
+  end
+
+  def method_missing(m, *args)
+    @down_stream.send(m, *args)
+  end
+
+  def respond_to_missing(_method_name, _include_private = false)
+    true
+  end
+
+  private
+
+  def hit_or_miss
+    hits   = @cache_hits.values.reduce(:+)
+    misses = @cache_misses.values.reduce(:+)
+    $log.debug "MiqDiskCache cache hits: #{hits}"
+    $log.debug "MiqDiskCache cache misses: #{misses}"
+  end
+
+  def entry_range(start_sector, number_sectors)
+    real_start_block, sector_offset = start_sector.divmod(@min_sectors_per_entry)
+    number_blocks     = number_sectors % @min_sectors_per_entry
+    sectors_to_read   = (number_blocks + (sector_offset > 0 ? 1 : 0)) * @min_sectors_per_entry
+    real_start_sector = real_start_block * @min_sectors_per_entry
+    end_sector        = real_start_sector + sectors_to_read - 1
+    Range.new(real_start_sector, end_sector)
+  end
+end

--- a/gems/pending/disk/modules/miq_dummy_disk.rb
+++ b/gems/pending/disk/modules/miq_dummy_disk.rb
@@ -1,0 +1,41 @@
+require 'memory_buffer'
+require_relative "../MiqDisk"
+require 'ostruct'
+
+module MiqDummyDisk
+  DEF_BLOCK_SIZE = 512
+  DEF_DISK_SIZE  = 1024
+
+  attr_reader :d_size, :blockSize, :dInfo
+
+  def self.new(d_info = nil)
+    @dInfo          = d_info || OpenStruct.new
+    @dInfo.fileName = "dummy disk"
+    @dInfo.d_size     ||= DEF_DISK_SIZE
+    @dInfo.block_size ||= DEF_BLOCK_SIZE
+    MiqDisk.new(self, @dInfo, 0)
+  end
+
+  def d_init
+    @blockSize = @dInfo.block_size
+    @diskType  = "dummy-disk"
+  end
+
+  def d_size
+    @d_size ||= @dInfo.d_size
+  end
+
+  def d_write(_pos, _buf, _len)
+    "MiqDummyDisk.d_write"
+  end
+
+  def d_read(pos, len)
+    return nil if pos >= @endByteAddr
+    len = @endByteAddr - pos if (pos + len) > @endByteAddr
+    buffer = MemoryBuffer.create(len)
+    buffer
+  end
+
+  def d_close
+  end
+end

--- a/gems/pending/disk/modules/miq_dummy_disk.rb
+++ b/gems/pending/disk/modules/miq_dummy_disk.rb
@@ -25,8 +25,8 @@ module MiqDummyDisk
     @d_size ||= @dInfo.d_size
   end
 
-  def d_write(_pos, _buf, _len)
-    "MiqDummyDisk.d_write"
+  def d_write(_pos, _buf, len)
+    len
   end
 
   def d_read(pos, len)

--- a/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
+++ b/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
@@ -75,8 +75,12 @@ describe MiqDiskCache do
     end
 
     describe "#d_write" do
-      it "should return a dummy string" do
-        expect(@miq_cache.d_write(0, "12345", 5)).to eq("MiqDummyDisk.d_write")
+      before do
+        @dummy_string = "12345"
+      end
+
+      it "should return the length of the dummy string" do
+        expect(@miq_cache.d_write(0, "12345", @dummy_string.length)).to eq(@dummy_string.length)
       end
     end
 

--- a/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
+++ b/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
@@ -5,15 +5,17 @@ require 'disk/modules/miq_dummy_disk'
 describe MiqDiskCache do
   DUMMY_BLOCKS    = 1000
   DUMMY_BLOCKSIZE = 4096
+  DUMMY_DATA      = "dummyinfo".freeze
   before do
     dummy_info            = OpenStruct.new
     dummy_info.d_size     = DUMMY_BLOCKS
     dummy_info.block_size = DUMMY_BLOCKSIZE
+    dummy_info.dummy_data = DUMMY_DATA
     @dummy_disk           = MiqDummyDisk.new(dummy_info)
   end
 
   context ".new" do
-    it "should raise an error, given a bad downstream module" do
+    it "should raise an error, given a bad upstream module" do
       expect do
         MiqDiskCache.new(nil)
       end.to raise_error(RuntimeError)
@@ -43,7 +45,7 @@ describe MiqDiskCache do
     end
 
     describe "#size" do
-      it "should return the size of the downstream disk in bytes" do
+      it "should return the size of the upstream disk in bytes" do
         expect(@miq_cache.size).to eq(DUMMY_BLOCKS * DUMMY_BLOCKSIZE)
       end
     end
@@ -63,6 +65,12 @@ describe MiqDiskCache do
     describe "#startByteAddr" do
       it "should return the expected start byte address" do
         expect(@miq_cache.startByteAddr).to eq(0)
+      end
+    end
+
+    describe "#dInfo" do
+      it "should return the upstream module dInfo data" do
+        expect(@miq_cache.dInfo.dummy_data).to eq(DUMMY_DATA)
       end
     end
 

--- a/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
+++ b/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
@@ -1,0 +1,118 @@
+require 'ostruct'
+require 'disk/modules/miq_disk_cache'
+require 'disk/modules/miq_dummy_disk'
+
+describe MiqDiskCache do
+  DUMMY_BLOCKS    = 1000
+  DUMMY_BLOCKSIZE = 4096
+  before do
+    dummy_info            = OpenStruct.new
+    dummy_info.d_size     = DUMMY_BLOCKS
+    dummy_info.block_size = DUMMY_BLOCKSIZE
+    @dummy_disk           = MiqDummyDisk.new(dummy_info)
+  end
+
+  context ".new" do
+    it "should raise an error, given a bad downstream module" do
+      expect do
+        MiqDiskCache.new(nil)
+      end.to raise_error(RuntimeError)
+    end
+
+    it "should return an MiqDisk object" do
+      miq_cache = MiqDiskCache.new(@dummy_disk)
+      expect(miq_cache).to be_kind_of(MiqDisk)
+    end
+  end
+
+  context "Instance methods" do
+    before do
+      @miq_cache = MiqDiskCache.new(@dummy_disk, 200, 32)
+    end
+
+    describe "#d_size" do
+      it "should return the expected disk cache size" do
+        expect(@miq_cache.d_size).to eq(DUMMY_BLOCKS)
+      end
+    end
+
+    describe "#blockSize" do
+      it "should return the expected disk cache block size" do
+        expect(@miq_cache.blockSize).to eq(DUMMY_BLOCKSIZE)
+      end
+    end
+
+    describe "#size" do
+      it "should return the size of the downstream disk in bytes" do
+        expect(@miq_cache.size).to eq(DUMMY_BLOCKS * DUMMY_BLOCKSIZE)
+      end
+    end
+
+    describe "#lbaStart" do
+      it "should return the expected start logical block address" do
+        expect(@miq_cache.lbaStart).to eq(0)
+      end
+    end
+
+    describe "#lbaEnd" do
+      it "should return the expected end logical block address" do
+        expect(@miq_cache.lbaEnd).to eq(DUMMY_BLOCKS)
+      end
+    end
+
+    describe "#startByteAddr" do
+      it "should return the expected start byte address" do
+        expect(@miq_cache.startByteAddr).to eq(0)
+      end
+    end
+
+    describe "#d_write" do
+      it "should return a dummy string" do
+        expect(@miq_cache.d_write(0, "12345", 5)).to eq("MiqDummyDisk.d_write")
+      end
+    end
+
+    describe "#endByteAddr" do
+      it "should return the expected end byte address" do
+        expect(@miq_cache.endByteAddr).to eq(DUMMY_BLOCKS * DUMMY_BLOCKSIZE)
+      end
+
+      it "should return a value consistent with the other values" do
+        expect(@miq_cache.endByteAddr).to eq(@miq_cache.startByteAddr + @miq_cache.lbaEnd * @miq_cache.blockSize)
+      end
+    end
+
+    describe "#getPartitions" do
+      it "should return an array" do
+        expect(@miq_cache.getPartitions).to be_kind_of(Array)
+      end
+
+      it "should not return any partitions" do
+        parts = @miq_cache.getPartitions
+        expect(parts.length).to eq(0)
+      end
+    end
+  end
+  context "Caching Stats" do
+    before do
+      @lru_hash_entries      = 200
+      @min_sectors_per_entry = 32
+      @miq_cache            = MiqDiskCache.new(@dummy_disk, @lru_hash_entries, @min_sectors_per_entry)
+      @start_hits           = @miq_cache.cache_hits.values.reduce(:+)
+      @start_hits           = @start_hits.nil? ? 0 : @start_hits
+      @start_misses         = @miq_cache.cache_misses.values.reduce(:+)
+      @start_misses         = @start_misses.nil? ? 0 : @start_misses
+      (@min_sectors_per_entry..(2 * @min_sectors_per_entry - 1)).each do |block|
+        @miq_cache.d_read(block * DUMMY_BLOCKSIZE, DUMMY_BLOCKSIZE)
+      end
+    end
+    it "should read from the cache repeatedly" do
+      hits = @miq_cache.cache_hits.values.reduce(:+)
+      expect(hits).to eq(@min_sectors_per_entry - 1 + @start_hits)
+    end
+    it "should read once from the underlying disk" do
+      misses = @miq_cache.cache_misses.values.reduce(:+)
+      expect(misses).to eq(1 + @start_misses)
+    end
+  end
+end

--- a/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
+++ b/gems/pending/spec/disk/modules/miq_disk_cache_spec.rb
@@ -80,7 +80,7 @@ describe MiqDiskCache do
       end
 
       it "should return the length of the dummy string" do
-        expect(@miq_cache.d_write(0, "12345", @dummy_string.length)).to eq(@dummy_string.length)
+        expect(@miq_cache.d_write(0, @dummy_string, @dummy_string.length)).to eq(@dummy_string.length)
       end
     end
 

--- a/gems/pending/spec/disk/modules/miq_dummy_disk_spec.rb
+++ b/gems/pending/spec/disk/modules/miq_dummy_disk_spec.rb
@@ -1,0 +1,109 @@
+require 'ostruct'
+require 'disk/modules/miq_dummy_disk'
+
+describe MiqDummyDisk do
+  DUMMY_DISK_BLOCKS    = 1000
+  DUMMY_DISK_BLOCKSIZE = 4096
+
+  context ".new" do
+    it "should not raise an error with arguments" do
+      expect do
+        d_info            = OpenStruct.new
+        d_info.d_size     = DUMMY_DISK_BLOCKS
+        d_info.block_size = DUMMY_DISK_BLOCKSIZE
+        MiqDummyDisk.new(d_info)
+      end.not_to raise_error
+    end
+
+    it "should not raise an error without arguments" do
+      expect do
+        MiqDummyDisk.new
+      end.not_to raise_error
+    end
+
+    it "should return an MiqDisk object without arguments" do
+      dummy_disk = MiqDummyDisk.new
+      expect(dummy_disk).to be_kind_of(MiqDisk)
+    end
+
+    it "should return an MiqDisk object with arguments" do
+      d_info            = OpenStruct.new
+      d_info.d_size     = DUMMY_DISK_BLOCKS
+      d_info.block_size = DUMMY_DISK_BLOCKSIZE
+      dummy_disk = MiqDummyDisk.new(d_info)
+      expect(dummy_disk).to be_kind_of(MiqDisk)
+    end
+  end
+
+  context "Instance methods" do
+    before do
+      d_info           = OpenStruct.new
+      d_info.d_size    = DUMMY_DISK_BLOCKS
+      d_info.block_size = DUMMY_DISK_BLOCKSIZE
+      @dummy_disk = MiqDummyDisk.new(d_info)
+    end
+
+    describe "#d_size" do
+      it "should return the expected dummy disk size" do
+        expect(@dummy_disk.d_size).to eq(DUMMY_DISK_BLOCKS)
+      end
+    end
+
+    describe "#blockSize" do
+      it "should return the expected dummy disk block size" do
+        expect(@dummy_disk.blockSize).to eq(DUMMY_DISK_BLOCKSIZE)
+      end
+    end
+
+    describe "#size" do
+      it "should return the size of the dummy disk in bytes" do
+        expect(@dummy_disk.size).to eq(DUMMY_DISK_BLOCKS * DUMMY_DISK_BLOCKSIZE)
+      end
+    end
+
+    describe "#lbaStart" do
+      it "should return the expected start logical block address" do
+        expect(@dummy_disk.lbaStart).to eq(0)
+      end
+    end
+
+    describe "#lbaEnd" do
+      it "should return the expected end logical block address" do
+        expect(@dummy_disk.lbaEnd).to eq(DUMMY_DISK_BLOCKS)
+      end
+    end
+
+    describe "#startByteAddr" do
+      it "should return the expected start byte address" do
+        expect(@dummy_disk.startByteAddr).to eq(0)
+      end
+    end
+
+    describe "#d_write" do
+      it "should return a dummy string" do
+        expect(@dummy_disk.d_write(0, "12345", 5)).to eq("MiqDummyDisk.d_write")
+      end
+    end
+
+    describe "#endByteAddr" do
+      it "should return the expected end byte address" do
+        expect(@dummy_disk.endByteAddr).to eq(DUMMY_DISK_BLOCKS * DUMMY_DISK_BLOCKSIZE)
+      end
+
+      it "should return a value consistent with the other values" do
+        expect(@dummy_disk.endByteAddr).to eq(@dummy_disk.startByteAddr + @dummy_disk.lbaEnd * @dummy_disk.blockSize)
+      end
+    end
+
+    describe "#getPartitions" do
+      it "should return an array" do
+        expect(@dummy_disk.getPartitions).to be_kind_of(Array)
+      end
+
+      it "should not return any partitions" do
+        parts = @dummy_disk.getPartitions
+        expect(parts.length).to eq(0)
+      end
+    end
+  end
+end

--- a/gems/pending/spec/disk/modules/miq_dummy_disk_spec.rb
+++ b/gems/pending/spec/disk/modules/miq_dummy_disk_spec.rb
@@ -85,7 +85,7 @@ describe MiqDummyDisk do
       end
 
       it "should return a dummy string" do
-        expect(@dummy_disk.d_write(0, "12345", @dummy_string.length)).to eq(@dummy_string.length)
+        expect(@dummy_disk.d_write(0, @dummy_string, @dummy_string.length)).to eq(@dummy_string.length)
       end
     end
 

--- a/gems/pending/spec/disk/modules/miq_dummy_disk_spec.rb
+++ b/gems/pending/spec/disk/modules/miq_dummy_disk_spec.rb
@@ -80,8 +80,12 @@ describe MiqDummyDisk do
     end
 
     describe "#d_write" do
+      before do
+        @dummy_string = "12345"
+      end
+
       it "should return a dummy string" do
-        expect(@dummy_disk.d_write(0, "12345", 5)).to eq("MiqDummyDisk.d_write")
+        expect(@dummy_disk.d_write(0, "12345", @dummy_string.length)).to eq(@dummy_string.length)
       end
     end
 


### PR DESCRIPTION
Add a new MiqDisk module which will do generic disk caching for other
MiqDisk modules.  To use it, instantiate the MiqDisk module in question and
pass it as an argument to the MiqDiskCache.new method.

Spec tests have been added for the object and its methods.

In addition a new dummy MiqDisk module (MiqDummyDisk) has been added to facilitate
the above spec tests (as well as more spec tests for the dummy disk module).

The logic for the caching mechanism here is taken directly from that implemented in the MiqHyperVDisk class.