### PR TITLE
Convert Api::Settings to Config::Options

### DIFF
--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -19,14 +19,12 @@ class ApiController
     end
 
     def entrypoint_versions
-      version_config[:definitions].collect do |version_specification|
-        if version_specification[:ident]
-          {
-            :name => version_specification[:name],
-            :href => "#{@req[:api_prefix]}/#{version_specification[:ident]}"
-          }
-        end
-      end.compact
+      version_config[:definitions].select(&:ident).collect do |version_specification|
+        {
+          :name => version_specification[:name],
+          :href => "#{@req[:api_prefix]}/#{version_specification[:ident]}"
+        }
+      end
     end
 
     def entrypoint_collections

--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -20,7 +20,7 @@ class ApiController
 
     def entrypoint_versions
       version_config[:definitions].collect do |version_specification|
-        if version_specification.key?(:ident)
+        if version_specification[:ident]
           {
             :name => version_specification[:name],
             :href => "#{@req[:api_prefix]}/#{version_specification[:ident]}"

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -34,7 +34,7 @@ class ApiController
       #
       def init_env
         $api_log.info("Initializing Environment for #{Api::Settings.base[:name]}")
-        @api_user_token_service ||= ApiUserTokenService.new(Api::Settings.data, :log_init => true)
+        @api_user_token_service ||= ApiUserTokenService.new(Api::Settings, :log_init => true)
         log_config
       end
 

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -123,7 +123,7 @@ class ApiController
     end
 
     def resource_can_have_custom_actions(type, cspec = nil)
-      cspec ||= collection_config[type.to_sym] if collection_config.key?(type.to_sym)
+      cspec ||= collection_config[type.to_sym] if collection_config[type.to_sym]
       cspec && cspec[:options].include?(:custom_actions)
     end
 
@@ -249,7 +249,7 @@ class ApiController
       aname = parse_action_name
 
       aspecnames = "#{target}_actions"
-      raise BadRequestError, "No actions are supported for #{cname} #{type}" unless cspec.key?(aspecnames.to_sym)
+      raise BadRequestError, "No actions are supported for #{cname} #{type}" unless cspec[aspecnames.to_sym]
 
       aspec = cspec[aspecnames.to_sym]
       action_hash = fetch_action_hash(aspec, mname, aname)
@@ -272,7 +272,7 @@ class ApiController
       if @req[:collection]
         cname = @req[:collection]
         ctype = "Collection"
-        raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config.key?(cname.to_sym)
+        raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config[cname.to_sym]
         cspec = collection_config[cname.to_sym]
         if cspec[:options].include?(:primary)
           if "#{@req[:c_id]}#{@req[:subcollection]}#{@req[:s_id]}".present?

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -411,8 +411,8 @@ class ApiController
     # href is the optional href for the action specs, required for resources
     #
     def gen_action_specs(collection, type, is_subcollection, href = nil, resource = nil)
-      if collection_config.key?(collection)
-        cspec = collection_config[collection]
+      cspec = collection_config[collection]
+      if cspec
         if type == :collection
           gen_action_spec_for_collections(collection, cspec, is_subcollection, href)
         else
@@ -423,7 +423,7 @@ class ApiController
 
     def gen_action_spec_for_collections(collection, cspec, is_subcollection, href)
       target = is_subcollection ? :subcollection_actions : :collection_actions
-      return [] unless cspec.key?(target)
+      return [] unless cspec[target]
       cspec[target].each.collect do |method, action_definitions|
         next unless render_actions_for_method(cspec[:verbs], method)
         typed_action_definitions = fetch_typed_subcollection_actions(method, is_subcollection) || action_definitions
@@ -437,7 +437,7 @@ class ApiController
 
     def gen_action_spec_for_resources(cspec, is_subcollection, href, resource)
       target = is_subcollection ? :subresource_actions : :resource_actions
-      return [] unless cspec.key?(target)
+      return [] unless cspec[target]
       cspec[target].each.collect do |method, action_definitions|
         next unless render_actions_for_method(cspec[:verbs], method)
         typed_action_definitions = fetch_typed_subcollection_actions(method, is_subcollection) || action_definitions
@@ -457,7 +457,7 @@ class ApiController
       return unless is_subcollection
       ctype = @req[:collection].to_sym
       sakey = "#{@req[:subcollection]}_subcollection_actions".to_sym
-      collection_config.fetch_path(ctype, sakey, method.to_sym)
+      collection_config[ctype][sakey] && collection_config[ctype][sakey][method.to_sym]
     end
 
     def api_user_role_allows?(action_identifier)

--- a/app/services/api_user_token_service.rb
+++ b/app/services/api_user_token_service.rb
@@ -1,5 +1,5 @@
 class ApiUserTokenService
-  def initialize(config = Api::Settings.data, args = {})
+  def initialize(config = Api::Settings, args = {})
     @config = config
     @svc_options = args
     @token_mgr = new_token_mgr(base_config[:module], base_config[:name], api_config)

--- a/lib/api/settings.rb
+++ b/lib/api/settings.rb
@@ -1,17 +1,6 @@
-class Api::Settings
-  def self.data
-    @data ||= YAML.load_file(Rails.root.join("config/api.yml"))
-  end
-
-  def self.base
-    data[:base]
-  end
-
-  def self.version
-    data[:version]
-  end
-
-  def self.collections
-    data[:collections]
+module Api
+  Settings = ::Config::Options.new.tap do |o|
+    o.add_source!(Rails.root.join("config/api.yml").to_s)
+    o.load!
   end
 end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -9,7 +9,8 @@ describe ApiController do
   end
 
   def test_collection_query(collection, collection_url, klass, attr = :id)
-    if Api::Settings.collections.fetch_path(collection, :collection_actions, :get)
+    collection_actions = Api::Settings.collections[collection][:collection_actions]
+    if collection_actions && collection_actions[:get]
       api_basic_authorize collection_action_identifier(collection, :read, :get)
     else
       api_basic_authorize

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -147,7 +147,7 @@ module ApiSpecHelper
   end
 
   def action_identifier(type, action, selection = :resource_actions, method = :post)
-    Api::Settings.collections.fetch_path(type, selection, method)
+    Api::Settings.collections[type][selection][method]
       .detect { |spec| spec[:name] == action.to_s }[:identifier]
   end
 
@@ -157,7 +157,7 @@ module ApiSpecHelper
 
   def subcollection_action_identifier(type, subtype, action, method = :post)
     subtype_actions = "#{subtype}_subcollection_actions".to_sym
-    if Api::Settings.collections.fetch_path(type, subtype_actions).present?
+    if Api::Settings.collections[type][subtype_actions]
       action_identifier(type, action, subtype_actions, method)
     else
       action_identifier(subtype, action, :subcollection_actions, method)


### PR DESCRIPTION
With this change Api::Settings does nothing more than point to a
Config::Options instance.

There are probably more refactorings to be made based on this change, but since it touches a number of files already I wanted to keep this fairly straightforward.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 