### PR TITLE
Add UI for associating and disassociating floating IPs w/ Openstack Cloud Instances

### DIFF
--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
@@ -1,0 +1,28 @@
+ManageIQ.angular.app.controller('vmCloudAssociateFloatingIpFormController', ['$http', '$scope', 'vmCloudAssociateFloatingIpFormId', 'miqService', function($http, $scope, vmCloudAssociateFloatingIpFormId, miqService) {
+  $scope.vmCloudModel = {
+    floating_ip: null,
+  };
+  $scope.floating_ips = [];
+  $scope.formId = vmCloudAssociateFloatingIpFormId;
+  $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+
+  ManageIQ.angular.scope = $scope;
+
+  $http.get('/vm_cloud/associate_floating_ip_form_fields/' + vmCloudAssociateFloatingIpFormId).success(function(data) {
+    $scope.floating_ips = data.floating_ips;
+    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+    miqService.sparkleOff();
+  });
+
+  $scope.cancelClicked = function() {
+    miqService.sparkleOn();
+    var url = '/vm_cloud/associate_floating_ip_vm/' + vmCloudAssociateFloatingIpFormId + '?button=cancel';
+    miqService.miqAjaxButton(url);
+  };
+
+  $scope.submitClicked = function() {
+    miqService.sparkleOn();
+    var url = '/vm_cloud/associate_floating_ip_vm/' + vmCloudAssociateFloatingIpFormId + '?button=submit';
+    miqService.miqAjaxButton(url, true);
+  };
+}]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
@@ -1,0 +1,28 @@
+ManageIQ.angular.app.controller('vmCloudDisassociateFloatingIpFormController', ['$http', '$scope', 'vmCloudDisassociateFloatingIpFormId', 'miqService', function($http, $scope, vmCloudDisassociateFloatingIpFormId, miqService) {
+  $scope.vmCloudModel = {
+    floating_ip: null,
+  };
+  $scope.floating_ips = [];
+  $scope.formId = vmCloudDisassociateFloatingIpFormId;
+  $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+
+  ManageIQ.angular.scope = $scope;
+
+  $http.get('/vm_cloud/disassociate_floating_ip_form_fields/' + vmCloudDisassociateFloatingIpFormId).success(function(data) {
+    $scope.floating_ips = data.floating_ips;
+    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+    miqService.sparkleOff();
+  });
+
+  $scope.cancelClicked = function() {
+    miqService.sparkleOn();
+    var url = '/vm_cloud/disassociate_floating_ip_vm/' + vmCloudDisassociateFloatingIpFormId + '?button=cancel';
+    miqService.miqAjaxButton(url);
+  };
+
+  $scope.submitClicked = function() {
+    miqService.sparkleOn();
+    var url = '/vm_cloud/disassociate_floating_ip_vm/' + vmCloudDisassociateFloatingIpFormId + '?button=submit';
+    miqService.miqAjaxButton(url, true);
+  };
+}]);

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -670,11 +670,9 @@ module ApplicationController::CiProcessing
         end
       end
     else
-      add_flash(_("Unable to associate %{floating_ip} with %{instance} \"%{name}\": %{details}") % {
-        :floating_ip => ui_lookup(:table => 'floating_ip'),
-        :instance    => ui_lookup(:table => 'vm_cloud'),
-        :name        => @record.name,
-        :details     => @record.unsupported_reason(:associate_floating_ip)}, :error)
+      add_flash(_("Unable to associate Floating IP with Instance \"%{name}\": %{details}") % {
+        :name    => @record.name,
+        :details => @record.unsupported_reason(:associate_floating_ip)}, :error)
     end
   end
   alias instance_associate_floating_ip associate_floating_ip_vms
@@ -709,35 +707,26 @@ module ApplicationController::CiProcessing
     @record = find_by_id_filtered(VmCloud, params[:id])
     case params[:button]
     when "cancel"
-      add_flash(_("Association of %{floating_ip} with %{instance} \"%{name}\" was cancelled by the user") % {
-        :floating_ip => ui_lookup(:table => "floating_ip"),
-        :instance    => ui_lookup(:table => "vm_cloud"),
-        :name        => @record.name})
+      add_flash(_("Association of Floating IP with Instance \"%{name}\" was cancelled by the user") % {:name => @record.name})
       @record = @sb[:action] = nil
     when "submit"
       if @record.supports_associate_floating_ip?
         floating_ip = params[:floating_ip]
         begin
           @record.associate_floating_ip(floating_ip)
-          add_flash(_("Associating %{floating_ip} %{address} with %{instance} \"%{name}\"") % {
-            :floating_ip => ui_lookup(:table => "floating_ip"),
-            :address     => floating_ip,
-            :instance    => ui_lookup(:table => 'vm_cloud'),
-            :name        => @record.name})
+          add_flash(_("Associating Floating IP %{address} with Instance \"%{name}\"") % {
+            :address => floating_ip,
+            :name    => @record.name})
         rescue => ex
-          add_flash(_("Unable to associate %{floating_ip} %{address} with %{instance} \"%{name}\": %{details}") % {
-            :floating_ip => ui_lookup(:table => "floating_ip"),
-            :address     => floating_ip,
-            :instance    => ui_lookup(:table => 'vm_cloud'),
-            :name        => @record.name,
-            :details     => get_error_message_from_fog(ex.to_s)}, :error)
+          add_flash(_("Unable to associate Floating IP %{address} with Instance \"%{name}\": %{details}") % {
+            :address => floating_ip,
+            :name    => @record.name,
+            :details => get_error_message_from_fog(ex.to_s)}, :error)
         end
       else
-        add_flash(_("Unable to associate %{floating_ip} with %{instance} \"%{name}\": %{details}") % {
-          :floating_ip => ui_lookup(:table => "floating_ip"),
-          :instance    => ui_lookup(:table => 'vm_cloud'),
-          :name        => @record.name,
-          :details     => @record.unsupported_reason(:associate_floating_ip)}, :error)
+        add_flash(_("Unable to associate Floating IP with Instance \"%{name}\": %{details}") % {
+          :name    => @record.name,
+          :details => @record.unsupported_reason(:associate_floating_ip)}, :error)
       end
       params[:id] = @record.id.to_s # reset id in params for show
       @record = nil
@@ -773,11 +762,9 @@ module ApplicationController::CiProcessing
         end
       end
     else
-      add_flash(_("Unable to disassociate %{floating_ip} from %{instance} \"%{name}\": %{details}") % {
-        :floating_ip => ui_lookup(:table => 'floating_ip'),
-        :instance    => ui_lookup(:table => 'vm_cloud'),
-        :name        => @record.name,
-        :details     => @record.unsupported_reason(:disassociate_floating_ip)}, :error)
+      add_flash(_("Unable to disassociate Floating IP from Instance \"%{name}\": %{details}") % {
+        :name    => @record.name,
+        :details => @record.unsupported_reason(:disassociate_floating_ip)}, :error)
     end
   end
   alias instance_disassociate_floating_ip disassociate_floating_ip_vms
@@ -814,35 +801,26 @@ module ApplicationController::CiProcessing
     @record = find_by_id_filtered(VmCloud, params[:id])
     case params[:button]
     when "cancel"
-      add_flash(_("Disassociation of %{floating_ip} from %{instance} \"%{name}\" was cancelled by the user") % {
-        :floating_ip => ui_lookup(:table => "floating_ip"),
-        :instance    => ui_lookup(:table => "vm_cloud"),
-        :name        => @record.name})
+      add_flash(_("Disassociation of Floating IP from Instance \"%{name}\" was cancelled by the user") % {:name => @record.name})
       @record = @sb[:action] = nil
     when "submit"
       if @record.supports_disassociate_floating_ip?
         floating_ip = params[:floating_ip]
         begin
           @record.disassociate_floating_ip(floating_ip)
-          add_flash(_("Disassociating %{floating_ip} %{address} from %{instance} \"%{name}\"") % {
-            :floating_ip => ui_lookup(:table => "floating_ip"),
-            :address     => floating_ip,
-            :instance    => ui_lookup(:table => 'vm_cloud'),
-            :name        => @record.name})
+          add_flash(_("Disassociating Floating IP %{address} from Instance \"%{name}\"") % {
+            :address => floating_ip,
+            :name    => @record.name})
         rescue => ex
-          add_flash(_("Unable to disassociate %{floating_ip} %{address} from %{instance} \"%{name}\": %{details}") % {
-            :floating_ip => ui_lookup(:table => "floating_ip"),
-            :address     => floating_ip,
-            :instance    => ui_lookup(:table => 'vm_cloud'),
-            :name        => @record.name,
-            :details     => get_error_message_from_fog(ex.to_s)}, :error)
+          add_flash(_("Unable to disassociate Floating IP %{address} from Instance \"%{name}\": %{details}") % {
+            :address => floating_ip,
+            :name    => @record.name,
+            :details => get_error_message_from_fog(ex.to_s)}, :error)
         end
       else
-        add_flash(_("Unable to disassociate %{floating_ip} from %{instance} \"%{name}\": %{details}") % {
-          :floating_ip => ui_lookup(:table => "floating_ip"),
-          :instance    => ui_lookup(:table => 'vm_cloud'),
-          :name        => @record.name,
-          :details     => @record.unsupported_reason(:disassociate_floating_ip)}, :error)
+        add_flash(_("Unable to disassociate Floating IP from Instance \"%{name}\": %{details}") % {
+          :name    => @record.name,
+          :details => @record.unsupported_reason(:disassociate_floating_ip)}, :error)
       end
       params[:id] = @record.id.to_s # reset id in params for show
       @record = nil

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -51,6 +51,8 @@ module ApplicationController::Explorer
     'tag'          => :s2, 'timeline'         => :s2, 'resize'          => :s2,
     'live_migrate' => :s2, 'attach'           => :s2, 'detach'          => :s2,
     'evacuate'     => :s2, 'service_dialog'   => :s2,
+    'associate_floating_ip'    => :s2,
+    'disassociate_floating_ip' => :s2,
 
     # specials
     'perf'         => :show,
@@ -80,7 +82,8 @@ module ApplicationController::Explorer
     elsif X_BUTTON_ALLOWED_ACTIONS[action] == :s2
       # don't need to set params[:id] and do find_checked_items for methods
       # like ownership, the code in those methods handle it
-      if %w(edit right_size resize attach detach live_migrate evacuate).include?(action)
+      if %w(edit right_size resize attach detach live_migrate evacuate
+            associate_floating_ip disassociate_floating_ip).include?(action)
         @_params[:id] = (params[:id] ? [params[:id]] : find_checked_items)[0]
       end
       if ['protect', 'tag'].include?(action)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1386,7 +1386,8 @@ module VmCommon
 
       locals = {:action_url => action, :record_id => @record ? @record.id : nil}
       if %w(clone migrate miq_request_new pre_prov publish
-            reconfigure resize live_migrate attach detach evacuate).include?(@sb[:action])
+            reconfigure resize live_migrate attach detach evacuate
+            associate_floating_ip disassociate_floating_ip).include?(@sb[:action])
         locals[:no_reset]        = true                              # don't need reset button on the screen
         locals[:submit_button]   = @sb[:action] != 'miq_request_new' # need submit button on the screen
         locals[:continue_button] = @sb[:action] == 'miq_request_new' # need continue button on the screen
@@ -1488,7 +1489,8 @@ module VmCommon
           ])
         # these subviews use angular, so they need to use a special partial
         # so the form buttons on the outer frame can be updated.
-        elsif %w(attach detach live_migrate evacuate ownership).include?(@sb[:action])
+        elsif %w(attach detach live_migrate evacuate ownership
+                 associate_floating_ip disassociate_floating_ip).include?(@sb[:action])
           presenter.update(:form_buttons_div, r[:partial => "layouts/angular/paging_div_buttons"])
         elsif action != "retire" && action != "reconfigure_update"
           presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons', :locals => locals])
@@ -1648,6 +1650,18 @@ module VmCommon
       partial = "vm_common/evacuate"
       header = _("Evacuating %{model} \"%{name}\"") % {:name => name, :model => ui_lookup(:table => table)}
       action = "evacuate_vm"
+    when "associate_floating_ip"
+      partial = "vm_common/associate_floating_ip"
+      header = _("Associating %{floating_ip} with %{model} \"%{name}\"") % {
+        :floating_ip => ui_lookup(:table => 'floating_ip'), :name => name, :model => ui_lookup(:table => table)
+      }
+      action = "associate_floating_ip_vm"
+    when "disassociate_floating_ip"
+      partial = "vm_common/disassociate_floating_ip"
+      header = _("Disassociating %{floating_ip} from %{model} \"%{name}\"") % {
+        :floating_ip => ui_lookup(:table => 'floating_ip'), :name => name, :model => ui_lookup(:table => table)
+      }
+      action = "disassociate_floating_ip_vm"
     when "clone", "migrate", "publish"
       partial = "miq_request/prov_edit"
       task_headers = {"clone"   => _("Clone %{vm_or_template}"),

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1652,14 +1652,14 @@ module VmCommon
       action = "evacuate_vm"
     when "associate_floating_ip"
       partial = "vm_common/associate_floating_ip"
-      header = _("Associating %{floating_ip} with %{model} \"%{name}\"") % {
-        :floating_ip => ui_lookup(:table => 'floating_ip'), :name => name, :model => ui_lookup(:table => table)
+      header = _("Associating Floating IP with %{model} \"%{name}\"") % {
+        :name => name, :model => ui_lookup(:table => table)
       }
       action = "associate_floating_ip_vm"
     when "disassociate_floating_ip"
       partial = "vm_common/disassociate_floating_ip"
-      header = _("Disassociating %{floating_ip} from %{model} \"%{name}\"") % {
-        :floating_ip => ui_lookup(:table => 'floating_ip'), :name => name, :model => ui_lookup(:table => table)
+      header = _("Disassociating Floating IP from %{model} \"%{name}\"") % {
+        :name => name, :model => ui_lookup(:table => table)
       }
       action = "disassociate_floating_ip_vm"
     when "clone", "migrate", "publish"

--- a/app/helpers/application_helper/button/instance_associate_floating_ip.rb
+++ b/app/helpers/application_helper/button/instance_associate_floating_ip.rb
@@ -1,0 +1,18 @@
+class ApplicationHelper::Button::InstanceAssociateFloatingIp < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if !@record.supports_associate_floating_ip?
+      self[:title] = @record.unsupported_reason(:associate_floating_ip)
+    elsif @record.cloud_tenant.nil? || @record.cloud_tenant.floating_ips.empty?
+      self[:title] = _("There are no %{floating_ips} available to this %{instance}.") % {
+        :floating_ips => ui_lookup(:tables => "floating_ips"),
+        :instance     => ui_lookup(:table => "vm_cloud")
+      }
+    end
+  end
+
+  def disabled?
+    !@record.supports_associate_floating_ip? ||
+      (@record.cloud_tenant.nil? || @record.cloud_tenant.floating_ips.empty?)
+  end
+end

--- a/app/helpers/application_helper/button/instance_associate_floating_ip.rb
+++ b/app/helpers/application_helper/button/instance_associate_floating_ip.rb
@@ -4,10 +4,7 @@ class ApplicationHelper::Button::InstanceAssociateFloatingIp < ApplicationHelper
     if !@record.supports_associate_floating_ip?
       self[:title] = @record.unsupported_reason(:associate_floating_ip)
     elsif @record.cloud_tenant.nil? || @record.cloud_tenant.floating_ips.empty?
-      self[:title] = _("There are no %{floating_ips} available to this %{instance}.") % {
-        :floating_ips => ui_lookup(:tables => "floating_ips"),
-        :instance     => ui_lookup(:table => "vm_cloud")
-      }
+      self[:title] = _("There are no Floating IPs available to this Instance.")
     end
   end
 

--- a/app/helpers/application_helper/button/instance_disassociate_floating_ip.rb
+++ b/app/helpers/application_helper/button/instance_disassociate_floating_ip.rb
@@ -1,0 +1,18 @@
+class ApplicationHelper::Button::InstanceDisassociateFloatingIp < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if !@record.supports_disassociate_floating_ip?
+      self[:title] = @record.unsupported_reason(:disassociate_floating_ip)
+    elsif @record.number_of(:floating_ips) == 0
+      self[:title] = _("%{instance} \"%{name}\" does not have any associated %{floating_ips}") % {
+        :instance     => ui_lookup(:table => 'vm_cloud'),
+        :name         => @record.name,
+        :floating_ips => ui_lookup(:tables => 'floating_ip')
+      }
+    end
+  end
+
+  def disabled?
+    !@record.supports_disassociate_floating_ip? || @record.number_of(:floating_ips) == 0
+  end
+end

--- a/app/helpers/application_helper/button/instance_disassociate_floating_ip.rb
+++ b/app/helpers/application_helper/button/instance_disassociate_floating_ip.rb
@@ -3,16 +3,14 @@ class ApplicationHelper::Button::InstanceDisassociateFloatingIp < ApplicationHel
     super
     if !@record.supports_disassociate_floating_ip?
       self[:title] = @record.unsupported_reason(:disassociate_floating_ip)
-    elsif @record.number_of(:floating_ips) == 0
-      self[:title] = _("%{instance} \"%{name}\" does not have any associated %{floating_ips}") % {
-        :instance     => ui_lookup(:table => 'vm_cloud'),
-        :name         => @record.name,
-        :floating_ips => ui_lookup(:tables => 'floating_ip')
+    elsif @record.number_of(:floating_ips).zero?
+      self[:title] = _("Instance \"%{name}\" does not have any associated Floating IPs") % {
+        :name => @record.name,
       }
     end
   end
 
   def disabled?
-    !@record.supports_disassociate_floating_ip? || @record.number_of(:floating_ips) == 0
+    !@record.supports_disassociate_floating_ip? || @record.number_of(:floating_ips).zero?
   end
 end

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -53,6 +53,18 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           t = N_('Detach a Cloud Volume from this Instance'),
           t,
           :klass => ApplicationHelper::Button::InstanceDetach),
+        button(
+          :instance_associate_floating_ip,
+          'fa fa-map-marker fa-lg',
+          t = N_('Associate a Floating IP with this Instance'),
+          t,
+          :klass => ApplicationHelper::Button::InstanceAssociateFloatingIp),
+        button(
+          :instance_disassociate_floating_ip,
+          'fa fa-map-marker fa-lg',
+          t = N_('Disassociate a Floating IP from this Instance'),
+          t,
+          :klass => ApplicationHelper::Button::InstanceDisassociateFloatingIp),
         separator,
         button(
           :instance_resize,

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -42,6 +42,7 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           'pficon pficon-edit fa-lg',
           t = N_('Edit Management Engine Relationship'),
           t),
+        separator,
         button(
           :instance_attach,
           'pficon pficon-volume fa-lg',
@@ -65,7 +66,6 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           t = N_('Disassociate a Floating IP from this Instance'),
           t,
           :klass => ApplicationHelper::Button::InstanceDisassociateFloatingIp),
-        separator,
         button(
           :instance_resize,
           'pficon pficon-edit fa-lg',

--- a/app/views/vm/show.html.haml
+++ b/app/views/vm/show.html.haml
@@ -11,5 +11,9 @@
     = render :partial => "vm_common/live_migrate"
   - elsif @evacuate
     = render :partial => "vm_common/evacuate"
+  - elsif @associate_floating_ip
+    = render :partial => "vm_common/associate_floating_ip"
+  - elsif @disassociate_floating_ip
+    = render :partial => "vm_common/disassociate_floating_ip"
   - else
     = render :partial => "vm_common/#{@showtype}", :locals => {:controller => "vm"}

--- a/app/views/vm_common/_associate_floating_ip.html.haml
+++ b/app/views/vm_common/_associate_floating_ip.html.haml
@@ -1,0 +1,33 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "vmCloudAssociateFloatingIpFormController"}
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Associate Floating IP')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Floating IP')
+      .col-md-8
+        %select{:name      => 'floating_ip',
+                'ng-model' => 'vmCloudModel.floating_ip',
+                'ng-options' => 'floating_ip.address as floating_ip.address for floating_ip in floating_ips track by floating_ip.id'}
+
+  %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
+                  'paging_div_buttons_id'            => "angular_paging_div_buttons",
+                  'paging_div_buttons_type'          => "Submit"}
+
+- unless @explorer
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        = button_tag("Submit",
+                     :class        => "btn btn-primary",
+                     "ng-click"    => "submitClicked()",
+                     "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
+                     "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+        = button_tag("Cancel",
+                      :class     => "btn btn-default",
+                      "ng-click" => "cancelClicked()")
+
+:javascript
+  ManageIQ.angular.app.value('vmCloudAssociateFloatingIpFormId', '#{@record.id}');
+  miq_bootstrap('#form_div');

--- a/app/views/vm_common/_associate_floating_ip.html.haml
+++ b/app/views/vm_common/_associate_floating_ip.html.haml
@@ -19,12 +19,12 @@
   %table{:width => '100%'}
     %tr
       %td{:align => 'right'}
-        = button_tag("Submit",
+        = button_tag(_("Submit"),
                      :class        => "btn btn-primary",
                      "ng-click"    => "submitClicked()",
                      "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
                      "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
-        = button_tag("Cancel",
+        = button_tag(_("Cancel"),
                       :class     => "btn btn-default",
                       "ng-click" => "cancelClicked()")
 

--- a/app/views/vm_common/_disassociate_floating_ip.html.haml
+++ b/app/views/vm_common/_disassociate_floating_ip.html.haml
@@ -1,0 +1,33 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "vmCloudDisassociateFloatingIpFormController"}
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Disassociate Floating IP')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Floating IP')
+      .col-md-8
+        %select{:name      => 'floating_ip',
+                'ng-model' => 'vmCloudModel.floating_ip',
+                'ng-options' => 'floating_ip.address as floating_ip.address for floating_ip in floating_ips track by floating_ip.id'}
+
+  %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
+                  'paging_div_buttons_id'            => "angular_paging_div_buttons",
+                  'paging_div_buttons_type'          => "Submit"}
+
+- unless @explorer
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        = button_tag("Submit",
+                     :class        => "btn btn-primary",
+                     "ng-click"    => "submitClicked()",
+                     "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
+                     "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+        = button_tag("Cancel",
+                      :class     => "btn btn-default",
+                      "ng-click" => "cancelClicked()")
+
+:javascript
+  ManageIQ.angular.app.value('vmCloudDisassociateFloatingIpFormId', '#{@record.id}');
+  miq_bootstrap('#form_div');

--- a/app/views/vm_common/_disassociate_floating_ip.html.haml
+++ b/app/views/vm_common/_disassociate_floating_ip.html.haml
@@ -19,12 +19,12 @@
   %table{:width => '100%'}
     %tr
       %td{:align => 'right'}
-        = button_tag("Submit",
+        = button_tag(_("Submit"),
                      :class        => "btn btn-primary",
                      "ng-click"    => "submitClicked()",
                      "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
                      "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
-        = button_tag("Cancel",
+        = button_tag(_("Cancel"),
                       :class     => "btn btn-default",
                       "ng-click" => "cancelClicked()")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2440,6 +2440,10 @@ Vmdb::Application.routes.draw do
         evacuate_form_fields
         live_migrate
         live_migrate_form_fields
+        associate_floating_ip
+        associate_floating_ip_form_fields
+        disassociate_floating_ip
+        disassociate_floating_ip_form_fields
         retire
         right_size
         show
@@ -2460,6 +2464,8 @@ Vmdb::Application.routes.draw do
         resize_vm
         evacuate_vm
         live_migrate_vm
+        associate_floating_ip_vm
+        disassociate_floating_ip_vm
         retire
         right_size
         set_checked_items
@@ -2496,6 +2502,10 @@ Vmdb::Application.routes.draw do
         evacuate
         evacuate_form_fields
         ownership_form_fields
+        associate_floating_ip
+        associate_floating_ip_form_fields
+        disassociate_floating_ip
+        disassociate_floating_ip_form_fields
       ) +
                compare_get,
       :post => %w(
@@ -2557,6 +2567,8 @@ Vmdb::Application.routes.draw do
         detach_volume
         evacuate_vm
         ownership_update
+        associate_floating_ip_vm
+        disassociate_floating_ip_vm
       ) +
                adv_search_post +
                compare_post +

--- a/spec/helpers/application_helper/buttons/instance_associate_floating_ip_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_associate_floating_ip_spec.rb
@@ -1,0 +1,73 @@
+describe ApplicationHelper::Button::InstanceAssociateFloatingIp do
+  describe '#disabled?' do
+    it "when the associate floating ip action is available then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = object_double(CloudTenant.new, :floating_ips => [1])
+      vm = object_double(VmCloud.new, :cloud_tenant => tenant, :supports_associate_floating_ip? => true)
+      button = described_class.new(
+        view_context, {}, {"record" => vm}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the associate floating ip action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_associate_floating_ip? => false)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+
+    it "when the there are no floating ips available then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = object_double(CloudTenant.new, :floating_ips => [])
+      vm = object_double(VmCloud.new, :cloud_tenant => tenant, :supports_associate_floating_ip? => true)
+      button = described_class.new(
+        view_context, {}, {"record" => vm}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the associate floating ip action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = object_double(CloudTenant.new, :number_of => 1)
+      vm = object_double(VmCloud.new,
+                         :supports_associate_floating_ip? => false,
+                         :cloud_tenant                    => tenant,
+                         :unsupported_reason              => "unavailable")
+      button = described_class.new(
+        view_context, {}, {"record" => vm}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("unavailable")
+    end
+
+    it "when there are no floating ips available the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = object_double(CloudTenant.new, :floating_ips => [])
+      vm = object_double(VmCloud.new,
+                         :cloud_tenant                    => tenant,
+                         :supports_associate_floating_ip? => true)
+      button = described_class.new(
+        view_context, {}, {"record" => vm}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("There are no Floating Ips available to this Instance.")
+    end
+
+    it "when the action is available, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = object_double(CloudTenant.new, :floating_ips => [1])
+      vm = object_double(VmCloud.new,
+                         :cloud_tenant                    => tenant,
+                         :supports_associate_floating_ip? => true)
+      button = described_class.new(
+        view_context, {}, {"record" => vm}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_associate_floating_ip_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_associate_floating_ip_spec.rb
@@ -54,7 +54,7 @@ describe ApplicationHelper::Button::InstanceAssociateFloatingIp do
         view_context, {}, {"record" => vm}, {}
       )
       button.calculate_properties
-      expect(button[:title]).to eq("There are no Floating Ips available to this Instance.")
+      expect(button[:title]).to eq("There are no Floating IPs available to this Instance.")
     end
 
     it "when the action is available, the button has no error in the title" do

--- a/spec/helpers/application_helper/buttons/instance_disassociate_floating_ip_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_disassociate_floating_ip_spec.rb
@@ -1,0 +1,65 @@
+describe ApplicationHelper::Button::InstanceDisassociateFloatingIp do
+  describe '#disabled?' do
+    it "when the disassociate ip action is available and the instance has floating ips then the button is enabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_disassociate_floating_ip? => true, :number_of => 1)}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the disassociate floating ip action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_disassociate_floating_ip? => false, :number_of => 1)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+
+    it "when the instance is not associated to any floating ips then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_disassociate_floating_ip? => true, :number_of => 0)}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the disassociate floating ip action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :supports_disassociate_floating_ip? => false, :number_of => 1, :unsupported_reason => "unavailable"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("unavailable")
+    end
+
+    it "when there are no floating ips to associate from the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :supports_disassociate_floating_ip? => true, :number_of => 0, :name => "TestVm"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq(_("%{instance} \"TestVm\" does not have any associated %{floating_ips}") % {
+        :instance     => ui_lookup(:table => 'vm_cloud'),
+        :floating_ips => ui_lookup(:tables => 'floating_ip')
+      })
+    end
+
+    it "when there are instances to detach from and the action is available, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          VmCloud.new, :supports_disassociate_floating_ip? => true, :number_of => 1
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_disassociate_floating_ip_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_disassociate_floating_ip_spec.rb
@@ -45,10 +45,7 @@ describe ApplicationHelper::Button::InstanceDisassociateFloatingIp do
         )}, {}
       )
       button.calculate_properties
-      expect(button[:title]).to eq(_("%{instance} \"TestVm\" does not have any associated %{floating_ips}") % {
-        :instance     => ui_lookup(:table => 'vm_cloud'),
-        :floating_ips => ui_lookup(:tables => 'floating_ip')
-      })
+      expect(button[:title]).to eq(_("Instance \"TestVm\" does not have any associated Floating IPs"))
     end
 
     it "when there are instances to detach from and the action is available, the button has no error in the title" do


### PR DESCRIPTION
This PR is for the UI and controller code from https://github.com/ManageIQ/manageiq/pull/9270 that needed to be split up because it was getting a bit big. It depends on https://github.com/ManageIQ/manageiq/pull/9475.

![screenshot at 2016-06-21 13 27 52](https://cloud.githubusercontent.com/assets/628956/16239734/43f6d5a8-37b4-11e6-9278-6e7987c08ae5.png)
![screenshot at 2016-06-21 13 28 19](https://cloud.githubusercontent.com/assets/628956/16239735/43f867c4-37b4-11e6-90a6-fc72e8123386.png)
![screenshot at 2016-06-21 13 29 37](https://cloud.githubusercontent.com/assets/628956/16239736/43fdbc88-37b4-11e6-96d2-617e8c82acf1.png)

@tzumainn 