### PR TITLE
Add multiendpoint support to providers API

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -128,6 +128,9 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_suspended,     :type => :integer
   virtual_total  :total_subnets,           :cloud_subnets
 
+  virtual_total  :connection_definitions, :type => :array
+  virtual_total  :connection_configurations, :type => :open_struct
+
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
   alias_attribute :to_s, :name
 
@@ -271,6 +274,7 @@ class ExtManagementSystem < ApplicationRecord
 
     delete_unused_connection_configurations(options)
   end
+  alias connection_definitions= connection_configurations=
 
   def delete_unused_connection_configurations(options)
     chosen_endpoints   = options.map { |x| x.fetch_path(:endpoint, :role).try(:to_sym) }.compact.uniq
@@ -293,6 +297,10 @@ class ExtManagementSystem < ApplicationRecord
     connections = OpenStruct.new(options)
     connections.roles = roles
     connections
+  end
+
+  def connection_definitions
+    endpoints.map { |endpoint| connection_configuration_by_role_as_hash(endpoint[:role].to_sym) }
   end
 
   # Takes a hash of connection data
@@ -322,6 +330,15 @@ class ExtManagementSystem < ApplicationRecord
       options = {:endpoint => endpoint, :authentication => auth}
       OpenStruct.new(options)
     end
+  end
+
+  def connection_configuration_by_role_as_hash(role)
+    configuration = {:endpoint       => endpoints.find_by(:role => role).as_json || {},
+                     :authentication => authentications.find_by(:authtype => authtype_by_role(role)).as_json || {}}
+
+    configuration[:authentication][:role] = authtype_by_role(role)
+
+    configuration.deep_symbolize_keys
   end
 
   def hostnames
@@ -626,6 +643,10 @@ class ExtManagementSystem < ApplicationRecord
     creds = {}
     creds[role] = options
     update_authentication(creds,options)
+  end
+
+  def authtype_by_role(role)
+    role == :default ? :bearer : role
   end
 
   def clear_association_cache

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -10,6 +10,8 @@ class Provider < ApplicationRecord
   has_many :managers, :class_name => "ExtManagementSystem"
 
   has_many :endpoints, :through => :managers, :autosave => true
+  has_many :connection_definitions, :through => :managers, :autosave => true
+  has_many :connection_configurations, :through => :managers, :autosave => true
 
   delegate :verify_ssl,
            :verify_ssl?,


### PR DESCRIPTION
**Descriptions**:
Add the `connection_definitions` field to the API GET method. It returns an array of endpoints and authentications hashes.
Add the `connection_definitions` settings to the API POST method's create and edit actions.

**Examples**:
GET `http://localhost:3000/api/providers/139?attributes=connection_definitions` renders:
```
{
  "href": "http://localhost:3000/api/providers/139",
  "id": 139,
  "name": "LABz",
  "created_on": "2016-07-05T12:43:52.458Z",
  ...
  "connection_definitions": [
    {
      "endpoint": {
        "id": 334,
        "role": "default",
        ...
      },
      "authentication": {
        "id": 235,
        "name": "ManageIQ::Providers::Openshift::ContainerManager LABz",
        "authtype": "bearer",
        ...
  ...
```
POST `http://localhost:3000/api/providers` with the json body:
```
{
    "name"                      : "LAB",
    "zone_id"                   : "1",
    "type": "ManageIQ::Providers::Openshift::ContainerManager",
    "connection_definitions" : [
        {"endpoint"       : {"role"     : "default",
                             "hostname" : "example.com",
                             "port"     : "8443"},
          "authentication" : {"role"     : "bearer",
                              "auth_key" : "eyJhbGciOi ...",
                              "userid"   : "_"}},
         {"endpoint"       : {"role"     : "hawkular",
                              "hostname" : "example.com",
                              "port"     : "443"},
           "authentication" : {"role"     : "hawkular",
                               "auth_key" : "eyJhbGciOi ...",
                               "userid"   : "_"}}
    ]
}
```
will crate a new OpenShift provider.

**Links**:
Issue: https://github.com/ManageIQ/manageiq/issues/9506