### PR TITLE
Avoid invoking AE in MiqReport specs

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -1,19 +1,8 @@
 shared_examples "custom_report_with_custom_attributes" do |base_report, custom_attribute_field|
   let(:options) { {:targets_hash => true, :userid => "admin"} }
-  let(:base_report_downcase) { base_report.downcase }
-  let(:miq_ae_uri) { "/EVM/AUTOMATE/test1?#{base_report}::#{base_report_downcase}=#{@resource.id}" }
   let(:custom_attributes_field) { custom_attribute_field.to_s.pluralize }
 
-  def invoke_ae
-    MiqAeEngine.instantiate(miq_ae_uri, @user)
-  end
-
   before do
-    EvmSpecHelper.local_miq_server
-    MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM',
-                                                  'AUTOMATE', 'test1', 'test')
-    @ae_method = ::MiqAeMethod.first
-    ae_result_key = 'foo'
     @user = FactoryGirl.create(:user_with_group)
 
     # create custom attributes
@@ -22,16 +11,6 @@ shared_examples "custom_report_with_custom_attributes" do |base_report, custom_a
 
     @resource = base_report == "Host" ? FactoryGirl.create(:host) : FactoryGirl.create(:vm_vmware)
     FactoryGirl.create(custom_attribute_field, :resource => @resource, :name => @key, :value => @value)
-
-    if custom_attribute_field == :ems_custom_attribute
-      custom_get_method = "ems_custom_get"
-    else
-      custom_get_method = "custom_get"
-    end
-
-    method = "$evm.root['#{ae_result_key}'] = $evm.root['#{base_report_downcase}'].#{custom_get_method}('#{@key}')"
-    @ae_method.update_attributes(:data => method)
-    @ae_object = invoke_ae.root(ae_result_key)
   end
 
   let(:report) do


### PR DESCRIPTION
These tests invoke the Automation Engine in order to set some custom
attributes on some Vms/Hosts. The #miq_custom_set method allows us to
circumvent this, simplifying the tests here.

This also addresses an issue for me where the automation engine method invocation fails because it assumes that ActiveSupport is on the load path. While it looks like that can't change for now, this gets these tests, which I especially care about, passing for me.

Props to @lpichler for pointing me to `#miq_custom_set`. @lpichler, with this substitution, are these tests still testing the right thing?

@miq-bot assign @gtanzillo 