### PR TITLE
Use one method for querying on Chargeback subclass

### DIFF
--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -237,7 +237,7 @@ module ReportController::Reports
       end
     end
 
-    if @edit[:new][:model].to_s.starts_with?("Chargeback")
+    if Chargeback.db_is_chargeback?(@edit[:new][:model])
       unless @edit[:new][:cb_show_typ]
         add_flash(_("Show Costs by must be selected"), :error)
         active_tab = "edit_3"

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -362,7 +362,7 @@ module ReportController::Reports::Editor
         ["#{req}_3", _("Filter")],
         ["#{req}_7", _("Preview")]
       ]
-    elsif chargeback_model?(@edit[:new][:model].to_s)
+    elsif Chargeback.db_is_chargeback?(@edit[:new][:model].to_s)
       @tabs = [
         ["#{req}_1", _("Columns")],
         ["#{req}_2", _("Formatting")],
@@ -544,7 +544,7 @@ module ReportController::Reports::Editor
         @edit[:new][:tz] = session[:user_tz]
         build_perf_interval_arrays(@edit[:new][:perf_interval]) # Build the start and end arrays for the performance interval chooser
       end
-      if chargeback_model?(@edit[:new][:model])
+      if Chargeback.db_is_chargeback?(@edit[:new][:model])
         @edit[:new][:cb_model] = Chargeback.report_cb_model(@edit[:new][:model])
         @edit[:new][:cb_interval] ||= "daily"                   # Default to Daily
         @edit[:new][:cb_interval_size] ||= 1
@@ -626,10 +626,6 @@ module ReportController::Reports::Editor
       @refresh_div = "filter_div"
       @refresh_partial = "form_filter"
     end
-  end
-
-  def chargeback_model?(model)
-    %w(ChargebackContainerProject ChargebackVm).include?(model)
   end
 
   def gfv_chargeback
@@ -1199,7 +1195,7 @@ module ReportController::Reports::Editor
       rpt.db_options[:target_pcts].push(@edit[:new][:perf_target_pct1])
       rpt.db_options[:target_pcts].push(@edit[:new][:perf_target_pct2]) if @edit[:new][:perf_target_pct2]
       rpt.db_options[:target_pcts].push(@edit[:new][:perf_target_pct3]) if @edit[:new][:perf_target_pct3]
-    elsif chargeback_model?(rpt.db)
+    elsif Chargeback.db_is_chargeback?(rpt.db)
       rpt.db_options[:rpt_type]     = @edit[:new][:model]
       options                       = {}  # CB options go in db_options[:options] key
       options[:interval]            = @edit[:new][:cb_interval]
@@ -1269,7 +1265,7 @@ module ReportController::Reports::Editor
     rpt.sortby = @edit[:new][:sortby1] == NOTHING_STRING ? nil : []  # Clear sortby if sortby1 not present, else set up array
 
     # Add in the chargeback static fields
-    if chargeback_model?(rpt.db) # For chargeback, add in static fields
+    if Chargeback.db_is_chargeback?(rpt.db) # For chargeback, add in static fields
       rpt.cols = %w(start_date display_range)
       name_col = @edit[:new][:model].constantize.report_name_field
       rpt.cols += [name_col]
@@ -1490,7 +1486,7 @@ module ReportController::Reports::Editor
       @edit[:new][:perf_limit_col] = @rpt.db_options[:limit_col]
       @edit[:new][:perf_limit_val] = @rpt.db_options[:limit_val]
       @edit[:new][:perf_target_pct1], @edit[:new][:perf_target_pct2], @edit[:new][:perf_target_pct3] = @rpt.db_options[:target_pcts]
-    elsif chargeback_model?(@rpt.db)
+    elsif Chargeback.db_is_chargeback?(@rpt.db)
       @edit[:new][:tz] = @rpt.tz ? @rpt.tz : session[:user_tz]    # Set the timezone, default to user's
       options = @rpt.db_options[:options]
       if options.key?(:owner) # Get the owner options
@@ -1773,7 +1769,7 @@ module ReportController::Reports::Editor
     end
 
     # Remove the non-cost and owner columns from the arrays for Chargeback
-    if chargeback_model?(rpt.db)
+    if Chargeback.db_is_chargeback?(rpt.db)
       f_len = fields.length
       for f_idx in 1..f_len # Go thru fields in reverse
         f_key = fields[f_len - f_idx].last

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -183,6 +183,6 @@ class Chargeback < ActsAsArModel
   end
 
   def self.db_is_chargeback?(db)
-    db && db.safe_constantize < Chargeback
+    db && db.present? && db.safe_constantize < Chargeback
   end
 end # class Chargeback

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1219,7 +1219,7 @@ class MiqExpression
     elsif model.ends_with?("Performance")
       @reporting_available_fields[model.to_s] ||= {}
       @reporting_available_fields[model.to_s][interval.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true, :interval => interval)
-    elsif model.to_s.start_with?("Chargeback")
+    elsif Chargeback.db_is_chargeback?(model)
       @reporting_available_fields[model.to_s] ||=
         MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) }
     else

--- a/app/views/report/_form_filter.html.haml
+++ b/app/views/report/_form_filter.html.haml
@@ -3,7 +3,7 @@
     = render :partial => "form_filter_performance"
   - if @edit[:new][:model] == TREND_MODEL
     -# No additional filters for trend reports
-  - elsif @edit[:new][:model].start_with?("Chargeback")
+  - elsif Chargeback.db_is_chargeback?(@edit[:new][:model])
     = render :partial => "form_filter_chargeback"
   - else
     -# Show expression editors for all other reports


### PR DESCRIPTION
Purpose or Intent
-----------------
- Use `is_db_chargeback?` instead of `chargeback_model` method 
- Refuse empty string in `is_db_chargeback?`
- Other places were found for using method  `is_db_chargeback?`

Links
-----
> issue https://github.com/ManageIQ/manageiq/issues/9456
> https://github.com/ManageIQ/manageiq/pull/8406

cc @martinpovolny @zeari 

@miq-bot add_label ui
@miq-bot add_label chargeback
@miq-bot add_label refactoring
