### PR TITLE
Move setting menu section under top-right menu.

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -202,7 +202,7 @@ module Menu
           Menu::Item.new('my_tasks',      N_('Tasks'),         'tasks',        {:feature => 'tasks', :any => true},        '/miq_task/index?jobs_tab=tasks'),
           Menu::Item.new('ops',           N_('Configuration'), 'ops_explorer', {:feature => 'ops_explorer', :any => true}, '/ops/explorer'),
           Menu::Item.new('about',         N_('About'),         'about',        {:feature => 'about'},                      '/support/index?support_tab=about')
-        ])
+        ], :top_right)
       end
 
       def default_menu

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,17 +11,6 @@
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
       %li{:class => "dropdown brand-white-label #{current_tenant.logo? ? "whitelabeled" : ""}"}
-      - Menu::Manager.menu(:top_right) do |menu_section|
-        - if menu_section.visible?
-          %li.dropdown
-            %a{:href => "#", :id => "dropdownMenu2", :class => "dropdown-toggle nav-item-iconic", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false"}
-              = _(menu_section.name)
-              %b.caret
-            %ul.dropdown-menu#custom_menu_div
-              - menu_section.items.each do |menu_item|
-                - if menu_item.visible?
-                  %li
-                    %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}= _(menu_item.name)
 
       = render :partial => "layouts/user_options"
   = render :partial => "layouts/spinner"

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -32,6 +32,13 @@
         %li.disabled
           %a{:href => "#"}
             = current_group.try(:description)
+      - Menu::Manager.menu(:top_right) do |menu_section|
+        - if menu_section.visible?
+          %li.divider
+          - menu_section.items.each do |menu_item|
+            - if menu_item.visible?
+              %li
+                %a{:href => menu_item.url, :onclick => 'return miqCheckForChanges()'}= _(menu_item.name)
       %li.divider
       %li
         %a{:href => "/dashboard/logout", :onclick => 'return miqCheckForChanges()', :title => _("Click to Logout")}


### PR DESCRIPTION
Move setting menu section under top-right menu.

![top-right-menu](https://cloud.githubusercontent.com/assets/51095/16375095/ff3d7912-3c59-11e6-86d3-7e22d60d6128.png)

Replaces: https://github.com/ManageIQ/manageiq/pull/9300