### PR TITLE
Disable 'Upload' button on Import Widgets page

### DIFF
--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -45,8 +45,18 @@
             placeholder: "No file chosen"
           });
       .col-md-6
-        = submit_tag(_("Upload"), :class => "btn btn-default import-upload")
-
+        = submit_tag(_("Upload"), :class => "btn btn-default", :id => "upload_widget", :disabled => true)
+        :javascript
+          $("#upload_file").on("change",
+             function(){
+               if ($(this).val()){
+                 $('#upload_widget').prop('disabled', false);
+               }
+               else {
+                 $('#upload_widget').prop('disabled', true);
+               }
+             }
+           );
   %hr
 
   %h3


### PR DESCRIPTION
Fixed the disabling Upload button on Import Widgets page.

Requested in https://github.com/ManageIQ/manageiq/pull/9200