### PR TITLE
Correct Widget import 'select all' button to work

### DIFF
--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -83,7 +83,7 @@
     });
 
     $('#check-all').click(function (e) {
-      $("#import-form table tbody input[type='checkbox']").prop('checked', $(this).prop('checked'));
+      $("#import-widgets-form table tbody input[type='checkbox']").prop('checked', $(this).prop('checked'));
     });
 
 


### PR DESCRIPTION
Cloud Intel -> Import/Export -> Widgets -> Import file 

Select all didn't select anything. Now it selects all widgets.

https://bugzilla.redhat.com/show_bug.cgi?id=1338492

@miq-bot add_label ui, bug