### PR TITLE
Cache storage.ems to make queue name lookup easier

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -37,8 +37,6 @@ module EmsRefresh
     targets_by_ems = targets.each_with_object(Hash.new { |h, k| h[k] = [] }) do |t, h|
       e = if t.kind_of?(EmsRefresh::Manager)
             t
-          elsif t.kind_of?(Storage)
-            t.ext_management_systems.first
           elsif t.respond_to?(:ext_management_system) && t.ext_management_system
             t.ext_management_system
           elsif t.respond_to?(:manager) && t.manager

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -8,8 +8,6 @@ module Metric::CiMixin::Capture
   def queue_name_for_metrics_collection
     ems = if self.kind_of?(ExtManagementSystem)
             self
-          elsif self.kind_of?(Storage)
-            ext_management_systems.first
           elsif self.respond_to?(:ext_management_system)
             ext_management_system
           end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -12,10 +12,8 @@ module Metric::CiMixin::Capture
             ext_management_systems.first
           elsif self.respond_to?(:ext_management_system)
             ext_management_system
-          else
-            raise _("Unsupported type %{name} (id: %{number})") % {:name => self.class.name, :number => id}
           end
-
+    raise _("Unsupported type %{name} (id: %{number})") % {:name => self.class.name, :number => id} if ems.nil?
     ems.metrics_collector_queue_name
   end
 

--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -98,6 +98,7 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
     return result if ems.nil?
     ems.storages.each do |s|
       next unless s.store_type == "NFS"
+      s.ext_management_system = ems
       result << build_ci_hash_struct(s, [:name, :free_space, :total_space])
     end
     result

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -868,9 +868,11 @@ class Storage < ApplicationRecord
   end
 
   def validate_smartstate_analysis
-    return {:available => false, :message => "Smartstate Analysis cannot be performed on selected Datastore"} if ext_management_systems.blank? ||
-                                                     !ext_management_system.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
-    {:available => true,   :message => nil}
+    if ext_management_systems.blank? || !ext_management_system.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
+      {:available => false, :message => "Smartstate Analysis cannot be performed on selected Datastore"}
+    else
+      {:available => true, :message => nil}
+    end
   end
 
   def tenant_identity

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -72,6 +72,14 @@ class Storage < ApplicationRecord
     name
   end
 
+  def ext_management_system=(ems)
+    @ext_management_system = ems
+  end
+
+  def ext_management_system
+    @ext_management_system ||= ext_management_systems.first
+  end
+
   def ext_management_systems
     @ext_management_systems ||= ExtManagementSystem.joins(:hosts => :storages).where(
       :host_storages => {:storage_id => id}).distinct.to_a
@@ -104,7 +112,7 @@ class Storage < ApplicationRecord
   def my_zone
     return MiqServer.my_zone if     ext_management_systems.empty?
     return MiqServer.my_zone unless ext_management_systems_in_zone(MiqServer.my_zone).empty?
-    ext_management_systems.first.my_zone
+    ext_management_system.my_zone
   end
 
   def scan_starting(miq_task_id, host)
@@ -861,11 +869,11 @@ class Storage < ApplicationRecord
 
   def validate_smartstate_analysis
     return {:available => false, :message => "Smartstate Analysis cannot be performed on selected Datastore"} if ext_management_systems.blank? ||
-                                                     !ext_management_systems.first.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
+                                                     !ext_management_system.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
     {:available => true,   :message => nil}
   end
 
   def tenant_identity
-    ext_management_systems.first.tenant_identity
+    ext_management_system.tenant_identity
   end
 end


### PR DESCRIPTION
This PR has 2 changes:

1. In Cap&U, sometimes we do not know what queue to use for a job and throw a null pointer exception. This throws a better exception.
2. For Cap&U, we use an ems to fetch a storage. Due to rails internals, we look up all ems records for every storage we put onto the queue. This allows us to avoid that.
3. This simplifies the interface for looking up the ems for an object.

For more details, commit 2 has a lot of verbiage.

Disclaimer: To avoid conflicts, I actually take advantage of this ability in another PR.