### PR TITLE
Build an arel scope as opposed to an ActiveRecord conditional hash

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -916,11 +916,11 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def ws_find_template_or_vm(_values, src_name, src_guid, ems_guid)
-    conditions = {}
-    conditions[:guid] = src_guid unless src_guid.blank?
-    conditions[:uid_ems] = ems_guid unless ems_guid.blank?
-    conditions['lower(name)'] = src_name unless src_name.blank?
-    source_vm_rbac_filter(VmOrTemplate.where(conditions)).first
+    scope = VmOrTemplate
+    scope = scope.where(:guid => src_guid) unless src_guid.blank?
+    scope = scope.where(:uid_ems => ems_guid) unless ems_guid.blank?
+    scope = scope.where(VmOrTemplate.arel_attribute("name").lower.eq(src_name)) unless src_name.blank?
+    source_vm_rbac_filter(scope).first
   end
 
   def ws_vm_fields(values, fields)

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -213,4 +213,25 @@ describe MiqProvisionVirtWorkflow do
       expect(workflow.allowed_template_condition).to eq(["vms.template = ? AND vms.ems_id in (?)", true, [ems.id]])
     end
   end
+
+  context "#ws_find_template_or_vm" do
+    let(:server) { double("MiqServer", :logon_status => :ready, :server_timezone => 'East') }
+    let(:sdn) { 'SysprepDomainName' }
+
+    before do
+      allow(MiqServer).to receive(:my_server).with(no_args).and_return(server)
+      allow(workflow).to receive_messages(:validate => true)
+      allow(workflow).to receive_messages(:get_dialogs => {})
+      workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => 123, :sysprep_enabled => 'fields',
+                                     :sysprep_domain_name => sdn)
+    end
+
+    it "does a lookup when src_name is blank" do
+      expect(workflow.ws_find_template_or_vm("", "", "asdf-adsf", "asdfadfasdf")).to be_nil
+    end
+
+    it "does a lookup when src_name is not blank" do
+      expect(workflow.ws_find_template_or_vm("", "VMWARE", "asdf-adsf", "asdfadfasdf")).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
> Calling the Postgres function - `lower(name)` (or any function for that matter) was
blowing up with an error that the column was not
found - using AREL to build the sql (instead of an AR hash) removes the problem.

>The specs around the problem are proving the code no longer blows up whether the `src_name` is passed in or not.


Steps for Testing/QA
--------------------
> Provisioning to VMWare using the `:clone_to_vm` option was previously blowing up - because `src_name` was no longer nil.  This code will no longer die with the same error.

