### PR TITLE
[api] fixing cli error

### DIFF
--- a/tools/rest_api.rb
+++ b/tools/rest_api.rb
@@ -218,7 +218,7 @@ class RestApi
         exit
       end
 
-      path = PREFIX
+      path = PREFIX.dup
       path << "/v#{opts[:apiversion]}" unless opts[:apiversion].empty?
 
       collection = ""


### PR DESCRIPTION

```
  tools/rest_api.rb:228:in `run': can't modify frozen String (RuntimeError)
  from tools/rest_api.rb:283:in `<main>'
```

We are building a path starting with PREFIX but it's frozen, just need to dup it.