### PR TITLE
Add Dialog#deep_copy method

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -100,6 +100,16 @@ class Dialog < ApplicationRecord
     DialogSerializer.new.serialize(Array[workflow.dialog])
   end
 
+  def deep_copy(new_attributes = {})
+    new_dialog = dup
+    new_dialog.dialog_tabs = dialog_tabs.collect(&:deep_copy)
+
+    new_attributes.each do |attr, value|
+      new_dialog.send("#{attr}=", value)
+    end
+    new_dialog
+  end
+
   private
 
   def dialog_field_hash

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -108,6 +108,12 @@ class DialogField < ApplicationRecord
     DialogFieldSerializer.serialize(self)
   end
 
+  def deep_copy
+    dup.tap do |new_field|
+      new_field.resource_action = resource_action.dup
+    end
+  end
+
   private
 
   def default_resource_action

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -26,4 +26,10 @@ class DialogGroup < ApplicationRecord
       end
     end
   end
+
+  def deep_copy
+    dup.tap do |new_group|
+      new_group.dialog_fields = dialog_fields.collect(&:deep_copy)
+    end
+  end
 end

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -29,4 +29,10 @@ class DialogTab < ApplicationRecord
       end
     end
   end
+
+  def deep_copy
+    dup.tap do |new_tab|
+      new_tab.dialog_groups = dialog_groups.collect(&:deep_copy)
+    end
+  end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -306,4 +306,26 @@ describe Dialog do
       dialog.validate_children
     end
   end
+
+  describe "#deep_copy" do
+    let(:dialog_service) { OrchestrationTemplateDialogService.new }
+    let(:template_hot)   { FactoryGirl.create(:orchestration_template_hot_with_content) }
+    let(:dialog) { dialog_service.create_dialog('test', template_hot) }
+
+    it "clones the dialog and all containing components" do
+      dialog_new = dialog.deep_copy(:name => 'test_cloned')
+      num_dialogs = Dialog.count
+      num_tabs = DialogTab.count
+      num_groups = DialogGroup.count
+      num_fields = DialogField.count
+      num_actions = ResourceAction.count
+
+      dialog_new.save!
+      expect(Dialog.count).to eq(num_dialogs * 2)
+      expect(DialogTab.count).to eq(num_tabs * 2)
+      expect(DialogGroup.count).to eq(num_groups * 2)
+      expect(DialogField.count).to eq(num_fields * 2)
+      expect(ResourceAction.count).to eq(num_actions * 2)
+    end
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Part of the work to support blueprint feature, we need to copy a service dialog. This includes all the tabs, groups, and fields contained in the dialog.

The new `deep_copy` method only creates a new object in memory. A subsequent call to `save` or `save!` will actually create the new dialog and its containing components to DB. Service dialog reinforces uniqueness of the name, so before the save the name needs to be changed. The method takes an optional hash to update the attributes. A new name can be provided through this parameter.
