### PR TITLE
Refactor the default view keys mapping in the _ui_2 view

### DIFF
--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -10,12 +10,11 @@
         %fieldset
           %h3
             = _('General')
-          - keys = {:tagging      => _('Tagging'),
-                    :compare      => _('Compare'),
-                    :compare_mode => _('Compare Mode'),
-                    :drift        => _('Drift'),
-                    :drift_mode   => _('Drift Mode')}
-          - keys.each do |resource, view_name|
+          - {:tagging      => _('Tagging'),
+             :compare      => _('Compare'),
+             :compare_mode => _('Compare Mode'),
+             :drift        => _('Drift'),
+             :drift_mode   => _('Drift Mode')}.each do |resource, view_name|
             .form-group
               %label.col-md-3.control-label
                 #{view_name}
@@ -26,13 +25,12 @@
           %fieldset
             %h3
               = _('Services')
-            - keys = {:service               => ["service",                        _('My Services')],
-                      :catalog               => ["catalog_items_accord",           _('Service Catalogs')],
-                      :servicetemplate       => ["catalog_items_view",             _('Catalog Items')],
-                      :orchestrationtemplate => ["orchestration_templates_accord", _('Orchestration Templates')],
-                      :vm                    => ["vms_instances_filter_accord",    _('VMs & Instances')],
-                      :miqtemplate           => ["templates_images_filter_accord", _('Templates & Images')]}
-            - keys.each do |resource, (feature, view_name)|
+            - {:service               => ["service",                        _('My Services')],
+               :catalog               => ["catalog_items_accord",           _('Service Catalogs')],
+               :servicetemplate       => ["catalog_items_view",             _('Catalog Items')],
+               :orchestrationtemplate => ["orchestration_templates_accord", _('Orchestration Templates')],
+               :vm                    => ["vms_instances_filter_accord",    _('VMs & Instances')],
+               :miqtemplate           => ["templates_images_filter_accord", _('Templates & Images')]}.each do |resource, (feature, view_name)|
               - if role_allows(:feature => feature)
                 .form-group
                   %label.col-md-3.control-label
@@ -43,19 +41,18 @@
           %fieldset
             %h3
               = _('Containers')
-            - keys = {:emscontainer           => "ems_container",
-                      :containernode          => "container_node",
-                      :containergroup         => "container_group",
-                      :containerservice       => "container_service",
-                      :containerroute         => "container_route",
-                      :containerproject       => "container_project",
-                      :containerreplicator    => "container_replicator",
-                      :containerimage         => "container_image",
-                      :containerimageregistry => "container_image_registry",
-                      :container              => "container",
-                      :containerbuild         => "container_build",
-                      :persistentvolume       => "persistent_volume"}
-            - keys.each do |resource, table_view_name|
+            - {:emscontainer           => "ems_container",
+               :containernode          => "container_node",
+               :containergroup         => "container_group",
+               :containerservice       => "container_service",
+               :containerroute         => "container_route",
+               :containerproject       => "container_project",
+               :containerreplicator    => "container_replicator",
+               :containerimage         => "container_image",
+               :containerimageregistry => "container_image_registry",
+               :container              => "container",
+               :containerbuild         => "container_build",
+               :persistentvolume       => "persistent_volume"}.each do |resource, table_view_name|
               .form-group
                 %label.col-md-3.control-label
                   = ui_lookup(:tables => table_view_name)
@@ -66,11 +63,10 @@
           %fieldset
             %h3
               = _('Middleware')
-            - keys = {:manageiq_providers_middlewaremanager => ["ems_middleware_show_list",        _('Middleware Providers')],
-                      :middlewareserver                     => ["middleware_server_show_list",     _('Middleware Servers')],
-                      :middlewaredeployment                 => ["middleware_deployment_show_list", _('Middleware Deployments')],
-                      :middlewaredatasource                 => ["middleware_datasource_show_list", _('Middleware Datasources')]}
-            - keys.each do |resource, (feature, view_name)|
+            - {:manageiq_providers_middlewaremanager => ["ems_middleware_show_list",        _('Middleware Providers')],
+               :middlewareserver                     => ["middleware_server_show_list",     _('Middleware Servers')],
+               :middlewaredeployment                 => ["middleware_deployment_show_list", _('Middleware Deployments')],
+               :middlewaredatasource                 => ["middleware_datasource_show_list", _('Middleware Datasources')]}.each do |resource, (feature, view_name)|
               - if role_allows(:feature => feature)
                 .form-group
                   %label.col-md-3.control-label
@@ -81,131 +77,47 @@
           %fieldset
             %h3
               = _('Clouds')
-            - if role_allows(:feature => "ems_cloud_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  #{ui_lookup(:tables => "ems_clouds")}
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:manageiq_providers_cloudmanager, @edit[:new][:views][:manageiq_providers_cloudmanager])
-            - if role_allows(:feature => "availability_zone_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Availability Zones')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:availabilityzone, @edit[:new][:views][:availabilityzone])
-            - if role_allows(:feature => "cloud_tenant_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Tenants')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:cloudtenant, @edit[:new][:views][:cloudtenant])
-            - if role_allows(:feature => "flavor_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Flavors')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:flavor, @edit[:new][:views][:flavor])
-            - if has_any_role?(%w(instances_accord instances_filter_accord))
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Instances')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:manageiq_providers_cloudmanager_vm, @edit[:new][:views][:manageiq_providers_cloudmanager_vm])
-            - if has_any_role?(%w(images_accord images_filter_accord))
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Images')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:manageiq_providers_cloudmanager_template, @edit[:new][:views][:manageiq_providers_cloudmanager_template])
-            - if role_allows(:feature => "orchestration_stack_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Stacks')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:orchestrationstack, @edit[:new][:views][:orchestrationstack])
-            - if role_allows(:feature => "cloud_volume_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Volumes')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:cloudvolume, @edit[:new][:views][:cloudvolume])
-            - if role_allows(:feature => "auth_key_pair_cloud_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Key Pairs')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:authkeypaircloud, @edit[:new][:views][:authkeypaircloud])
-            - if role_allows(:feature => "cloud_object_store_container_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Object Store')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:cloudobjectstorecontainer, @edit[:new][:views][:cloudobjectstorecontainer])
+            - {:manegeiq_providers_cloudmanager => ["ems_cloud_show_list",                    _('Cloud Providers')],
+               :availabilityzone                => ["availability_zone_show_list",            _('Availability Zones')],
+               :cloudtenat                      => ["cloud_tenant_show_list",                 _('Tenants')],
+               :flavor                          => ["flavor_show_list",                       _('Flavors')],
+               :manageiq_providers_cloudmanager_vm       => [["instances_accord",
+                                                              "instances_filter_accord"], _('Instances')],
+               :manageiq_providers_cloudmanager_template => [["images_accord",
+                                                              "images_filter_accord"],    _('Images')],
+               :orchestrationstack        => ["orchestration_stack_show_list",          _('Stacks')],
+               :cloudvolume               => ["cloud_volume_show_list",                 _('Volumes')],
+               :authkeypaircloud          => ["auth_key_pair_cloud_show_list",          _('Key Pairs')],
+               :cloudobjectstorecontainer => ["cloud_object_store_container_show_list", _('Object Store')]}.each do |resource, (feature, view_name)|
+              - if has_any_role?(Array(feature))
+                .form-group
+                  %label.col-md-3.control-label
+                    = view_name
+                  .col-md-8
+                    %ul.list-inline= render_view_buttons(resource, @edit[:new][:views][resource])
         - if has_any_role?(%w(ems_infra_show_list ems_cluster_show_list host_show_list resource_pool_show_list storage_show_list vandt_accord vms_filter_accord templates_filter_accord))
           %fieldset
             %h3
               = _('Infrastructure')
-            - if role_allows(:feature => "ems_infra_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = ui_lookup(:tables => "ems_infras")
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:manageiq_providers_inframanager, @edit[:new][:views][:manageiq_providers_inframanager])
-            - if role_allows(:feature => "ems_cluster_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = title_for_clusters
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:emscluster, @edit[:new][:views][:emscluster])
-            - if role_allows(:feature => "host_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = title_for_hosts
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:host, @edit[:new][:views][:host])
-            - if has_any_role?(%w(vandt_accord vms_filter_accord))
-              .form-group
-                %label.col-md-3.control-label
-                  = _('VMs & Templates')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:vmortemplate, @edit[:new][:views][:vmortemplate])
-            - if has_any_role?(%w(vandt_accord vms_filter_accord))
-              .form-group
-                %label.col-md-3.control-label
-                  = _('VMs')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:manageiq_providers_inframanager_vm, @edit[:new][:views][:manageiq_providers_inframanager_vm])
-            - if has_any_role?(%w(vandt_accord templates_filter_accord))
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Templates')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:manageiq_providers_inframanager_template, @edit[:new][:views][:manageiq_providers_inframanager_template])
-            - if role_allows(:feature => "resource_pool_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Resource Pools')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:resourcepool, @edit[:new][:views][:resourcepool])
-            - if role_allows(:feature => "storage_show_list")
-              .form-group
-                %label.col-md-3.control-label
-                  = ui_lookup(:tables => "storages")
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:storage, @edit[:new][:views][:storage])
-            - if role_allows(:feature => "providers_accord")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Configuration Management Providers')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:cm_providers, @edit[:new][:views][:cm_providers])
-            - if role_allows(:feature => "configured_systems_filter_accord")
-              .form-group
-                %label.col-md-3.control-label
-                  = _('Configuration Management Configured Systems')
-                .col-md-8
-                  %ul.list-inline= render_view_buttons(:cm_configured_systems,
-                                                    @edit[:new][:views][:cm_configured_systems])
+            - {:manageiq_providers_inframanager  => ["ems_infra_show_list",   _('Infrastructure Providers')],
+               :emscluster            => ["ems_cluster_show_list",            _('Clusters')],
+               :host                  => ["host_show_list",                   _('Hosts')],
+               :vmortemplate          => [["vandt_accord",
+                                           "vms_filter_accord"],              _('VMs & Templates')],
+               :manageiq_providers_inframanager_vm       => [["vandt_accord",
+                                                              "vms_filter_accord"],       _('VMs')],
+               :manageiq_providers_inframanager_template => [["vandt_accord",
+                                                              "templates_filter_accord"], _('Templates')],
+               :resourcepool          => ["resource_pool_show_list",          _('Resource Pools')],
+               :storage               => ["storage_show_list",                _('Datastores')],
+               :cm_providers          => ["providers_accord",                 _('Configuration Management Providers')],
+               :cm_configured_systems => ["configured_systems_filter_accord", _('Configuration Management Configured Systems')]}.each do |resource, (feature, view_name)|
+              - if has_any_role?(Array(feature))
+                .form-group
+                  %label.col-md-3.control-label
+                    = view_name
+                  .col-md-8
+                    %ul.list-inline= render_view_buttons(resource, @edit[:new][:views][resource])
         - if get_vmdb_config[:product][:storage]
           %fieldset
             %h3


### PR DESCRIPTION
This PR is cleaning up the default views keys mapping and their rendering. I've done that as I needed to debug wrong keys mapping between the view and the DEFAULT_VIEWS ui constant(in ui_constants.rb).

Probably good idea is moving those keys to the helper to not pollute the view with those mappings and also the iterrations through the mappings. For now this PR is the cleaning of the view.