### PR TITLE
Update sys-proctable to 1.1.x.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -50,7 +50,7 @@ gem "trollop",                 "~>2.0",             :require => false
 gem "uuidtools",               "~>2.1.3",           :require => false
 gem "winrm",                   "~>1.7.2",           :require => false
 gem "winrm-elevated",          "~>0.4.0",           :require => false
-gem 'sys-proctable',           "~> 1.0",            :require => false
+gem 'sys-proctable',           "~>1.1.0",           :require => false
 
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")


### PR DESCRIPTION
This updates the sys-proctable gem to 1.1.x. This version has updated code for OS X, which has been converted to pure Ruby using an FFI wrapper around libproc. Also, the license has been changed to Apache 2.0.

This is a step towards helping with https://github.com/ManageIQ/manageiq/pull/9422.
