### PR TITLE
Properly clear search for Datastores filters

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -866,9 +866,9 @@ module ApplicationController::Filter
             adv_search_build(vm_model_from_active_tree(x_active_tree))
           end
           session[:edit] = @edit              # Set because next method will restore @edit from session
-          listnav_search_selected(search_id)  # Clear or set the adv search filter
-          self.x_node = "root"
         end
+        listnav_search_selected(search_id)  # Clear or set the adv search filter
+        self.x_node = "root"
         replace_right_cell
       end
       format.html do


### PR DESCRIPTION
Several unintended behaviors occur on the Compute > Infra > Datastores screen after clearing a filter and then closing the advanced search modal:

**(Before)**
![screen shot 2016-06-27 at 11 58 52 am](https://cloud.githubusercontent.com/assets/39493/16425744/dafab7b0-3d1a-11e6-8f9d-0d54c7c23584.png)

This code uses clearing logic used on other filter/tree-view screens to properly clear out filters on the Datastores screen.

**(After)**

![screen shot 2016-06-28 at 10 14 29 am](https://cloud.githubusercontent.com/assets/39493/16425798/1cbaec92-3d1b-11e6-89b0-2a57a5db6a3c.png)

Addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1349894
https://bugzilla.redhat.com/show_bug.cgi?id=1349888

/cc @h-kataria 