### PR TITLE
Don't add the /ovirt-engine prefix to oVirt ems_ref

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -220,4 +220,11 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     end
     _log.info("#{log_header} Completed.")
   end
+
+  # Calculates an "ems_ref" from the "href" attribute provided by the oVirt REST API, removing the
+  # "/ovirt-engine/" prefix, as for historic reasons the "ems_ref" stored in the database does not
+  # contain it, it only contains the "/api" prefix which was used by older versions of the engine.
+  def self.make_ems_ref(href)
+    href && href.sub(%r{^/ovirt-engine/}, '/')
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
@@ -56,6 +56,6 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParser
 
   def self.ems_ref_from_object_in_event(data)
     return nil unless data.respond_to?(:[])
-    data[:href]
+    ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(data[:href])
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -43,9 +43,11 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       committed   = storage_inv[:committed].to_i
       uncommitted = total - committed
 
+      ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(storage_inv[:href])
+
       new_result = {
-        :ems_ref             => storage_inv[:href],
-        :ems_ref_obj         => storage_inv[:href],
+        :ems_ref             => ems_ref,
+        :ems_ref_obj         => ems_ref,
         :name                => storage_inv[:name],
         :store_type          => storage_type,
         :storage_domain_type => storage_inv[:type].try(:downcase),
@@ -109,10 +111,12 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
         ipmi_address = host_inv.attributes.fetch_path(:power_management, :address)
       end
 
+      ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(host_inv[:href])
+
       new_result = {
         :type             => 'ManageIQ::Providers::Redhat::InfraManager::Host',
-        :ems_ref          => host_inv[:href],
-        :ems_ref_obj      => host_inv[:href],
+        :ems_ref          => ems_ref,
+        :ems_ref_obj      => ems_ref,
         :name             => host_inv[:name] || hostname,
         :hostname         => hostname,
         :ipaddress        => ipaddress,
@@ -367,10 +371,12 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       hardware[:guest_devices], guest_device_uids[mor] = vm_inv_to_guest_device_hashes(vm_inv, lan_uids[host_mor])
       hardware[:networks] = vm_inv_to_network_hashes(vm_inv, guest_device_uids[mor])
 
+      ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_inv[:href])
+
       new_result = {
         :type              => template ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm",
-        :ems_ref           => vm_inv[:href],
-        :ems_ref_obj       => vm_inv[:href],
+        :ems_ref           => ems_ref,
+        :ems_ref_obj       => ems_ref,
         :uid_ems           => vm_inv[:id],
         :memory_reserve    => vm_memory_reserve(vm_inv),
         :name              => URI.decode(vm_inv[:name]),
@@ -591,9 +597,11 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       }
       result_res_pools << default_res_pool
 
+      ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(data[:href])
+
       new_result = {
-        :ems_ref       => data[:href],
-        :ems_ref_obj   => data[:href],
+        :ems_ref       => ems_ref,
+        :ems_ref_obj   => ems_ref,
         :uid_ems       => data[:id],
         :name          => data[:name],
 
@@ -636,11 +644,13 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       vms = vm_uids.values.select { |v| v.fetch_path(:ems_cluster, :datacenter_id) == uid }
       vm_folder[:ems_children] = {:vms => vms}
 
+      ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(data[:href])
+
       new_result = {
         :name         => data[:name],
         :type         => 'Datacenter',
-        :ems_ref      => data[:href],
-        :ems_ref_obj  => data[:href],
+        :ems_ref      => ems_ref,
+        :ems_ref_obj  => ems_ref,
         :uid_ems      => uid,
 
         :ems_children => {:folders => [host_folder, vm_folder]}

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -53,4 +53,14 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       @ems.vm_reconfigure(@vm, :spec => @spec)
     end
   end
+
+  context ".make_ems_ref" do
+    it "removes the /ovirt-engine prefix" do
+      expect(described_class.make_ems_ref("/ovirt-engine/api/vms/123")).to eq("/api/vms/123")
+    end
+
+    it "does not remove the /api prefix" do
+      expect(described_class.make_ems_ref("/api/vms/123")).to eq("/api/vms/123")
+    end
+  end
 end


### PR DESCRIPTION
Currently when version 4 of oVirt is added as a provider, the "ems_ref"
attribute of the objects stored in the database contains the "/ovirt-engine"
prefix, because that is what the "href" attribute returned by oVirt contains.
As a result, depending on the version of oVirt this "ems_ref" attribute will be
different: /ovirt-engine/api/* for version 4 and just /api/* for version 3.
This complicates migration from version 3 to version 4 of oVirt, as the both
prefixes need to be supported. To avoid that problem this patch changes the
provider so that the "ems_ref" will be calculated always in the same way,
regardless of the version of oVirt used. To keep backwards compatibility with
objects already stored in the database the value will be /api/*, as it used to
be with version 3 of oVirt.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>