### PR TITLE
Add missing gettext into widget export screen

### DIFF
--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -64,7 +64,7 @@
             :multiple => true)
 
     .pull-right
-      = submit_tag("Export", :class => "btn btn-primary export-widgets btn-disabled")
+      = submit_tag(_("Export"), :class => "btn btn-primary export-widgets btn-disabled")
 
 :javascript
   $(function() {


### PR DESCRIPTION
Visible under Cloud Intel -> Reports -> Import / Export -> Widgets

https://bugzilla.redhat.com/show_bug.cgi?id=1232768