### PR TITLE
Capture and report evmserverd start failures

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -333,7 +333,13 @@ Static Network Configuration
         if ask_yn?("\nStart #{I18n.t("product.name")}")
           say("\nStarting #{I18n.t("product.name")} Server...")
           Logging.logger.info("EVM server start initiated by appliance console.")
-          LinuxAdmin::Service.new("evmserverd").start
+          begin
+            LinuxAdmin::Service.new("evmserverd").start
+          rescue AwesomeSpawn::CommandResultError => e
+            say e.result.output
+            say e.result.error
+            say ""
+          end
           press_any_key
         end
 


### PR DESCRIPTION
Purpose of this PR
-----------------

This PR will prevent a stack trace and provide direction to the user for diagnosing failed
evmserverd services starts.

I borrowed the AwesomeSpawn::CommandResultError handling from the "advanced_settings" case.

I realize this code could be DRYed if the evmserverd processing were moved to a separate 
ApplianceConsole::EvmServerd class but that is beyond the scope of this PR and should
be handled separately

I tested by copying the updated files to a live CFME appliance and ran without a DB configured.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1302395

Commit comment:
------------------------

This fix it to avoid a stack trace and provide
direction for diagnosing failures.

https://bugzilla.redhat.com/show_bug.cgi?id=1302395

