### PR TITLE
Custom attributes as dynamic virtual columns in reports

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1343,6 +1343,8 @@ module ReportController::Reports::Editor
     user = current_user
     rpt.user = user
     rpt.miq_group = user.current_group
+
+    rpt.add_includes_for_virtual_custom_attributes
   end
 
   def add_field_to_col_order(rpt, field)

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1701,7 +1701,10 @@ module ReportController::Reports::Editor
     pivot_cols = {}
     rpt.col_formats ||= Array.new(rpt.col_order.length)   # Create array of nils if col_formats not present (backward compat)
     rpt.col_order.each_with_index do |col, idx|
-      if !col.include?(".")  # Main table field
+      if col.starts_with?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
+        field_key = rpt.db + "-" + col
+        field_value = col.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, "")
+      elsif !col.include?(".")  # Main table field
         field_key = rpt.db + "-" + col
         field_value = friendly_model_name(rpt.db) +
                       Dictionary.gettext(rpt.db + "." + col.split("__").first, :type => :column, :notfound => :titleize)

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1133,6 +1133,25 @@ class MiqExpression
     result
   end
 
+  def self._custom_details_for(model, options)
+    klass = model.safe_constantize
+    return [] unless klass < CustomAttributeMixin
+
+    custom_attributes_details = []
+
+    klass.custom_keys.each do |custom_key|
+      custom_detail_column = [model, CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX + custom_key].join("-")
+      custom_detail_name = custom_key
+      if options[:include_model]
+        model_name = Dictionary.gettext(model, :type => :model, :notfound => :titleize)
+        custom_detail_name = [model_name, custom_key].join(" : ")
+      end
+      custom_attributes_details.push([custom_detail_name, custom_detail_column])
+    end
+
+    custom_attributes_details
+  end
+
   def self._model_details(relats, opts)
     result = []
     relats[:reflections].each do|_assoc, ref|

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1126,9 +1126,16 @@ class MiqExpression
     result = []
     unless opts[:typ] == "count" || opts[:typ] == "find"
       result = get_column_details(relats[:columns], model, model, opts).sort! { |a, b| a.to_s <=> b.to_s }
+      custom_details = _custom_details_for(model, opts)
+      result.concat(custom_details.sort_by!(&:to_s)) unless custom_details.empty?
       result.concat(tag_details(model, model, opts)) if opts[:include_tags] == true
     end
-    result.concat(_model_details(relats, opts).sort! { |a, b| a.to_s <=> b.to_s })
+
+    model_details = _model_details(relats, opts)
+
+    model_details.sort_by!(&:to_s)
+    result.concat(model_details)
+
     @classifications = nil
     result
   end

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -901,7 +901,14 @@ class MiqExpression
     else
       model = tables.blank? ? nil : tables.split(".").last.singularize.camelize
       dict_col = model.nil? ? col : [model, col].join(".")
-      ret << Dictionary.gettext(dict_col, :type => :column, :notfound => :titleize) if col
+      column_human = if col
+                       if col.starts_with?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
+                         col.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, "")
+                       else
+                         Dictionary.gettext(dict_col, :type => :column, :notfound => :titleize)
+                       end
+                     end
+      ret << column_human if col
     end
     ret = " #{ret}" unless ret.include?(":")
     ret

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1133,8 +1133,12 @@ class MiqExpression
     result = []
     unless opts[:typ] == "count" || opts[:typ] == "find"
       result = get_column_details(relats[:columns], model, model, opts).sort! { |a, b| a.to_s <=> b.to_s }
-      custom_details = _custom_details_for(model, opts)
-      result.concat(custom_details.sort_by!(&:to_s)) unless custom_details.empty?
+
+      unless opts[:disallow_loading_virtual_custom_attributes]
+        custom_details = _custom_details_for(model, opts)
+        result.concat(custom_details.sort_by(&:to_s)) unless custom_details.empty?
+      end
+
       result.concat(tag_details(model, model, opts)) if opts[:include_tags] == true
     end
 
@@ -1212,7 +1216,9 @@ class MiqExpression
     @miq_adv_search_lists[model.to_s] ||= {}
 
     case what.to_sym
-    when :exp_available_fields then @miq_adv_search_lists[model.to_s][:exp_available_fields] ||= MiqExpression.model_details(model, :typ => "field", :include_model => true)
+    when :exp_available_fields then
+      options = {:typ => "field", :include_model => true, :disallow_loading_virtual_custom_attributes => false}
+      @miq_adv_search_lists[model.to_s][:exp_available_fields] ||= MiqExpression.model_details(model, options)
     when :exp_available_counts then @miq_adv_search_lists[model.to_s][:exp_available_counts] ||= MiqExpression.model_details(model, :typ => "count", :include_model => true)
     when :exp_available_finds  then @miq_adv_search_lists[model.to_s][:exp_available_finds]  ||= MiqExpression.model_details(model, :typ => "find",  :include_model => true)
     end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -196,4 +196,10 @@ class MiqReport < ApplicationRecord
   def page_size
     rpt_options.try(:fetch_path, :pdf, :page_size) || "a4"
   end
+
+  def load_custom_attributes
+    klass = db.safe_constantize
+    return unless klass < CustomAttributeMixin
+    klass.load_custom_attributes_for(cols)
+  end
 end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -202,4 +202,11 @@ class MiqReport < ApplicationRecord
     return unless klass < CustomAttributeMixin
     klass.load_custom_attributes_for(cols)
   end
+
+  # this method adds :custom_attributes => {} to MiqReport#include
+  # when report with virtual custom attributes is stored
+  # we need preload custom_attributes table to main query for building report for elimination of superfluous queries
+  def add_includes_for_virtual_custom_attributes
+    include[:custom_attributes] ||= {} if CustomAttributeMixin.select_virtual_custom_attributes(cols).present?
+  end
 end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -209,4 +209,12 @@ class MiqReport < ApplicationRecord
   def add_includes_for_virtual_custom_attributes
     include[:custom_attributes] ||= {} if CustomAttributeMixin.select_virtual_custom_attributes(cols).present?
   end
+
+  # this method removes loading (:custom_attributes => {}) relations for custom_attributes before report is built
+  # :custom_attributes => {} was added in method add_includes_for_virtual_custom_attributes in MiqReport#include
+  # vc_attributes == Virtual Custom Attributes
+  def remove_loading_relations_for_virtual_custom_attributes
+    vc_attributes = CustomAttributeMixin.select_virtual_custom_attributes(cols).present?
+    include.delete(:custom_attributes) if vc_attributes.present? && include && include[:custom_attributes].blank?
+  end
 end

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -188,6 +188,8 @@ module MiqReport::Generator
 
     includes = get_include_for_find(include)
 
+    load_custom_attributes
+
     time_profile.tz ||= tz if time_profile # Default time zone in profile to report time zone
     ext_options = {:tz => tz, :time_profile => time_profile}
     # TODO: these columns need to be converted to real SQL columns

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -353,6 +353,8 @@ module MiqReport::Generator
     data = data.to_a
     objs = data[0] && data[0].kind_of?(Integer) ? klass.where(:id => data) : data.compact
 
+    remove_loading_relations_for_virtual_custom_attributes
+
     # Add resource columns to performance reports cols and col_order arrays for widget click thru support
     if klass.to_s.ends_with?("Performance")
       res_cols = ['resource_name', 'resource_type', 'resource_id']

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -28,6 +28,11 @@ module CustomAttributeMixin
       CustomAttribute.where(:resource_type => base_class).distinct.pluck(:name)
     end
 
+    def self.load_custom_attributes_for(cols)
+      custom_attributes = CustomAttributeMixin.select_virtual_custom_attributes(cols)
+      custom_attributes.each { |custom_attribute| add_custom_attribute(custom_attribute) }
+    end
+
     def self.add_custom_attribute(custom_attribute)
       virtual_column(custom_attribute.to_sym, :type => :string, :uses => :custom_attributes)
 
@@ -36,6 +41,10 @@ module CustomAttributeMixin
         custom_attributes.detect { |x| custom_attribute_without_prefix == x.name }.try(:value)
       end
     end
+  end
+
+  def self.select_virtual_custom_attributes(cols)
+    cols.nil? ? [] : cols.select { |x| x.start_with?(CUSTOM_ATTRIBUTES_PREFIX) }
   end
 
   def miq_custom_keys

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -1,6 +1,8 @@
 module CustomAttributeMixin
   extend ActiveSupport::Concern
 
+  CUSTOM_ATTRIBUTES_PREFIX = "virtual_custom_attribute_".freeze
+
   included do
     has_many   :custom_attributes,     :as => :resource, :dependent => :destroy
     has_many   :miq_custom_attributes, -> { where(:source => 'EVM') }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -21,6 +21,10 @@ module CustomAttributeMixin
         miq_custom_set(custom_str, value)
       end
     end
+
+    def self.custom_keys
+      CustomAttribute.where(:resource_type => base_class).distinct.pluck(:name)
+    end
   end
 
   def miq_custom_keys

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -27,6 +27,15 @@ module CustomAttributeMixin
     def self.custom_keys
       CustomAttribute.where(:resource_type => base_class).distinct.pluck(:name)
     end
+
+    def self.add_custom_attribute(custom_attribute)
+      virtual_column(custom_attribute.to_sym, :type => :string, :uses => :custom_attributes)
+
+      define_method(custom_attribute.to_sym) do
+        custom_attribute_without_prefix = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
+        custom_attributes.detect { |x| custom_attribute_without_prefix == x.name }.try(:value)
+      end
+    end
   end
 
   def miq_custom_keys

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -80,7 +80,7 @@ class Tag < ApplicationRecord
     ns = options.fetch(:ns, '/user')
     ns = "" if [:none, "none", "*", nil].include?(ns)
     ns += "/" + options[:cat] if options[:cat]
-    ns.downcase
+    ns.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX) ? ns : ns.downcase
   end
 
   def self.filter_ns(tags, ns)


### PR DESCRIPTION
### Purpose or intent
Note: There are still couple issue in diplaying this field etc. Mostly of them are tracked in pivot tracker. Link below

Initial implementation of reporting custom attributes with behaviour as normal field.
Is basically normalizing custom attributes in report and you can generated reportf(after):
![screen shot 2016-06-30 at 19 08 21](https://cloud.githubusercontent.com/assets/14937244/16497207/1989eba4-3ef6-11e6-8484-0e54a57c71cf.png)

instead of(before):
![screen shot 2016-06-30 at 19 08 11](https://cloud.githubusercontent.com/assets/14937244/16497209/1bff2264-3ef6-11e6-957b-8da1e693af13.png)

with using all common features(filtering, ... ) in report definition

I can separated this PR into parts:

**1. Building list for Available Fields with custom attributes**
![screen shot 2016-06-30 at 19 12 47](https://cloud.githubusercontent.com/assets/14937244/16497332/a9b7bd50-3ef6-11e6-8e89-c1025d71e1ae.png)
Commits: 
https://github.com/ManageIQ/manageiq/pull/9451/commits/fa127742b0e92a63430f92f49130b6f149e3cc37 
https://github.com/ManageIQ/manageiq/pull/9451/commits/bfa7ba8eccf07df02df21884106d22c44aee9d06
https://github.com/ManageIQ/manageiq/pull/9451/commits/4be4a0ee72e4fcc9b23f65ca11a4303731bc1c73

**2. Support for loading dynamic virtual columns**
This is adding virtual columns dynamically.
Commit: https://github.com/ManageIQ/manageiq/pull/9451/commits/5cb347f6d08a4f57b960b1832a4233d3ff93a453

**3. Load these virtual columns when report generated**
Commit: https://github.com/ManageIQ/manageiq/pull/9451/commits/bebbd7d48ca60f980d38b6f8a53f745c3482543e

**4. Other issues: Tackling with saving report a removing association for build report**
https://github.com/ManageIQ/manageiq/pull/9451/commits/0c5a34f3b9d684f5b19d1456bda93f146ffa747c
https://github.com/ManageIQ/manageiq/pull/9451/commits/c9f8d004f85f7448d95bd60faedb9a56f1a2edfe
...

### What needs to be stored in report definition (MiqReport)
Let's assume that we have Vm report and one field for name of VM and 3 our new virtual columns, so then we have minimally in db:
MiqReport#cols
```
[
    [0] "name",
    [1] "virtual_custom_attribute_attr_name_1_1",
    [2] "virtual_custom_attribute_attr_name_1_3",
    [3] "virtual_custom_attribute_attr_name_2_1"
]
```

MiqReport#col_order
```
[
    [0] "name",
    [1] "virtual_custom_attribute_attr_name_1_1",
    [2] "virtual_custom_attribute_attr_name_1_3",
    [3] "virtual_custom_attribute_attr_name_2_1"
]
```

MiqReport#include
```
{
    :custom_attributes => {}
}
```
^^ this is need for preloading this table in base query for reporting.


### Utility  scripts
How to add some custom attributtes for Vms
````
Vm.all.each do |vm|
  $evm = MiqAeMethodService::MiqAeService.new(MiqAeEngine::MiqAeWorkspaceRuntime.new)
  vm = $evm.vmdb('vm', vm.id )
  vm.custom_set("ATTR_Name_1_#{vm.id}", 'Some string you want to add')
  vm.custom_set("ATTR_Name_2_#{vm.id}", 'Some string you want to add')
end
```

## Links 
https://bugzilla.redhat.com/show_bug.cgi?id=1292860
https://www.pivotaltracker.com/n/projects/1608513/stories/121954975