### PR TITLE
Toolbars: support for string interpolations inside gettext

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -10,6 +10,16 @@ class ApplicationHelper::Button::Basic < Hash
     end
   end
 
+  # Return content under key such as :text or :confirm run through gettext or
+  # evalated in the context of controller variables and helper methods.
+  def localized(key)
+    case self[key]
+    when NilClass then ''
+    when Proc     then instance_eval(&self[key])
+    else               _(self[key])
+    end
+  end
+
   def calculate_properties
     self[:enabled] = !disabled? if self[:enabled].nil?
   end

--- a/app/helpers/application_helper/toolbar/miq_policies_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policies_center.rb
@@ -9,7 +9,12 @@ class ApplicationHelper::Toolbar::MiqPoliciesCenter < ApplicationHelper::Toolbar
         button(
           :policy_new,
           'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New #{ui_lookup(:model=>@sb[:nodeid])} #{@sb[:mode].capitalize} Policy'),
+          t = proc do
+              _('Add a New %{model} %{mode} Policy') % {
+                :model => ui_lookup(:model => @sb[:nodeid]),
+                :mode  => @sb[:mode].capitalize
+              }
+          end,
           t,
           :url_parms => "?typ=basic"),
       ]

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -110,7 +110,7 @@ module ToolbarHelper
                            'data-toggle' => "dropdown",
                          )) do
         (toolbar_image(props) +
-          _(props[:text].to_s) + "&nbsp;".html_safe +
+          props.localized(:text) + "&nbsp;".html_safe +
           content_tag(:span, '', :class => "caret")).html_safe
       end
       out << content_tag(:ul, :class => 'dropdown-menu') do
@@ -132,7 +132,7 @@ module ToolbarHelper
                            :type  => "button",
                            :class => "#{cls}btn btn-default")) do
       (toolbar_image(props) +
-        _(props[:text].to_s) + "&nbsp;".html_safe).html_safe
+        props.localized(:text) + "&nbsp;".html_safe).html_safe
     end
   end
 
@@ -162,7 +162,7 @@ module ToolbarHelper
       content_tag(:a, prepare_data_keys(props)
                   .update(:href => '#')
                   .update(prepare_tag_keys(props))) do
-        (toolbar_image(props) + _(props[:text].to_s).html_safe)
+        (toolbar_image(props) + props.localized(:text).html_safe)
       end
     end
   end
@@ -180,7 +180,7 @@ module ToolbarHelper
       content_tag(:a, prepare_data_keys(props)
                       .update(:href => '#')
                       .update(prepare_tag_keys(props))) do
-        (toolbar_image(props) + _(props[:text].to_s).html_safe)
+        (toolbar_image(props) + props.localized(:text).html_safe)
       end
     end
   end
@@ -198,11 +198,11 @@ module ToolbarHelper
   #
   def prepare_tag_keys(props)
     h = data_hash_keys(props)
-    h.update('title'      => _(props[:title]),
+    h.update('title'      => props.localized(:title),
              'id'         => props[:id],
              'data-click' => props[:id])
     h['name'] = props[:name] if props.key?(:name)
-    h['data-confirm-tb'] = _(props[:confirm]) if props.key?(:confirm)
+    h['data-confirm-tb'] = props.localized(:confirm) if props.key?(:confirm)
     h
   end
 

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -45,7 +45,7 @@ class ExplorerPresenter
   #
 
   def initialize(options = {})
-    @options = HashWithIndifferentAccess.new(
+    @options = {
       :lock_unlock_trees    => {},
       :set_visible_elements => {},
       :update_partials      => {},
@@ -57,7 +57,7 @@ class ExplorerPresenter
       :osf_node             => '',
       :show_miq_buttons     => false,
       :load_chart           => nil
-    ).update(options)
+    }.update(options)
   end
 
   def reset_changes


### PR DESCRIPTION
Purpose or Intent:
-----------------
Find a way to do proper i18n on interpolated strings in toolbar buttons.

Problem:
--------
Currently i18n does not work for toolbar strings with interpolation. The strings contain interpolation of controller variables that is expanded via `eval` the result is passed through gettext. The interpolations include calls to `ui_lookup`. As result, these produce correct result only for English and only by accident.

Howto fix it:
-------------
1. Collect the correct strings for the catalog. According to the i18n gudelines.
1. The translation needs to be done at render time with the proper locale set.
1. The controller variables and `ui_lookup*` calls need to be evaluated with the proper locale in the proper context.

TODO:
-----
1. convert all toolbars -- might be better with separate PRs
1. remove `eval` calls
1. update catalogs