### PR TITLE
extract boot deps from Gemfile and gems/pending/Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,10 @@
 # VMDB specific gems
 #
 
-gem "rails",                           "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
-gem "rails-controller-testing",        :require => false
 gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",      "~>0.1.2", :require => false
 gem "websocket-driver",                "~>0.6.3"
 
-gem "config",                          "~>1.1.0", :git => "git://github.com/ManageIQ/config.git", :branch => "overwrite_arrays"
 gem "deep_merge",                      "~>1.0.1", :git => "git://github.com/ManageIQ/deep_merge.git", :branch => "overwrite_arrays"
 
 # Local gems
@@ -27,11 +24,6 @@ gem "lodash-rails",                   "~>3.10.0"
 # gem "patternfly-sass",                "~>3.4.0"
 gem 'patternfly-sass', :github => 'manageiq/patternfly-sass', :branch => 'tertiary-nav'
 gem "sass-rails"
-gem "sprockets-es6",                  "~>0.9.0",  :require => "sprockets/es6"
-
-# Vendored and required
-gem "ruport",                         "=1.7.0",                       :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
-
 
 # Vendored but not required
 gem "net-ldap",                       "~>0.7.0",   :require => false
@@ -49,49 +41,33 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 gem "color",                          "~>1.8"
-gem "default_value_for",              "~>3.0.2.alpha-miq.1", :git => "git://github.com/jrafanie/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
 gem "draper",                         "~>2.1.0", :git => "git://github.com/janraasch/draper.git", :branch => "feature/rails5-compatibility" # https://github.com/drapergem/draper/pull/712
-gem "hamlit-rails",                   "~>0.1.0"
-gem "high_voltage",                   "~>2.4.0"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "novnc-rails",                    "~>0.2"
 gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "puma",                           "~>3.3.0"
 gem "recursive-open-struct",          "~>1.0.0"
 gem "responders",                     "~>2.0"
-gem "secure_headers",                 "~>3.0.0"
 #gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 
 # Needed by the REST API
-gem "gettext_i18n_rails",             "~>1.4.0"
-gem "gettext_i18n_rails_js",          "~>1.0.3"
-gem "fast_gettext",                   "~>1.1.0"
 gem "jbuilder",                       "~>2.3.1"
-gem "paperclip",                      "~>4.3.0"
 gem "rails-i18n",                     "~>5.x"
 
 # Needed by External Auth
 gem "ruby-dbus"
 
 # Not vendored and not required
-gem "ancestry",                       "~>2.1.0",   :require => false
-gem "ansible_tower_client",           "~>0.3.0",   :require => false
 gem "aws-sdk",                        "~>2.2.19",  :require => false
-gem "dalli",                          "~>2.7.4",   :require => false
 gem "elif",                           "=0.1.0",    :require => false
 gem "google-api-client",              "~>0.8.6",   :require => false
 gem "fog-google",                     "~>0.3.0",   :require => false
-gem "hamlit",                         "~>2.0.0",   :require => false
 gem "inifile",                        "~>3.0",     :require => false
 gem "logging",                        "~>1.8",     :require => false  # Ziya depends on this
-gem "net_app_manageability",          ">=0.1.0",   :require => false
 gem "net-ping",                       "~>1.7.4",   :require => false
 gem "net-ssh",                        "=3.2.0",    :require => false
-gem "omniauth",                       "~>1.3.1",   :require => false
-gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",   :require => false
 gem "ovirt_metrics",                  "~>1.2.0",   :require => false
-gem "ruby_parser",                    "~>3.7",     :require => false
 gem "ruby-progressbar",               "~>1.7.0",   :require => false
 gem "rufus-scheduler",                "~>3.1.3",   :require => false
 gem "rugged",                         "~>0.23.0",  :require => false
@@ -116,12 +92,9 @@ unless ENV['APPLIANCE']
     gem "sqlite3",                      :require => false
 
     gem "brakeman",         "~>3.1.0",  :require => false
-    gem "capybara",         "~>2.5.0",  :require => false
-    gem "factory_girl",     "~>4.5.0",  :require => false
   end
 
   group :development, :test do
-    gem "rspec-rails",      "~>3.5.x"
     gem "parallel_tests"
     gem "good_migrations"
   end
@@ -140,5 +113,6 @@ dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
 eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 
 # Load other additional Gemfiles
+eval_gemfile("Gemfile.boot")
 eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 Dir.glob("bundler.d/*.rb").each { |f| eval_gemfile(File.expand_path(f, __dir__)) }

--- a/Gemfile.boot
+++ b/Gemfile.boot
@@ -1,0 +1,46 @@
+gem "rails",                           "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
+gem "rails-controller-testing",        :require => false
+gem "config",                          "~>1.1.0", :git => "git://github.com/ManageIQ/config.git", :branch => "overwrite_arrays"
+gem "sprockets-es6",                  "~>0.9.0",  :require => "sprockets/es6"
+
+# Vendored and required
+gem "ruport",                         "=1.7.0",                       :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
+
+# Not vendored, but required
+gem "default_value_for",              "~>3.0.2.alpha-miq.1", :git => "git://github.com/jrafanie/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
+gem "hamlit-rails",                   "~>0.1.0"
+gem "high_voltage",                   "~>2.4.0"
+gem "secure_headers",                 "~>3.0.0"
+
+# Needed by the REST API
+gem "gettext_i18n_rails",             "~>1.4.0"
+gem "gettext_i18n_rails_js",          "~>1.0.3"
+gem "fast_gettext",                   "~>1.1.0"
+gem "paperclip",                      "~>4.3.0"
+
+# Not vendored and not required
+gem "ancestry",                       "~>2.1.0",   :require => false
+gem "ansible_tower_client",           "~>0.3.0",   :require => false
+gem "dalli",                          "~>2.7.4",   :require => false
+gem "hamlit",                         "~>2.0.0",   :require => false
+gem "net_app_manageability",          ">=0.1.0",   :require => false
+gem "omniauth",                       "~>1.3.1",   :require => false
+gem "omniauth-google-oauth2",         "~>0.2.6"
+gem "ruby_parser",                    "~>3.7",     :require => false
+
+### Start of gems excluded from the appliances.
+# The gems listed below do not need to be packaged until we find it necessary or useful.
+# Only add gems here that we do not need on an appliance.
+#
+unless ENV['APPLIANCE']
+  group :test do
+    gem "capybara",         "~>2.5.0",  :require => false
+    gem "factory_girl",     "~>4.5.0",  :require => false
+  end
+
+  group :development, :test do
+    gem "rspec-rails",      "~>3.5.x"
+  end
+end
+
+eval_gemfile(File.expand_path("gems/pending/Gemfile.boot", __dir__))

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -1,7 +1,3 @@
-raise "Ruby versions less than 2.2 are unsupported!" if RUBY_VERSION < "2.2.0"
-
-source 'https://rubygems.org'
-
 # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
 gem "bundler",       ">= 1.8.4"
 gem "rake",          "~>10.1"
@@ -13,49 +9,29 @@ gem "actionpack",              "~> 5.0.x", :git => "git://github.com/rails/rails
 gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
 
 # Not locally modified and not required
-gem "addressable",             "~> 2.4",            :require => false
-gem "awesome_spawn",           "~> 1.3",            :require => false
 gem "azure-armrest",           "=0.2.7",            :require => false
-gem "bcrypt",                  "~> 3.1.10",         :require => false
-gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false
-gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
 gem "fog-openstack",           "~>0.1.5",           :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
-gem "image-inspector-client",  "~>1.0.2",           :require => false
-gem "iniparse",                                     :require => false
-gem "kubeclient",              "=1.1.3",            :require => false
-gem "hawkular-client",         "=2.0.0",            :require => false
-gem "linux_admin",             "~>0.16.0",          :require => false
-gem "log4r",                   "=1.1.8",            :require => false
-gem "memoist",                 "~>0.14.0",          :require => false
-gem "memory_buffer",           ">=0.1.0",           :require => false
-gem "more_core_extensions",    "~>2.0.0",           :require => false
 gem "net-sftp",                "~>2.1.2",           :require => false
 gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=1.1.0",            :require => false
 gem "openscap",                "~>0.4.3",           :require => false
 gem "ovirt",                   "~>0.10.0",          :require => false
-gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false
 gem "rubyzip",                 "~>1.2.0",           :require => false
 gem "zip-zip",                 "~>0.3.0",           :require => false
 gem "rufus-lru",               "~>1.0.3",           :require => false
-gem "sys-uname",               "~>1.0.1",           :require => false
 gem "trollop",                 "~>2.0",             :require => false
-gem "uuidtools",               "~>2.1.3",           :require => false
 gem "winrm",                   "~>1.7.2",           :require => false
 gem "winrm-elevated",          "~>0.4.0",           :require => false
-gem 'sys-proctable',           "~>1.1.0",           :require => false
 
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")
-  gem "linux_block_device", ">=0.1.0", :require => false
-
   if RbConfig::CONFIG["host_cpu"] == "x86"  # 32 bit Linux.
     gem "large_file_linux", "~>0.1.0", :require => false
   end
@@ -69,10 +45,6 @@ group :appliance do
   gem "rdoc",                  :require => false  # HACK to run test suite on SCL ruby
 end
 
-# Locally modified but not required
-gem "handsoap", "~>0.2.5", :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-3"
-gem "rubywbem",            :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
-
 # Windows only. Do not put in Gemfile.lock on other platforms.
 if Gem.win_platform?
   gem "win32-process", "~>0.8.0", :require => false, :platforms => [:mswin, :mingw]
@@ -84,15 +56,11 @@ end
 #
 unless ENV['APPLIANCE']
   group :test do
-    gem "coveralls",                    :require => false
     gem "test-unit",                    :require => false
     gem "camcorder",                    :require => false
     gem "jasmine",       "~>2.4.0",     :require => false
     gem "phantomjs",     "=1.9.8.0",    :require => false
     gem "rspec",         "~>3.5.x",     :require => false
-    gem "timecop",       "~>0.7.3",     :require => false
-    gem "vcr",           "~>2.6",       :require => false
-    gem "webmock",       "~>1.12",      :require => false
     gem "xml-simple",    "~>1.1.0",     :require => false  # Used by test/xml/tc_xmlhash_methods.rb
   end
 end

--- a/gems/pending/Gemfile.boot
+++ b/gems/pending/Gemfile.boot
@@ -1,0 +1,45 @@
+raise "Ruby versions less than 2.2 are unsupported!" if RUBY_VERSION < "2.2.0"
+source 'https://rubygems.org'
+
+# Not locally modified and not required
+gem "addressable",             "~> 2.4",            :require => false
+gem "awesome_spawn",           "~> 1.3",            :require => false
+gem "bcrypt",                  "~> 3.1.10",         :require => false
+gem "binary_struct",           "~> 2.1",            :require => false
+gem "ezcrypto",                "=0.7",              :require => false
+gem "image-inspector-client",  "~>1.0.2",           :require => false
+gem "iniparse",                                     :require => false
+gem "kubeclient",              "=1.1.3",            :require => false
+gem "hawkular-client",         "=2.0.0",            :require => false
+gem "linux_admin",             "~>0.16.0",          :require => false
+gem "log4r",                   "=1.1.8",            :require => false
+gem "memoist",                 "~>0.14.0",          :require => false
+gem "memory_buffer",           ">=0.1.0",           :require => false
+gem "more_core_extensions",    "~>2.0.0",           :require => false
+gem "pg",                      "~>0.18.2",          :require => false
+gem "sys-uname",               "~>1.0.1",           :require => false
+gem 'sys-proctable',           "~>1.1.0",           :require => false
+gem "uuidtools",               "~>2.1.3",           :require => false
+
+# Linux-only section
+if RbConfig::CONFIG["host_os"].include?("linux")
+  gem "linux_block_device", ">=0.1.0", :require => false
+end
+
+# Locally modified but not required
+gem "handsoap", "~>0.2.5", :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-3"
+gem "rubywbem",            :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
+
+
+### Start of gems excluded from the appliances.
+# The gems listed below do not need to be packaged until we find it necessary or useful.
+# Only add gems here that we do not need on an appliance.
+#
+unless ENV['APPLIANCE']
+  group :test do
+    gem "coveralls",                    :require => false
+    gem "timecop",       "~>0.7.3",     :require => false
+    gem "vcr",           "~>2.6",       :require => false
+    gem "webmock",       "~>1.12",      :require => false
+  end
+end


### PR DESCRIPTION
Extracted dependencies required to boot the application into Gemfile.boot
Gemfile.boot can be used by the provider gems to add minimal dependencies to make the gem boot manageiq as the test dummy app
This does not introduce new dependencies!

`BUNDLE_GEMFILE=Gemfile.boot bundle ; BUNDLE_GEMFILE=Gemfile.boot bundle exec rails c`

See https://github.com/ManageIQ/manageiq-providers-amazon/pull/8 for use case