### PR TITLE
Convert cloud key pair form to angular

### DIFF
--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -32,18 +32,18 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
     var keyPairEditButtonClicked = function(buttonName, serializeFields) {
         miqService.sparkleOn();
 
-        //todo - save values to server
         var url = '/auth_key_pair_cloud/key_pair_save/' + keyPairFormId + '?button=' + buttonName;
         $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
-        var moreUrlParams = $.param(miqService.serializeModel($scope.keyPairModel));
-        if(moreUrlParams)
-            url += '&' + decodeURIComponent(moreUrlParams);
-        miqService.miqAjaxButton(url, false);
+        if(serializeFields) {
+            miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));
+        } else {
+            miqService.miqAjaxButton(url, false);
+        }
         miqService.sparkleOff();
     };
 
     $scope.cancelClicked = function() {
-        keyPairEditButtonClicked('cancel');
+        keyPairEditButtonClicked('cancel', false);
         $scope.angularForm.$setPristine(true);
     };
 

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -33,7 +33,7 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
         miqService.sparkleOn();
 
         //todo - save values to server
-        var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
+        var url = '/auth_key_pair_cloud/key_pair_save/' + keyPairFormId + '?button=' + buttonName;
         $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
         var moreUrlParams = $.param(miqService.serializeModel($scope.keyPairModel));
         if(moreUrlParams)

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -1,0 +1,66 @@
+ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope', 'keyPairFormId', 'miqService', function($http, $scope, keyPairFormId, miqService) {
+    var init = function() {
+        $scope.keyPairModel = {
+            name: '',
+            public_key: '',
+            ems_id: ''
+        };
+        $scope.formId = keyPairFormId;
+        $scope.afterGet = false;
+        $scope.modelCopy = angular.copy( $scope.keyPairModel );
+        $scope.model = 'keyPairModel';
+        $scope.ems_choices = [];
+        ManageIQ.angular.scope = $scope;
+
+        miqService.sparkleOn();
+        $http.get('/auth_key_pair_cloud/ems_form_choices').success(function(data) {
+            $scope.ems_choices = data.ems_choices;
+            if($scope.ems_choices.length > 0) {
+                $scope.keyPairModel.ems = $scope.ems_choices[0];
+            }
+            $scope.afterGet = true;
+            miqService.sparkleOff();
+        });
+
+        if (keyPairFormId == 'new') {
+            $scope.newRecord = true;
+        } else {
+            $scope.newRecord = false;
+        }
+    };
+
+    var keyPairEditButtonClicked = function(buttonName, serializeFields) {
+        miqService.sparkleOn();
+
+        //todo - save values to server
+        var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
+        $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
+        var moreUrlParams = $.param(miqService.serializeModel($scope.keyPairModel));
+        if(moreUrlParams)
+            url += '&' + decodeURIComponent(moreUrlParams);
+        miqService.miqAjaxButton(url, false);
+        miqService.sparkleOff();
+    };
+
+    $scope.cancelClicked = function() {
+        keyPairEditButtonClicked('cancel');
+        $scope.angularForm.$setPristine(true);
+    };
+
+    $scope.resetClicked = function() {
+        $scope.keyPairModel = angular.copy( $scope.modelCopy );
+        $scope.angularForm.$setPristine(true);
+        miqService.miqFlash("warn", __("All changes have been reset"));
+    };
+
+    $scope.saveClicked = function() {
+        keyPairEditButtonClicked('save', true);
+        $scope.angularForm.$setPristine(true);
+    };
+
+    $scope.addClicked = function() {
+        $scope.saveClicked();
+    };
+
+    init();
+}]);

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -32,7 +32,7 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
     var keyPairEditButtonClicked = function(buttonName, serializeFields) {
         miqService.sparkleOn();
 
-        var url = '/auth_key_pair_cloud/key_pair_save/' + keyPairFormId + '?button=' + buttonName;
+        var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
         $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
         if(serializeFields) {
             miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -91,6 +91,18 @@ class AuthKeyPairCloudController < ApplicationController
     end
   end
 
+  # REST call for provider choices
+  def ems_form_choices
+    assert_privileges("auth_key_pair_cloud_new")
+    ems_choices = []
+    ems_choices = ManageIQ::Providers::CloudManager.select { |ems| ems.class::AuthKeyPair.is_available?(:create_key_pair, ems) }.map do |ems|
+      {:name => ems.name, :id => ems.id}
+    end
+    render :json => {
+      :ems_choices => ems_choices
+    }
+  end
+
   def new
     assert_privileges("auth_key_pair_cloud_new")
     @key_pair = ManageIQ::Providers::CloudManager::AuthKeyPair.new

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -73,10 +73,11 @@ class AuthKeyPairCloudController < ApplicationController
     assert_privileges("auth_key_pair_cloud_new")
     ems_choices = ManageIQ::Providers::CloudManager.select do |ems|
       ems.class::AuthKeyPair.is_available?(:create_key_pair, ems)
-    end.map do |ems|
+    end
+    ems_choices.each do |ems|
       {:name => ems.name, :id => ems.id}
     end
-    render json: { ems_choices: ems_choices  }
+    render :json => {:ems_choices => ems_choices}
   end
 
   def new
@@ -96,21 +97,20 @@ class AuthKeyPairCloudController < ApplicationController
 
     kls = ManageIQ::Providers::CloudManager::AuthKeyPair
     options = {
-        :name => params[:name],
-        :public_key => !!params[:public_key] ? params[:public_key] : nil,
-        :ems_id => !!params[:ems_id] ? params[:ems_id] : nil
+      :name       => params[:name],
+      :public_key => params[:public_key],
+      :ems_id     => params[:ems_id]
     }
 
     case params[:button]
     when "cancel"
       render :update do |page|
         page << javascript_prologue
-        page.redirect_to :action => 'show_list',
+        page.redirect_to :action    => 'show_list',
                          :flash_msg => _("Add of new %{model} was cancelled by the user") % {
                            :model => ui_lookup(:table => 'auth_key_pair_cloud')
                          }
       end
-
     when "save"
       ext_management_system = find_by_id_filtered(ManageIQ::Providers::CloudManager, options[:ems_id])
       kls = kls.class_by_ems(ext_management_system)
@@ -145,7 +145,6 @@ class AuthKeyPairCloudController < ApplicationController
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       end
-
     when "validate"
       @in_a_form = true
       ext_management_system = find_by_id_filtered(ManageIQ::Providers::CloudManager, options[:ems_id])

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -92,7 +92,7 @@ class AuthKeyPairCloudController < ApplicationController
     )
   end
 
-  def key_pair_save
+  def create
     assert_privileges("auth_key_pair_cloud_new")
 
     kls = ManageIQ::Providers::CloudManager::AuthKeyPair

--- a/app/views/auth_key_pair_cloud/_form.html.haml
+++ b/app/views/auth_key_pair_cloud/_form.html.haml
@@ -37,11 +37,15 @@
         %label.col-md-2.control-label
           = _('Provider')
         .col-md-8
-          %select{:name                         => "ems_id",
+          = select_tag("ems_id",
+                  "",
                   "ng-model"                    => "keyPairModel.ems",
-                  "ng-options"                  => "ems.name for ems in ems_choices track by ems.id",
+                  "ng-options"                  => "ems.name for ems in ems_choices",
                   "id"                          => "ems_id",
-                  "required"                    => ""}
+                  "required"                    => "",
+                  "pf-select"                   => true)
+          :javascript
+            miqInitSelectPicker();
     = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript

--- a/app/views/auth_key_pair_cloud/_form.html.haml
+++ b/app/views/auth_key_pair_cloud/_form.html.haml
@@ -3,50 +3,50 @@
   %br
   %br
 
-.form-horizontal{:id => "start_form_div", :style => "display:none"}
-  %form#form_div{:name           => "angularForm",
-                 'ng-controller' => "keyPairCloudFormController",
-                 'ng-show'       => "afterGet",
+.form-horizontal{:id => 'start_form_div', :style => 'display:none'}
+  %form#form_div{:name           => 'angularForm',
+                 'ng-controller' => 'keyPairCloudFormController',
+                 'ng-show'       => 'afterGet',
                  :novalidate     => true}
-    = render :partial => "layouts/flash_msg"
+    = render :partial => 'layouts/flash_msg'
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
-      %label.col-md-2.control-label{"for" => "name"}
+      %label.col-md-2.control-label{:for => 'name'}
         = _('Name')
       .col-md-8
-        %input.form-control{:type            => "text",
-                            :name            => "name",
-                            "id"             => "name",
-                            'ng-model'       => "keyPairModel.name",
+        %input.form-control{:type            => 'text',
+                            :name            => 'name',
+                            :id              => 'name',
+                            'ng-model'       => 'keyPairModel.name',
                             :maxlength       => MAX_NAME_LEN,
                             :required        => true,
-                            :checkchange     => "",
-                            "auto-focus"     => true,
-                            "start-form-div" => "start_form_div"}
+                            :checkchange     => '',
+                            'auto-focus'     => true,
+                            'start-form-div' => 'start_form_div'}
         %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
     .form-group
-      %label.col-md-2.control-label{"for" => "public_key"}
+      %label.col-md-2.control-label{"for" => 'public_key'}
         = _('Public Key (optional)')
       .col-md-8
-        %textarea.form-control{"name"            => "public_key",
-                               "id"             => "public_key",
-                               "ng-model"       => "keyPairModel.public_key",
-                               "rows"           => 10}
+        %textarea.form-control{:name           => 'public_key',
+                               :id             => 'public_key',
+                               'ng-model'      => 'keyPairModel.public_key',
+                               :rows           => 10}
     .form-horizontal
       .form-group
         %label.col-md-2.control-label
           = _('Provider')
         .col-md-8
-          = select_tag("ems_id",
-                  "",
-                  "ng-model"                    => "keyPairModel.ems",
-                  "ng-options"                  => "ems.name for ems in ems_choices",
-                  "id"                          => "ems_id",
-                  "required"                    => "",
-                  "pf-select"                   => true)
+          = select_tag('ems_id',
+                  '',
+                  'ng-model'                   => 'keyPairModel.ems',
+                  'ng-options'                 => 'ems.name for ems in ems_choices',
+                  :id                          => 'ems_id',
+                  :required                    => '',
+                  'pf-select'                  => true)
           :javascript
             miqInitSelectPicker();
-    = render :partial => "layouts/angular/x_edit_buttons_angular"
+    = render :partial => 'layouts/angular/x_edit_buttons_angular'
 
 :javascript
   ManageIQ.angular.app.value('keyPairFormId', '#{@key_pair.id || "new"}');

--- a/app/views/auth_key_pair_cloud/_form.html.haml
+++ b/app/views/auth_key_pair_cloud/_form.html.haml
@@ -9,7 +9,7 @@
                  'ng-show'       => "afterGet",
                  :novalidate     => true}
     = render :partial => "layouts/flash_msg"
-    .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
+    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "name"}
         = _('Name')
       .col-md-8
@@ -22,7 +22,7 @@
                             :checkchange     => "",
                             "auto-focus"     => true,
                             "start-form-div" => "start_form_div"}
-        %span.help-block{"ng-show" => "angularForm.description.$error.required"}
+        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
           = _("Required")
     .form-group
       %label.col-md-2.control-label{"for" => "public_key"}

--- a/app/views/auth_key_pair_cloud/_form.html.haml
+++ b/app/views/auth_key_pair_cloud/_form.html.haml
@@ -1,44 +1,49 @@
-#main_div
-  - url = url_for(:action => 'form_field_changed', :id => @key_pair.id || "new")
+%h3
+  = _('Basic Information')
+  %br
+  %br
 
-  = render :partial => "layouts/flash_msg"
-
-  %h3
-    = _('Basic Information')
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
+.form-horizontal{:id => "start_form_div", :style => "display:none"}
+  %form#form_div{:name           => "angularForm",
+                 'ng-controller' => "keyPairCloudFormController",
+                 'ng-show'       => "afterGet",
+                 :novalidate     => true}
+    = render :partial => "layouts/flash_msg"
+    .form-group{"ng-class" => "{'has-error': angularForm.description.$invalid}"}
+      %label.col-md-2.control-label{"for" => "name"}
         = _('Name')
       .col-md-8
-        = text_field_tag("name",
-                          @edit[:new][:name],
-                          :maxlength => 50,
-                          :class => "form-control",
-                          "data-miq_focus" => true,
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+        %input.form-control{:type            => "text",
+                            :name            => "name",
+                            "id"             => "name",
+                            'ng-model'       => "keyPairModel.name",
+                            :maxlength       => MAX_NAME_LEN,
+                            :required        => true,
+                            :checkchange     => "",
+                            "auto-focus"     => true,
+                            "start-form-div" => "start_form_div"}
+        %span.help-block{"ng-show" => "angularForm.description.$error.required"}
+          = _("Required")
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-2.control-label{"for" => "public_key"}
         = _('Public Key (optional)')
       .col-md-8
-        = text_area_tag("public_key",
-                          @edit[:new][:public_key],
-                          :size => "50x10",
-                          :class => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _('Provider')
-      .col-md-8
-        = select_tag("ems_id",
-                      options_for_select(@edit[:ems_choices].sort, @edit[:new][:ems_id]),
-                      :multiple => false,
-                      "data-miq_sparkle_on" => true,
-                      "data-miq_sparkle_off" => true,
-                      :class    => "selectpicker",
-                      "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    :javascript
-       miqInitSelectPicker();
-       miqSelectPickerEvent("ems_id", "#{url}")
+        %textarea.form-control{"name"            => "public_key",
+                               "id"             => "public_key",
+                               "ng-model"       => "keyPairModel.public_key",
+                               "rows"           => 10}
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Provider')
+        .col-md-8
+          %select{:name                         => "ems_id",
+                  "ng-model"                    => "keyPairModel.ems",
+                  "ng-options"                  => "ems.name for ems in ems_choices track by ems.id",
+                  "id"                          => "ems_id",
+                  "required"                    => ""}
+    = render :partial => "layouts/angular/x_edit_buttons_angular"
 
-  = render(:partial => '/layouts/edit_buttons', :locals  => {:ajax_buttons => true, :record_id => @key_pair.id || "", :action_url => "#{@key_pair.id ? 'update' : 'create'}"})
+:javascript
+  ManageIQ.angular.app.value('keyPairFormId', '#{@key_pair.id || "new"}');
+  miq_bootstrap('#form_div');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,6 @@ Vmdb::Application.routes.draw do
         create
         dynamic_checkbox_refresh
         form_field_changed
-        key_pair_save
         listnav_search_selected
         panel_control
         quick_search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Vmdb::Application.routes.draw do
         create
         dynamic_checkbox_refresh
         form_field_changed
+        key_pair_save
         listnav_search_selected
         panel_control
         quick_search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,8 @@ Vmdb::Application.routes.draw do
         show
         show_list
         tagging_edit
-        tag_edit_form_field_changed
+        tag_edit_form_field_changed,
+        ems_form_choices
       ) + compare_get,
       :post => %w(
         button

--- a/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
+++ b/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
@@ -1,0 +1,93 @@
+describe('keyPairCloudFormController', function() {
+    var $scope, $controller, $httpBackend, miqService;
+
+    beforeEach(module('ManageIQ'));
+
+    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
+        miqService = _miqService_;
+        spyOn(miqService, 'showButtons');
+        spyOn(miqService, 'hideButtons');
+        spyOn(miqService, 'buildCalendar');
+        spyOn(miqService, 'miqAjaxButton');
+        spyOn(miqService, 'sparkleOn');
+        spyOn(miqService, 'sparkleOff');
+        $scope = $rootScope.$new();
+        spyOn($scope, '$broadcast');
+        $scope.keyPairModel = { name: 'name', public_key: 'key', ems_id: 4, ems: { id: 4 } };
+
+        //$scope.hostForm.$invalid = false;
+        $httpBackend = _$httpBackend_;
+        var providerResponse = {"ems_choices":
+            [{"name": "OS1", "id":5}
+        ]};
+
+        $httpBackend.whenGET('/auth_key_pair_cloud/ems_form_choices').respond(providerResponse);
+        $controller = _$controller_('keyPairCloudFormController', {
+            $scope: $scope,
+            keyPairFormId: 'new',
+            miqService: miqService
+        });
+    }));
+
+    afterEach(function() {
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('initialization', function() {
+        beforeEach(function() {
+            $httpBackend.flush();
+            $scope.angularForm = {
+                $setPristine: function (value){}
+            };
+        });
+        describe('when the keyPairFormId is new', function() {
+            it('sets the name to blank', function () {
+                expect($scope.keyPairModel.name).toEqual('');
+            });
+            it('sets the hostname to blank', function () {
+                expect($scope.keyPairModel.public_key).toEqual('');
+            });
+        });
+    });
+
+    describe('#saveClicked', function() {
+        beforeEach(function() {
+            $httpBackend.flush();
+            $scope.angularForm = {
+                $setPristine: function (value){}
+            };
+            $scope.saveClicked();
+        });
+
+        it('turns the spinner on via the miqService', function() {
+            expect(miqService.sparkleOn).toHaveBeenCalled();
+        });
+
+        it('turns the spinner on twice', function() {
+            expect(miqService.sparkleOn.calls.count()).toBe(2);
+        });
+
+        it('delegates to miqService.miqAjaxButton', function() {
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/key_pair_save/new?button=save', miqService.serializeModel($scope.keyPairModel));
+        });
+    });
+
+    describe('#cancelClicked', function() {
+        beforeEach(function() {
+            $httpBackend.flush();
+            $scope.angularForm = {
+                $setPristine: function (value){}
+            };
+            $scope.cancelClicked();
+        });
+
+        it('turns the spinner on via the miqService', function() {
+            expect(miqService.sparkleOn).toHaveBeenCalled();
+        });
+
+        it('delegates to miqService.restAjaxButton', function() {
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/key_pair_save/new?button=cancel', false);
+        });
+    });
+});

--- a/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
+++ b/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
@@ -69,7 +69,7 @@ describe('keyPairCloudFormController', function() {
         });
 
         it('delegates to miqService.miqAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/key_pair_save/new?button=save', miqService.serializeModel($scope.keyPairModel));
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel($scope.keyPairModel));
         });
     });
 
@@ -87,7 +87,7 @@ describe('keyPairCloudFormController', function() {
         });
 
         it('delegates to miqService.restAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/key_pair_save/new?button=cancel', false);
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel', false);
         });
     });
 });


### PR DESCRIPTION
Purpose or Intent
-----------------
Convert the Compute > Clouds > Key Pairs form to Angular.

<img width="892" alt="screen shot 2016-06-27 at 3 48 38 pm" src="https://cloud.githubusercontent.com/assets/7306953/16393442/d66cd88c-3c7e-11e6-8f3a-e60573f3c1d5.png">

This included modifying the controller to remove any @edit variables and retrieve cloud providers for the dropdown.  The create method was also changed to allow for a POST from the new Angular controller.  All other functionality should be identical to the way it currently works.

Steps for Testing/QA
--------------------
> No additional testing is necessary other than verifying the key pair add form works the same way it used to (with the exception of having the required validation on the client side.
