### PR TITLE
ServiceOrder#checkout* - save checkout date in placed_at

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -41,13 +41,15 @@ class ServiceOrder < ApplicationRecord
     raise "Invalid operation [checkout] for Service Order in state [#{state}]" if ordered?
     _log.info("Service Order checkout for service: #{name}")
     process_checkout(miq_requests)
-    update_attributes(:state => STATE_ORDERED)
+    update_attributes(:state     => STATE_ORDERED,
+                      :placed_at => Time.zone.now)
   end
 
   def checkout_immediately
     _log.info("Service Order checkout immediately for service: #{name}")
     process_checkout(miq_requests)
-    update_attributes(:state => STATE_ORDERED)
+    update_attributes(:state     => STATE_ORDERED,
+                      :placed_at => Time.zone.now)
   end
 
   def process_checkout(miq_requests)

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -36,6 +36,7 @@ describe ServiceOrder do
     service_order.miq_requests << [request, request2, request3]
     service_order.checkout
     expect(service_order).to be_ordered
+    expect(service_order.placed_at).not_to be_nil
   end
 
   it "should raise an error on checkout for ordered service order" do


### PR DESCRIPTION
The ServiceOrder model has had a `placed_at` attribute from the start, but it's never actually used.. this changes `#checkout` and `#checkout_immediately` to always fill in `placed_at`

\+ a corresponding spec change

@tinaafitz could you take a look please? We do need the "date ordered" info for [order history](https://github.com/ManageIQ/manageiq-ui-self_service/pull/46) in SSUI..