### PR TITLE
Show the configure drop-down when no editable domains exist

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -714,6 +714,8 @@ class ApplicationHelper::ToolbarBuilder
         return true unless editable_domain?(@record)
       when "miq_ae_domain_unlock"
         return true if editable_domain?(@record) || @record.priority.to_i == 0
+      when "miq_ae_domain_edit", "miq_ae_namespace_edit", "miq_ae_instance_copy", "miq_ae_method_copy"
+        return false unless editable_domain?(@record)
       else
         return true unless editable_domain?(@record)
       end
@@ -1126,10 +1128,16 @@ class ApplicationHelper::ToolbarBuilder
         return N_("Read Only Domain cannot be deleted.") unless editable_domain
       when "miq_ae_domain_edit"
         return N_("Read Only Domain cannot be edited") unless editable_domain
-      when "miq_ae_domain_lock"
+      when "miq_ae_domain_lock", "miq_ae_namespace_edit"
         return N_("Domain is Locked.") unless editable_domain
       when "miq_ae_domain_unlock"
         return N_("Domain is Unlocked.") if editable_domain
+      end
+    when "MiqAeNamespace", "MiqAeClass", "MiqAeInstance", "MiqAeMethod"
+      if %w(miq_ae_namespace_copy miq_ae_instance_copy miq_ae_class_copy miq_ae_method_copy).include?(id) &&
+        !editable_domain?(@record) && !domains_available_for_copy?
+
+        return N_("At least one domain should be enabled & unlocked")
       end
     when "MiqAlert"
       case id
@@ -1510,5 +1518,11 @@ class ApplicationHelper::ToolbarBuilder
     url_parm = parse_ampersand.post_match if parse_ampersand.present?
     encoded_url = URI.encode(url_parm)
     Rack::Utils.parse_query URI("?#{encoded_url}").query
+  end
+
+  def domains_available_for_copy?
+    User.current_tenant.any_editable_domains? &&
+    MiqAeDomain.any_unlocked? &&
+    MiqAeDomain.any_enabled?
   end
 end

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -103,6 +103,10 @@ class MiqAeDomain < MiqAeNamespace
     MiqAeDomain.reset_priority_by_ordered_ids(ids)
   end
 
+  def self.any_enabled?
+    MiqAeDomain.enabled.count > 0
+  end
+
   def self.any_unlocked?
     MiqAeDomain.where('system is null OR system = ?', [false]).count > 0
   end


### PR DESCRIPTION
Under Automate, if no writable domains are available, the "configuration" drop-down is simply hidden and it's not clear what to do next. Giving the user some guidance may be preferable. 


**Before**
![screen shot 2016-06-24 at 4 32 49 pm](https://cloud.githubusercontent.com/assets/39493/16353041/5a68cb9e-3a29-11e6-8969-4bb0e914b7b6.png)

-------

**After**
![screen shot 2016-06-24 at 4 31 33 pm](https://cloud.githubusercontent.com/assets/39493/16353042/64179ef4-3a29-11e6-844f-9c5f273fa07a.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1347162

/cc @h-kataria 