### PR TITLE
fix datacenter_name methods not found bug in #ws_template_fileds _log

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -912,8 +912,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       raise _("No source template was found from input data:<%{data}>") % {:data => data.inspect}
     end
 
-    msg = "VM Found: <#{src.name}> <#{src.guid}> <#{src.uid_ems}>  "
-    msg += "Datacenter:<#{src.datacenter_name}>" if src.respond_to? :datacenter_name
+    msg = "VM Found: <#{src.name}> <#{src.guid}> <#{src.uid_ems}>"
+    msg += " Datacenter:<#{src.datacenter_name}>" if src.respond_to? :datacenter_name
     _log.info msg
 
     src

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -911,7 +911,11 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     if src.nil?
       raise _("No source template was found from input data:<%{data}>") % {:data => data.inspect}
     end
-    _log.info "VM Found: <#{src.name}> <#{src.guid}> <#{src.uid_ems}>  Datacenter:<#{src.datacenter_name}>"
+
+    msg = "VM Found: <#{src.name}> <#{src.guid}> <#{src.uid_ems}>  "
+    msg += "Datacenter:<#{src.datacenter_name}>" if src.respond_to? :datacenter_name
+    _log.info msg
+
     src
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
In #ws_template_fields it ask for **`datacenter_name`** for **`src`** we found, but when we would like to do a **`clone_to_vm`** **`src`** is a **`CloudManager::Vm`** object it dosen't have **`datacenter_name`** methods. So I added a condition for this log to fix it.

Links
-----
> * [PR relevant issue or pull_request](https://github.com/ManageIQ/manageiq/issues/9504)


Steps for Testing/QA
--------------------
> [Optional] Please tell me how to test a log message in MIQ if it's necessary 

