### PR TITLE
Implement live search on various screens

### DIFF
--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -44,6 +44,7 @@
                      options_for_select([["<#{_('Determine at Run Time')}>", nil]] + ALL_TIMEZONES,
                                         @edit[:new][:profile][:tz]),
                      :disabled              => disabled,
+                     "data-live-search"     => "true",
                      "data-miq_sparkle_on"  => true,
                      "data-miq_sparkle_off" => true,
                      :class    => "selectpicker")

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -52,7 +52,8 @@
             .col-md-8
               = select_tag("start_page",
                            options_for_select(session[:start_pages], @edit[:new][:display][:startpage]),
-                           :class    => "selectpicker")
+                           "data-live-search" => "true",
+                           :class             => "selectpicker")
 
             :javascript
               miqSelectPickerEvent("start_page", "#{url}")

--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -14,6 +14,7 @@
           = select_tag("tag_cat",
             options_for_select(@categories.sort_by{|key, _| key.downcase}, @edit[:cat].name),
             "data-miq_observe"     => {:url => url}.to_json,
+            "data-live-search"     => "true",
             "class"                => "selectpicker")
           :javascript
             miqInitSelectPicker();

--- a/app/views/miq_capacity/_bottlenecks_options.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_options.html.haml
@@ -31,6 +31,7 @@
         = select_tag("tl_#{typ}_tz",
           options_for_select(ALL_TIMEZONES,
           @sb[:bottlenecks][:tl_options][:tz]),
+          "data-live-search" => "true",
           "class" => "selectpicker",
           "data-miq_sparkle_on"  => true,
           "data-miq_sparkle_off" => true)

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -27,6 +27,7 @@
         = select_tag("filter_value",
                       options_for_select(options, @sb[:planning][:options][:filter_value]),
                       :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                      "data-live-search"     => "true",
                       "class"                => "selectpicker",
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true,
@@ -69,6 +70,7 @@
           = select_tag("chosen_vm",
                         options_for_select(options, @sb[:planning][:options][:chosen_vm]),
                         :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
+                        "data-live-search"     => "true",
                         "class"                => "selectpicker",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true)

--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -28,6 +28,7 @@
                        options_for_select(ALL_TIMEZONES),
                        "ng-model"    => "scheduleModel.time_zone",
                        "checkchange" => "",
+                       "data-live-search"            => "true",
                        "selectpicker-for-select-tag" => "")
           \&nbsp;&nbsp;
           = _("* Changing the Time Zone will reset the Starting Date and Time fields below")

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -71,7 +71,8 @@
       .col-md-8
         = select_tag('server_timezone',
                       options_for_select(ALL_TIMEZONES, @edit[:new][:server][:timezone]),
-                      :class    => "selectpicker")
+                      "data-live-search" => "true",
+                      :class             => "selectpicker")
     :javascript
       miqSelectPickerEvent('server_timezone', "#{url}")
 

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -13,6 +13,7 @@
         = select_tag('chosen_model',
           options_for_select(@edit[:models].sort, @edit[:new][:model]),
           :multiple              => false,
+          "data-live-search"     => "true",
           :class                 => "selectpicker")
         :javascript
           miqInitSelectPicker();

--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -53,7 +53,8 @@
       .col-md-8
         = select_tag("time_zone",
           options_for_select(ALL_TIMEZONES, @edit[:tz]),
-          :class => "selectpicker")
+          "data-live-search" => "true",
+          :class             => "selectpicker")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("time_zone", "#{url}");


### PR DESCRIPTION
First implementation of "live search" for bootstrap-select in:

* My Settings > Time Zone
* Appliance Time Zone - Configuration/Configure/Server Settings
* My Settings > Start Page 
* Reports > Schedule Editor: Report/Filter selection drop downs
* Reports > Dashboard editor: Add a widget
* Reports > Configure Report Columns
* Optimize > Planning - list of VMs/Hosts
* Optimize > Bottlenecks > Time Zone
* Ops > Schedules > Time Zone
* Tag Assignment

https://trello.com/c/Nb38Rq7o

New
<img width="894" alt="screen shot 2016-06-27 at 3 18 16 pm" src="https://cloud.githubusercontent.com/assets/1287144/16392589/bb17c276-3c7a-11e6-95d2-8325f218e66c.png">

New
<img width="291" alt="screen shot 2016-06-27 at 3 06 31 pm" src="https://cloud.githubusercontent.com/assets/1287144/16392594/bb200530-3c7a-11e6-8e4a-c10900b002be.png">

New
<img width="720" alt="screen shot 2016-06-27 at 3 28 03 pm" src="https://cloud.githubusercontent.com/assets/1287144/16392770/9744d504-3c7b-11e6-8e42-7e7f5d6c6fbb.png">

New
<img width="484" alt="screen shot 2016-06-28 at 11 05 51 am" src="https://cloud.githubusercontent.com/assets/1287144/16420693/53bd027a-3d20-11e6-92b6-6d9a7c013483.png">

New
<img width="518" alt="screen shot 2016-06-28 at 11 05 45 am" src="https://cloud.githubusercontent.com/assets/1287144/16420692/53b9f4cc-3d20-11e6-87ad-45e6dd916bb1.png">

New
<img width="958" alt="screen shot 2016-06-28 at 11 16 20 am" src="https://cloud.githubusercontent.com/assets/1287144/16421018/8eca973c-3d21-11e6-941c-781c4ed9e13f.png">

New
<img width="554" alt="screen shot 2016-06-28 at 11 36 35 am" src="https://cloud.githubusercontent.com/assets/1287144/16421846/5221cb90-3d24-11e6-8248-61c4e4fc1c17.png">

New
<img width="669" alt="screen shot 2016-06-28 at 12 36 41 pm" src="https://cloud.githubusercontent.com/assets/1287144/16424148/f3c6f30a-3d2c-11e6-89d0-673f2f0c5f46.png">

