### PR TITLE
[api] Refactor @req hash to plain old ruby object

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -161,7 +161,7 @@ class ApiController < ApplicationController
   end
 
   def redirect_api_request(method)
-    collection    = @req[:collection] || "entrypoint"
+    collection    = @req.collection || "entrypoint"
     target_method = "#{method}_#{collection}"
     if respond_to?(target_method)
       send(target_method)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -148,7 +148,6 @@ class ApiController < ApplicationController
     @description     = base_config[:description]
     @version         = base_config[:version]
     @prefix          = "/#{@module}"
-    @req             = {}      # To store API request details by parse_api_request
     @api_config      = VMDB::Config.new("vmdb").config[@module.to_sym] || {}
   end
 

--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -68,11 +68,11 @@ class ApiController
       {
         :userid     => user.userid,
         :name       => user.name,
-        :user_href  => "#{@req[:api_prefix]}/users/#{user.id}",
+        :user_href  => "#{@req.api_prefix}/users/#{user.id}",
         :group      => group.description,
-        :group_href => "#{@req[:api_prefix]}/groups/#{group.id}",
+        :group_href => "#{@req.api_prefix}/groups/#{group.id}",
         :role       => group.miq_user_role_name,
-        :role_href  => "#{@req[:api_prefix]}/roles/#{group.miq_user_role.id}",
+        :role_href  => "#{@req.api_prefix}/roles/#{group.miq_user_role.id}",
         :tenant     => group.tenant.name,
         :groups     => user.miq_groups.pluck(:description),
       }
@@ -154,7 +154,7 @@ class ApiController
       {
         "name"   => action[:name],
         "method" => method,
-        "href"   => "#{@req[:api_prefix]}/#{collection}"
+        "href"   => "#{@req.api_prefix}/#{collection}"
       }
     end
 
@@ -185,7 +185,7 @@ class ApiController
       collection_config.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(collection, cspec), result|
         ident = cspec[:identifier]
         next unless ident
-        href = "#{@req[:api_prefix]}/#{collection}"
+        href = "#{@req.api_prefix}/#{collection}"
         result[ident] << href
       end
     end

--- a/app/controllers/api_controller/categories.rb
+++ b/app/controllers/api_controller/categories.rb
@@ -23,7 +23,7 @@ class ApiController
     private
 
     def request_additional_attributes
-      @req[:additional_attributes] = %w(name)
+      @additional_attributes = %w(name)
     end
   end
 end

--- a/app/controllers/api_controller/container_deployments.rb
+++ b/app/controllers/api_controller/container_deployments.rb
@@ -2,7 +2,7 @@ class ApiController
   module ContainerDeployments
     def show_container_deployments
       validate_api_action
-      if @req[:c_id] == "container_deployment_data"
+      if @req.c_id == "container_deployment_data"
         render_resource :container_deployments, :data => ContainerDeploymentService.new.all_data
       else
         show_generic(:container_deployments)

--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -22,7 +22,7 @@ class ApiController
       version_config[:definitions].select(&:ident).collect do |version_specification|
         {
           :name => version_specification[:name],
-          :href => "#{@req[:api_prefix]}/#{version_specification[:ident]}"
+          :href => "#{@req.api_prefix}/#{version_specification[:ident]}"
         }
       end
     end

--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -6,28 +6,28 @@ class ApiController
 
     def show_generic(type)
       validate_api_action
-      if @req[:subcollection]
-        render_collection_type @req[:subcollection].to_sym, @req[:s_id], true
+      if @req.subcollection
+        render_collection_type @req.subcollection.to_sym, @req.s_id, true
       else
-        render_collection_type type, @req[:c_id]
+        render_collection_type type, @req.c_id
       end
     end
 
     def update_generic(type)
       validate_api_action
-      if @req[:subcollection]
-        render_normal_update type, update_collection(@req[:subcollection].to_sym, @req[:s_id], true)
+      if @req.subcollection
+        render_normal_update type, update_collection(@req.subcollection.to_sym, @req.s_id, true)
       else
-        render_normal_update type, update_collection(type, @req[:c_id])
+        render_normal_update type, update_collection(type, @req.c_id)
       end
     end
 
     def destroy_generic(type)
       validate_api_action
-      if @req[:subcollection]
-        delete_subcollection_resource @req[:subcollection].to_sym, @req[:s_id]
+      if @req.subcollection
+        delete_subcollection_resource @req.subcollection.to_sym, @req.s_id
       else
-        send(target_resource_method(false, type, :delete), type, @req[:c_id])
+        send(target_resource_method(false, type, :delete), type, @req.c_id)
       end
       render_normal_destroy
     end
@@ -75,7 +75,7 @@ class ApiController
 
     def delete_resource(type, id = nil, _data = nil)
       klass = collection_class(type)
-      id ||= @req[:c_id]
+      id ||= @req.c_id
       raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
       api_log_info("Deleting #{type} id #{id}")
       resource_search(id, type, klass)
@@ -106,8 +106,8 @@ class ApiController
     end
 
     def custom_action_resource(type, id, data = nil)
-      action = @req[:action].downcase
-      id ||= @req[:c_id]
+      action = @req.action.downcase
+      id ||= @req.c_id
       if id.blank?
         raise BadRequestError, "Must specify an id for invoking the custom action #{action} on a #{type} resource"
       end

--- a/app/controllers/api_controller/logger.rb
+++ b/app/controllers/api_controller/logger.rb
@@ -73,7 +73,7 @@ class ApiController
     private
 
     def log_request_body
-      log_request("Body", JSON.pretty_generate(json_body)) if api_log_debug? && json_body.present?
+      log_request("Body", JSON.pretty_generate(@req.json_body)) if api_log_debug? && @req.json_body.present?
     end
 
     def log_request(header, data)

--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -81,7 +81,7 @@ class ApiController
     #
     def normalize_url(value)
       svalue = value.to_s
-      pref   = @req[:api_prefix]
+      pref   = @req.api_prefix
       svalue.match(pref) ? svalue : "#{pref}/#{svalue}"
     end
 
@@ -96,7 +96,7 @@ class ApiController
     # Let's normalize href accessible resources
     #
     def normalize_resource(value)
-      value.to_s.starts_with?("/") ? "#{@req[:base]}#{value}" : value
+      value.to_s.starts_with?("/") ? "#{@req.base}#{value}" : value
     end
 
     #

--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -10,13 +10,6 @@ class ApiController
       [offset, limit]
     end
 
-    def json_body
-      @req[:body] ||= begin
-        body = request.body.read if request.body
-        body.blank? ? {} : JSON.parse(body)
-      end
-    end
-
     def hash_fetch(hash, element, default = {})
       hash[element] || default
     end
@@ -125,8 +118,8 @@ class ApiController
     end
 
     def attribute_selection
-      if params['attributes'] || @req[:additional_attributes]
-        params['attributes'].to_s.split(",") | Array(@req[:additional_attributes]) | ID_ATTRS
+      if params['attributes'] || @additional_attributes
+        params['attributes'].to_s.split(",") | Array(@additional_attributes) | ID_ATTRS
       else
         "all"
       end

--- a/app/controllers/api_controller/parser/request_adapter.rb
+++ b/app/controllers/api_controller/parser/request_adapter.rb
@@ -1,0 +1,81 @@
+class ApiController
+  module Parser
+    class RequestAdapter
+      def initialize(req, params)
+        @request = req
+        @params = params
+      end
+
+      def action
+        # for basic HTTP POST, default action is "create" with data being the POST body
+        @action ||= method == :put ? 'edit' : (json_body['action'] || 'create')
+      end
+
+      def api_prefix
+        @api_prefix ||= "#{base}#{prefix}"
+      end
+
+      def base
+        url.partition(fullpath)[0] # http://target
+      end
+
+      def collection
+        @params[:collection]
+      end
+
+      def c_id
+        @params[:c_id]
+      end
+
+      def json_body
+        @json_body ||= begin
+                         body = @request.body.read if @request.body
+                         body.blank? ? {} : JSON.parse(body)
+                       end
+      end
+
+      def method
+        @method ||= @request.request_method.downcase.to_sym # :get, :patch, ...
+      end
+
+      def path
+        URI.parse(url).path.sub(/\/*$/, '') # /api/...
+      end
+
+      def subcollection
+        @params[:subcollection]
+      end
+
+      def s_id
+        @params[:s_id]
+      end
+
+      def version
+        @version ||= if version_override?
+                       @params[:version][1..-1] # Switching API Version
+                     else
+                       Api::Settings.base[:version] # Default API Version
+                     end
+      end
+
+      private
+
+      def version_override?
+        @params[:version] && @params[:version].match(Api::Settings.version[:regex]) # v#.# version signature
+      end
+
+      def fullpath
+        @request.original_fullpath # /api/...&param=value...
+      end
+
+      def prefix
+        prefix = "/#{path.split('/')[1]}" # /api
+        version_override? ? "#{prefix}/#{@params[:version]}" : prefix
+      end
+
+      def url
+        @request.original_url # http://target/api/...
+      end
+    end
+  end
+end

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -45,7 +45,7 @@ class ApiController
     # We want reftype to reflect subcollection if targeting as such.
     #
     def gen_reftype(type, opts)
-      opts[:is_subcollection] ? "#{@req[:collection]}/#{@req[:c_id]}/#{type}" : type
+      opts[:is_subcollection] ? "#{@req.collection}/#{@req.c_id}/#{type}" : type
     end
 
     # Methods for Serialization as Jbuilder Objects.
@@ -455,8 +455,8 @@ class ApiController
 
     def fetch_typed_subcollection_actions(method, is_subcollection)
       return unless is_subcollection
-      ctype = @req[:collection].to_sym
-      sakey = "#{@req[:subcollection]}_subcollection_actions".to_sym
+      ctype = @req.collection.to_sym
+      sakey = "#{@req.subcollection}_subcollection_actions".to_sym
       collection_config[ctype][sakey] && collection_config[ctype][sakey][method.to_sym]
     end
 

--- a/app/controllers/api_controller/reports.rb
+++ b/app/controllers/api_controller/reports.rb
@@ -8,14 +8,14 @@ class ApiController
     end
 
     def show_reports
-      if @req[:subcollection] == "results" && (@req[:s_id] || expand?(:resources)) && attribute_selection == "all"
-        @req[:additional_attributes] = %w(result_set)
+      if @req.subcollection == "results" && (@req.s_id || expand?(:resources)) && attribute_selection == "all"
+        @additional_attributes = %w(result_set)
       end
       show_generic(:reports)
     end
 
     def show_results
-      @req[:additional_attributes] = %w(result_set)
+      @additional_attributes = %w(result_set)
       show_generic(:results)
     end
 

--- a/app/controllers/api_controller/results.rb
+++ b/app/controllers/api_controller/results.rb
@@ -11,25 +11,25 @@ class ApiController
     end
 
     def add_href_to_result(hash, type, id)
-      hash[:href] = "#{@req[:api_prefix]}/#{type}/#{id}"
+      hash[:href] = "#{@req.api_prefix}/#{type}/#{id}"
       hash
     end
 
     def add_parent_href_to_result(hash)
-      hash[:href] = "#{@req[:api_prefix]}/#{@req[:collection]}/#{@req[:c_id]}"
+      hash[:href] = "#{@req.api_prefix}/#{@req.collection}/#{@req.c_id}"
       hash
     end
 
     def add_task_to_result(hash, task_id)
       hash[:task_id]   = task_id
-      hash[:task_href] = "#{@req[:api_prefix]}/tasks/#{task_id}"
+      hash[:task_href] = "#{@req.api_prefix}/tasks/#{task_id}"
       hash
     end
 
     def add_tag_to_result(hash, tag_spec)
       hash[:tag_category] = tag_spec[:category] if tag_spec[:category].present?
       hash[:tag_name]     = tag_spec[:name] if tag_spec[:name].present?
-      hash[:tag_href]     = "#{@req[:api_prefix]}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
+      hash[:tag_href]     = "#{@req.api_prefix}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
       hash
     end
 
@@ -37,13 +37,13 @@ class ApiController
       return hash if object.blank?
       ctype_pref = ctype.to_s.singularize
       hash["#{ctype_pref}_id".to_sym]   = object.id
-      hash["#{ctype_pref}_href".to_sym] = "#{@req[:api_prefix]}/#{ctype}/#{object.id}"
+      hash["#{ctype_pref}_href".to_sym] = "#{@req.api_prefix}/#{ctype}/#{object.id}"
       hash
     end
 
     def add_report_result_to_result(hash, result_id)
       hash[:result_id] = result_id
-      hash[:result_href] = "#{@req[:api_prefix]}/results/#{result_id}"
+      hash[:result_href] = "#{@req.api_prefix}/results/#{result_id}"
       hash
     end
 

--- a/app/controllers/api_controller/service_dialogs.rb
+++ b/app/controllers/api_controller/service_dialogs.rb
@@ -9,7 +9,7 @@ class ApiController
     end
 
     def show_service_dialogs
-      @req[:additional_attributes] = %w(content) if attribute_selection == "all"
+      @additional_attributes = %w(content) if attribute_selection == "all"
       show_generic(:service_dialogs)
     end
 
@@ -28,7 +28,7 @@ class ApiController
     # Virtual attribute accessors
     #
     def fetch_service_dialogs_content(resource)
-      case @req[:collection]
+      case @req.collection
       when "service_templates"
         service_template = parent_resource_obj
       when "services"

--- a/app/controllers/api_controller/settings.rb
+++ b/app/controllers/api_controller/settings.rb
@@ -2,7 +2,7 @@ class ApiController
   module Settings
     def show_settings
       validate_api_action
-      category = @req[:c_id]
+      category = @req.c_id
       selected_sections =
         if category
           raise NotFound, "Settings category #{category} not found" unless exposed_settings.include?(category)

--- a/app/controllers/api_controller/users.rb
+++ b/app/controllers/api_controller/users.rb
@@ -3,12 +3,12 @@ class ApiController
 
   module Users
     def update_users
-      aname = parse_action_name
+      aname = @req.action
       if aname == "edit" && !api_user_role_allows?(aname) && update_target_is_api_user?
         if json_body_resource.try(:keys) != %w(password)
           raise BadRequestError, "Cannot update non-password attributes of the authenticated user resource"
         end
-        render_normal_update :users, update_collection(:users, @req[:c_id])
+        render_normal_update :users, update_collection(:users, @req.c_id)
       else
         update_generic(:users)
       end
@@ -40,7 +40,7 @@ class ApiController
     private
 
     def update_target_is_api_user?
-      @auth_user_obj.id == @req[:c_id].to_i
+      @auth_user_obj.id == @req.c_id.to_i
     end
 
     def parse_set_group(data)


### PR DESCRIPTION
Previously, we parsed some information about the incoming request into `ApiController@req` hash. Some of the items in the hash has been initialized early&always the others later on request. After this change, we have `Request` class to hold this information, and it calculates various bits only when needed.

The upside is that
 * we have code&data related to user request encapsulated in single class/file
 * the `@req` statically typed (auto-completion, docs, less typos)
 * some of the `@req` attributes are private now
 * we have dropped an item from @req that was loosely related to user request
 * we have decreased number of methods in `ApiController`
 * future features (such as compressed ids) will be more straight forward to implement. (in fact, I started looking this code with compressed_ids feature in mind).

This PR consists of small isolated commits, each doing exactly one refactoring step. Although, I can squash them to a single commit if needed.

@abellotti, @imtayadeway I would love to hear your thoughts on this. The `ApiController` is composition of many concerns. Do we want to keep the class model flat like this by design? I naturally incline towards separation of responsibilities such this pr, however I must say the ApiController is in very good shape (almost no code repetition there), and perhaps you would like to keep the mode flat for some reason?

@miq-bot add_label api, refactoring