### PR TITLE
Enhancement to expose the Automate model via /api/automate

### DIFF
--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  class AutomateController < BaseController
+    def show
+      ae_browser = MiqAeBrowser.new(@auth_user_obj)
+      begin
+        resources = ae_browser.search(@req.c_suffix, ae_search_options)
+      rescue => err
+        raise BadRequestError, err.to_s
+      end
+      attributes = params['attributes'] ? %w(fqname) | params['attributes'].to_s.split(',') : nil
+      resources = resources.collect { |resource| filter_ae_resource(resource, attributes) } if attributes
+      render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
+    end
+
+    private
+
+    def filter_ae_resource(resource, attributes = nil)
+      attributes.blank? ? resource : resource.slice(*attributes)
+    end
+
+    def ae_search_options
+      # For /api/automate (discovering domains, scope is 1 if unspecified)
+      # Otherwise, we default depth to 0 (current object), use -1 for unlimited depth search
+      depth = if params[:depth]
+                params[:depth] == "-1" ? nil : params[:depth].to_i
+              else
+                @req.c_suffix.blank? ? 1 : 0
+              end
+      search_options = {:depth => depth, :serialize => true}
+      search_options[:state_machines] = true if search_option?(:state_machines)
+      search_options
+    end
+  end
+end

--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -8,15 +8,11 @@ module Api
         raise BadRequestError, err.to_s
       end
       attributes = params['attributes'] ? %w(fqname) | params['attributes'].to_s.split(',') : nil
-      resources = resources.collect { |resource| filter_ae_resource(resource, attributes) } if attributes
+      resources = resources.collect { |resource| resource.slice(*attributes) } if attributes.present?
       render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
     end
 
     private
-
-    def filter_ae_resource(resource, attributes = nil)
-      attributes.blank? ? resource : resource.slice(*attributes)
-    end
 
     def ae_search_options
       # For /api/automate (discovering domains, scope is 1 if unspecified)

--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -100,6 +100,14 @@ module Api
         params['by_tag']
       end
 
+      def search_options
+        params['search_options'].to_s.split(",")
+      end
+
+      def search_option?(what)
+        search_options.map(&:downcase).include?(what.to_s)
+      end
+
       def decorator_selection
         params['decorators'].to_s.split(",")
       end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -371,6 +371,7 @@ module Api
       end
 
       def physical_attribute_selection(resource)
+        return [] if resource.kind_of?(Hash)
         physical_attributes = @req.attributes.select { |attr| attr_physical?(resource, attr) }
         physical_attributes.present? ? ID_ATTRS | physical_attributes : []
       end

--- a/config/api.yml
+++ b/config/api.yml
@@ -47,6 +47,21 @@
     :options:
     - :primary
     :verbs: *gd
+  :automate:
+    :description: Automate
+    :options:
+    - :arbitrary_resource_path
+    - :collection
+    :verbs: *g
+    :klass: MiqAeDomain
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_ae_domain_view
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_ae_domain_view
   :automation_requests:
     :description: Automation Requests
     :options:

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -1,0 +1,86 @@
+#
+# REST API Request Tests - /api/automate
+#
+describe "Automate API" do
+  before(:each) do
+    MiqAeDatastore.reset
+    FactoryGirl.create(:miq_ae_domain, :name => "ManageIQ", :tenant_id => @group.tenant.id)
+    FactoryGirl.create(:miq_ae_domain, :name => "Custom",   :tenant_id => @group.tenant.id)
+    system_class = FactoryGirl.create(:miq_ae_class, :name => "System", :namespace => "Custom")
+    FactoryGirl.create(:miq_ae_field, :name    => "on_entry", :class_id => system_class.id,
+                                      :aetype  => "state",    :datatype => "string")
+  end
+
+  context "Automate Queries" do
+    it "returns domains by default" do
+      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+
+      run_get automate_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to a_hash_including(
+        "name"      => "automate",
+        "subcount"  => 2,
+        "resources" => match_array([a_hash_including("name" => "Custom",   "fqname" => "/Custom"),
+                                    a_hash_including("name" => "ManageIQ", "fqname" => "/ManageIQ")])
+      )
+    end
+
+    it "default to depth 0 for non-root queries" do
+      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+
+      run_get automate_url("custom")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["resources"]).to match_array(
+        [a_hash_including("name" => "Custom", "fqname" => "/Custom")]
+      )
+    end
+
+    it "supports depth 1" do
+      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+
+      run_get(automate_url("custom"), :depth => 1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["resources"]).to match_array(
+        [a_hash_including("name" => "Custom", "fqname" => "/Custom",        "domain_fqname" => "/"),
+         a_hash_including("name" => "System", "fqname" => "/Custom/System", "domain_fqname" => "/System")]
+      )
+    end
+
+    it "supports depth -1" do
+      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+
+      run_get(automate_url, :depth => -1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["resources"]).to match_array(
+        [a_hash_including("name" => "ManageIQ", "fqname" => "/ManageIQ"),
+         a_hash_including("name" => "Custom",   "fqname" => "/Custom"),
+         a_hash_including("name" => "System",   "fqname" => "/Custom/System")]
+      )
+    end
+
+    it "supports state_machines search option" do
+      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+
+      run_get(automate_url, :depth => -1, :search_options => "state_machines")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["resources"]).to match_array(
+        [a_hash_including("name" => "Custom",   "fqname" => "/Custom"),
+         a_hash_including("name" => "System",   "fqname" => "/Custom/System")]
+      )
+    end
+
+    it "always return the fqname" do
+      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+
+      run_get(automate_url("custom/system"), :attributes => "name")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["resources"]).to match_array([{"name" => "System", "fqname" => "/Custom/System"}])
+    end
+  end
+end

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -18,11 +18,13 @@ describe "Automate API" do
       run_get automate_url
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to a_hash_including(
+      expect(response.parsed_body).to include(
         "name"      => "automate",
         "subcount"  => 2,
-        "resources" => match_array([a_hash_including("name" => "Custom",   "fqname" => "/Custom"),
-                                    a_hash_including("name" => "ManageIQ", "fqname" => "/ManageIQ")])
+        "resources" => a_collection_containing_exactly(
+          a_hash_including("name" => "Custom",   "fqname" => "/Custom"),
+          a_hash_including("name" => "ManageIQ", "fqname" => "/ManageIQ")
+        )
       )
     end
 
@@ -32,7 +34,7 @@ describe "Automate API" do
       run_get automate_url("custom")
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["resources"]).to match_array(
+      expect(response.parsed_body["resources"]).to match(
         [a_hash_including("name" => "Custom", "fqname" => "/Custom")]
       )
     end

--- a/tools/rest_api.rb
+++ b/tools/rest_api.rb
@@ -44,6 +44,7 @@ class RestApi
     SCRIPTDIR_ACTIONS    = %w(ls run).freeze
     SUB_COMMANDS         = ACTIONS + %w(edit vi) + SCRIPTDIR_ACTIONS
     API_PARAMETERS       = %w(expand attributes decorators limit offset
+                              depth search_options
                               sort_by sort_order sort_options
                               filter by_tag provider_class requester_type).freeze
 


### PR DESCRIPTION
Enhancement to expose the Automate model via /api/automate
    
- /api/automate
- Adding support for depth and optional search_options
- Default depth of 1 for /api/automate (domain discovery)
- Default depth of 0 for all others
- Depth of -1 for unlimited depth
- Updated API CLI to support --depth as well as --search-options


PivotalTracker: https://www.pivotaltracker.com/story/show/121850007
