### PR TITLE
Sort Saved report tree in Cloud Intel

### DIFF
--- a/app/presenters/tree_builder_report_reports_class.rb
+++ b/app/presenters/tree_builder_report_reports_class.rb
@@ -4,7 +4,7 @@ class TreeBuilderReportReportsClass < TreeBuilder
   private
 
   def x_get_tree_r_kids(object, count_only)
-    objects = MiqReportResult.with_current_user_groups_and_report(object.id).to_a
-    count_only_or_objects(count_only, objects, nil)
+    scope = MiqReportResult.with_current_user_groups_and_report(object.id)
+    count_only ? scope.size : scope.order("last_run_on DESC").to_a
   end
 end

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -36,7 +36,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    objects = MiqReportResult.with_current_user_groups_and_report(from_cid(object[:id].split('-').last)).to_a
-    count_only_or_objects(count_only, objects, nil)
+    scope = MiqReportResult.with_current_user_groups_and_report(from_cid(object[:id].split('-').last))
+    count_only ? scope.size : scope.order("last_run_on DESC").to_a
   end
 end


### PR DESCRIPTION
Report results are sorted by a date they were last run on.

Issue #9444 

Before:
![before](https://cloud.githubusercontent.com/assets/9210860/16374213/c686ce9c-3c55-11e6-9314-9e49c15b5378.png)
After:
![screen shot 2016-06-28 at 9 04 25 am](https://cloud.githubusercontent.com/assets/9210860/16406587/7303cc06-3d0f-11e6-817d-0e4c6c7ea243.png)


@miq-bot add_label bug, ui

