### PR TITLE
Create MiQ Alerts on Middleware Provider

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -353,10 +353,10 @@ module MiqPolicyController::AlertProfiles
       if old_alerts.nil? && new_alerts.nil?
         operation = :update_assignments
         old_alerts = new_alerts = @alert_profile.miq_alerts.collect(&:id)
-        assigned = @alert_profile.get_assigned_tos
       else
         operation = :update_alerts
       end
+      assigned = @alert_profile.get_assigned_tos
       MiqQueue.put(
         :class_name  => "ManageIQ::Providers::Hawkular::MiddlewareManager",
         :method_name => "update_alert_profile",

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -4,6 +4,8 @@ module ManageIQ::Providers
   class Hawkular::MiddlewareManager < ManageIQ::Providers::MiddlewareManager
     require 'hawkular/hawkular_client'
 
+    require_nested :AlertManager
+    require_nested :AlertProfileManager
     require_nested :EventCatcher
     require_nested :LiveMetricsCapture
     require_nested :MiddlewareDeployment
@@ -269,11 +271,37 @@ module ManageIQ::Providers
     end
 
     def self.update_alert(*args)
-      _log.debug("Updating an alert on Hawkular provider: #{args}")
+      operation = args[0][:operation]
+      alert = args[0][:alert]
+      miq_alert = {
+        :id          => alert[:id],
+        :enabled     => alert[:enabled],
+        :description => alert[:description],
+        :conditions  => alert[:expression]
+      }
+      MiddlewareManager.find_each { |m| m.alert_manager.process_alert(operation, miq_alert) }
     end
 
     def self.update_alert_profile(*args)
-      _log.debug("Updating an alert profile on Hawkular provider: #{args}")
+      alert_profile_arg = args[0]
+      miq_alert_profile = {
+        :id                  => alert_profile_arg[:profile_id],
+        :old_alerts_ids      => alert_profile_arg[:old_alerts],
+        :new_alerts_ids      => alert_profile_arg[:new_alerts],
+        :old_assignments_ids => process_old_assignments_ids(alert_profile_arg[:old_assignments]),
+        :new_assignments_ids => process_new_assignments_ids(alert_profile_arg[:new_assignments])
+      }
+      MiddlewareManager.find_each do |m|
+        m.alert_profile_manager.process_alert_profile(alert_profile_arg[:operation], miq_alert_profile)
+      end
+    end
+
+    def alert_manager
+      @alert_manager ||= ManageIQ::Providers::Hawkular::MiddlewareManager::AlertManager.new(self)
+    end
+
+    def alert_profile_manager
+      @alert_profile_manager ||= ManageIQ::Providers::Hawkular::MiddlewareManager::AlertProfileManager.new(self)
     end
 
     private
@@ -321,5 +349,32 @@ module ManageIQ::Providers
         end
       end
     end
+
+    def self.process_old_assignments_ids(old_assignments)
+      old_assignments_ids = []
+      unless old_assignments.empty?
+        if old_assignments[0].class.name == "MiqEnterprise"
+          MiddlewareManager.find_each { |m| m.middleware_servers.find_each { |eap| old_assignments_ids << eap.id } }
+        else
+          old_assignments_ids = old_assignments.collect(&:id)
+        end
+      end
+      old_assignments_ids
+    end
+
+    def self.process_new_assignments_ids(new_assignments)
+      new_assignments_ids = []
+      unless new_assignments.nil? || new_assignments["assign_to"].nil?
+        if new_assignments["assign_to"] == "enterprise"
+          # Note that in this version the assign to enterprise is resolved at the moment of the assignment
+          # In following iterations, enterprise assignment should be managed dynamically on the provider
+          MiddlewareManager.find_each { |m| m.middleware_servers.find_each { |eap| new_assignments_ids << eap.id } }
+        else
+          new_assignments_ids = new_assignments["objects"]
+        end
+      end
+      new_assignments_ids
+    end
+    private_class_method :process_old_assignments_ids, :process_new_assignments_ids
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
@@ -1,0 +1,85 @@
+module ManageIQ::Providers
+  class Hawkular::MiddlewareManager::AlertManager
+    require 'hawkular/hawkular_client'
+
+    def initialize(ems)
+      @alerts_client = ems.connect.alerts
+    end
+
+    def process_alert(operation, miq_alert)
+      group_trigger = convert_to_group_trigger(miq_alert)
+      group_conditions = convert_to_group_conditions(miq_alert)
+      case operation
+      when :new
+        @alerts_client.create_group_trigger(group_trigger)
+        @alerts_client.set_group_conditions(group_trigger.id,
+                                            :FIRING,
+                                            group_conditions)
+      when :update
+        @alerts_client.update_group_trigger(group_trigger)
+        @alerts_client.set_group_conditions(group_trigger.id,
+                                            :FIRING,
+                                            group_conditions)
+      when :delete
+        @alerts_client.delete_group_trigger(group_trigger.id)
+      end
+    end
+
+    def convert_to_group_trigger(miq_alert)
+      ::Hawkular::Alerts::Trigger.new('id'          => "MiQ-#{miq_alert[:id]}",
+                                      'name'        => miq_alert[:description],
+                                      'description' => miq_alert[:description],
+                                      'enabled'     => miq_alert[:enabled],
+                                      'type'        => :GROUP,
+                                      'eventType'   => :EVENT)
+    end
+
+    def convert_to_group_conditions(miq_alert)
+      eval_method = miq_alert[:conditions][:eval_method]
+      options = miq_alert[:conditions][:options]
+      case eval_method
+      when "mw_accumulated_gc_duration"       then generate_mw_gc_condition(eval_method, options)
+      when "mw_heap_used", "mw_non_heap_used" then generate_mw_jvm_conditions(eval_method, options)
+      end
+    end
+
+    def generate_mw_gc_condition(eval_method, options)
+      c = ::Hawkular::Alerts::Trigger::Condition.new({})
+      c.trigger_mode = :FIRING
+      c.data_id = MiddlewareServer.supported_metrics_by_column[eval_method]
+      c.type = :RATE
+      c.operator = convert_operator(options[:mw_operator])
+      c.threshold = options[:value_mw_garbage_collector].to_i
+      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new([c])
+    end
+
+    def generate_mw_jvm_conditions(eval_method, options)
+      data_id = MiddlewareServer.supported_metrics_by_column[eval_method]
+      data2_id = MiddlewareServer.supported_metrics_by_column["mw_heap_max"]
+      c = []
+      c[0] = generate_mw_compare_condition(data_id, data2_id, :GT, options[:value_mw_greater_than].to_f / 100)
+      c[1] = generate_mw_compare_condition(data_id, data2_id, :LT, options[:value_mw_less_than].to_f / 100)
+      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new(c)
+    end
+
+    def generate_mw_compare_condition(data_id, data2_id, operator, data2_multiplier)
+      c = ::Hawkular::Alerts::Trigger::Condition.new({})
+      c.trigger_mode = :FIRING
+      c.data_id = data_id
+      c.data2_id = data2_id
+      c.type = :COMPARE
+      c.operator = operator
+      c.data2_multiplier = data2_multiplier
+      c
+    end
+
+    def convert_operator(op)
+      case op
+      when "<"       then :LT
+      when "<=", "=" then :LTE
+      when ">"       then :GT
+      when ">="      then :GTE
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
@@ -1,0 +1,110 @@
+module ManageIQ::Providers
+  class Hawkular::MiddlewareManager::AlertProfileManager
+    require 'hawkular/hawkular_client'
+
+    def initialize(ems)
+      @alerts_client = ems.connect.alerts
+    end
+
+    def process_alert_profile(operation, miq_alert_profile)
+      profile_id = miq_alert_profile[:id]
+      old_alerts_ids = miq_alert_profile[:old_alerts_ids]
+      new_alerts_ids = miq_alert_profile[:new_alerts_ids]
+      old_assignments_ids = miq_alert_profile[:old_assignments_ids]
+      new_assignments_ids = miq_alert_profile[:new_assignments_ids]
+      case operation
+      when :update_alerts
+        update_alerts(profile_id, old_alerts_ids, new_alerts_ids, old_assignments_ids)
+      when :update_assignments
+        update_assignments(profile_id, old_alerts_ids, old_assignments_ids, new_assignments_ids)
+      end
+    end
+
+    def update_alerts(profile_id, old_alerts_ids, new_alerts_ids, old_assignments_ids)
+      unless old_assignments_ids.empty?
+        to_remove_alerts_ids = old_alerts_ids - new_alerts_ids
+        to_add_alerts_ids = new_alerts_ids - old_alerts_ids
+        to_remove_alerts_ids.each do |alert_id|
+          group_trigger = @alerts_client.get_single_trigger "MiQ-#{alert_id}", true
+          unassign_members(group_trigger, profile_id, old_assignments_ids)
+        end
+        to_add_alerts_ids.each do |alert_id|
+          group_trigger = @alerts_client.get_single_trigger "MiQ-#{alert_id}", true
+          assign_members(group_trigger, profile_id, old_assignments_ids)
+        end
+      end
+    end
+
+    def update_assignments(profile_id, old_alerts_ids, old_assignments_ids, new_assignments_ids)
+      to_unassign_ids = old_assignments_ids - new_assignments_ids
+      to_assign_ids = new_assignments_ids - old_assignments_ids
+      if to_unassign_ids.any? || to_assign_ids.any?
+        old_alerts_ids.each do |alert_id|
+          group_trigger = @alerts_client.get_single_trigger "MiQ-#{alert_id}", true
+          unassign_members(group_trigger, profile_id, to_unassign_ids) unless to_unassign_ids.empty?
+          assign_members(group_trigger, profile_id, to_assign_ids) unless to_assign_ids.empty?
+        end
+      end
+    end
+
+    def unassign_members(group_trigger, profile_id, members_ids)
+      context, profiles = unassign_members_context(group_trigger, profile_id)
+      group_trigger.context = context
+      @alerts_client.update_group_trigger(group_trigger)
+      if profiles.empty?
+        members_ids.each do |member_id|
+          @alerts_client.orphan_member("#{group_trigger.id}-#{member_id}")
+          @alerts_client.delete_trigger("#{group_trigger.id}-#{member_id}")
+        end
+      end
+    end
+
+    def unassign_members_context(group_trigger, profile_id)
+      context = group_trigger.context.nil? ? {} : group_trigger.context
+      profiles = context['miq.alert_profiles'].nil? ? [] : context['miq.alert_profiles'].split(",")
+      profiles -= [profile_id.to_s]
+      context['miq.alert_profiles'] = profiles.uniq.join(",")
+      [context, profiles]
+    end
+
+    def assign_members(group_trigger, profile_id, members_ids)
+      group_trigger.context = assign_members_context(group_trigger, profile_id)
+      @alerts_client.update_group_trigger(group_trigger)
+      members = @alerts_client.list_members group_trigger.id
+      current_members_ids = members.collect(&:id)
+      members_ids.each do |member_id|
+        next if current_members_ids.include?("#{group_trigger.id}-#{member_id}")
+        create_new_member(group_trigger, member_id)
+      end
+    end
+
+    def assign_members_context(group_trigger, profile_id)
+      context = group_trigger.context.nil? ? {} : group_trigger.context
+      profiles = context['miq.alert_profiles'].nil? ? [] : context['miq.alert_profiles'].split(",")
+      profiles.push(profile_id.to_s)
+      context['miq.alert_profiles'] = profiles.uniq.join(",")
+      context
+    end
+
+    def create_new_member(group_trigger, member_id)
+      server = MiddlewareServer.find(member_id)
+      new_member = ::Hawkular::Alerts::Trigger::GroupMemberInfo.new
+      new_member.group_id = group_trigger.id
+      new_member.member_id = "#{group_trigger.id}-#{member_id}"
+      new_member.member_name = "#{group_trigger.name} for #{server.name}"
+      new_member.data_id_map = calculate_member_data_id_map(server, group_trigger)
+      @alerts_client.create_member_trigger(new_member)
+    end
+
+    def calculate_member_data_id_map(server, group_trigger)
+      data_id_map = {}
+      group_trigger.conditions.each do |condition|
+        data_id_map[condition.data_id] = "MI~R~[#{server.feed}/#{server.nativeid}]~MT~#{condition.data_id}"
+        unless condition.data2_id.nil?
+          data_id_map[condition.data2_id] = "MI~R~[#{server.feed}/#{server.nativeid}]~MT~#{condition.data2_id}"
+        end
+      end
+      data_id_map
+    end
+  end
+end

--- a/app/models/mixins/live_metrics_mixin.rb
+++ b/app/models/mixins/live_metrics_mixin.rb
@@ -55,6 +55,10 @@ module LiveMetricsMixin
       @live_metrics_config['supported_metrics']
     end
 
+    def supported_metrics_by_column
+      @supported_metrics_by_column ||= supported_metrics.invert
+    end
+
     def load_live_metrics_config
       live_metrics_file = File.join(LIVE_METRICS_DIR, "#{name.demodulize.underscore}.yaml")
       live_metrics_config = File.exist?(live_metrics_file) ? YAML.load_file(live_metrics_file) : {}


### PR DESCRIPTION
This PR is a continuation of #9441 and #9460.
Once that MiQ Alerts are sent to the Middleware provider, these alerts needs to be synchronized internally on hawkular.
This means that a MiQ Alert is translated into a Group Trigger in Hawkular terminology and assignments of MiQ Alert Profiles should be translated into members of Group Triggers.
On this way, a MiQ Alert definition now can detect the conditions on Middleware provider side.
On following work we will complete the end-to-end flow, connecting the incoming events from the Middleware provider with the MiQ Alert defined.
