### PR TITLE
Cap&U split up capture_infra_targets to allow tuning

### DIFF
--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -9,11 +9,7 @@ module Metric::Targets
   end
 
   def self.capture_infra_targets(zone, options)
-    # Preload all of the objects we are going to be inspecting.
-    includes = {:ext_management_systems => {:hosts => {:ems_cluster => :tags, :tags => {}}}}
-    includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
-    includes[:ext_management_systems][:hosts][:vms] = :ext_management_system unless options[:exclude_vms]
-    MiqPreloader.preload(zone, includes)
+    preload_infra_targets_data(zone, options)
     all_hosts = capture_host_targets(zone)
     targets = hosts = only_enabled(all_hosts)
     targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
@@ -58,6 +54,14 @@ module Metric::Targets
     end
 
     targets
+  end
+
+  def self.preload_infra_targets_data(zone, options)
+    # Preload all of the objects we are going to be inspecting.
+    includes = {:ext_management_systems => {:hosts => {:ems_cluster => :tags, :tags => {}}}}
+    includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
+    includes[:ext_management_systems][:hosts][:vms] = :ext_management_system unless options[:exclude_vms]
+    MiqPreloader.preload(zone, includes)
   end
 
   def self.capture_host_targets(zone)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -16,7 +16,7 @@ module Metric::Targets
 
     all_hosts = zone.ext_management_systems.flat_map(&:hosts)
     targets = all_hosts
-    targets += all_hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
+    targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
 
     targets = only_enabled(targets)
     targets += capture_vm_targets(targets, Host, options)
@@ -60,6 +60,14 @@ module Metric::Targets
     end
 
     targets
+  end
+
+  # @param [Host] all hosts that have an ems
+  # disabled hosts are passed in. this may change in the future
+  # @return [Array<Storage>] supported storages
+  # hosts preloaded storages and tags
+  def self.capture_storage_targets(hosts)
+    hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) }
   end
 
   def self.capture_vm_targets(targets, parent_class, options)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -14,8 +14,9 @@ module Metric::Targets
     includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
     MiqPreloader.preload(zone, includes)
 
-    targets = zone.hosts
-    targets += zone.storages.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
+    all_hosts = zone.ext_management_systems.flat_map(&:hosts)
+    targets = all_hosts
+    targets += all_hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
 
     targets = only_enabled(targets)
     targets += capture_vm_targets(targets, Host, options)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -14,9 +14,7 @@ module Metric::Targets
     includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
     includes[:ext_management_systems][:hosts][:vms] = :ext_management_system unless options[:exclude_vms]
     MiqPreloader.preload(zone, includes)
-
-    # keeping all_hosts around because capture storage targets runs off of all hosts not enabled ones
-    all_hosts = zone.ext_management_systems.flat_map(&:hosts)
+    all_hosts = capture_host_targets(zone)
     targets = hosts = only_enabled(all_hosts)
     targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
     targets += capture_vm_targets(hosts) unless options[:exclude_vms]
@@ -60,6 +58,12 @@ module Metric::Targets
     end
 
     targets
+  end
+
+  def self.capture_host_targets(zone)
+    # keeping all_hosts around because capture storage targets runs off of all hosts and
+    # not just enabled ones. if that changes, then move the filtering into here.
+    zone.ext_management_systems.flat_map(&:hosts)
   end
 
   # @param [Host] all hosts that have an ems

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -15,7 +15,7 @@ module Metric::Targets
     MiqPreloader.preload(zone, includes)
 
     targets = zone.hosts
-    targets += zone.storages.select { |s| Storage::SUPPORTED_STORAGE_TYPES.include?(s.store_type) } unless options[:exclude_storages]
+    targets += zone.storages.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
 
     # If it can and does have a cluster, then ask that, otherwise, ask host itself.
     targets = targets.select do |t|

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -89,6 +89,11 @@ module Metric::Targets
             vm.association(:ems_cluster).target = host.ems_cluster if vm.ems_cluster_id
           end
         end
+        unless options[:exclude_storages]
+          host.storages.each do |storage|
+            storage.ext_management_system = ems
+          end
+        end
       end
     end
   end

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -17,14 +17,17 @@ module Metric::Targets
     targets = zone.hosts
     targets += zone.storages.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
 
-    # If it can and does have a cluster, then ask that, otherwise, ask host itself.
-    targets = targets.select do |t|
-      t.respond_to?(:ems_cluster) && t.ems_cluster ? t.ems_cluster.perf_capture_enabled? : t.perf_capture_enabled?
-    end
-
+    targets = only_enabled(targets)
     targets += capture_vm_targets(targets, Host, options)
 
     targets
+  end
+
+  def self.only_enabled(targets)
+    # If it can and does have a cluster, then ask that, otherwise, ask host itself.
+    targets.select do |t|
+      t.respond_to?(:ems_cluster) && t.ems_cluster ? t.ems_cluster.perf_capture_enabled? : t.perf_capture_enabled?
+    end
   end
 
   # @return vms under all availability zones

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -878,4 +878,9 @@ class Storage < ApplicationRecord
   def tenant_identity
     ext_management_system.tenant_identity
   end
+
+  # @param [String, Storage] store_type upcased version of the storage type
+  def self.supports?(store_type)
+    Storage::SUPPORTED_STORAGE_TYPES.include?(store_type)
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Scheduled job `perf_capture_timer` is responsible for kicking off Cap&U for the system.
It is split up into 2 parts:

1. Determine which resource (i.e.: `Host`, `Storage`, `Vm`) need Cap & U. **this pr** #9447
2. Submits them into the queue for further processing. ~~#9477~~

This PR focuses **part 1** and the themes are based upon 2 pain points from the past year:

a. Ensure the resources have an `Ems` assigned.
b. Make performance measurement easier.

This work makes it more explicit which data is loaded and available for part 2, (i.e.: submitting into the queue).
Currently, part 2 is the main bottleneck but non-trivial to fix.


Details
----------

- Explicitly use `Zone.ems` to fetch records. This ensures that all records will all have an`Ems` assigned.
- Extract a method for each resource type from `capture_infra_targets`. This simplifies the process and makes it easier to track down performance issues.
- Calculate enabled `hosts` up front and store in it's own variable. This makes it unnecessary to run further host selection logic.
- Extract convenience method to determine supported storage types.
- Merged all preload logic into a single call (for minor savings).

/cc @jrafanie This is from a conversation we had. I just need this to get in so I know which tags are available for part 2. Ok to pawn off on someone else once you have a one over

Results
----------

While this is attempting to organize code, it does have performance impact.
For 1 ems, 100 VMs, 10 hosts, and 13 storages. It ran 50 (6%) fewer queries resulting in 2% fewer objects allocated (~4MB of memory savings).

|       ms | objects     |queries | query (ms) |     rows |comments
|      ---:|       ---:|     ---:|     ---:|      ---:| ---
|  2,798.3 | 1,997,671 |  961 |   684.9 |   11,202 |before
|  2,546.1 | 1,961,437 |  908 |   556.1 |   11,149 |after
