### PR TITLE
Use additional lookup when locating relationships in Automate Engine

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
@@ -1,11 +1,15 @@
 module MiqAeEngine
   class MiqAeDomainSearch
-    attr_accessor :prepend_namespace
     def initialize
       @fqns_id_cache       = {}
       @fqns_id_class_cache = {}
       @partial_ns          = []
       @prepend_namespace   = nil
+    end
+
+    def prepend_namespace=(ns)
+      @prepend_namespace = ns.chomp('/').sub(/^\//, '')
+      $miq_ae_logger.info("Prepend namespace [#{@prepend_namespace} during domain search")
     end
 
     def ae_user=(obj)

--- a/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
@@ -1,9 +1,11 @@
 module MiqAeEngine
   class MiqAeDomainSearch
+    attr_accessor :prepend_namespace
     def initialize
       @fqns_id_cache       = {}
       @fqns_id_class_cache = {}
       @partial_ns          = []
+      @prepend_namespace   = nil
     end
 
     def ae_user=(obj)
@@ -35,7 +37,9 @@ module MiqAeEngine
         end
       end
       @partial_ns << ns unless @partial_ns.include?(ns)
-      find_first_fq_domain(uri, ns, klass, instance, method)
+      updated_ns = find_first_fq_domain(uri, "#{@prepend_namespace}/#{ns}", klass, instance, method) if @prepend_namespace
+      updated_ns ||= find_first_fq_domain(uri, ns, klass, instance, method)
+      updated_ns || ns
     end
 
     def find_first_fq_domain(uri, ns, klass, instance, method)
@@ -45,12 +49,13 @@ module MiqAeEngine
       parts.unshift("")
       matching_domain = get_matching_domain(parts, klass, instance, method)
       matching_domain ||= get_matching_domain(parts, klass, MiqAeObject::MISSING_INSTANCE, method)
+      updated_ns = nil
       if matching_domain
-        parts[0]     = matching_domain
-        ns = parts.join('/')
-        $miq_ae_logger.info("Updated namespace [#{uri}  #{ns}]")
+        parts[0]   = matching_domain
+        updated_ns = parts.join('/')
+        $miq_ae_logger.info("Updated namespace [#{uri}  #{updated_ns}]")
       end
-      ns
+      updated_ns
     end
 
     def get_matching_domain(ns_parts, klass, instance, method)

--- a/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
@@ -8,7 +8,7 @@ module MiqAeEngine
     end
 
     def prepend_namespace=(ns)
-      @prepend_namespace = ns.chomp('/').sub(/^\//, '')
+      @prepend_namespace = ns.chomp('/').sub(%r{^/}, '')
       $miq_ae_logger.info("Prepend namespace [#{@prepend_namespace} during domain search")
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -136,6 +136,10 @@ module MiqAeMethodService
       @persist_state_hash[name]
     end
 
+    def prepend_namespace(ns)
+      @workspace.prepend_namespace(ns)
+    end
+
     def instantiate(uri)
       obj = @workspace.instantiate(uri, @workspace.ae_user, @workspace.current_object)
       return nil if obj.nil?

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -137,7 +137,7 @@ module MiqAeMethodService
     end
 
     def prepend_namespace=(ns)
-      @workspace.prepend_namespace=(ns)
+      @workspace.prepend_namespace = ns
     end
 
     def instantiate(uri)

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -136,8 +136,8 @@ module MiqAeMethodService
       @persist_state_hash[name]
     end
 
-    def prepend_namespace(ns)
-      @workspace.prepend_namespace(ns)
+    def prepend_namespace=(ns)
+      @workspace.prepend_namespace=(ns)
     end
 
     def instantiate(uri)

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -99,6 +99,7 @@ module MiqAeEngine
       $miq_ae_logger.info("Instantiating [#{uri}]") if root.nil?
       @ae_user = user
       @dom_search.ae_user = user
+      @dom_search.prepend_namespace  = root['prepend_namespace'] if root && root['prepend_namespace']
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = MiqAeUri.split(uri, "miqaedb")
 
       raise MiqAeException::InvalidPathFormat, "Unsupported Scheme [#{scheme}]" unless MiqAeUri.scheme_supported?(scheme)

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -56,7 +56,7 @@ module MiqAeEngine
       @ae_user = nil
     end
 
-    delegate :prepend_namespace, :to =>  :@dom_search
+    delegate :prepend_namespace=, :to =>  :@dom_search
 
     def readonly?
       @readonly

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -56,6 +56,8 @@ module MiqAeEngine
       @ae_user = nil
     end
 
+    delegate :prepend_namespace, :to =>  :@dom_search
+
     def readonly?
       @readonly
     end
@@ -99,7 +101,6 @@ module MiqAeEngine
       $miq_ae_logger.info("Instantiating [#{uri}]") if root.nil?
       @ae_user = user
       @dom_search.ae_user = user
-      @dom_search.prepend_namespace  = root['prepend_namespace'] if root && root['prepend_namespace']
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = MiqAeUri.split(uri, "miqaedb")
 
       raise MiqAeException::InvalidPathFormat, "Unsupported Scheme [#{scheme}]" unless MiqAeUri.scheme_supported?(scheme)

--- a/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
@@ -54,7 +54,7 @@ module MiqAeDomainSearchSpec
     it "#get_alternate_domain with vendor" do
       create_vendor_ae_instances
       search.ae_user = user
-      search.prepend_namespace = "AMAZON"
+      search.prepend_namespace = "/AMAZON/"
       ns = search.get_alternate_domain('miqaedb', '/TEST/PROV/ONE', 'TEST', 'PROV', 'ONE')
       expect(ns).to eq('AMAZON/AMAZON/TEST')
     end
@@ -62,7 +62,7 @@ module MiqAeDomainSearchSpec
     it "#get_alternate_domain_method with vendor" do
       create_vendor_ae_methods
       search.ae_user = user
-      search.prepend_namespace = "OPENSTACK"
+      search.prepend_namespace = "/OPENSTACK/"
       ns = search.get_alternate_domain_method('miqaedb', '/TEST/WILMA/OBELIX', 'TEST', 'WILMA', 'OBELIX')
       expect(ns).to eq('OPENSTACK/OPENSTACK/TEST')
     end

--- a/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
@@ -12,11 +12,27 @@ module MiqAeDomainSearchSpec
                       :instance_name => 'DOGMATIX')
     end
 
+    def create_vendor_ae_instances
+      create_ae_model(:name => 'AMAZON', :ae_namespace => 'AMAZON/TEST', :ae_class => 'PROV',
+                      :instance_name => 'ONE')
+      create_ae_model(:name => 'MIQ', :ae_namespace => 'TEST', :ae_class => 'PROV',
+                      :instance_name => 'ONE')
+    end
+
     def create_ae_methods
       create_ae_model_with_method(:name => 'FRED', :ae_namespace => 'FRED',
                                   :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_script => 'x=1')
       create_ae_model_with_method(:name => 'BARNEY', :ae_namespace => 'FRED',
+                                  :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_script => 'x=1')
+    end
+
+    def create_vendor_ae_methods
+      create_ae_model_with_method(:name => 'OPENSTACK', :ae_namespace => 'OPENSTACK/TEST',
+                                  :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_script => 'x=1')
+      create_ae_model_with_method(:name => 'BARNEY', :ae_namespace => 'TEST',
                                   :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_script => 'x=1')
     end
@@ -33,6 +49,22 @@ module MiqAeDomainSearchSpec
       search.ae_user = user
       ns = search.get_alternate_domain_method('miqaedb', '/FRED/WILMA/OBELIX', 'FRED', 'WILMA', 'OBELIX')
       expect(ns).to eq('BARNEY/FRED')
+    end
+
+    it "#get_alternate_domain with vendor" do
+      create_vendor_ae_instances
+      search.ae_user = user
+      search.prepend_namespace = "AMAZON"
+      ns = search.get_alternate_domain('miqaedb', '/TEST/PROV/ONE', 'TEST', 'PROV', 'ONE')
+      expect(ns).to eq('AMAZON/AMAZON/TEST')
+    end
+
+    it "#get_alternate_domain_method with vendor" do
+      create_vendor_ae_methods
+      search.ae_user = user
+      search.prepend_namespace = "OPENSTACK"
+      ns = search.get_alternate_domain_method('miqaedb', '/TEST/WILMA/OBELIX', 'TEST', 'WILMA', 'OBELIX')
+      expect(ns).to eq('OPENSTACK/OPENSTACK/TEST')
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -138,7 +138,7 @@ module MiqAeServiceSpec
   end
 
   describe MiqAeService do
-    context "#prepend_namespace" do
+    context "#prepend_namespace=" do
       let(:options) { {} }
       let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
       let(:miq_ae_service) { MiqAeService.new(workspace) }
@@ -146,9 +146,9 @@ module MiqAeServiceSpec
 
       it "set namespace" do
         allow(workspace).to receive(:persist_state_hash).and_return({})
-        expect(workspace).to receive(:prepend_namespace).with(ns)
+        expect(workspace).to receive(:prepend_namespace=).with(ns)
 
-        miq_ae_service.prepend_namespace(ns)
+        miq_ae_service.prepend_namespace = ns
       end
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -136,4 +136,20 @@ module MiqAeServiceSpec
       end
     end
   end
+
+  describe MiqAeService do
+    context "#prepend_namespace" do
+      let(:options) { {} }
+      let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
+      let(:miq_ae_service) { MiqAeService.new(workspace) }
+      let(:ns) { "fred" }
+
+      it "set namespace" do
+        allow(workspace).to receive(:persist_state_hash).and_return({})
+        expect(workspace).to receive(:prepend_namespace).with(ns)
+
+        miq_ae_service.prepend_namespace(ns)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
> For pluggable provider based Automate Models we need the ability for the provider model to overwrite the base functionality provided in the ManageIQ domain. When a new request comes into Automate, the parse_provider_category_method has the option to set a "prepend_namespace" attribute by calling $evm.prepend_namespace. The engine would add this namespace to every relationship/method that it tries to do a lookup on, if the instance/method exists with the "prepend_namespace" it will get used, If the instance/method doesn't exist the original relationship/method will be searched, which allows us to fallback to the default implementation in ManageIQ domain.
> 
> Guidelines:
>   * To set the prepend_namespace call $evm.prepend_namespace(<<string>>) from automate method
>   * The value should match the provider namespace


Links
-----
> * https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/ae_datastore/ManageIQ/System/Process.class/__methods__/parse_provider_category.rb
 

