### PR TITLE
Change order of _type and _id in index for polymorph relations

### DIFF
--- a/db/migrate/20160627112436_fix_lives_on_index_on_middleware_servers.rb
+++ b/db/migrate/20160627112436_fix_lives_on_index_on_middleware_servers.rb
@@ -1,0 +1,6 @@
+class FixLivesOnIndexOnMiddlewareServers < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :middleware_servers, :column => [:lives_on_type, :lives_on_id ]
+    add_index :middleware_servers, [:lives_on_id, :lives_on_type]
+  end
+end

--- a/db/migrate/20160627114232_fix_counterpart_index_on_configured_systems.rb
+++ b/db/migrate/20160627114232_fix_counterpart_index_on_configured_systems.rb
@@ -1,0 +1,6 @@
+class FixCounterpartIndexOnConfiguredSystems < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :configured_systems, :column => [:counterpart_type, :counterpart_id ]
+    add_index :configured_systems, [:counterpart_id, :counterpart_type]
+  end
+end


### PR DESCRIPTION
the index should have the column that narrows the result faster
as the first column. And this is _id

This came up on gitter
https://gitter.im/ManageIQ/manageiq/providers?at=576d64fe0d6f4b6641ff886d