### PR TITLE
Reset ManageIQ automate domain to get the latest changes with bin/update

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -15,7 +15,11 @@ Dir.chdir APP_ROOT do
   puts "\n== Seeding database =="
   system "bin/rake db:seed GOOD_MIGRATIONS=skip"
 
-
   puts "\n== Resetting tests =="
   system "bin/rake test:vmdb:setup"
+
+  unless ENV["SKIP_AUTOMATE_RESET"]
+    puts "\n== Resetting Automate Domains =="
+    system "bin/rake evm:automate:reset"
+  end
 end


### PR DESCRIPTION
Developers doing a `git pull` does not update the automate domain.  Adding this to bin/update to avoid future confusion.