### PR TITLE
Update activerecord-session_store gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "ruport",                         "=1.7.0",                       :git => "g
 gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-8"
 gem "simple-rss",                     "~>1.3.1",   :require => false
-gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
+gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"
 
 # Not vendored, but required
 gem "mime-types",                     "~>2.6.1",   :require => "mime/types/columnar"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@
 gem "rails",                           "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
 gem "rails-controller-testing",        :require => false
 gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
-gem "activerecord-session_store",      "~>0.1.2", :require => false
+gem "activerecord-session_store",      "~>1.0.0"
 gem "websocket-driver",                "~>0.6.3"
 
 gem "config",                          "~>1.1.0", :git => "git://github.com/ManageIQ/config.git", :branch => "overwrite_arrays"
@@ -83,7 +83,6 @@ gem "google-api-client",              "~>0.8.6",   :require => false
 gem "fog-google",                     "~>0.3.0",   :require => false
 gem "hamlit",                         "~>2.0.0",   :require => false
 gem "inifile",                        "~>3.0",     :require => false
-gem "logging",                        "~>1.8",     :require => false  # Ziya depends on this
 gem "net_app_manageability",          ">=0.1.0",   :require => false
 gem "net-ping",                       "~>1.7.4",   :require => false
 gem "net-ssh",                        "=3.2.0",    :require => false


### PR DESCRIPTION
https://github.com/rails/activerecord-session_store/pull/66 added rails 5 compatibility to the activerecord-session_store gem

Without this, we were not able to support UI load balancing which requires session information be stored in the database.

The logging gem also had to be updated (in this case the restriction removed) as it was causing a dependency issue versioned as it was.

https://bugzilla.redhat.com/show_bug.cgi?id=1300018