### PR TITLE
[api] Refactoring methods to verbs for container deployments

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -158,7 +158,7 @@
     :description: Container Provider Deployment
     :identifier: container_deployment
     :klass: ContainerDeployment
-    :methods: *70174834084700
+    :verbs: *70174834084700
     :options:
     - :collection
     :collection_actions:


### PR DESCRIPTION

The methods were changed to verbs, but the API merge for that did not change the just merged
container deployment PR.

