### PR TITLE
Change aggregate_logical_cpus to non deprecated

### DIFF
--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -111,8 +111,12 @@ class ApiController
     def normalize_select_attributes(obj, opts)
       if opts[:render_attributes].present?
         opts[:render_attributes]
+      elsif obj.respond_to?(:attributes) && obj.class.respond_to?(:virtual_attribute_names)
+        obj.attributes.keys - obj.class.virtual_attribute_names
+      elsif obj.respond_to?(:attributes)
+        obj.attributes.keys
       else
-        obj.respond_to?(:attributes) ? obj.attributes.keys : obj.keys
+        obj.keys
       end
     end
 

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -220,6 +220,18 @@ describe ApiController do
       expect(provider.port).to eq(8080)
     end
 
+    it "only returns real attributes" do
+      api_basic_authorize collection_action_identifier(:providers, :edit)
+
+      provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
+
+      run_post(providers_url(provider.id), gen_request(:edit, "name" => "updated provider", "port" => "8080"))
+
+      response_keys = response_hash.keys
+      expect(response_keys).to include("tenant_id")
+      expect(response_keys).not_to include("total_vms")
+    end
+
     it "supports updates of credentials" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 


### PR DESCRIPTION
High level
--------

We defined `aggregate_logical_cpus` as an attribute on a few models. The `api/normalizer.rb` uses these attributes to generate the columns that are sent to the user. So this deprecated column is included in this list. This was causing a deprecation notice:

```
DEPRECATION WARNING: aggregate_logical_cpus is deprecated
and will be removed from ManageIQ D-release
(use aggregate_cpu_total_cores instead)
(called from block in normalize_hash at
app/controllers/api_controller/normalizer.rb:22)
```

Low Level
----

Instead of bringing back all attributes, virtual and regular, this brings back only regular attributes.
So virtual attributes, some of which are deprecated, most of which are a separate query, are looked up.

This only applies when no attributes are specified. If an attribute is requested, it is brought back whether it is deprecated or not.

@abellotti please confirm the process to change the public api and when it is possible from a versioning perspective.
