### PR TITLE
Cap&U move perf_capture_now? to capture

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -183,7 +183,16 @@ module Metric::Capture
       interval_name = perf_target_to_interval_name(target)
 
       options = target_options[target]
-      target.perf_capture_queue(interval_name, options)
+
+      if options[:force] || target.perf_capture_now?
+        target.perf_capture_queue(interval_name, options)
+      else
+        _log.debug do
+          log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
+          "Skipping capture of #{log_target} -" +
+            "Performance last captured on [#{target.last_perf_capture_on}] is within threshold"
+        end
+      end
 
       if !target.kind_of?(Storage) && use_historical && target.last_perf_capture_on.nil?
         target.perf_capture_queue('historical')

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -18,7 +18,6 @@ module Metric::CiMixin::Capture
   def perf_capture_queue(interval_name, options = {})
     start_time = options[:start_time]
     end_time   = options[:end_time]
-    force      = options[:force] # Force capture to run regardless of last capture time
     priority   = options[:priority] || Metric::Capture.const_get("#{interval_name.upcase}_PRIORITY")
     task_id    = options[:task_id]
     zone       = options[:zone] || my_zone
@@ -30,11 +29,6 @@ module Metric::CiMixin::Capture
     end_time = end_time.utc unless end_time.nil?
 
     log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
-
-    if interval_name != 'historical' && start_time.nil? && !force && !self.perf_capture_now?
-      _log.debug "Skipping capture of #{log_target} - Performance last captured on [#{last_perf_capture_on}] is within threshold"
-      return
-    end
 
     # Determine what items we should be queuing up
     items = []
@@ -228,7 +222,7 @@ module Metric::CiMixin::Capture
 
     _log.info "Realtime capture requested for #{log_target}"
 
-    perf_capture_queue('realtime', :force => true, :priority => MiqQueue::HIGH_PRIORITY)
+    perf_capture_queue('realtime', :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def perf_capture_now?

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -224,8 +224,4 @@ module Metric::CiMixin::Capture
 
     perf_capture_queue('realtime', :priority => MiqQueue::HIGH_PRIORITY)
   end
-
-  def perf_capture_now?
-    last_perf_capture_on.nil? || (last_perf_capture_on < Metric::Capture.capture_threshold(self))
-  end
 end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1367,16 +1367,16 @@ describe Metric do
   def assert_perf_capture_now(target, mode)
     Timecop.freeze(Time.now) do
       target.update_attribute(:last_perf_capture_on, nil)
-      expect(target.perf_capture_now?).to be_truthy
+      expect(Metric::Capture.perf_capture_now?(target)).to be_truthy
 
       target.update_attribute(:last_perf_capture_on, Time.now.utc - 15.minutes)
-      expect(target.perf_capture_now?).to be_truthy
+      expect(Metric::Capture.perf_capture_now?(target)).to be_truthy
 
       target.update_attribute(:last_perf_capture_on, Time.now.utc - 7.minutes)
-      expect(mode == :with_alerts ? target.perf_capture_now? : !target.perf_capture_now?).to be_truthy
+      expect(mode == :with_alerts ? Metric::Capture.perf_capture_now?(target) : !Metric::Capture.perf_capture_now?(target)).to be_truthy
 
       target.update_attribute(:last_perf_capture_on, Time.now.utc - 1.minutes)
-      expect(target.perf_capture_now?).not_to be_truthy
+      expect(Metric::Capture.perf_capture_now?(target)).not_to be_truthy
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Scheduled job `perf_capture_timer` is responsible for kicking off Cap&U for the system.
It is split up into 2 parts:

1. Determine which resource (i.e.: `Host`, `Storage`, `Vm`) need Cap & U. #9447
2. Submits them into the queue for further processing. **this pr** #9477

This PR focuses on **part 2** and the themes is to access `perf_capture_now?` from an individual target method, to a method that works on all targets:

1. Move `target_options` logic out of `queue_captures`
2. Move `perf_capture_now?` and `capture_threshold` from `target.rb` to `capture.rb`

Currently this job is taking too long. It is timing out and resources are not scheduled for cap&u. The bottle neck is `perf_capture_now?`.

The crux of the problem is in order to determine when a task needs to run, it needs to determine if a resource has an alert assigned to it - which is essentially done in `assignment_mixin#get_assigned_for_target`. This method queries the tags for a resource hierarchy and ends up bring back duplicate data.

The solution is to fetch all alert data at once up front. This will bring back less data and perform fewer queries. But in order to reduce the queries, it needs to be accessed with all targets. And this is the reason for this PR: Move `perf_capture_now?` out from the individual target and instead up to the `capture` level, which has access to all targets.

I can follow this story further, but I thought this refactoring was a good first step. I will link further PRs to this one.

/cc @jrafanie @NickLaMuro 
