### PR TITLE
Add methods for associating and disassociating floating IPs w/ Openstack Cloud Instances

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -82,11 +82,11 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   end
 
   def validate_associate_floating_ip
-    validate_unsupported(_("Associate Floating IP Operation"))
+    {:available => supports_associate_floating_ip?, :message => unsupported_reason(:associate_floating_ip)}
   end
 
   def validate_disassociate_floating_ip
-    validate_unsupported(_("Disassociate Floating IP Operation"))
+    {:available => supports_disassociate_floating_ip?, :message => unsupported_reason(:disassociate_floating_ip)}
   end
 
   def raw_associate_floating_ip(_ip_address)

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -81,14 +81,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     super
   end
 
-  def validate_associate_floating_ip
-    {:available => supports_associate_floating_ip?, :message => unsupported_reason(:associate_floating_ip)}
-  end
-
-  def validate_disassociate_floating_ip
-    {:available => supports_disassociate_floating_ip?, :message => unsupported_reason(:disassociate_floating_ip)}
-  end
-
   def raw_associate_floating_ip(_ip_address)
     raise NotImplementedError, _("raw_associate_floating_ip must be implemented in a subclass")
   end

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -81,6 +81,30 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     super
   end
 
+  def validate_associate_floating_ip
+    validate_unsupported(_("Associate Floating IP Operation"))
+  end
+
+  def validate_disassociate_floating_ip
+    validate_unsupported(_("Disassociate Floating IP Operation"))
+  end
+
+  def raw_associate_floating_ip(_ip_address)
+    raise NotImplementedError, _("raw_associate_floating_ip must be implemented in a subclass")
+  end
+
+  def associate_floating_ip(ip_address)
+    raw_associate_floating_ip(ip_address)
+  end
+
+  def raw_disassociate_floating_ip(_ip_address)
+    raise NotImplementedError, _("raw_disassociate_floating_ip must be implemented in a subclass")
+  end
+
+  def disassociate_floating_ip(ip_address)
+    raw_disassociate_floating_ip(ip_address)
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   include_concern 'Operations'
   include_concern 'RemoteConsole'
   include_concern 'Resize'
+  include_concern 'AssociateIp'
 
   supports :smartstate_analysis do
     feature_supported, reason = check_feature_support('smartstate_analysis')

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
@@ -16,7 +16,6 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::AssociateIp
         unsupported_reason_add(:disassociate_floating_ip,
                                _("This %{instance} does not have any associated %{floating_ips}") % {
                                  :instance     => ui_lookup(:table => 'vm_cloud'),
-                                 :name         => name,
                                  :floating_ips => ui_lookup(:tables => 'floating_ip')
                                })
       end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
@@ -1,26 +1,25 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::AssociateIp
-  def validate_associate_floating_ip
-    if cloud_tenant.nil? || Rbac.filtered(cloud_tenant.floating_ips).empty?
-      message = _("There are no %{floating_ips} available to this %{instance}.") % {
-        :floating_ips => ui_lookup(:tables => "floating_ips"),
-        :instance     => ui_lookup(:table => "vm_cloud")
-      }
-      {:available => false, :message => message}
-    else
-      {:available => true, :message => nil}
-    end
-  end
+  extend ActiveSupport::Concern
 
-  def validate_disassociate_floating_ip
-    if floating_ips.empty?
-      message = _("This %{instance} does not have any associated %{floating_ips}") % {
-        :instance     => ui_lookup(:table => 'vm_cloud'),
-        :name         => name,
-        :floating_ips => ui_lookup(:tables => 'floating_ip')
-      }
-      {:available => false, :message => message}
-    else
-      {:available => true, :message => nil}
+  included do
+    supports :associate_floating_ip do
+      if cloud_tenant.nil? || Rbac.filtered(cloud_tenant.floating_ips).empty?
+        unsupported_reason_add(:associate_floating_ip,
+                               _("There are no %{floating_ips} available to this %{instance}.") % {
+                                 :floating_ips => ui_lookup(:tables => "floating_ips"),
+                                 :instance     => ui_lookup(:table => "vm_cloud")
+                               })
+      end
+    end
+    supports :disassociate_floating_ip do
+      if floating_ips.empty?
+        unsupported_reason_add(:disassociate_floating_ip,
+                               _("This %{instance} does not have any associated %{floating_ips}") % {
+                                 :instance     => ui_lookup(:table => 'vm_cloud'),
+                                 :name         => name,
+                                 :floating_ips => ui_lookup(:tables => 'floating_ip')
+                               })
+      end
     end
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
@@ -1,0 +1,48 @@
+module ManageIQ::Providers::Openstack::CloudManager::Vm::AssociateIp
+  def validate_associate_floating_ip
+    if cloud_tenant.nil? || Rbac.filtered(cloud_tenant.floating_ips).empty?
+      message = _("There are no %{floating_ips} available to this %{instance}.") % {
+        :floating_ips => ui_lookup(:tables => "floating_ips"),
+        :instance     => ui_lookup(:table => "vm_cloud")
+      }
+      {:available => false, :message => message}
+    else
+      {:available => true, :message => nil}
+    end
+  end
+
+  def validate_disassociate_floating_ip
+    if floating_ips.empty?
+      message = _("This %{instance} does not have any associated %{floating_ips}") % {
+        :instance     => ui_lookup(:table => 'vm_cloud'),
+        :name         => name,
+        :floating_ips => ui_lookup(:tables => 'floating_ip')
+      }
+      {:available => false, :message => message}
+    else
+      {:available => true, :message => nil}
+    end
+  end
+
+  def raw_associate_floating_ip(floating_ip)
+    ext_management_system.with_provider_connection(compute_connection_options) do |connection|
+      connection.associate_address(ems_ref, floating_ip)
+    end
+  rescue => err
+    _log.error "vm=[#{name}], floating_ip=[#{floating_ip}], error: #{err}"
+    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+  end
+
+  def raw_disassociate_floating_ip(floating_ip)
+    ext_management_system.with_provider_connection(compute_connection_options) do |connection|
+      connection.disassociate_address(ems_ref, floating_ip)
+    end
+  rescue => err
+    _log.error "vm=[#{name}], floating_ip=[#{floating_ip}], error: #{err}"
+    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+  end
+
+  def compute_connection_options
+    {:service => 'Compute', :tenant_name => cloud_tenant.name}
+  end
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/associate_ip.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::AssociateIp
 
   included do
     supports :associate_floating_ip do
-      if cloud_tenant.nil? || Rbac.filtered(cloud_tenant.floating_ips).empty?
+      if cloud_tenant.nil? || cloud_tenant.floating_ips.empty?
         unsupported_reason_add(:associate_floating_ip,
                                _("There are no %{floating_ips} available to this %{instance}.") % {
                                  :floating_ips => ui_lookup(:tables => "floating_ips"),

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -32,6 +32,8 @@ class VmOrTemplate < ApplicationRecord
   include AvailabilityMixin
 
   supports_not :retire
+  supports_not :associate_floating_ip
+  supports_not :disassociate_floating_ip
 
   has_many :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy,
            :class_name => "CustomAttribute"

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -372,10 +372,10 @@
       :description: Refresh Cloud Providers
       :feature_type: control
       :identifier: ems_cloud_refresh
-    - :name: Re-check Authentication Status 
+    - :name: Re-check Authentication Status
       :description: Re-check Authentication Status of Cloud Providers
       :feature_type: control
-      :identifier: ems_cloud_recheck_auth_status 
+      :identifier: ems_cloud_recheck_auth_status
   - :name: Modify
     :description: Modify Cloud Providers
     :feature_type: admin
@@ -4634,6 +4634,14 @@
         :description: Evacuate Instance
         :feature_type: control
         :identifier: instance_evacuate
+      - :name: Associate Floating IP
+        :description: Associate Floating IP with Instance
+        :feature_type: control
+        :identifier: instance_associate_floating_ip
+      - :name: Disassociate Floating IP
+        :description: Disassociate Floating IP from Instance
+        :feature_type: control
+        :identifier: instance_disassociate_floating_ip
     - :name: Modify
       :description: Modify Instances
       :feature_type: admin

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
@@ -10,6 +10,9 @@ module MiqAeMethodService
     expose :validate_resize_confirm
     expose :validate_resize_revert
 
+    expose :associate_floating_ip,    :override_return => nil
+    expose :disassociate_floating_ip, :override_return => nil
+
     def attach_volume(volume_id, device = nil, options = {})
       sync_or_async_ems_operation(options[:sync], "attach_volume", [volume_id, device])
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -72,12 +72,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
 
       it "checks associate_floating_ip is_available? when floating ips are available" do
         expect(Rbac).to receive(:filtered).and_return([1]) # fake a floating ip being available
-        expect(vm.is_available?(:associate_floating_ip)).to eq true
+        expect(vm.supports_associate_floating_ip?).to eq true
       end
 
       it "checks associate_floating_ip is_available? when floating ips are not available" do
         expect(Rbac).to receive(:filtered).and_return([])
-        expect(vm.is_available?(:associate_floating_ip)).to eq false
+        expect(vm.supports_associate_floating_ip?).to eq false
       end
     end
 
@@ -91,12 +91,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
 
       it "checks disassociate_floating_ip is_available? when floating ips are associated with the instance" do
         expect(vm).to receive(:floating_ips).and_return([1]) # fake a floating ip being associated
-        expect(vm.is_available?(:disassociate_floating_ip)).to eq true
+        expect(vm.supports_disassociate_floating_ip?).to eq true
       end
 
       it "checks disassociate_floating_ip is_available? when no floating ips are associated with the instance" do
         expect(vm).to receive(:floating_ips).and_return([])
-        expect(vm.is_available?(:disassociate_floating_ip)).to eq false
+        expect(vm.supports_disassociate_floating_ip?).to eq false
       end
     end
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -71,12 +71,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       end
 
       it "checks associate_floating_ip is_available? when floating ips are available" do
-        expect(Rbac).to receive(:filtered).and_return([1]) # fake a floating ip being available
+        expect(vm.cloud_tenant).to receive(:floating_ips).and_return([1]) # fake a floating ip being available
         expect(vm.supports_associate_floating_ip?).to eq true
       end
 
       it "checks associate_floating_ip is_available? when floating ips are not available" do
-        expect(Rbac).to receive(:filtered).and_return([])
+        expect(vm.cloud_tenant).to receive(:floating_ips).and_return([])
         expect(vm.supports_associate_floating_ip?).to eq false
       end
     end


### PR DESCRIPTION
This PR is just the backend code from https://github.com/ManageIQ/manageiq/pull/9270 which was getting a little big and needed to be split.

* Add methods to the Openstack instance model for
  associating and disassociating floating ips
  with Openstack cloud instances.
* Expose Associate and Disassociate Floating IP
  to Automate.

@tzumainn 