### PR TITLE
Handle images with multiple DVDs for SCVMM

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
@@ -10,7 +10,7 @@ function get_vms($vms){
 
     $vm_hash["Properties"] = $_
     $vm_hash["Networks"] = $_.VirtualNetworkAdapters.IPv4Addresses
-    $vm_hash["DVDs"] = $_.VirtualDVDDrives | Select -Expand ISO
+    $vm_hash["DVDs"] = @($_.VirtualDVDDrives | Select -Expand ISO | Select -Property ID, Name, SharePath, Size)
     $vm_hash["vmnet"] = $_.VirtualNetworkAdapters | Select VMNetwork
     $results[$id]= $vm_hash
   }
@@ -25,7 +25,7 @@ function get_images($ims){
     $i_hash = @{}
     $id = $_.ID
     $i_hash["Properties"] = $_
-    $i_hash["DVDs"] = $_.VirtualDVDDrives | Select -Expand ISO
+    $i_hash["DVDs"] = @($_.VirtualDVDDrives | Select -Expand ISO | Select -Property ID, Name, SharePath, Size)
     $i_hash["vmnet"] = $_.VirtualNetworkAdapters | Select VMNetwork
     $results[$id]= $i_hash
   }

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -409,7 +409,7 @@ module ManageIQ::Providers::Microsoft
                  when "ISOImage"  then process_iso_image(vm)
                  end
 
-      devices.compact
+      devices.flatten.compact
     end
 
     def process_vm_physical_dvd_drive(dvd)
@@ -430,22 +430,18 @@ module ManageIQ::Providers::Microsoft
     end
 
     def process_iso_image(vm)
-      path = vm[:DVDs][:Props][:SharePath]
-      size = vm[:DVDs][:Props][:Size]
-      uid  = vm[:DVDs][:Props][:ID]
-      name = vm[:DVDs][:Props][:Name]
-
-      new_result = {
-        :size            => size / 1.megabyte,
-        :device_type     => 'cdrom',  # TODO: add DVD to model
-        :present         => true,
-        :controller_type => 'IDE',
-        :mode            => 'persistent',
-        :filename        => path,
-        :uid_ems         => uid,
-        :device_name     => name,
-      }
-      new_result
+      vm[:DVDs].collect do |dvd|
+        {
+          :size            => dvd[:MS][:Size] / 1.megabyte,
+          :device_type     => 'cdrom', # TODO: add DVD to model
+          :present         => true,
+          :controller_type => 'IDE',
+          :mode            => 'persistent',
+          :filename        => dvd[:MS][:SharePath],
+          :uid_ems         => dvd[:MS][:ID],
+          :device_name     => dvd[:MS][:Name],
+        }
+      end
     end
 
     def process_vm_storages(properties)

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -24,10 +24,12 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
 
       assert_table_counts
       assert_ems
-      # assert_specific_cluster
+      assert_specific_cluster
       assert_specific_host
       assert_esx_host
       assert_specific_vm
+      assert_specific_guest_devices
+      assert_specific_snapshot
       assert_specific_storage
       assert_relationship_tree
     end
@@ -36,79 +38,83 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
   def assert_table_counts
     expect(ExtManagementSystem.count).to eq(1)
     expect(EmsFolder.count).to eq(4) # HACK: Folder structure for UI a la VMware
-    expect(EmsCluster.count).to eq(0)
-    expect(Host.count).to eq(2)
+    expect(EmsCluster.count).to eq(1)
+    expect(Host.count).to eq(3)
     expect(ResourcePool.count).to eq(0)
-    expect(Vm.count).to eq(3)
-    expect(VmOrTemplate.count).to eq(4)
+    expect(Vm.count).to eq(4)
+    expect(VmOrTemplate.count).to eq(7)
     expect(CustomAttribute.count).to eq(0)
     expect(CustomizationSpec.count).to eq(0)
-    expect(Disk.count).to eq(4)
-    expect(GuestDevice.count).to eq(14)
-    expect(Hardware.count).to eq(6)
+    expect(Disk.count).to eq(7)
+    expect(GuestDevice.count).to eq(9)
+    expect(Hardware.count).to eq(10)
     expect(Lan.count).to eq(2)
     expect(MiqScsiLun.count).to eq(0)
     expect(MiqScsiTarget.count).to eq(0)
-    expect(Network.count).to eq(3)
-    expect(OperatingSystem.count).to eq(6)
+    expect(Network.count).to eq(4)
+    expect(OperatingSystem.count).to eq(10)
     expect(Snapshot.count).to eq(1)
-    expect(Switch.count).to eq(2)
+    expect(Switch.count).to eq(4)
     expect(SystemService.count).to eq(0)
-    expect(Relationship.count).to eq(11)
-    expect(MiqQueue.count).to eq(4)
-    expect(Storage.count).to eq(2)
+    expect(Relationship.count).to eq(14)
+    expect(MiqQueue.count).to eq(7)
+    expect(Storage.count).to eq(6)
   end
 
   def assert_ems
     expect(@ems).to have_attributes(
       :api_version => "2.1.0",
-      :uid_ems     => "dce10b7e-f8e5-4c56-974e-83099c3000fb"
+      :uid_ems     => "a2b45b8b-ff0e-425c-baf7-24626963a27c"
     )
 
     expect(@ems.ems_folders.size).to eq(4) # HACK: Folder structure for UI a la VMware
-    expect(@ems.ems_clusters.size).to eq(0)
+    expect(@ems.ems_clusters.size).to eq(1)
     expect(@ems.resource_pools.size).to eq(0)
 
-    expect(@ems.storages.size).to eq(2)
-    expect(@ems.hosts.size).to eq(2)
-    expect(@ems.vms_and_templates.size).to eq(4)
-    expect(@ems.vms.size).to eq(3)
-    expect(@ems.miq_templates.size).to eq(1)
+    expect(@ems.storages.size).to eq(6)
+    expect(@ems.hosts.size).to eq(3)
+    expect(@ems.vms_and_templates.size).to eq(7)
+    expect(@ems.vms.size).to eq(4)
+    expect(@ems.miq_templates.size).to eq(3)
     expect(@ems.customization_specs.size).to eq(0)
   end
 
   def assert_specific_storage
-    storage_name = "file://dell-r410-01.cloudformswin.lab.redhat.com/C:/"
+    storage_name = "file://qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com" \
+      "/C:/ClusterStorage/CLUSP04%20Prod%20Volume%203-1"
+
     @storage = Storage.find_by_name(storage_name)
+
     expect(@storage).to have_attributes(
-      :ems_ref                     => "1c00651a-ca2a-4676-976b-55875305a89f",
+      :ems_ref                     => "15fb039d-027a-4113-8504-a37fd0994dca",
       :name                        => storage_name,
-      :store_type                  => nil,
-      :total_space                 => 499_738_734_592,
-      :free_space                  => 463_193_792_512,
+      :store_type                  => "CSVFS",
+      :total_space                 => 563_757_445_120,
+      :free_space                  => 462_748_672_000,
       :multiplehostaccess          => 1,
-      :location                    => "1c00651a-ca2a-4676-976b-55875305a89f",
+      :location                    => "15fb039d-027a-4113-8504-a37fd0994dca",
       :thin_provisioning_supported => true
       )
   end
 
   def assert_specific_cluster
-    @cluster = EmsCluster.find_by_name("US_East")
+    @cluster = EmsCluster.find_by_name("hyperv_cluster")
+
     expect(@cluster).to have_attributes(
-      :ems_ref => "0be27f13-2a7a-4803-8d12-a460b94fdd71",
-      :uid_ems => "0be27f13-2a7a-4803-8d12-a460b94fdd71",
-      :name    => "US_East",
+      :ems_ref => "8e830204-6448-4817-b220-34af48ccf8ca",
+      :uid_ems => "8e830204-6448-4817-b220-34af48ccf8ca",
+      :name    => "hyperv_cluster",
     )
   end
 
   def assert_specific_host
-    hostname = "dell-r410-03.cloudformswin.lab.redhat.com"
+    hostname = "qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com"
     @host = ManageIQ::Providers::Microsoft::InfraManager::Host.find_by_name(hostname)
     expect(@host).to have_attributes(
-      :ems_ref          => "6a2c5120-2931-4cc2-a445-8d28dfc73e03",
+      :ems_ref          => "18060bb0-05b9-40fb-b1e3-dfccb8d85c6b",
       :name             => hostname,
       :hostname         => hostname,
-      :ipaddress        => "10.8.96.25",
+      :ipaddress        => "10.16.4.54",
       :vmm_vendor       => "microsoft",
       :vmm_version      => "6.3.9600.17787",
       :vmm_product      => "HyperV",
@@ -117,17 +123,17 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     )
 
     expect(@host.operating_system).to have_attributes(
-      :product_name => "Microsoft Windows Server 2012 R2 Datacenter ",
+      :product_name => "Microsoft Windows Server 2012 R2 Standard ",
       :version      => "6.3.9600",
       :product_type => "microsoft"
     )
 
     expect(@host.hardware).to have_attributes(
-      :cpu_speed            => 2394,
+      :cpu_speed            => 2133,
       :cpu_type             => "Intel Xeon 179",
       :manufacturer         => "Intel",
       :model                => "Xeon",
-      :memory_mb            => 131_059,
+      :memory_mb            => 73_716,
       :memory_console       => nil,
       :cpu_sockets          => 2,
       :cpu_total_cores      => 16,
@@ -138,13 +144,13 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :memory_usage         => nil
     )
 
-    expect(@host.hardware.guest_devices.size).to eq(6)
-    expect(@host.hardware.nics.size).to eq(4)
+    expect(@host.hardware.guest_devices.size).to eq(3)
+    expect(@host.hardware.nics.size).to eq(3)
     nic = @host.hardware.nics.find_by_device_name("Ethernet")
     expect(nic).to have_attributes(
       :device_name     => "Ethernet",
       :device_type     => "ethernet",
-      :location        => "PCI bus 3, device 0, function 0",
+      :location        => "PCI bus 16, device 0, function 0",
       :present         => true,
       :controller_type => "ethernet"
     )
@@ -159,14 +165,17 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
   end
 
   def assert_specific_vm
-    v = ManageIQ::Providers::Microsoft::InfraManager::Vm.find_by_name("linux2")
+    v = ManageIQ::Providers::Microsoft::InfraManager::Vm.find_by_name("WS2008R2Core-JK")
+
+    location = "\\ProgramData\\Microsoft\\Windows\\Hyper-V\\Virtual Machines" \
+      "\\6D327596-1341-4072-81F1-2658DB7F073B.xml"
 
     expect(v).to have_attributes(
       :template         => false,
-      :ems_ref          => "c4425913-7043-4d2a-a229-75f051a8127b",
+      :ems_ref          => "14249d0a-0bd8-44cb-9edc-53707f66053f",
       :vendor           => "microsoft",
-      :power_state      => "on",
-      :location         => "\\ProgramData\\Microsoft\\Windows\\Hyper-V\\linux2\\Virtual Machines\\95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84.xml",
+      :power_state      => "off",
+      :location         => location,
       :tools_status     => "OS shutdown: true, Time synchronization: true, Data exchange: true, Heartbeat: true, Backup: true",
       :boot_time        => nil,
       :connection_state => "connected",
@@ -176,63 +185,94 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     expect(v.host).to eq(@host)
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "Red Hat Enterprise Linux 7 (64 bit)"
+      :product_name => "Unknown"
     )
 
     expect(v.custom_attributes.size).to eq(0)
     expect(v.snapshots.size).to eq(1)
 
     expect(v.hardware).to have_attributes(
-      :guest_os           => "Red Hat Enterprise Linux 7 (64 bit)",
-      :guest_os_full_name => "Red Hat Enterprise Linux 7 (64 bit)",
-      :bios               => "a3bd95a2-dd8d-4242-bd57-02621c4eb153",
+      :guest_os           => "Unknown",
+      :guest_os_full_name => "Unknown",
+      :bios               => "2c67139b-76e1-40fd-896f-407ee9efc447",
       :cpu_total_cores    => 1,
       :annotation         => nil,
       :memory_mb          => 512
     )
 
     expect(v.hardware.disks.size).to eq(1)
-    disk = v.hardware.disks.find_by_device_name("Blank Disk - Small_77376D2F-3967-476A-942A-6314A3337EEC")
+    disk = v.hardware.disks.find_by_device_name("WS2008R2Corex64Ent_5882F22A-B8DF-4D7C-BB30-F4E302D242AA")
+
+    location = "C:\\Users\\Public\\Documents\\Hyper-V\\Virtual hard disks" \
+      "\\WS2008R2Corex64Ent_5882F22A-B8DF-4D7C-BB30-F4E302D242AA.avhd"
+
     expect(disk).to have_attributes(
-      :device_name     => "Blank Disk - Small_77376D2F-3967-476A-942A-6314A3337EEC",
+      :device_name     => "WS2008R2Corex64Ent_5882F22A-B8DF-4D7C-BB30-F4E302D242AA",
       :device_type     => "disk",
       :controller_type => "IDE",
       :present         => true,
-      :filename        => "C:\\ProgramData\\Microsoft\\Windows\\Hyper-V\\linux2\\Blank Disk - Small_77376D2F-3967-476A-942A-6314A3337EEC.avhd",
-      :location        => "C:\\ProgramData\\Microsoft\\Windows\\Hyper-V\\linux2\\Blank Disk - Small_77376D2F-3967-476A-942A-6314A3337EEC.avhd",
-      :size            => 16.gigabytes,
+      :filename        => location,
+      :location        => location,
+      :size            => 136_365_211_648,
       :mode            => "persistent",
       :disk_type       => "thin",  # TODO: need to add a differencing disk
       :start_connected => true
     )
 
-    expect(v.snapshots.size).to eq(1)
-    snapshot = v.snapshots.find_by_name("linux2 - (02/23/2016 10:35:23)")
-    expect(snapshot).to have_attributes(
-      :uid         => "406845EA-0CF6-44CD-9D96-24A157DF5736",
-      :ems_ref     => "406845EA-0CF6-44CD-9D96-24A157DF5736",
-      :parent_uid  => "95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84",
-      :name        => "linux2 - (02/23/2016 10:35:23)",
-      :description => nil,
-    )
     # TODO: Add "Stored" status value in DB. This is a VM that has been provisioned but not deployed
+  end
 
-    expect(v.hardware.guest_devices.size).to eq(1)
-    dvd = v.hardware.guest_devices.first
-    expect(dvd).to have_attributes(
-      :device_name     => "CentOS-7-x86_64-Minimal-1511.iso",
+  def assert_specific_snapshot
+    v = ManageIQ::Providers::Microsoft::InfraManager::Vm.find_by_name("WS2008R2Core-JK")
+
+    expect(v.snapshots.size).to eq(1)
+    snapshot = v.snapshots.first
+
+    expect(snapshot).to have_attributes(
+      :uid         => "8E6AA643-7EF1-4945-811D-857017D921A1",
+      :ems_ref     => "8E6AA643-7EF1-4945-811D-857017D921A1",
+      :parent_uid  => "6D327596-1341-4072-81F1-2658DB7F073B",
+      :name        => "WS2008R2Core-JK - (2/17/2016 - 2:10:53 PM)",
+      :description => nil
+    )
+  end
+
+  def assert_specific_guest_devices
+    v0 = ManageIQ::Providers::Microsoft::InfraManager::Vm.find_by_name("CFME-56011-JT")
+    v1 = ManageIQ::Providers::Microsoft::InfraManager::Vm.find_by_name("jerrykbiker-dnd")
+    v2 = ManageIQ::Providers::Microsoft::InfraManager::Vm.find_by_name("DualDVDa")
+
+    expect(v0.hardware.guest_devices.size).to eq(0)
+    expect(v1.hardware.guest_devices.size).to eq(1)
+    expect(v2.hardware.guest_devices.size).to eq(2)
+
+    expect(v0.hardware.guest_devices).to be_empty
+
+    expect(v1.hardware.guest_devices.first).to have_attributes(
+      :device_name     => "LinuxAgent",
       :device_type     => "cdrom",
-      :filename        => "C:\\ProgramData\\Microsoft\\Windows\\Hyper-V\\linux2\\CentOS-7-x86_64-Minimal-1511.iso",
+      :filename        => "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd\\LinuxAgent.iso",
       :controller_type => "IDE",
       :present         => true,
       :start_connected => true,
     )
 
-    v = Vm.find_by_name("vm_linux1")
-    dvd = v.hardware.guest_devices.first
-    expect(dvd).to have_attributes(
-      :device_name => "vm_linux1",
-      :filename    => "F:",
+    expect(v2.hardware.guest_devices[0]).to have_attributes(
+      :device_name     => "en_visio_professional_2016_x005F_x86_x005F_x64_dvd_6962139",
+      :device_type     => "cdrom",
+      :filename        => "C:\\tmp\\en_visio_professional_2016_x005F_x86_x005F_x64_dvd_6962139.iso",
+      :controller_type => "IDE",
+      :present         => true,
+      :start_connected => true,
+    )
+
+    expect(v2.hardware.guest_devices[1]).to have_attributes(
+      :device_name     => "en_office_professional_plus_2016_x005F_x86_x005F_x64_dvd_6962141",
+      :device_type     => "cdrom",
+      :filename        => "C:\\tmp\\en_office_professional_plus_2016_x005F_x86_x005F_x64_dvd_6962141.iso",
+      :controller_type => "IDE",
+      :present         => true,
+      :start_connected => true,
     )
   end
 
@@ -241,14 +281,17 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       [EmsFolder, "Datacenters", {:hidden => true}] => {
         [Datacenter, "SCVMM"] => {
           [EmsFolder, "host", {:hidden => true}] => {
-            [ManageIQ::Providers::Microsoft::InfraManager::Host, "dell-r410-01.cloudformswin.lab.redhat.com"] => {},
-            [ManageIQ::Providers::Microsoft::InfraManager::Host, "dell-r410-03.cloudformswin.lab.redhat.com"] => {},
+            [EmsCluster, "hyperv_cluster"]                                                     => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Host, "dhcp129-212.brq.redhat.com"] => {},
           },
           [EmsFolder, "vm", {:hidden => true}]   => {
-            [ManageIQ::Providers::Microsoft::InfraManager::Template, "linux_template"] => {},
-            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "linux2"]               => {},
-            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "vm_linux1"]            => {},
-            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "testing_provisioning"] => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Template, "cfme-54402-12011420"] => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Template, "cfme-hyperv-5.5.0.13-2.x86_64"] => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Template, "cfme-hyperv-5.5.3.4-1.x86_64"]  => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "CFME-56011-JT"]                       => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "DualDVDa"]                            => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "WS2008R2Core-JK"]                     => {},
+            [ManageIQ::Providers::Microsoft::InfraManager::Vm, "jerrykbiker-dnd"]                     => {},
           }
         }
       }

--- a/spec/tools/scvmm_data/generate_data.rb
+++ b/spec/tools/scvmm_data/generate_data.rb
@@ -1,18 +1,26 @@
 require 'trollop'
+require 'io/console'
+
 ARGV.shift if ARGV[0] == '--'
+
 opts = Trollop.options do
   banner "Generate SCVMM test data.\n\nUsage: rails runner #{$PROGRAM_NAME} [-- options]\n\nOptions:\n\t"
   opt :username,  "User Name",  :type => :string
   opt :hostname,  "IP Address", :type => :string
-  opt :port,      "Port",       :type => :integer
+  opt :port,      "Port",       :type => :integer, :default => 5985
 end
+
 Trollop.die "username must be passed" unless opts[:username_given]
 Trollop.die "hostname must be passed" unless opts[:hostname]
 
-require 'io/console' if RUBY_VERSION < "2"
 STDOUT.write("Password: ")
 password = STDIN.noecho(&:gets).chomp
 puts
+
+puts "Using the following information:"
+puts "Hostname: " + opts[:hostname]
+puts "Username: " + opts[:username]
+puts "Port: "     + opts[:port].to_s
 
 puts "Connecting"
 win_rm = ManageIQ::Providers::Microsoft::InfraManager.raw_connect(

--- a/spec/tools/scvmm_data/get_inventory_output.yml
+++ b/spec/tools/scvmm_data/get_inventory_output.yml
@@ -20,8 +20,6 @@
           - "(UserOrGroup#0) {  }"
           - "(UserOrGroup#0) {  }"
           - "(UserOrGroup#0) {  }"
-          - "(UserOrGroup#0) {  }"
-          - "(UserOrGroup#0) {  }"
           :Profile: Administrator
           :UserRoleProfile: Administrator
           :MarkedForDeletion: false
@@ -31,8 +29,8 @@
           :ObjectType: UserRole
           :IsFullyCached: true
       :UserRoleId: 75700cd5-893e-4f68-ada7-50ef4668acc6
-      :FullyQualifiedDomainName: Dev-scvmm2k12.cloudformswin.lab.redhat.com
-      :FQDN: Dev-scvmm2k12.cloudformswin.lab.redhat.com
+      :FullyQualifiedDomainName: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+      :FQDN: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
       :Channel: &4
         :ToString: Microsoft.VirtualManager.Remoting.IVirtualManagerService
       :ObjectCache: &5
@@ -40,33 +38,33 @@
         :Props:
           :RelationshipTable: Microsoft.SystemCenter.VirtualMachineManager.RelationshipTable
       :OpsMgrServer: 
-      :CEIPOptIn: false
+      :CEIPOptIn: true
       :VMRCAccessAccount: 
       :VMRCDefaultPort: 5900
       :VMConnectDefaultPort: 2179
       :MinimumSupportedAgentVersion: 2.0.4271.0
       :MinimumSupportedGuestAgentVersion: 3.0.1469.0
       :LibraryRefresherEnabled: true
-      :LibraryRefresherFrequency: 1
-      :DatabaseServerName: DEV-win2k12sql
-      :DatabaseInstanceName: DEV-win2k12sql
+      :LibraryRefresherFrequency: 4
+      :DatabaseServerName: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+      :DatabaseInstanceName: SCVMM2
       :DatabaseName: VirtualManagerDB
-      :ConnectedUserName: CLOUDFORMSWIN\scvmm
+      :ConnectedUserName: CFME-QE-VMM-AD\Administrator
       :ConnectedUserGroups: &6
         :ToString: Microsoft.VirtualManager.Remoting.AccountCollection
       :UserName: Windows User
-      :CompanyName: Red Hat - Cloudforms
+      :CompanyName: QE
       :ProductVersion: 3.2.8145.0
       :DatabaseVersion: 3.2.7510.0
       :QFEDatabaseVersion: 3.2.8145.0
-      :ProductID: 03535-092-6002024-02363
+      :ProductID: 
       :LicenseType:
-        :ToString: Volume
-        :I32: 1
+        :ToString: Unknown
+        :I32: 5
       :EvaluationDaysLeft: 0
       :ManagedComputer:
       - &7
-        :ToString: Dev-scvmm2k12.cloudformswin.lab.redhat.com
+        :ToString: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
         :Props:
           :StateString: Responding
           :RoleString: Library, VMM Server
@@ -74,29 +72,29 @@
           :VersionState: UpToDate
           :VersionStateString: Up-to-date
           :MarkedForDeletion: false
-          :Name: Dev-scvmm2k12.cloudformswin.lab.redhat.com
+          :Name: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
           :MostRecentTaskID: 
           :MostRecentTaskUIState: 
           :MostRecentTask: 
-          :FullyQualifiedDomainName: Dev-scvmm2k12.cloudformswin.lab.redhat.com
-          :FQDN: Dev-scvmm2k12.cloudformswin.lab.redhat.com
-          :ComputerName: Dev-scvmm2k12
+          :FullyQualifiedDomainName: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :FQDN: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :ComputerName: scvmm2
           :Description: Virtual Machine Manager Library Files
           :AgentVersion: 3.2.8145.0
           :Role: Library, VMMServerRole
-          :UpdatedDate: 2016-01-20 15:45:52.637000000 -05:00
+          :UpdatedDate: 2015-02-20 15:03:28.070000000 -05:00
           :ComplianceStatus: 
           :ServerConnection: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
-          :ID: dce10b7e-f8e5-4c56-974e-83099c3000fb
+          :ID: a2b45b8b-ff0e-425c-baf7-24626963a27c
           :IsViewOnly: false
           :ObjectType: AgentServer
           :IsFullyCached: true
           :MostRecentTaskIfLocal: 
-      :VMMServiceAccount: CLOUDFORMSWIN\scvmm
+      :VMMServiceAccount: CFME-QE-VMM-AD\Administrator
       :IsHighlyAvailable: false
       :FailoverVMMNodes: 
       :ActiveVMMNode: 
-      :AutomaticLogicalNetworkCreationEnabled: false
+      :AutomaticLogicalNetworkCreationEnabled: true
       :AutomaticVirtualNetworkCreationEnabled: false
       :LogicalNetworkMatchOption:
         :ToString: FirstDNSSuffixLabel
@@ -107,38 +105,38 @@
       :ForOnBehalfOf: false
       :PortACL: 
   :datastores:
-    :284c1ea0-fc51-474a-bbec-372021806117:
-      :ToString: C:\
+    :15fb039d-027a-4113-8504-a37fd0994dca:
+      :ToString: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
       :Props:
-        :Name: C:\
-        :StorageVolumeID: 3d0c4879-d6cf-11e5-80b3-806e6f6e6963
-        :ObjectID: "\\\\?\\Volume{3d0c4879-d6cf-11e5-80b3-806e6f6e6963}\\"
-        :HostVolumeID: 3d0c4879-d6cf-11e5-80b3-806e6f6e6963
+        :Name: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+        :StorageVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
+        :ObjectID: "\\\\?\\Volume{cd0c3151-b540-4d65-87f9-ac3156ae703f}\\"
+        :HostVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
         :MountPoints:
-        - C:\
-        :Capacity: 299630587904
-        :FreeSpace: 267202084864
-        :VolumeLabel: 
-        :FileSystem: NTFS
+        - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+        :Capacity: 563757445120
+        :FreeSpace: 462748672000
+        :VolumeLabel: CSV-NA-Disk
+        :FileSystem: CSVFS
         :IsSANMigrationPossible: false
-        :IsClustered: false
-        :IsClusterSharedVolume: false
+        :IsClustered: true
+        :IsClusterSharedVolume: true
         :InUse: false
         :VMHost: &1
-          :ToString: dell-r410-03.cloudformswin.lab.redhat.com
+          :ToString: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
           :Props:
-            :RunAsAccount: 
-            :MostRecentTaskID: a45a922f-7815-46bd-9116-b47ad83ffc1f
-            :MostRecentTaskUIState: Failed
-            :MostRecentTask: Refresh Performance Data
-            :OverallStateString: OK
-            :OverallState: OK
+            :RunAsAccount: JTSCVMM
+            :MostRecentTaskID: 22c8bd5f-b9ad-4028-96fd-32eb2c5b014b
+            :MostRecentTaskUIState: SucceedWithInfo
+            :MostRecentTask: Refresh virtual machine properties
+            :OverallStateString: Needs Attention
+            :OverallState: NeedsAttention
             :CommunicationStateString: Responding
             :CommunicationState: Responding
-            :Name: dell-r410-03.cloudformswin.lab.redhat.com
-            :FullyQualifiedDomainName: dell-r410-03.cloudformswin.lab.redhat.com
-            :ComputerName: dell-r410-03
-            :DomainName: cloudformswin.lab.redhat.com
+            :Name: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :FullyQualifiedDomainName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :ComputerName: qeblade33
+            :DomainName: cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
             :Description: 
             :RemoteUserName: 
             :OverrideHostGroupReserves: false
@@ -147,9 +145,11 @@
             :DiskSpaceReserveMB: 10240
             :MaxDiskIOReservation: 10000
             :MemoryReserveMB: 2048
-            :VMPaths: &71
-            - C:\ProgramData\Microsoft\Windows\Hyper-V
-            :BaseDiskPaths: &72 []
+            :VMPaths: &37
+            - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+            - C:\ClusterStorage\netapp_crud_vol
+            :BaseDiskPaths: &38
+            - "\\\\cfme_hyperv\\scvmm2"
             :PROEnabled: false
             :MaintenanceHost: false
             :AvailableForPlacement: true
@@ -159,359 +159,21 @@
             :LogicalProcessorCount: 16
             :PhysicalCPUCount: 2
             :CoresPerCPU: 8
-            :L2CacheSize: 2048
-            :L3CacheSize: 12288
-            :BusSpeed: 5860
-            :ProcessorSpeed: 2394
+            :L2CacheSize: 256
+            :L3CacheSize: 8192
+            :BusSpeed: 4800
+            :ProcessorSpeed: 2133
             :ProcessorModel: Xeon
             :ProcessorManufacturer: Intel
             :ProcessorArchitecture: 9
             :ProcessorFamily: '179'
-            :CpuUtilization: 0
-            :TotalMemory: 137425408000
-            :AvailableMemory: 127010
-            :OperatingSystem: 'Microsoft Windows Server 2012 R2 Datacenter '
+            :CpuUtilization: 11
+            :TotalMemory: 77297573888
+            :AvailableMemory: 20920
+            :OperatingSystem: 'Microsoft Windows Server 2012 R2 Standard '
             :OperatingSystemVersion: 6.3.9600
-            :DVDDrives: F:;G:;
-            :DVDDriveList:
-            - F
-            - G
-            :VirtualizationPlatformString: Microsoft Hyper-V
-            :VirtualizationPlatform: HyperV
-            :VirtualizationPlatformDetail: Microsoft Hyper-V
-            :IsVirtualizationSoftwareDetailUnknown: false
-            :IsViridianHost: true
-            :SupportsLiveMigration: false
-            :FloppyDrives: 
-            :FloppyDriveList: []
-            :VMHostGroup: All Hosts
-            :HostCluster: 
-            :RemoteConnectEnabled: true
-            :RemoteConnectPort: 2179
-            :SecureRemoteConnectEnabled: false
-            :VMRCCertificateAvailable: false
-            :EnableLiveMigration: false
-            :LiveMigrationMaximum: 2
-            :LiveStorageMigrationMaximum: 2
-            :UseAnyMigrationSubnet: false
-            :MigrationSubnet: &73 []
-            :MigrationSubnetUserManaged: &74 []
-            :MigrationAuthProtocol: CredSSP
-            :MigrationPerformanceOption: UseCompression
-            :SslTcpPort: 5985
-            :SslCertificateHash: 
-            :SshTcpPort: 0
-            :SshPublicKeyHash: 
-            :SshPublicKey: 
-            :IsRemoteFXRoleInstalled: false
-            :IsCPUSLAT: true
-            :IsNumaSpanningEnabled: true
-            :GPUMemoryTotalMB: 
-            :GPUMemoryAvailableMB: 
-            :ClusterNodeStatus: Unknown
-            :TimeZone: -300
-            :HyperVState: Running
-            :HyperVStateString: Running
-            :HyperVVersion: 6.3.9600.17787
-            :HyperVVersionState: UpToDate
-            :PerimeterNetworkHost: false
-            :NonTrustedDomainHost: false
-            :MaximumMemoryPerVM: 1048576
-            :MinimumMemoryPerVM: 32
-            :SuggestedMaximumMemoryPerVM: 512
-            :ModifiedTime: 2016-02-29 19:53:09.520876000 -05:00
-            :Agent: dell-r410-03.cloudformswin.lab.redhat.com
-            :ManagedComputer: dell-r410-03.cloudformswin.lab.redhat.com
-            :VMs:
-            - vm_linux1
-            - linux2
-            :Disks:
-            - "\\\\.\\PHYSICALDRIVE0"
-            - "\\\\.\\PHYSICALDRIVE1"
-            - "\\\\.\\PHYSICALDRIVE2"
-            :GPUs: []
-            :InstalledVirtualSwitchExtensions:
-            - Microsoft VMM DHCPv4 Server Switch Extension
-            - Microsoft NDIS Capture
-            - Microsoft Virtual Ethernet Switch Native Extension
-            - Microsoft Windows Filtering Platform
-            :DiskVolumes:
-            - C:\
-            - "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
-            :RegisteredStorageFileShares: []
-            :FibreChannelHbas: []
-            :FibreChannelVirtualSANs: []
-            :SASHbas:
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :InternetSCSIHbas: []
-            :VMwareResourcePool: 
-            :IsConfiguredForOutOfBandManagement: false
-            :PhysicalMachine: 4c4c4544-0038-3810-8053-cac04f585231
-            :HealthMonitors:
-            - Overall
-            - Hyper-V Role Version
-            - WMI Performance Counter
-            - Host Agent Service
-            - Hyper-V Role Overall
-            - Hyper-V Virtual Machine Management Service
-            - Network
-            - WinRM
-            - Host Agent Overall
-            - Host Agent Version
-            :RemoteStorageTotalCapacity: 0
-            :RemoteStorageAvailableCapacity: 0
-            :LocalStorageTotalCapacity: 300000000000
-            :LocalStorageAvailableCapacity: 267277864960
-            :TotalStorageCapacity: 300000000000
-            :AvailableStorageCapacity: 267277864960
-            :UsedStorageCapacity: 32722135040
-            :IsDedicatedToNetworkVirtualizationGateway: false
-            :FibreChannelWorldWidePortNameMinimum: C003FF3CB93B0000
-            :FibreChannelWorldWidePortNameMaximum: C003FF3CB93BFFFF
-            :FibreChannelWorldWideNodeName: C003FF0000FFFF00
-            :VMConnectCertificateThumbprint: 
-            :Custom1: 
-            :Custom2: 
-            :Custom3: 
-            :Custom4: 
-            :Custom5: 
-            :Custom6: 
-            :Custom7: 
-            :Custom8: 
-            :Custom9: 
-            :Custom10: 
-            :CustomProperty: {}
-            :FibreChannelSANStatus: DeployTargetDoesNotHaveHBA (1204)
-            :ISCSISANStatus: DeployTargetDoesNotHaveIscsiInitiator (1231)
-            :NPIVFibreChannelSANStatus: DeployHostIsNotNPIVCapable (1252)
-            :CertificateRequest: 
-            :ComputerState: Responding
-            :VirtualizationManager: 
-            :ServerConnection:
-              :S: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
-            :ID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-            :IsViewOnly: false
-            :ObjectType: VMHost
-            :MarkedForDeletion: false
-            :IsFullyCached: true
-            :MostRecentTaskIfLocal: Refresh Performance Data
-          :MS:
-            :FQDN: dell-r410-03.cloudformswin.lab.redhat.com
-            :LogicalCPUCount: 16
-            :CPUSpeed: 2394
-            :CPUModel: Xeon
-            :CPUManufacturer: Intel
-            :CPUArchitecture: 9
-            :CPUFamily: '179'
-            :VMRCEnabled: true
-            :VMRCPort: 2179
-            :SecureVMRCEnabled: false
-            :VirtualServerState: Running
-            :VirtualServerStateString: Running
-            :VirtualServerVersion: 6.3.9600.17787
-            :VirtualServerVersionState: UpToDate
-            :ServicingWindows: &9
-              :S: 
-        :IsAvailableForPlacement: true
-        :HostDiskID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-        :StorageDiskID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-        :HostDisk: &2
-          :ToString: "\\\\.\\PHYSICALDRIVE0"
-          :Props:
-            :Name: "\\\\.\\PHYSICALDRIVE0"
-            :Signature: 2866457588
-            :UniqueID: '2866457588'
-            :Capacity: 300000000000
-            :AvailableCapacity: 267277864960
-            :PhysicallyAvailableCapacity: 267280279552
-            :DeviceID: "\\\\.\\PHYSICALDRIVE0"
-            :Index: 0
-            :IsClustered: false
-            :IsSanAttached: false
-            :IsPassThroughCapable: false
-            :ClusterDisk: 
-            :VMHost: *1
-            :LibraryServer: 
-            :DiskID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-            :Location: 
-            :SMLunId: 50000393B8426D34
-            :SMLunIdFormat: 9
-            :SMLunIdNamespace: 2
-            :Bus: 0
-            :Lun: 0
-            :Port: 
-            :Target: 0
-            :StorageLogicalUnit: 
-            :Classification: Local Storage
-            :DiskVolumes:
-            - C:\
-            - "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
-            :PartitionStyle: MasterBootRecord
-            :DiskStatus: Online
-            :IsViewOnly: false
-            :ServerConnection:
-              :S: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
-            :ID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-            :ObjectType: VMHostDisk
-            :MarkedForDeletion: false
-            :IsFullyCached: true
-        :StorageDisk: *2
-        :Classification: &11
-          :ToString: Local Storage
-          :Props:
-            :StorageClassificationData: (StorageClassificationData#0) { id = 6575a34f-4685-4c0d-9b32-ec28948a7884,
-              LastUpdatedTimestamp = 1/20/2016 3:45:06 PM, objectType = StorageClassification,
-              name = "Local Storage", Enabled = True, Accessibility = Public, description
-              = "Local Storage", CreationTime = 1/20/2016 3:45:06 PM, modifiedTime
-              = 1/20/2016 3:45:06 PM }
-            :StoragePool: []
-            :ObjectType: StorageClassification
-            :Accessibility: Public
-            :Name: Local Storage
-            :IsViewOnly: false
-            :Description: Local Storage
-            :AddedTime: 2016-01-20 10:45:06.990000000 -05:00
-            :ModifiedTime: 2016-01-20 10:45:06.990000000 -05:00
-            :Enabled: true
-            :MostRecentTask: 
-            :ServerConnection:
-              :S: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
-            :ID: 6575a34f-4685-4c0d-9b32-ec28948a7884
-            :MarkedForDeletion: false
-            :IsFullyCached: true
-            :MostRecentTaskIfLocal: 
-        :StoragePool: 
-        :ServerConnection: &8
-          :ToString: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
-          :Props:
-            :Name: localhost
-            :Port: 8100
-            :IsConnected: true
-            :ServerInterfaceVersion: 2.1.0
-            :Profile: Administrator
-            :UserRole: *3
-            :UserRoleId: 75700cd5-893e-4f68-ada7-50ef4668acc6
-            :FullyQualifiedDomainName: Dev-scvmm2k12.cloudformswin.lab.redhat.com
-            :FQDN: Dev-scvmm2k12.cloudformswin.lab.redhat.com
-            :Channel: *4
-            :ObjectCache: *5
-            :OpsMgrServer: 
-            :CEIPOptIn: false
-            :VMRCAccessAccount: 
-            :VMRCDefaultPort: 5900
-            :VMConnectDefaultPort: 2179
-            :MinimumSupportedAgentVersion: 2.0.4271.0
-            :MinimumSupportedGuestAgentVersion: 3.0.1469.0
-            :LibraryRefresherEnabled: true
-            :LibraryRefresherFrequency: 1
-            :DatabaseServerName: DEV-win2k12sql
-            :DatabaseInstanceName: DEV-win2k12sql
-            :DatabaseName: VirtualManagerDB
-            :ConnectedUserName: CLOUDFORMSWIN\scvmm
-            :ConnectedUserGroups: *6
-            :UserName: Windows User
-            :CompanyName: Red Hat - Cloudforms
-            :ProductVersion: 3.2.8145.0
-            :DatabaseVersion: 3.2.7510.0
-            :QFEDatabaseVersion: 3.2.8145.0
-            :ProductID: 03535-092-6002024-02363
-            :LicenseType: Volume
-            :EvaluationDaysLeft: 0
-            :ManagedComputer:
-            - *7
-            :VMMServiceAccount: CLOUDFORMSWIN\scvmm
-            :IsHighlyAvailable: false
-            :FailoverVMMNodes: 
-            :ActiveVMMNode: 
-            :AutomaticLogicalNetworkCreationEnabled: false
-            :AutomaticVirtualNetworkCreationEnabled: false
-            :LogicalNetworkMatchOption: FirstDNSSuffixLabel
-            :BackupLogicalNetworkMatchOption: VirtualNetworkSwitchName
-            :ForOnBehalfOf: false
-            :PortACL: 
-        :ID: 284c1ea0-fc51-474a-bbec-372021806117
-        :IsViewOnly: false
-        :ObjectType:
-          :ToString: VMHostVolume
-          :I32: 10
-        :MarkedForDeletion: false
-        :IsFullyCached: true
-    :1c00651a-ca2a-4676-976b-55875305a89f:
-      :ToString: C:\
-      :Props:
-        :Name: C:\
-        :StorageVolumeID: 219c146f-cad3-11e5-80b3-806e6f6e6963
-        :ObjectID: 
-        :HostVolumeID: 219c146f-cad3-11e5-80b3-806e6f6e6963
-        :MountPoints:
-        - C:\
-        :Capacity: 499738734592
-        :FreeSpace: 463193792512
-        :VolumeLabel: 
-        :FileSystem: 
-        :IsSANMigrationPossible: false
-        :IsClustered: false
-        :IsClusterSharedVolume: false
-        :InUse: false
-        :VMHost: &10
-          :ToString: dell-r410-01.cloudformswin.lab.redhat.com
-          :Props:
-            :RunAsAccount: 
-            :MostRecentTaskID: 06be14e2-b6f3-4f53-a7e6-1124908f1d2c
-            :MostRecentTaskUIState: Failed
-            :MostRecentTask: Refresh Performance Data
-            :OverallStateString: OK
-            :OverallState: OK
-            :CommunicationStateString: Responding
-            :CommunicationState: Responding
-            :Name: dell-r410-01.cloudformswin.lab.redhat.com
-            :FullyQualifiedDomainName: dell-r410-01.cloudformswin.lab.redhat.com
-            :ComputerName: dell-r410-01
-            :DomainName: cloudformswin.lab.redhat.com
-            :Description: 
-            :RemoteUserName: 
-            :OverrideHostGroupReserves: false
-            :CPUPercentageReserve: 10
-            :NetworkPercentageReserve: 0
-            :DiskSpaceReserveMB: 10240
-            :MaxDiskIOReservation: 10000
-            :MemoryReserveMB: 2048
-            :VMPaths: &54
-            - C:\ProgramData\Microsoft\Windows\Hyper-V
-            :BaseDiskPaths: &55 []
-            :PROEnabled: false
-            :MaintenanceHost: false
-            :AvailableForPlacement: true
-            :IsEmbedded: false
-            :CredentialsNeeded: false
-            :PausedForNetworkIncompatibility: false
-            :LogicalProcessorCount: 16
-            :PhysicalCPUCount: 2
-            :CoresPerCPU: 8
-            :L2CacheSize: 2048
-            :L3CacheSize: 12288
-            :BusSpeed: 5860
-            :ProcessorSpeed: 2394
-            :ProcessorModel: Xeon
-            :ProcessorManufacturer: Intel
-            :ProcessorArchitecture: 9
-            :ProcessorFamily: '179'
-            :CpuUtilization: 0
-            :TotalMemory: 137425408000
-            :AvailableMemory: 127532
-            :OperatingSystem: 'Microsoft Windows Server 2012 R2 Datacenter '
-            :OperatingSystemVersion: 6.3.9600
-            :DVDDrives: F:;G:;
-            :DVDDriveList:
-            - F
-            - G
+            :DVDDrives: 
+            :DVDDriveList: []
             :VirtualizationPlatformString: Microsoft Hyper-V
             :VirtualizationPlatform: HyperV
             :VirtualizationPlatformDetail: Microsoft Hyper-V
@@ -521,7 +183,7 @@
             :FloppyDrives: 
             :FloppyDriveList: []
             :VMHostGroup: All Hosts
-            :HostCluster: 
+            :HostCluster: hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
             :RemoteConnectEnabled: true
             :RemoteConnectPort: 2179
             :SecureRemoteConnectEnabled: false
@@ -529,9 +191,15 @@
             :EnableLiveMigration: true
             :LiveMigrationMaximum: 2
             :LiveStorageMigrationMaximum: 2
-            :UseAnyMigrationSubnet: true
-            :MigrationSubnet: &56 []
-            :MigrationSubnetUserManaged: &57 []
+            :UseAnyMigrationSubnet: false
+            :MigrationSubnet: &44
+            - fe80::345a:45bf:224c:b551/128
+            - 10.16.4.54/32
+            - 11.1.1.2/32
+            :MigrationSubnetUserManaged: &45
+            - false
+            - false
+            - false
             :MigrationAuthProtocol: CredSSP
             :MigrationPerformanceOption: UseCompression
             :SslTcpPort: 5985
@@ -544,8 +212,8 @@
             :IsNumaSpanningEnabled: true
             :GPUMemoryTotalMB: 
             :GPUMemoryAvailableMB: 
-            :ClusterNodeStatus: Unknown
-            :TimeZone: -300
+            :ClusterNodeStatus: Running
+            :TimeZone: -420
             :HyperVState: Running
             :HyperVStateString: Running
             :HyperVVersion: 6.3.9600.17787
@@ -555,61 +223,87 @@
             :MaximumMemoryPerVM: 1048576
             :MinimumMemoryPerVM: 32
             :SuggestedMaximumMemoryPerVM: 512
-            :ModifiedTime: 2016-02-29 19:51:46.917145200 -05:00
-            :Agent: dell-r410-01.cloudformswin.lab.redhat.com
-            :ManagedComputer: dell-r410-01.cloudformswin.lab.redhat.com
+            :ModifiedTime: 2016-07-11 15:46:42.450779800 -04:00
+            :Agent: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :ManagedComputer: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
             :VMs:
-            - testing_provisioning
+            - SCVMM16
+            - WS2008R2Core
+            - proxy-cfme-dnd
+            - CFME-56012-JT
+            - taigotest
+            - CFME-5541-JT
+            - HV2016CTP4
+            - WIN7-5609-JT
+            - WS2008R2Core-JK
+            - Win7SmallTmpl
+            - CFME-5610-JT
+            - Local33SSATest
+            - CFME-56012b
+            - Ubu1404LTS
+            - CFME-5550-JT
+            - DualDVDa
+            - PERF-56010a
+            - scvmm-sp1-1
+            - cluster-storage
+            - WS16CTP4
+            - jerrykbiker-dnd
+            - CFME-5609-JT
+            - CFME-5540-JT
+            - MIQ-627-JT
+            - CFME-56013-JT
+            - CFME-56011-JT
             :Disks:
-            - "\\\\.\\PHYSICALDRIVE1"
             - "\\\\.\\PHYSICALDRIVE0"
+            - "\\\\.\\PHYSICALDRIVE3"
             - "\\\\.\\PHYSICALDRIVE2"
+            - "\\\\.\\PHYSICALDRIVE1"
             :GPUs: []
             :InstalledVirtualSwitchExtensions:
-            - Microsoft Windows Filtering Platform
-            - Microsoft VMM DHCPv4 Server Switch Extension
             - Microsoft Virtual Ethernet Switch Native Extension
+            - Microsoft VMM DHCPv4 Server Switch Extension
+            - Microsoft Windows Filtering Platform
             - Microsoft NDIS Capture
             :DiskVolumes:
             - C:\
-            - "\\\\?\\Volume{219c146e-cad3-11e5-80b3-806e6f6e6963}\\"
-            :RegisteredStorageFileShares: []
+            - "\\\\?\\Volume{b58fecc1-c453-11e4-80b4-806e6f6e6963}\\"
+            - C:\ClusterStorage\netapp_crud_vol
+            - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+            :RegisteredStorageFileShares:
+            - scvmm2
             :FibreChannelHbas: []
             :FibreChannelVirtualSANs: []
             :SASHbas:
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            - PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :InternetSCSIHbas: []
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :InternetSCSIHbas:
+            - ROOT\ISCSIPRT\0000_0
             :VMwareResourcePool: 
             :IsConfiguredForOutOfBandManagement: false
-            :PhysicalMachine: 4c4c4544-0031-5210-8050-c2c04f4b5331
+            :PhysicalMachine: 463b9e30-9f60-e011-8346-5cf3fc1c83ec
             :HealthMonitors:
-            - Hyper-V Virtual Machine Management Service
-            - Host Agent Overall
-            - Hyper-V Role Version
-            - Network
-            - Host Agent Service
-            - Host Agent Version
-            - Overall
-            - WMI Performance Counter
-            - Hyper-V Role Overall
             - WinRM
-            :RemoteStorageTotalCapacity: 0
-            :RemoteStorageAvailableCapacity: 0
-            :LocalStorageTotalCapacity: 500107862016
-            :LocalStorageAvailableCapacity: 463269437440
-            :TotalStorageCapacity: 500107862016
-            :AvailableStorageCapacity: 463269437440
-            :UsedStorageCapacity: 36838424576
+            - Hyper-V Role Version
+            - Host Agent Version
+            - Host Agent Service
+            - WMI Performance Counter
+            - Overall
+            - Host Agent Overall
+            - Hyper-V Role Overall
+            - Hyper-V Virtual Machine Management Service
+            - Network
+            :RemoteStorageTotalCapacity: 832233830400
+            :RemoteStorageAvailableCapacity: 528009306112
+            :LocalStorageTotalCapacity: 1000215724032
+            :LocalStorageAvailableCapacity: 153700024320
+            :TotalStorageCapacity: 1832449554432
+            :AvailableStorageCapacity: 681709330432
+            :UsedStorageCapacity: 1150740224000
             :IsDedicatedToNetworkVirtualizationGateway: false
-            :FibreChannelWorldWidePortNameMinimum: C003FF831E9E0000
-            :FibreChannelWorldWidePortNameMaximum: C003FF831E9EFFFF
+            :FibreChannelWorldWidePortNameMinimum: C003FFDA8ADA0000
+            :FibreChannelWorldWidePortNameMaximum: C003FFDA8ADAFFFF
             :FibreChannelWorldWideNodeName: C003FF0000FFFF00
             :VMConnectCertificateThumbprint: 
             :Custom1: 
@@ -624,22 +318,23 @@
             :Custom10: 
             :CustomProperty: {}
             :FibreChannelSANStatus: DeployTargetDoesNotHaveHBA (1204)
-            :ISCSISANStatus: DeployTargetDoesNotHaveIscsiInitiator (1231)
+            :ISCSISANStatus: DeployHostDoesNotHaveMPIO (1253)
             :NPIVFibreChannelSANStatus: DeployHostIsNotNPIVCapable (1252)
             :CertificateRequest: 
             :ComputerState: Responding
             :VirtualizationManager: 
-            :ServerConnection: *8
-            :ID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
+            :ServerConnection:
+              :S: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
+            :ID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
             :IsViewOnly: false
             :ObjectType: VMHost
             :MarkedForDeletion: false
-            :IsFullyCached: true
-            :MostRecentTaskIfLocal: Refresh Performance Data
+            :IsFullyCached: false
+            :MostRecentTaskIfLocal: Refresh virtual machine properties
           :MS:
-            :FQDN: dell-r410-01.cloudformswin.lab.redhat.com
+            :FQDN: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
             :LogicalCPUCount: 16
-            :CPUSpeed: 2394
+            :CPUSpeed: 2133
             :CPUModel: Xeon
             :CPUManufacturer: Intel
             :CPUArchitecture: 9
@@ -651,30 +346,31 @@
             :VirtualServerStateString: Running
             :VirtualServerVersion: 6.3.9600.17787
             :VirtualServerVersionState: UpToDate
-            :ServicingWindows: *9
+            :ServicingWindows: &11
+              :S: 
         :IsAvailableForPlacement: true
-        :HostDiskID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
-        :StorageDiskID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
-        :HostDisk: &12
-          :ToString: "\\\\.\\PHYSICALDRIVE0"
+        :HostDiskID: 1a044003-9f71-4191-9263-9b3641479a48
+        :StorageDiskID: 1a044003-9f71-4191-9263-9b3641479a48
+        :HostDisk: &2
+          :ToString: "\\\\.\\PHYSICALDRIVE3"
           :Props:
-            :Name: "\\\\.\\PHYSICALDRIVE0"
-            :Signature: 29360191
-            :UniqueID: '29360191'
-            :Capacity: 500107862016
-            :AvailableCapacity: 463269437440
-            :PhysicallyAvailableCapacity: 463271567360
-            :DeviceID: "\\\\.\\PHYSICALDRIVE0"
-            :Index: 0
-            :IsClustered: false
-            :IsSanAttached: false
-            :IsPassThroughCapable: false
-            :ClusterDisk: 
-            :VMHost: *10
+            :Name: "\\\\.\\PHYSICALDRIVE3"
+            :Signature: 197977995
+            :UniqueID: '197977995'
+            :Capacity: 563760691200
+            :AvailableCapacity: 462748672000
+            :PhysicallyAvailableCapacity: 462751918080
+            :DeviceID: "\\\\.\\PHYSICALDRIVE3"
+            :Index: 3
+            :IsClustered: true
+            :IsSanAttached: true
+            :IsPassThroughCapable: true
+            :ClusterDisk: netapp_csv_scvmm2
+            :VMHost: *1
             :LibraryServer: 
-            :DiskID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
+            :DiskID: 1a044003-9f71-4191-9263-9b3641479a48
             :Location: 
-            :SMLunId: 50014EE0ADB4ECB5
+            :SMLunId: 600A098038303373662447685A564964
             :SMLunIdFormat: 9
             :SMLunIdNamespace: 2
             :Bus: 0
@@ -682,23 +378,683 @@
             :Port: 
             :Target: 0
             :StorageLogicalUnit: 
-            :Classification: *11
+            :Classification: Remote Storage
             :DiskVolumes:
-            - C:\
-            - "\\\\?\\Volume{219c146e-cad3-11e5-80b3-806e6f6e6963}\\"
+            - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
             :PartitionStyle: MasterBootRecord
-            :DiskStatus: Online
+            :DiskStatus: Reserved
             :IsViewOnly: false
-            :ServerConnection: *8
-            :ID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
+            :ServerConnection:
+              :S: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
+            :ID: 1a044003-9f71-4191-9263-9b3641479a48
             :ObjectType: VMHostDisk
             :MarkedForDeletion: false
             :IsFullyCached: true
-        :StorageDisk: *12
-        :Classification: *11
+        :StorageDisk: *2
+        :Classification: &8
+          :ToString: Remote Storage
+          :Props:
+            :StorageClassificationData: (StorageClassificationData#0) { id = a458947d-f9f9-4d3f-80c6-7ce9ba1baeac,
+              LastUpdatedTimestamp = 2/20/2015 12:01:38 PM, objectType = StorageClassification,
+              name = "Remote Storage", Enabled = True, Accessibility = Public, description
+              = "Remote Storage", CreationTime = 2/20/2015 12:01:38 PM, modifiedTime
+              = 2/20/2015 12:01:38 PM }
+            :StoragePool: []
+            :ObjectType: StorageClassification
+            :Accessibility: Public
+            :Name: Remote Storage
+            :IsViewOnly: false
+            :Description: Remote Storage
+            :AddedTime: 2015-02-20 07:01:38.193000000 -05:00
+            :ModifiedTime: 2015-02-20 07:01:38.193000000 -05:00
+            :Enabled: true
+            :MostRecentTask: 
+            :ServerConnection:
+              :S: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
+            :ID: a458947d-f9f9-4d3f-80c6-7ce9ba1baeac
+            :MarkedForDeletion: false
+            :IsFullyCached: true
+            :MostRecentTaskIfLocal: 
         :StoragePool: 
-        :ServerConnection: *8
-        :ID: 1c00651a-ca2a-4676-976b-55875305a89f
+        :ServerConnection: &9
+          :ToString: Microsoft.SystemCenter.VirtualMachineManager.Remoting.ServerConnection
+          :Props:
+            :Name: localhost
+            :Port: 8100
+            :IsConnected: true
+            :ServerInterfaceVersion: 2.1.0
+            :Profile: Administrator
+            :UserRole: *3
+            :UserRoleId: 75700cd5-893e-4f68-ada7-50ef4668acc6
+            :FullyQualifiedDomainName: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :FQDN: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :Channel: *4
+            :ObjectCache: *5
+            :OpsMgrServer: 
+            :CEIPOptIn: true
+            :VMRCAccessAccount: 
+            :VMRCDefaultPort: 5900
+            :VMConnectDefaultPort: 2179
+            :MinimumSupportedAgentVersion: 2.0.4271.0
+            :MinimumSupportedGuestAgentVersion: 3.0.1469.0
+            :LibraryRefresherEnabled: true
+            :LibraryRefresherFrequency: 4
+            :DatabaseServerName: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :DatabaseInstanceName: SCVMM2
+            :DatabaseName: VirtualManagerDB
+            :ConnectedUserName: CFME-QE-VMM-AD\Administrator
+            :ConnectedUserGroups: *6
+            :UserName: Windows User
+            :CompanyName: QE
+            :ProductVersion: 3.2.8145.0
+            :DatabaseVersion: 3.2.7510.0
+            :QFEDatabaseVersion: 3.2.8145.0
+            :ProductID: 
+            :LicenseType: Unknown
+            :EvaluationDaysLeft: 0
+            :ManagedComputer:
+            - *7
+            :VMMServiceAccount: CFME-QE-VMM-AD\Administrator
+            :IsHighlyAvailable: false
+            :FailoverVMMNodes: 
+            :ActiveVMMNode: 
+            :AutomaticLogicalNetworkCreationEnabled: true
+            :AutomaticVirtualNetworkCreationEnabled: false
+            :LogicalNetworkMatchOption: FirstDNSSuffixLabel
+            :BackupLogicalNetworkMatchOption: VirtualNetworkSwitchName
+            :ForOnBehalfOf: false
+            :PortACL: 
+        :ID: 15fb039d-027a-4113-8504-a37fd0994dca
+        :IsViewOnly: false
+        :ObjectType:
+          :ToString: VMHostVolume
+          :I32: 10
+        :MarkedForDeletion: false
+        :IsFullyCached: true
+    :df15d6c7-79a2-4740-a630-8627e1f25957:
+      :ToString: C:\ClusterStorage\netapp_crud_vol
+      :Props:
+        :Name: C:\ClusterStorage\netapp_crud_vol
+        :StorageVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+        :ObjectID: "\\\\?\\Volume{cadbe3e4-e781-44aa-95ff-e6d4708bdc09}\\"
+        :HostVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+        :MountPoints:
+        - C:\ClusterStorage\netapp_crud_vol
+        :Capacity: 268470042624
+        :FreeSpace: 65260634112
+        :VolumeLabel: csv_cluster1
+        :FileSystem: CSVFS
+        :IsSANMigrationPossible: false
+        :IsClustered: true
+        :IsClusterSharedVolume: true
+        :InUse: false
+        :VMHost: *1
+        :IsAvailableForPlacement: true
+        :HostDiskID: 787f92b3-03d9-4df9-84d1-a9b80612af4b
+        :StorageDiskID: 787f92b3-03d9-4df9-84d1-a9b80612af4b
+        :HostDisk: &10
+          :ToString: "\\\\.\\PHYSICALDRIVE2"
+          :Props:
+            :Name: "\\\\.\\PHYSICALDRIVE2"
+            :Signature: 2772963379
+            :UniqueID: '2772963379'
+            :Capacity: 268473139200
+            :AvailableCapacity: 65260634112
+            :PhysicallyAvailableCapacity: 65263730688
+            :DeviceID: "\\\\.\\PHYSICALDRIVE2"
+            :Index: 2
+            :IsClustered: true
+            :IsSanAttached: true
+            :IsPassThroughCapable: true
+            :ClusterDisk: netapp_crud_vol
+            :VMHost: *1
+            :LibraryServer: 
+            :DiskID: 787f92b3-03d9-4df9-84d1-a9b80612af4b
+            :Location: 
+            :SMLunId: 600A098038303373635D47744C625947
+            :SMLunIdFormat: 9
+            :SMLunIdNamespace: 2
+            :Bus: 0
+            :Lun: 0
+            :Port: 
+            :Target: 0
+            :StorageLogicalUnit: 
+            :Classification: *8
+            :DiskVolumes:
+            - C:\ClusterStorage\netapp_crud_vol
+            :PartitionStyle: MasterBootRecord
+            :DiskStatus: Reserved
+            :IsViewOnly: false
+            :ServerConnection: *9
+            :ID: 787f92b3-03d9-4df9-84d1-a9b80612af4b
+            :ObjectType: VMHostDisk
+            :MarkedForDeletion: false
+            :IsFullyCached: true
+        :StorageDisk: *10
+        :Classification: *8
+        :StoragePool: 
+        :ServerConnection: *9
+        :ID: df15d6c7-79a2-4740-a630-8627e1f25957
+        :IsViewOnly: false
+        :ObjectType:
+          :ToString: VMHostVolume
+          :I32: 10
+        :MarkedForDeletion: false
+        :IsFullyCached: true
+    :c7ec11d5-65da-412c-ae30-b946f343daad:
+      :ToString: C:\
+      :Props:
+        :Name: C:\
+        :StorageVolumeID: 1889d148-fcb9-11e3-80b5-806e6f6e6963
+        :ObjectID: "\\\\?\\Volume{1889d148-fcb9-11e3-80b5-806e6f6e6963}\\"
+        :HostVolumeID: 1889d148-fcb9-11e3-80b5-806e6f6e6963
+        :MountPoints:
+        - C:\
+        :Capacity: 997629882368
+        :FreeSpace: 85444444160
+        :VolumeLabel: 
+        :FileSystem: NTFS
+        :IsSANMigrationPossible: false
+        :IsClustered: false
+        :IsClusterSharedVolume: false
+        :InUse: false
+        :VMHost: &12
+          :ToString: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :Props:
+            :RunAsAccount: JTSCVMM
+            :MostRecentTaskID: 0a930a4f-3baf-4fcd-a037-bf266517ddbe
+            :MostRecentTaskUIState: Completed
+            :MostRecentTask: Refresh virtual machine properties
+            :OverallStateString: Needs Attention
+            :OverallState: NeedsAttention
+            :CommunicationStateString: Responding
+            :CommunicationState: Responding
+            :Name: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :FullyQualifiedDomainName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :ComputerName: qeblade26
+            :DomainName: cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :Description: 
+            :RemoteUserName: 
+            :OverrideHostGroupReserves: false
+            :CPUPercentageReserve: 10
+            :NetworkPercentageReserve: 0
+            :DiskSpaceReserveMB: 10240
+            :MaxDiskIOReservation: 10000
+            :MemoryReserveMB: 2048
+            :VMPaths: &83
+            - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+            - C:\ClusterStorage\netapp_crud_vol
+            :BaseDiskPaths: &84
+            - "\\\\cfme_hyperv\\scvmm2"
+            :PROEnabled: false
+            :MaintenanceHost: false
+            :AvailableForPlacement: true
+            :IsEmbedded: false
+            :CredentialsNeeded: false
+            :PausedForNetworkIncompatibility: false
+            :LogicalProcessorCount: 8
+            :PhysicalCPUCount: 2
+            :CoresPerCPU: 4
+            :L2CacheSize: 256
+            :L3CacheSize: 8192
+            :BusSpeed: 4800
+            :ProcessorSpeed: 2133
+            :ProcessorModel: Xeon
+            :ProcessorManufacturer: Intel
+            :ProcessorArchitecture: 9
+            :ProcessorFamily: '179'
+            :CpuUtilization: 27
+            :TotalMemory: 77297573888
+            :AvailableMemory: 39698
+            :OperatingSystem: 'Microsoft Windows Server 2012 R2 Standard '
+            :OperatingSystemVersion: 6.3.9600
+            :DVDDrives: 
+            :DVDDriveList: []
+            :VirtualizationPlatformString: Microsoft Hyper-V
+            :VirtualizationPlatform: HyperV
+            :VirtualizationPlatformDetail: Microsoft Hyper-V
+            :IsVirtualizationSoftwareDetailUnknown: false
+            :IsViridianHost: true
+            :SupportsLiveMigration: true
+            :FloppyDrives: 
+            :FloppyDriveList: []
+            :VMHostGroup: All Hosts
+            :HostCluster: hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :RemoteConnectEnabled: true
+            :RemoteConnectPort: 2179
+            :SecureRemoteConnectEnabled: false
+            :VMRCCertificateAvailable: false
+            :EnableLiveMigration: true
+            :LiveMigrationMaximum: 2
+            :LiveStorageMigrationMaximum: 2
+            :UseAnyMigrationSubnet: false
+            :MigrationSubnet: &86
+            - fe80::b1b6:dd38:ad16:594e/128
+            - 10.16.4.47/32
+            - 10.1.1.1/32
+            :MigrationSubnetUserManaged: &87
+            - false
+            - false
+            - false
+            :MigrationAuthProtocol: CredSSP
+            :MigrationPerformanceOption: UseCompression
+            :SslTcpPort: 5985
+            :SslCertificateHash: 
+            :SshTcpPort: 0
+            :SshPublicKeyHash: 
+            :SshPublicKey: 
+            :IsRemoteFXRoleInstalled: false
+            :IsCPUSLAT: true
+            :IsNumaSpanningEnabled: true
+            :GPUMemoryTotalMB: 
+            :GPUMemoryAvailableMB: 
+            :ClusterNodeStatus: Running
+            :TimeZone: -240
+            :HyperVState: Running
+            :HyperVStateString: Running
+            :HyperVVersion: 6.3.9600.17787
+            :HyperVVersionState: UpToDate
+            :PerimeterNetworkHost: false
+            :NonTrustedDomainHost: false
+            :MaximumMemoryPerVM: 1048576
+            :MinimumMemoryPerVM: 32
+            :SuggestedMaximumMemoryPerVM: 512
+            :ModifiedTime: 2016-07-11 15:44:15.927780100 -04:00
+            :Agent: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :ManagedComputer: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :VMs:
+            - lcouzens_rr99
+            - LargeWin12DTemplate
+            - scvmm-sp1
+            - scvmm2
+            - dajo-dsl
+            - SmallWin12Template
+            - ws2008r2d-sp1-26
+            - s_appl_downstream-56z_160624_OsNx9fCt
+            - SmallWin7Template
+            - jt_dnd_w12r2d_scvmm_dev
+            - django-win7-jt
+            - ws12r2dc-2DVDs
+            - Centos-Test1
+            - miq-nightly-201606272000
+            - cfme-vmm-ad-bu-DND
+            - Engineering - win10ent64
+            - SmallWin7Template
+            - smis_netapp_dnd
+            - jt_dnd_w12r2d_dev
+            - SmallLinuxVM
+            :Disks:
+            - "\\\\.\\PHYSICALDRIVE2"
+            - "\\\\.\\PHYSICALDRIVE1"
+            - "\\\\.\\PHYSICALDRIVE0"
+            :GPUs: []
+            :InstalledVirtualSwitchExtensions:
+            - Microsoft Virtual Ethernet Switch Native Extension
+            - Microsoft NDIS Capture
+            - Microsoft Windows Filtering Platform
+            - Microsoft VMM DHCPv4 Server Switch Extension
+            :DiskVolumes:
+            - "\\\\?\\Volume{1889d147-fcb9-11e3-80b5-806e6f6e6963}\\"
+            - C:\ClusterStorage\netapp_crud_vol
+            - C:\
+            - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+            :RegisteredStorageFileShares:
+            - scvmm2
+            :FibreChannelHbas: []
+            :FibreChannelVirtualSANs: []
+            :SASHbas:
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            - PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :InternetSCSIHbas:
+            - ROOT\ISCSIPRT\0000_0
+            :VMwareResourcePool: 
+            :IsConfiguredForOutOfBandManagement: false
+            :PhysicalMachine: 88f93543-9f60-e011-9109-5cf3fc1c861c
+            :HealthMonitors:
+            - Host Agent Version
+            - Host Agent Overall
+            - Network
+            - Host Agent Service
+            - WinRM
+            - Hyper-V Role Overall
+            - Hyper-V Role Version
+            - Overall
+            - WMI Performance Counter
+            - Hyper-V Virtual Machine Management Service
+            :RemoteStorageTotalCapacity: 832233830400
+            :RemoteStorageAvailableCapacity: 528009306112
+            :LocalStorageTotalCapacity: 997998985216
+            :LocalStorageAvailableCapacity: 85522284544
+            :TotalStorageCapacity: 1830232815616
+            :AvailableStorageCapacity: 613531590656
+            :UsedStorageCapacity: 1216701224960
+            :IsDedicatedToNetworkVirtualizationGateway: false
+            :FibreChannelWorldWidePortNameMinimum: C003FFE46FE20000
+            :FibreChannelWorldWidePortNameMaximum: C003FFE46FE2FFFF
+            :FibreChannelWorldWideNodeName: C003FF0000FFFF00
+            :VMConnectCertificateThumbprint: 
+            :Custom1: 
+            :Custom2: 
+            :Custom3: 
+            :Custom4: 
+            :Custom5: 
+            :Custom6: 
+            :Custom7: 
+            :Custom8: 
+            :Custom9: 
+            :Custom10: 
+            :CustomProperty: {}
+            :FibreChannelSANStatus: DeployTargetDoesNotHaveHBA (1204)
+            :ISCSISANStatus: DeployHostDoesNotHaveMPIO (1253)
+            :NPIVFibreChannelSANStatus: DeployHostIsNotNPIVCapable (1252)
+            :CertificateRequest: 
+            :ComputerState: Responding
+            :VirtualizationManager: 
+            :ServerConnection: *9
+            :ID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+            :IsViewOnly: false
+            :ObjectType: VMHost
+            :MarkedForDeletion: false
+            :IsFullyCached: false
+            :MostRecentTaskIfLocal: Refresh virtual machine properties
+          :MS:
+            :FQDN: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :LogicalCPUCount: 8
+            :CPUSpeed: 2133
+            :CPUModel: Xeon
+            :CPUManufacturer: Intel
+            :CPUArchitecture: 9
+            :CPUFamily: '179'
+            :VMRCEnabled: true
+            :VMRCPort: 2179
+            :SecureVMRCEnabled: false
+            :VirtualServerState: Running
+            :VirtualServerStateString: Running
+            :VirtualServerVersion: 6.3.9600.17787
+            :VirtualServerVersionState: UpToDate
+            :ServicingWindows: *11
+        :IsAvailableForPlacement: true
+        :HostDiskID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+        :StorageDiskID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+        :HostDisk: &13
+          :ToString: "\\\\.\\PHYSICALDRIVE0"
+          :Props:
+            :Name: "\\\\.\\PHYSICALDRIVE0"
+            :Signature: 625485
+            :UniqueID: '625485'
+            :Capacity: 997998985216
+            :AvailableCapacity: 85522284544
+            :PhysicallyAvailableCapacity: 85524389888
+            :DeviceID: "\\\\.\\PHYSICALDRIVE0"
+            :Index: 0
+            :IsClustered: false
+            :IsSanAttached: false
+            :IsPassThroughCapable: false
+            :ClusterDisk: 
+            :VMHost: *12
+            :LibraryServer: 
+            :DiskID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+            :Location: 
+            :SMLunId: 600508E0000000009A2B20C106C8800E
+            :SMLunIdFormat: 9
+            :SMLunIdNamespace: 2
+            :Bus: 0
+            :Lun: 0
+            :Port: 
+            :Target: 1
+            :StorageLogicalUnit: 
+            :Classification: Local Storage
+            :DiskVolumes:
+            - "\\\\?\\Volume{1889d147-fcb9-11e3-80b5-806e6f6e6963}\\"
+            - C:\
+            :PartitionStyle: MasterBootRecord
+            :DiskStatus: Online
+            :IsViewOnly: false
+            :ServerConnection: *9
+            :ID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+            :ObjectType: VMHostDisk
+            :MarkedForDeletion: false
+            :IsFullyCached: true
+        :StorageDisk: *13
+        :Classification: &14
+          :ToString: Local Storage
+          :Props:
+            :StorageClassificationData: (StorageClassificationData#0) { id = 6575a34f-4685-4c0d-9b32-ec28948a7884,
+              LastUpdatedTimestamp = 2/20/2015 12:01:38 PM, objectType = StorageClassification,
+              name = "Local Storage", Enabled = True, Accessibility = Public, description
+              = "Local Storage", CreationTime = 2/20/2015 12:01:38 PM, modifiedTime
+              = 2/20/2015 12:01:38 PM }
+            :StoragePool: []
+            :ObjectType: StorageClassification
+            :Accessibility: Public
+            :Name: Local Storage
+            :IsViewOnly: false
+            :Description: Local Storage
+            :AddedTime: 2015-02-20 07:01:38.193000000 -05:00
+            :ModifiedTime: 2015-02-20 07:01:38.193000000 -05:00
+            :Enabled: true
+            :MostRecentTask: 
+            :ServerConnection: *9
+            :ID: 6575a34f-4685-4c0d-9b32-ec28948a7884
+            :MarkedForDeletion: false
+            :IsFullyCached: true
+            :MostRecentTaskIfLocal: 
+        :StoragePool: 
+        :ServerConnection: *9
+        :ID: c7ec11d5-65da-412c-ae30-b946f343daad
+        :IsViewOnly: false
+        :ObjectType:
+          :ToString: VMHostVolume
+          :I32: 10
+        :MarkedForDeletion: false
+        :IsFullyCached: true
+    :8cf02787-8199-4754-b800-0d98dac52640:
+      :ToString: C:\
+      :Props:
+        :Name: C:\
+        :StorageVolumeID: b58fecc2-c453-11e4-80b4-806e6f6e6963
+        :ObjectID: "\\\\?\\Volume{b58fecc2-c453-11e4-80b4-806e6f6e6963}\\"
+        :HostVolumeID: b58fecc2-c453-11e4-80b4-806e6f6e6963
+        :MountPoints:
+        - C:\
+        :Capacity: 499738734592
+        :FreeSpace: 153622286336
+        :VolumeLabel: 
+        :FileSystem: NTFS
+        :IsSANMigrationPossible: false
+        :IsClustered: false
+        :IsClusterSharedVolume: false
+        :InUse: false
+        :VMHost: *1
+        :IsAvailableForPlacement: true
+        :HostDiskID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+        :StorageDiskID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+        :HostDisk: &15
+          :ToString: "\\\\.\\PHYSICALDRIVE0"
+          :Props:
+            :Name: "\\\\.\\PHYSICALDRIVE0"
+            :Signature: 3547188299
+            :UniqueID: '3547188299'
+            :Capacity: 500107862016
+            :AvailableCapacity: 153700024320
+            :PhysicallyAvailableCapacity: 153702154240
+            :DeviceID: "\\\\.\\PHYSICALDRIVE0"
+            :Index: 0
+            :IsClustered: false
+            :IsSanAttached: false
+            :IsPassThroughCapable: false
+            :ClusterDisk: 
+            :VMHost: *1
+            :LibraryServer: 
+            :DiskID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+            :Location: 
+            :SMLunId: 5000C50034A77567
+            :SMLunIdFormat: 9
+            :SMLunIdNamespace: 2
+            :Bus: 0
+            :Lun: 0
+            :Port: 
+            :Target: 1
+            :StorageLogicalUnit: 
+            :Classification: *14
+            :DiskVolumes:
+            - C:\
+            - "\\\\?\\Volume{b58fecc1-c453-11e4-80b4-806e6f6e6963}\\"
+            :PartitionStyle: MasterBootRecord
+            :DiskStatus: Online
+            :IsViewOnly: false
+            :ServerConnection: *9
+            :ID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+            :ObjectType: VMHostDisk
+            :MarkedForDeletion: false
+            :IsFullyCached: true
+        :StorageDisk: *15
+        :Classification: *14
+        :StoragePool: 
+        :ServerConnection: *9
+        :ID: 8cf02787-8199-4754-b800-0d98dac52640
+        :IsViewOnly: false
+        :ObjectType:
+          :ToString: VMHostVolume
+          :I32: 10
+        :MarkedForDeletion: false
+        :IsFullyCached: true
+    :ae3f8983-34c4-4e87-8680-ed04b817d9e3:
+      :ToString: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+      :Props:
+        :Name: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+        :StorageVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
+        :ObjectID: "\\\\?\\Volume{cd0c3151-b540-4d65-87f9-ac3156ae703f}\\"
+        :HostVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
+        :MountPoints:
+        - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+        :Capacity: 563757445120
+        :FreeSpace: 462748672000
+        :VolumeLabel: CSV-NA-Disk
+        :FileSystem: CSVFS
+        :IsSANMigrationPossible: false
+        :IsClustered: true
+        :IsClusterSharedVolume: true
+        :InUse: false
+        :VMHost: *12
+        :IsAvailableForPlacement: true
+        :HostDiskID: fb5fb3ca-dcf8-4b51-9e89-0356ae1ec2ab
+        :StorageDiskID: fb5fb3ca-dcf8-4b51-9e89-0356ae1ec2ab
+        :HostDisk: &16
+          :ToString: "\\\\.\\PHYSICALDRIVE2"
+          :Props:
+            :Name: "\\\\.\\PHYSICALDRIVE2"
+            :Signature: 197977995
+            :UniqueID: '197977995'
+            :Capacity: 563760691200
+            :AvailableCapacity: 462748672000
+            :PhysicallyAvailableCapacity: 462751918080
+            :DeviceID: "\\\\.\\PHYSICALDRIVE2"
+            :Index: 2
+            :IsClustered: true
+            :IsSanAttached: true
+            :IsPassThroughCapable: true
+            :ClusterDisk: netapp_csv_scvmm2
+            :VMHost: *12
+            :LibraryServer: 
+            :DiskID: fb5fb3ca-dcf8-4b51-9e89-0356ae1ec2ab
+            :Location: 
+            :SMLunId: 600A098038303373662447685A564964
+            :SMLunIdFormat: 9
+            :SMLunIdNamespace: 2
+            :Bus: 0
+            :Lun: 0
+            :Port: 
+            :Target: 0
+            :StorageLogicalUnit: 
+            :Classification: *8
+            :DiskVolumes:
+            - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+            :PartitionStyle: MasterBootRecord
+            :DiskStatus: Reserved
+            :IsViewOnly: false
+            :ServerConnection: *9
+            :ID: fb5fb3ca-dcf8-4b51-9e89-0356ae1ec2ab
+            :ObjectType: VMHostDisk
+            :MarkedForDeletion: false
+            :IsFullyCached: true
+        :StorageDisk: *16
+        :Classification: *8
+        :StoragePool: 
+        :ServerConnection: *9
+        :ID: ae3f8983-34c4-4e87-8680-ed04b817d9e3
+        :IsViewOnly: false
+        :ObjectType:
+          :ToString: VMHostVolume
+          :I32: 10
+        :MarkedForDeletion: false
+        :IsFullyCached: true
+    :08d617e5-5593-4dc7-95fa-5b06784656f3:
+      :ToString: C:\ClusterStorage\netapp_crud_vol
+      :Props:
+        :Name: C:\ClusterStorage\netapp_crud_vol
+        :StorageVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+        :ObjectID: "\\\\?\\Volume{cadbe3e4-e781-44aa-95ff-e6d4708bdc09}\\"
+        :HostVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+        :MountPoints:
+        - C:\ClusterStorage\netapp_crud_vol
+        :Capacity: 268470042624
+        :FreeSpace: 65260634112
+        :VolumeLabel: csv_cluster1
+        :FileSystem: CSVFS
+        :IsSANMigrationPossible: false
+        :IsClustered: true
+        :IsClusterSharedVolume: true
+        :InUse: false
+        :VMHost: *12
+        :IsAvailableForPlacement: true
+        :HostDiskID: fe21974c-5709-4bdf-b642-44b3a80e41a8
+        :StorageDiskID: fe21974c-5709-4bdf-b642-44b3a80e41a8
+        :HostDisk: &17
+          :ToString: "\\\\.\\PHYSICALDRIVE1"
+          :Props:
+            :Name: "\\\\.\\PHYSICALDRIVE1"
+            :Signature: 2772963379
+            :UniqueID: '2772963379'
+            :Capacity: 268473139200
+            :AvailableCapacity: 65260634112
+            :PhysicallyAvailableCapacity: 65263730688
+            :DeviceID: "\\\\.\\PHYSICALDRIVE1"
+            :Index: 1
+            :IsClustered: true
+            :IsSanAttached: true
+            :IsPassThroughCapable: true
+            :ClusterDisk: netapp_crud_vol
+            :VMHost: *12
+            :LibraryServer: 
+            :DiskID: fe21974c-5709-4bdf-b642-44b3a80e41a8
+            :Location: 
+            :SMLunId: 600A098038303373635D47744C625947
+            :SMLunIdFormat: 9
+            :SMLunIdNamespace: 2
+            :Bus: 0
+            :Lun: 0
+            :Port: 
+            :Target: 0
+            :StorageLogicalUnit: 
+            :Classification: *8
+            :DiskVolumes:
+            - C:\ClusterStorage\netapp_crud_vol
+            :PartitionStyle: MasterBootRecord
+            :DiskStatus: Reserved
+            :IsViewOnly: false
+            :ServerConnection: *9
+            :ID: fe21974c-5709-4bdf-b642-44b3a80e41a8
+            :ObjectType: VMHostDisk
+            :MarkedForDeletion: false
+            :IsFullyCached: true
+        :StorageDisk: *17
+        :Classification: *8
+        :StoragePool: 
+        :ServerConnection: *9
+        :ID: 08d617e5-5593-4dc7-95fa-5b06784656f3
         :IsViewOnly: false
         :ObjectType:
           :ToString: VMHostVolume
@@ -706,58 +1062,52 @@
         :MarkedForDeletion: false
         :IsFullyCached: true
   :clusters:
-    :d9a2261c-7c46-4e0f-83c1-44d779d71594:
+    :8e830204-6448-4817-b220-34af48ccf8ca:
       :Properties:
-        :ToString: CFME-ESX55-Cluster
+        :ToString: hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
         :Props:
-          :Name: CFME-ESX55-Cluster
-          :ClusterName: CFME-ESX55-Cluster
-          :DomainName: 
+          :Name: hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :ClusterName: hyperv_cluster
+          :DomainName: cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
           :Description: 
-          :HostGroup: &13
+          :HostGroup: &39
             :ToString: All Hosts
             :Props:
               :IsRoot: true
-              :CreationDate: 2016-01-20 15:45:54.683000000 -05:00
+              :CreationDate: 2015-02-20 15:03:33.773000000 -05:00
               :Creator: 
               :Description: 
-              :ModificationDate: 2016-01-20 15:45:54.683000000 -05:00
-              :ModifiedBy: 
+              :ModificationDate: 2016-03-21 23:29:18.090000000 -04:00
+              :ModifiedBy: CFME-QE-VMM-AD\Administrator
               :Name: All Hosts
               :ParentVMHostGroup: 
               :ParentHostGroup: 
               :Path: All Hosts
               :Hosts:
+              - dhcp129-212.brq.redhat.com
+              - *12
               - *1
-              - *10
-              - cfme-esx-55-03
-              - cfme-esx-55-02
-              - cfme-esx-55-01
-              - cfme-esx-55-04
               :AllChildHosts:
+              - dhcp129-212.brq.redhat.com
+              - *12
               - *1
-              - *10
-              - cfme-esx-55-03
-              - cfme-esx-55-02
-              - cfme-esx-55-01
-              - cfme-esx-55-04
               :AllChildGroups: []
               :ChildGroups: []
               :CustomProperty: {}
               :AllChildClusters:
-              - CFME-ESX55-Cluster
+              - hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :ChildClusters:
-              - CFME-ESX55-Cluster
+              - hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :IsUnencryptedFileTransferEnabled: false
               :InheritNetworkSettings: false
               :AllocatedLogicalUnitTotalCapacity: 0
               :AllocatedLogicalUnitAvailableCapacity: 0
-              :HostRemoteStorageTotalCapacity: 0
-              :HostRemoteStorageAvailableCapacity: 0
-              :HostLocalStorageTotalCapacity: 800107862016
-              :HostLocalStorageAvailableCapacity: 730547302400
+              :HostRemoteStorageTotalCapacity: 1664467660800
+              :HostRemoteStorageAvailableCapacity: 1056018612224
+              :HostLocalStorageTotalCapacity: 1998214709248
+              :HostLocalStorageAvailableCapacity: 239222308864
               :AvailableLogicalUnitCount: 0
-              :ServerConnection: *8
+              :ServerConnection: *9
               :ID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
               :IsViewOnly: false
               :ObjectType: VMHostGroup
@@ -767,700 +1117,188 @@
               :AllowUnencryptedTransfers: false
           :ClusterReserve: 1
           :ClusterReserveState:
-            :ToString: Unknown
-            :I32: 2
+            :ToString: OK
+            :I32: 0
           :ClusterReserveDetails: 
           :CustomProperty: {}
           :IsVMwareHAEnabled: false
           :IsVMwareDrsEnabled: false
-          :AvailableStorageNode: 
+          :AvailableStorageNode: *1
           :Nodes:
-          - &31
-            :ToString: cfme-esx-55-03
-            :Props:
-              :RunAsAccount: ESX Admin
-              :MostRecentTaskID: 8b7045ef-e923-4ee4-85fa-6a26eaf3a8dd
-              :MostRecentTaskUIState: Failed
-              :MostRecentTask: Add virtual machine host
-              :OverallStateString: Adding...
-              :OverallState: Adding
-              :CommunicationStateString: Connecting...
-              :CommunicationState: Connecting
-              :Name: cfme-esx-55-03
-              :FullyQualifiedDomainName: cfme-esx-55-03
-              :ComputerName: cfme-esx-55-03
-              :DomainName: cfme-esx-55-03
-              :Description: 
-              :RemoteUserName: localhost\root
-              :OverrideHostGroupReserves: false
-              :CPUPercentageReserve: 10
-              :NetworkPercentageReserve: 0
-              :DiskSpaceReserveMB: 10240
-              :MaxDiskIOReservation: 10000
-              :MemoryReserveMB: 2048
-              :VMPaths: &29 []
-              :BaseDiskPaths: &30 []
-              :PROEnabled: false
-              :MaintenanceHost: false
-              :AvailableForPlacement: true
-              :IsEmbedded: false
-              :CredentialsNeeded: true
-              :PausedForNetworkIncompatibility: false
-              :LogicalProcessorCount: 0
-              :PhysicalCPUCount: 0
-              :CoresPerCPU: 0
-              :L2CacheSize: 0
-              :L3CacheSize: 0
-              :BusSpeed: 0
-              :ProcessorSpeed: 0
-              :ProcessorModel: 
-              :ProcessorManufacturer: 
-              :ProcessorArchitecture: 0
-              :ProcessorFamily: 
-              :CpuUtilization: 0
-              :TotalMemory: 0
-              :AvailableMemory: 0
-              :OperatingSystem: Unknown
-              :OperatingSystemVersion: '0.0'
-              :DVDDrives: 
-              :DVDDriveList: []
-              :VirtualizationPlatformString: VMware ESX Server
-              :VirtualizationPlatform: VMWareESX
-              :VirtualizationPlatformDetail: VMware ESX Server
-              :IsVirtualizationSoftwareDetailUnknown: false
-              :IsViridianHost: false
-              :SupportsLiveMigration: false
-              :FloppyDrives: 
-              :FloppyDriveList: []
-              :VMHostGroup: *13
-              :HostCluster: CFME-ESX55-Cluster
-              :RemoteConnectEnabled: true
-              :RemoteConnectPort: 5900
-              :SecureRemoteConnectEnabled: false
-              :VMRCCertificateAvailable: false
-              :EnableLiveMigration: false
-              :LiveMigrationMaximum: 0
-              :LiveStorageMigrationMaximum: 0
-              :UseAnyMigrationSubnet: false
-              :MigrationSubnet: &37 []
-              :MigrationSubnetUserManaged: &38 []
-              :MigrationAuthProtocol: CredSSP
-              :MigrationPerformanceOption: Standard
-              :SslTcpPort: 443
-              :SslCertificateHash: 
-              :SshTcpPort: 22
-              :SshPublicKeyHash: 
-              :SshPublicKey: 
-              :IsRemoteFXRoleInstalled: false
-              :IsCPUSLAT: false
-              :IsNumaSpanningEnabled: 
-              :GPUMemoryTotalMB: 
-              :GPUMemoryAvailableMB: 
-              :ClusterNodeStatus: Unknown
-              :TimeZone: 
-              :HyperVState: Unknown
-              :HyperVStateString: Unknown
-              :HyperVVersion: '0.0'
-              :HyperVVersionState: UpToDate
-              :PerimeterNetworkHost: false
-              :NonTrustedDomainHost: false
-              :MaximumMemoryPerVM: 0
-              :MinimumMemoryPerVM: 0
-              :SuggestedMaximumMemoryPerVM: 0
-              :ModifiedTime: 2016-02-24 11:48:26.253000000 -05:00
-              :Agent: cfme-esx-55-03
-              :ManagedComputer: cfme-esx-55-03
-              :VMs: []
-              :Disks: []
-              :GPUs: []
-              :InstalledVirtualSwitchExtensions: []
-              :DiskVolumes: []
-              :RegisteredStorageFileShares: []
-              :FibreChannelHbas: []
-              :FibreChannelVirtualSANs: []
-              :SASHbas: []
-              :InternetSCSIHbas: []
-              :VMwareResourcePool: 
-              :IsConfiguredForOutOfBandManagement: false
-              :PhysicalMachine: 
-              :HealthMonitors: []
-              :RemoteStorageTotalCapacity: 0
-              :RemoteStorageAvailableCapacity: 0
-              :LocalStorageTotalCapacity: 0
-              :LocalStorageAvailableCapacity: 0
-              :TotalStorageCapacity: 0
-              :AvailableStorageCapacity: 0
-              :UsedStorageCapacity: 0
-              :IsDedicatedToNetworkVirtualizationGateway: false
-              :FibreChannelWorldWidePortNameMinimum: 
-              :FibreChannelWorldWidePortNameMaximum: 
-              :FibreChannelWorldWideNodeName: 
-              :VMConnectCertificateThumbprint: 
-              :Custom1: 
-              :Custom2: 
-              :Custom3: 
-              :Custom4: 
-              :Custom5: 
-              :Custom6: 
-              :Custom7: 
-              :Custom8: 
-              :Custom9: 
-              :Custom10: 
-              :CustomProperty: {}
-              :FibreChannelSANStatus: SANNotConfigured (1245)
-              :ISCSISANStatus: SANNotConfigured (1245)
-              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
-              :CertificateRequest: 
-              :ComputerState: Adding
-              :VirtualizationManager: 
-              :ServerConnection: *8
-              :ID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
-              :IsViewOnly: false
-              :ObjectType: VMHost
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: Add virtual machine host
-            :MS:
-              :FQDN: cfme-esx-55-03
-              :LogicalCPUCount: 0
-              :CPUSpeed: 0
-              :CPUModel: 
-              :CPUManufacturer: 
-              :CPUArchitecture: 0
-              :CPUFamily: 
-              :VMRCEnabled: true
-              :VMRCPort: 5900
-              :SecureVMRCEnabled: false
-              :VirtualServerState: Unknown
-              :VirtualServerStateString: Unknown
-              :VirtualServerVersion: '0.0'
-              :VirtualServerVersionState: UpToDate
-              :ServicingWindows: *9
-          - &32
-            :ToString: cfme-esx-55-02
-            :Props:
-              :RunAsAccount: ESX Admin
-              :MostRecentTaskID: af5b8a7e-da60-4b62-837c-c1e876328410
-              :MostRecentTaskUIState: Failed
-              :MostRecentTask: Add virtual machine host
-              :OverallStateString: Adding...
-              :OverallState: Adding
-              :CommunicationStateString: Connecting...
-              :CommunicationState: Connecting
-              :Name: cfme-esx-55-02
-              :FullyQualifiedDomainName: cfme-esx-55-02
-              :ComputerName: cfme-esx-55-02
-              :DomainName: cfme-esx-55-02
-              :Description: 
-              :RemoteUserName: localhost\root
-              :OverrideHostGroupReserves: false
-              :CPUPercentageReserve: 10
-              :NetworkPercentageReserve: 0
-              :DiskSpaceReserveMB: 10240
-              :MaxDiskIOReservation: 10000
-              :MemoryReserveMB: 2048
-              :VMPaths: &48 []
-              :BaseDiskPaths: &49 []
-              :PROEnabled: false
-              :MaintenanceHost: false
-              :AvailableForPlacement: true
-              :IsEmbedded: false
-              :CredentialsNeeded: true
-              :PausedForNetworkIncompatibility: false
-              :LogicalProcessorCount: 0
-              :PhysicalCPUCount: 0
-              :CoresPerCPU: 0
-              :L2CacheSize: 0
-              :L3CacheSize: 0
-              :BusSpeed: 0
-              :ProcessorSpeed: 0
-              :ProcessorModel: 
-              :ProcessorManufacturer: 
-              :ProcessorArchitecture: 0
-              :ProcessorFamily: 
-              :CpuUtilization: 0
-              :TotalMemory: 0
-              :AvailableMemory: 0
-              :OperatingSystem: Unknown
-              :OperatingSystemVersion: '0.0'
-              :DVDDrives: 
-              :DVDDriveList: []
-              :VirtualizationPlatformString: VMware ESX Server
-              :VirtualizationPlatform: VMWareESX
-              :VirtualizationPlatformDetail: VMware ESX Server
-              :IsVirtualizationSoftwareDetailUnknown: false
-              :IsViridianHost: false
-              :SupportsLiveMigration: false
-              :FloppyDrives: 
-              :FloppyDriveList: []
-              :VMHostGroup: *13
-              :HostCluster: CFME-ESX55-Cluster
-              :RemoteConnectEnabled: true
-              :RemoteConnectPort: 5900
-              :SecureRemoteConnectEnabled: false
-              :VMRCCertificateAvailable: false
-              :EnableLiveMigration: false
-              :LiveMigrationMaximum: 0
-              :LiveStorageMigrationMaximum: 0
-              :UseAnyMigrationSubnet: false
-              :MigrationSubnet: &50 []
-              :MigrationSubnetUserManaged: &51 []
-              :MigrationAuthProtocol: CredSSP
-              :MigrationPerformanceOption: Standard
-              :SslTcpPort: 443
-              :SslCertificateHash: 
-              :SshTcpPort: 22
-              :SshPublicKeyHash: 
-              :SshPublicKey: 
-              :IsRemoteFXRoleInstalled: false
-              :IsCPUSLAT: false
-              :IsNumaSpanningEnabled: 
-              :GPUMemoryTotalMB: 
-              :GPUMemoryAvailableMB: 
-              :ClusterNodeStatus: Unknown
-              :TimeZone: 
-              :HyperVState: Unknown
-              :HyperVStateString: Unknown
-              :HyperVVersion: '0.0'
-              :HyperVVersionState: UpToDate
-              :PerimeterNetworkHost: false
-              :NonTrustedDomainHost: false
-              :MaximumMemoryPerVM: 0
-              :MinimumMemoryPerVM: 0
-              :SuggestedMaximumMemoryPerVM: 0
-              :ModifiedTime: 2016-02-24 11:48:27.520000000 -05:00
-              :Agent: cfme-esx-55-02
-              :ManagedComputer: cfme-esx-55-02
-              :VMs: []
-              :Disks: []
-              :GPUs: []
-              :InstalledVirtualSwitchExtensions: []
-              :DiskVolumes: []
-              :RegisteredStorageFileShares: []
-              :FibreChannelHbas: []
-              :FibreChannelVirtualSANs: []
-              :SASHbas: []
-              :InternetSCSIHbas: []
-              :VMwareResourcePool: 
-              :IsConfiguredForOutOfBandManagement: false
-              :PhysicalMachine: 
-              :HealthMonitors: []
-              :RemoteStorageTotalCapacity: 0
-              :RemoteStorageAvailableCapacity: 0
-              :LocalStorageTotalCapacity: 0
-              :LocalStorageAvailableCapacity: 0
-              :TotalStorageCapacity: 0
-              :AvailableStorageCapacity: 0
-              :UsedStorageCapacity: 0
-              :IsDedicatedToNetworkVirtualizationGateway: false
-              :FibreChannelWorldWidePortNameMinimum: 
-              :FibreChannelWorldWidePortNameMaximum: 
-              :FibreChannelWorldWideNodeName: 
-              :VMConnectCertificateThumbprint: 
-              :Custom1: 
-              :Custom2: 
-              :Custom3: 
-              :Custom4: 
-              :Custom5: 
-              :Custom6: 
-              :Custom7: 
-              :Custom8: 
-              :Custom9: 
-              :Custom10: 
-              :CustomProperty: {}
-              :FibreChannelSANStatus: SANNotConfigured (1245)
-              :ISCSISANStatus: SANNotConfigured (1245)
-              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
-              :CertificateRequest: 
-              :ComputerState: Adding
-              :VirtualizationManager: 
-              :ServerConnection: *8
-              :ID: d4c780ae-2251-44f7-b624-111bd25e7400
-              :IsViewOnly: false
-              :ObjectType: VMHost
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: Add virtual machine host
-            :MS:
-              :FQDN: cfme-esx-55-02
-              :LogicalCPUCount: 0
-              :CPUSpeed: 0
-              :CPUModel: 
-              :CPUManufacturer: 
-              :CPUArchitecture: 0
-              :CPUFamily: 
-              :VMRCEnabled: true
-              :VMRCPort: 5900
-              :SecureVMRCEnabled: false
-              :VirtualServerState: Unknown
-              :VirtualServerStateString: Unknown
-              :VirtualServerVersion: '0.0'
-              :VirtualServerVersionState: UpToDate
-              :ServicingWindows: *9
-          - &33
-            :ToString: cfme-esx-55-01
-            :Props:
-              :RunAsAccount: ESX Admin
-              :MostRecentTaskID: 3180e43e-d149-41d9-a868-4fcafe80b680
-              :MostRecentTaskUIState: Failed
-              :MostRecentTask: Add virtual machine host
-              :OverallStateString: Adding...
-              :OverallState: Adding
-              :CommunicationStateString: Connecting...
-              :CommunicationState: Connecting
-              :Name: cfme-esx-55-01
-              :FullyQualifiedDomainName: cfme-esx-55-01
-              :ComputerName: cfme-esx-55-01
-              :DomainName: cfme-esx-55-01
-              :Description: 
-              :RemoteUserName: localhost\root
-              :OverrideHostGroupReserves: false
-              :CPUPercentageReserve: 10
-              :NetworkPercentageReserve: 0
-              :DiskSpaceReserveMB: 10240
-              :MaxDiskIOReservation: 10000
-              :MemoryReserveMB: 2048
-              :VMPaths: &101 []
-              :BaseDiskPaths: &102 []
-              :PROEnabled: false
-              :MaintenanceHost: false
-              :AvailableForPlacement: true
-              :IsEmbedded: false
-              :CredentialsNeeded: true
-              :PausedForNetworkIncompatibility: false
-              :LogicalProcessorCount: 0
-              :PhysicalCPUCount: 0
-              :CoresPerCPU: 0
-              :L2CacheSize: 0
-              :L3CacheSize: 0
-              :BusSpeed: 0
-              :ProcessorSpeed: 0
-              :ProcessorModel: 
-              :ProcessorManufacturer: 
-              :ProcessorArchitecture: 0
-              :ProcessorFamily: 
-              :CpuUtilization: 0
-              :TotalMemory: 0
-              :AvailableMemory: 0
-              :OperatingSystem: Unknown
-              :OperatingSystemVersion: '0.0'
-              :DVDDrives: 
-              :DVDDriveList: []
-              :VirtualizationPlatformString: VMware ESX Server
-              :VirtualizationPlatform: VMWareESX
-              :VirtualizationPlatformDetail: VMware ESX Server
-              :IsVirtualizationSoftwareDetailUnknown: false
-              :IsViridianHost: false
-              :SupportsLiveMigration: false
-              :FloppyDrives: 
-              :FloppyDriveList: []
-              :VMHostGroup: *13
-              :HostCluster: CFME-ESX55-Cluster
-              :RemoteConnectEnabled: true
-              :RemoteConnectPort: 5900
-              :SecureRemoteConnectEnabled: false
-              :VMRCCertificateAvailable: false
-              :EnableLiveMigration: false
-              :LiveMigrationMaximum: 0
-              :LiveStorageMigrationMaximum: 0
-              :UseAnyMigrationSubnet: false
-              :MigrationSubnet: &103 []
-              :MigrationSubnetUserManaged: &104 []
-              :MigrationAuthProtocol: CredSSP
-              :MigrationPerformanceOption: Standard
-              :SslTcpPort: 443
-              :SslCertificateHash: 
-              :SshTcpPort: 22
-              :SshPublicKeyHash: 
-              :SshPublicKey: 
-              :IsRemoteFXRoleInstalled: false
-              :IsCPUSLAT: false
-              :IsNumaSpanningEnabled: 
-              :GPUMemoryTotalMB: 
-              :GPUMemoryAvailableMB: 
-              :ClusterNodeStatus: Unknown
-              :TimeZone: 
-              :HyperVState: Unknown
-              :HyperVStateString: Unknown
-              :HyperVVersion: '0.0'
-              :HyperVVersionState: UpToDate
-              :PerimeterNetworkHost: false
-              :NonTrustedDomainHost: false
-              :MaximumMemoryPerVM: 0
-              :MinimumMemoryPerVM: 0
-              :SuggestedMaximumMemoryPerVM: 0
-              :ModifiedTime: 2016-02-24 11:48:23.407000000 -05:00
-              :Agent: cfme-esx-55-01
-              :ManagedComputer: cfme-esx-55-01
-              :VMs: []
-              :Disks: []
-              :GPUs: []
-              :InstalledVirtualSwitchExtensions: []
-              :DiskVolumes: []
-              :RegisteredStorageFileShares: []
-              :FibreChannelHbas: []
-              :FibreChannelVirtualSANs: []
-              :SASHbas: []
-              :InternetSCSIHbas: []
-              :VMwareResourcePool: 
-              :IsConfiguredForOutOfBandManagement: false
-              :PhysicalMachine: 
-              :HealthMonitors: []
-              :RemoteStorageTotalCapacity: 0
-              :RemoteStorageAvailableCapacity: 0
-              :LocalStorageTotalCapacity: 0
-              :LocalStorageAvailableCapacity: 0
-              :TotalStorageCapacity: 0
-              :AvailableStorageCapacity: 0
-              :UsedStorageCapacity: 0
-              :IsDedicatedToNetworkVirtualizationGateway: false
-              :FibreChannelWorldWidePortNameMinimum: 
-              :FibreChannelWorldWidePortNameMaximum: 
-              :FibreChannelWorldWideNodeName: 
-              :VMConnectCertificateThumbprint: 
-              :Custom1: 
-              :Custom2: 
-              :Custom3: 
-              :Custom4: 
-              :Custom5: 
-              :Custom6: 
-              :Custom7: 
-              :Custom8: 
-              :Custom9: 
-              :Custom10: 
-              :CustomProperty: {}
-              :FibreChannelSANStatus: SANNotConfigured (1245)
-              :ISCSISANStatus: SANNotConfigured (1245)
-              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
-              :CertificateRequest: 
-              :ComputerState: Adding
-              :VirtualizationManager: 
-              :ServerConnection: *8
-              :ID: 529da423-9493-4a00-9634-37c83dc1fe0e
-              :IsViewOnly: false
-              :ObjectType: VMHost
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: Add virtual machine host
-            :MS:
-              :FQDN: cfme-esx-55-01
-              :LogicalCPUCount: 0
-              :CPUSpeed: 0
-              :CPUModel: 
-              :CPUManufacturer: 
-              :CPUArchitecture: 0
-              :CPUFamily: 
-              :VMRCEnabled: true
-              :VMRCPort: 5900
-              :SecureVMRCEnabled: false
-              :VirtualServerState: Unknown
-              :VirtualServerStateString: Unknown
-              :VirtualServerVersion: '0.0'
-              :VirtualServerVersionState: UpToDate
-              :ServicingWindows: *9
-          - &34
-            :ToString: cfme-esx-55-04
-            :Props:
-              :RunAsAccount: ESX Admin
-              :MostRecentTaskID: 1a5ce85a-e208-4da0-a9a7-8374846fc94a
-              :MostRecentTaskUIState: Failed
-              :MostRecentTask: Add virtual machine host
-              :OverallStateString: Adding...
-              :OverallState: Adding
-              :CommunicationStateString: Connecting...
-              :CommunicationState: Connecting
-              :Name: cfme-esx-55-04
-              :FullyQualifiedDomainName: cfme-esx-55-04
-              :ComputerName: cfme-esx-55-04
-              :DomainName: cfme-esx-55-04
-              :Description: 
-              :RemoteUserName: localhost\root
-              :OverrideHostGroupReserves: false
-              :CPUPercentageReserve: 10
-              :NetworkPercentageReserve: 0
-              :DiskSpaceReserveMB: 10240
-              :MaxDiskIOReservation: 10000
-              :MemoryReserveMB: 2048
-              :VMPaths: &41 []
-              :BaseDiskPaths: &42 []
-              :PROEnabled: false
-              :MaintenanceHost: false
-              :AvailableForPlacement: true
-              :IsEmbedded: false
-              :CredentialsNeeded: true
-              :PausedForNetworkIncompatibility: false
-              :LogicalProcessorCount: 0
-              :PhysicalCPUCount: 0
-              :CoresPerCPU: 0
-              :L2CacheSize: 0
-              :L3CacheSize: 0
-              :BusSpeed: 0
-              :ProcessorSpeed: 0
-              :ProcessorModel: 
-              :ProcessorManufacturer: 
-              :ProcessorArchitecture: 0
-              :ProcessorFamily: 
-              :CpuUtilization: 0
-              :TotalMemory: 0
-              :AvailableMemory: 0
-              :OperatingSystem: Unknown
-              :OperatingSystemVersion: '0.0'
-              :DVDDrives: 
-              :DVDDriveList: []
-              :VirtualizationPlatformString: VMware ESX Server
-              :VirtualizationPlatform: VMWareESX
-              :VirtualizationPlatformDetail: VMware ESX Server
-              :IsVirtualizationSoftwareDetailUnknown: false
-              :IsViridianHost: false
-              :SupportsLiveMigration: false
-              :FloppyDrives: 
-              :FloppyDriveList: []
-              :VMHostGroup: *13
-              :HostCluster: CFME-ESX55-Cluster
-              :RemoteConnectEnabled: true
-              :RemoteConnectPort: 5900
-              :SecureRemoteConnectEnabled: false
-              :VMRCCertificateAvailable: false
-              :EnableLiveMigration: false
-              :LiveMigrationMaximum: 0
-              :LiveStorageMigrationMaximum: 0
-              :UseAnyMigrationSubnet: false
-              :MigrationSubnet: &44 []
-              :MigrationSubnetUserManaged: &45 []
-              :MigrationAuthProtocol: CredSSP
-              :MigrationPerformanceOption: Standard
-              :SslTcpPort: 443
-              :SslCertificateHash: 
-              :SshTcpPort: 22
-              :SshPublicKeyHash: 
-              :SshPublicKey: 
-              :IsRemoteFXRoleInstalled: false
-              :IsCPUSLAT: false
-              :IsNumaSpanningEnabled: 
-              :GPUMemoryTotalMB: 
-              :GPUMemoryAvailableMB: 
-              :ClusterNodeStatus: Unknown
-              :TimeZone: 
-              :HyperVState: Unknown
-              :HyperVStateString: Unknown
-              :HyperVVersion: '0.0'
-              :HyperVVersionState: UpToDate
-              :PerimeterNetworkHost: false
-              :NonTrustedDomainHost: false
-              :MaximumMemoryPerVM: 0
-              :MinimumMemoryPerVM: 0
-              :SuggestedMaximumMemoryPerVM: 0
-              :ModifiedTime: 2016-02-24 11:48:22.863000000 -05:00
-              :Agent: cfme-esx-55-04
-              :ManagedComputer: cfme-esx-55-04
-              :VMs: []
-              :Disks: []
-              :GPUs: []
-              :InstalledVirtualSwitchExtensions: []
-              :DiskVolumes: []
-              :RegisteredStorageFileShares: []
-              :FibreChannelHbas: []
-              :FibreChannelVirtualSANs: []
-              :SASHbas: []
-              :InternetSCSIHbas: []
-              :VMwareResourcePool: 
-              :IsConfiguredForOutOfBandManagement: false
-              :PhysicalMachine: 
-              :HealthMonitors: []
-              :RemoteStorageTotalCapacity: 0
-              :RemoteStorageAvailableCapacity: 0
-              :LocalStorageTotalCapacity: 0
-              :LocalStorageAvailableCapacity: 0
-              :TotalStorageCapacity: 0
-              :AvailableStorageCapacity: 0
-              :UsedStorageCapacity: 0
-              :IsDedicatedToNetworkVirtualizationGateway: false
-              :FibreChannelWorldWidePortNameMinimum: 
-              :FibreChannelWorldWidePortNameMaximum: 
-              :FibreChannelWorldWideNodeName: 
-              :VMConnectCertificateThumbprint: 
-              :Custom1: 
-              :Custom2: 
-              :Custom3: 
-              :Custom4: 
-              :Custom5: 
-              :Custom6: 
-              :Custom7: 
-              :Custom8: 
-              :Custom9: 
-              :Custom10: 
-              :CustomProperty: {}
-              :FibreChannelSANStatus: SANNotConfigured (1245)
-              :ISCSISANStatus: SANNotConfigured (1245)
-              :NPIVFibreChannelSANStatus: SANNotConfigured (1245)
-              :CertificateRequest: 
-              :ComputerState: Adding
-              :VirtualizationManager: 
-              :ServerConnection: *8
-              :ID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
-              :IsViewOnly: false
-              :ObjectType: VMHost
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: Add virtual machine host
-            :MS:
-              :FQDN: cfme-esx-55-04
-              :LogicalCPUCount: 0
-              :CPUSpeed: 0
-              :CPUModel: 
-              :CPUManufacturer: 
-              :CPUArchitecture: 0
-              :CPUFamily: 
-              :VMRCEnabled: true
-              :VMRCPort: 5900
-              :SecureVMRCEnabled: false
-              :VirtualServerState: Unknown
-              :VirtualServerStateString: Unknown
-              :VirtualServerVersion: '0.0'
-              :VirtualServerVersionState: UpToDate
-              :ServicingWindows: *9
+          - *12
+          - *1
           :VMwareResourcePool: 
           :VirtualizationPlatform:
-            :ToString: VMWareVC
-            :I32: 3
+            :ToString: HyperV
+            :I32: 2
           :HostGroupID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
           :AvailableVolumes: []
-          :SharedVolumes: []
-          :RegisteredStorageFileShares: []
-          :RefresherErrors: &35 []
-          :IPAddresses: []
+          :SharedVolumes:
+          - &40
+            :ToString: C:\ClusterStorage\netapp_crud_vol
+            :Props:
+              :Name: C:\ClusterStorage\netapp_crud_vol
+              :StorageVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+              :ObjectID: "\\\\?\\Volume{cadbe3e4-e781-44aa-95ff-e6d4708bdc09}\\"
+              :HostVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+              :MountPoints:
+              - C:\ClusterStorage\netapp_crud_vol
+              :Capacity: 268470042624
+              :FreeSpace: 65260634112
+              :VolumeLabel: csv_cluster1
+              :FileSystem: CSVFS
+              :IsSANMigrationPossible: false
+              :IsClustered: true
+              :IsClusterSharedVolume: true
+              :InUse: false
+              :VMHost: *12
+              :IsAvailableForPlacement: true
+              :HostDiskID: fe21974c-5709-4bdf-b642-44b3a80e41a8
+              :StorageDiskID: fe21974c-5709-4bdf-b642-44b3a80e41a8
+              :HostDisk: *17
+              :StorageDisk: *17
+              :Classification: *8
+              :StoragePool: 
+              :ServerConnection: *9
+              :ID: 08d617e5-5593-4dc7-95fa-5b06784656f3
+              :IsViewOnly: false
+              :ObjectType: VMHostVolume
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - &41
+            :ToString: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+            :Props:
+              :Name: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+              :StorageVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
+              :ObjectID: "\\\\?\\Volume{cd0c3151-b540-4d65-87f9-ac3156ae703f}\\"
+              :HostVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
+              :MountPoints:
+              - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+              :Capacity: 563757445120
+              :FreeSpace: 462748672000
+              :VolumeLabel: CSV-NA-Disk
+              :FileSystem: CSVFS
+              :IsSANMigrationPossible: false
+              :IsClustered: true
+              :IsClusterSharedVolume: true
+              :InUse: false
+              :VMHost: *12
+              :IsAvailableForPlacement: true
+              :HostDiskID: fb5fb3ca-dcf8-4b51-9e89-0356ae1ec2ab
+              :StorageDiskID: fb5fb3ca-dcf8-4b51-9e89-0356ae1ec2ab
+              :HostDisk: *16
+              :StorageDisk: *16
+              :Classification: *8
+              :StoragePool: 
+              :ServerConnection: *9
+              :ID: ae3f8983-34c4-4e87-8680-ed04b817d9e3
+              :IsViewOnly: false
+              :ObjectType: VMHostVolume
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :RegisteredStorageFileShares:
+          - &29
+            :ToString: scvmm2
+            :Props:
+              :Name: scvmm2
+              :ShareName: scvmm2
+              :SharePath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2"
+              :LocalPath: 
+              :Capacity: 5222680231936
+              :CapacityMB: 4980736
+              :FreeSpace: 3464933376000
+              :FreeSpaceMB: 3304417
+              :StorageClassification: *8
+              :InheritedStorageClassification: 
+              :ObjectState: Pending
+              :ObjectId: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2"
+              :TargetNamespace: 
+              :StorageVolumeID: 00000000-0000-0000-0000-000000000000
+              :StorageVolume: 
+              :IsManaged: false
+              :CreationTime: 2015-12-16 19:11:36.980000000 Z
+              :StorageFileServer: 
+              :IsAvailableForPlacement: true
+              :MountPoints:
+              - "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2"
+              :HostAssociations: []
+              :ClusterAssociations:
+              - 8e830204-6448-4817-b220-34af48ccf8ca
+              - 8e830204-6448-4817-b220-34af48ccf8ca
+              :LibraryServer: 
+              :ResiliencySettingName: 
+              :PhysicalDiskRedundancy: 
+              :NumberOfColumns: 
+              :ObjectType: StorageFileShare
+              :Accessibility: Public
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-16 14:11:36.980000000 -05:00
+              :ModifiedTime: 2016-07-11 15:41:42.693000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: a82c8338-63e7-4adc-986c-fa0d041ef18a
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :RefresherErrors: &42 []
+          :IPAddresses:
+          - :ToString: 10.16.4.55
+            :Props:
+              :Address: 923013130
+              :AddressFamily: InterNetwork
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: false
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: 10.16.4.55
           :QuorumDiskResourceName: 
           :ValidationResult:
             :ToString: TestNotRun
             :I32: 0
           :ValidationReportPath: 
-          :ClusterCoreResources: &36 []
-          :VMHostManagementCredential: &28
-            :ToString: ESX Admin
+          :ClusterCoreResources: &43
+          - :ToString: Cluster Name,2
             :Props:
-              :Name: ESX Admin
-              :UserName: root
-              :Domain: 
+              :Name: Cluster Name
+              :Type: ComputerName
+              :Status: ClusterResourceOnline
+              :InstanceNumber: 1
+          - :ToString: Cluster IP Address,2
+            :Props:
+              :Name: Cluster IP Address
+              :Type: IpAddress
+              :Status: ClusterResourceOnline
+              :InstanceNumber: 2
+          :VMHostManagementCredential: &36
+            :ToString: JTSCVMM
+            :Props:
+              :Name: JTSCVMM
+              :UserName: JTSCVMM
+              :Domain: CFME-QE-VMM-AD
               :Enabled: true
               :IsBuiltIn: false
               :GrantedToList: []
               :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
               :UserRole: *3
-              :Owner: CLOUDFORMSWIN\scvmm
+              :Owner: CFME-QE-VMM-AD\Administrator
               :ObjectType: RunAsAccount
               :Accessibility: Public
               :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-29 19:59:13.064694600 -05:00
-              :ModifiedTime: 2016-02-29 19:59:13.064694600 -05:00
+              :Description: None SCVMM Administrative account
+              :AddedTime: 2016-07-11 15:47:18.409779700 -04:00
+              :ModifiedTime: 2016-07-11 15:47:18.409779700 -04:00
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 6722367d-8042-4db3-8428-55d26ad142d2
+              :ServerConnection: *9
+              :ID: d15d8453-f8dd-4c7d-bcf4-9137ec2c2594
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :ServerConnection: *8
-          :ID: d9a2261c-7c46-4e0f-83c1-44d779d71594
+          :ServerConnection: *9
+          :ID: 8e830204-6448-4817-b220-34af48ccf8ca
           :IsViewOnly: false
           :ObjectType:
             :ToString: HostCluster
@@ -1468,9 +1306,507 @@
           :MarkedForDeletion: false
           :IsFullyCached: true
   :images:
-    :e8aae9d0-55af-4f72-b357-265b8fdd23e4:
+    :77a06eb2-6b7a-4cb7-98ca-48bb00d12743:
       :Properties:
-        :ToString: linux_template
+        :ToString: cfme-hyperv-5.5.0.13-2.x86_64
+        :Props:
+          :IsCustomizable: true
+          :Description: 
+          :SANCopyCapable: false
+          :Status:
+            :ToString: Normal
+            :I32: 0
+          :ProductKeyHasValue: false
+          :GuiRunOnceCommands: []
+          :JoinDomain: 
+          :JoinWorkgroup: WORKGROUP
+          :OrgName: 
+          :DomainAdmin: 
+          :JoinDomainRunAsAccount: 
+          :DomainAdminPasswordIsServiceSetting: false
+          :FullName: 
+          :Admin: 
+          :AdminPasswordRunAsAccount: 
+          :AdminPasswordHasValue: false
+          :DomainAdminPasswordHasValue: false
+          :TimeZone: 35
+          :MergeAnswerFile: false
+          :OSType:
+            :ToString: Linux
+            :I32: 1
+          :DNSDomainName: 
+          :KeyFile: 
+          :KeyString: 
+          :SysprepScript: 
+          :ServerFeatures: []
+          :AutoLogonCredential: 
+          :AutoLogonCount: 
+          :UnattendSettings: {}
+          :DomainJoinOrganizationalUnit: 
+          :TotalVHDCapacity: 42951106560
+          :NicCount: 1
+          :ApplicationProfile: 
+          :SQLProfile: 
+          :ComputerTierTemplate: 
+          :ServiceSettingsInProductKey: []
+          :VirtualizationPlatform:
+            :ToString: Unknown
+            :I32: 0
+          :Location: 
+          :CreationTime: 2015-12-04 12:22:03.837000000 -05:00
+          :OperatingSystem: &28
+            :ToString: Red Hat Enterprise Linux 7 (64 bit)
+            :Props:
+              :Name: Red Hat Enterprise Linux 7 (64 bit)
+              :Description: Red Hat Enterprise Linux 7 (64 bit)
+              :Version: 
+              :Architecture: amd64
+              :Edition: 
+              :OSType: Linux
+              :IsWindows: false
+              :ProductType: 
+              :IsCustomizationAllowed: true
+              :IsApplicationDeploymentAllowed: false
+              :RequiresAdministratorAccountNameInSysprep: false
+              :RequiresXMLSysprepFormat: false
+              :AllowsOrgNameInSysprep: false
+              :RequiresPIDInSysprep: true
+              :ServerConnection: *9
+              :ID: 5ee4aa4b-e087-4fb1-856e-da9ed885b904
+              :IsViewOnly: false
+              :ObjectType: OperatingSystem
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :HasVMAdditions: false
+          :VMAddition: Not Detected
+          :NumLockEnabled: 
+          :CPUCount: 4
+          :IsHighlyAvailable: false
+          :HAVMPriority: 
+          :IsDRProtectionRequired: false
+          :RecoveryPointObjective: 
+          :ProtectionProvider: 
+          :ReplicationGroupId: 
+          :ReplicationGroup: 
+          :LimitCPUFunctionality: false
+          :LimitCPUForMigration: false
+          :Memory: 6120
+          :DynamicMemoryEnabled: false
+          :DynamicMemoryMaximumMB: 
+          :DynamicMemoryBufferPercentage: 
+          :MemoryWeight: 
+          :VirtualVideoAdapterEnabled: false
+          :MonitorMaximumCount: 
+          :MonitorResolutionMaximum: 
+          :BootOrder: 
+          :FirstBootDevice: 
+          :SecureBootEnabled: 
+          :ComputerName: "*"
+          :UseHardwareAssistedVirtualization: false
+          :SANStatus:
+          - :ToString: TemplateVHDsNotPresentOnSANCopyCapableLuns (26150)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 26150
+              :ErrorCodeString: '26150'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : TemplateVHDsNotPresentOnSANCopyCapableLuns
+                ; Message : All template virtual hard disks are not present on SAN
+                copy capable logical units, hence template is not SAN copy capable.
+                ; Recommended Action : Bring storage pool under management if template
+                logical units are not managed or attach virtual hard disks which are
+                SAN copy capable to template and retry the operation.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: All template virtual hard disks are not present on SAN copy
+                capable logical units, hence template is not SAN copy capable.
+              :CloudProblem: All template virtual hard disks are not present on SAN
+                copy capable logical units, hence template is not SAN copy capable.
+              :RecommendedAction: Bring storage pool under management if template
+                logical units are not managed or attach virtual hard disks which are
+                SAN copy capable to template and retry the operation.
+              :RecommendedActionCLI: Bring storage pool under management if template
+                logical units are not managed or attach virtual hard disks which are
+                SAN copy capable to template and retry the operation.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: TemplateVHDsNotPresentOnSANCopyCapableLuns
+              :GetMessageFormatterHandler: 
+          :CostCenter: 
+          :QuotaPoint: 1
+          :IsTagEmpty: true
+          :Tag: "(none)"
+          :CustomProperties:
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          :CustomProperty: {}
+          :UndoDisksEnabled: false
+          :CPUType: &19
+            :ToString: 3.60 GHz Xeon (2 MB L2 cache)
+            :Props:
+              :Name: 3.60 GHz Xeon (2 MB L2 cache)
+              :ServerConnection: *9
+              :ID: b0957fcd-95e3-4d7e-8993-30a280f7207b
+              :IsViewOnly: false
+              :ObjectType: ProcessorType
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :ExpectedCPUUtilization: 20
+          :DiskIO: 0
+          :NetworkUtilization: 0
+          :RelativeWeight: 100
+          :CPUReserve: 0
+          :CPUMax: 100
+          :CPUPerVirtualNumaNodeMaximum: 
+          :MemoryPerVirtualNumaNodeMaximumMB: 
+          :VirtualNumaNodesPerSocketMaximum: 
+          :DynamicMemoryMinimumMB: 
+          :NumaIsolationRequired: 
+          :Generation: 1
+          :VirtualDVDDrives: []
+          :VirtualHardDisks:
+          - &18
+            :ToString: cfme-hyperv-5.5.0.13-2.x86_64.vhd
+            :Props:
+              :OperatingSystem: Unknown
+              :VHDType: DynamicallyExpanding
+              :VHDFormatType: VHD
+              :VirtualizationPlatform: Unknown
+              :MaximumSize: 42951106560
+              :ParentDisk: 
+              :SANCopyCapable: false
+              :IsCachedVhd: false
+              :ComplianceStatus: 
+              :Tag: 
+              :HasProductKey: false
+              :Location: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs\\cfme-hyperv-5.5.0.13-2.x86_64.vhd"
+              :Release: 
+              :State: Normal
+              :LibraryShareId: 13f362dc-f853-42f0-81a8-e940303fea3f
+              :SharePath: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs\\cfme-hyperv-5.5.0.13-2.x86_64.vhd"
+              :FileShare: 
+              :Directory: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs"
+              :Size: 1896372736
+              :IsOrphaned: false
+              :FamilyName: 
+              :Namespace: Global
+              :ReleaseTime: 
+              :HostVolumeId: 357bbc1b-bd00-4030-a237-270227a18d0c
+              :HostVolume: 
+              :Classification: 
+              :HostId: c4fd75e3-5c4d-4ee7-9ed7-ce7d6657e836
+              :HostType: LibraryServer
+              :HostName: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: 
+              :LibraryServer: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VirtualHardDisk
+              :Accessibility: Public
+              :Name: cfme-hyperv-5.5.0.13-2.x86_64.vhd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 12:21:46.230000000 -05:00
+              :ModifiedTime: 2016-06-24 20:07:08.713000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: e1c91e15-7cfc-4bf0-818a-83c4d1717030
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualDiskDrives:
+          - :ToString: cfme-hyperv-5.5.0.13-2.x86_64
+            :Props:
+              :VirtualHardDiskId: e1c91e15-7cfc-4bf0-818a-83c4d1717030
+              :VirtualHardDisk: *18
+              :PassThroughDisk: 
+              :IsVHD: true
+              :HasSharedStorage: false
+              :CreateDiffDisk: false
+              :BusType: IDE
+              :Bus: 0
+              :Lun: 0
+              :PendingDiskAssociation: false
+              :Classification: 
+              :VolumeType: None
+              :ObjectType: VirtualDiskDrive
+              :Accessibility: Public
+              :Name: cfme-hyperv-5.5.0.13-2.x86_64
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 12:22:03.097000000 -05:00
+              :ModifiedTime: 2016-06-24 20:07:15.950000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 56239d64-0298-442d-8e67-414ef27145a9
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ShareSCSIBus: false
+          :VirtualNetworkAdapters:
+          - :ToString: cfme-hyperv-5.5.0.13-2.x86_64
+            :Props:
+              :SlotId: 0
+              :VirtualNetwork: 
+              :VMwarePortGroup: 
+              :MACAddressType: Dynamic
+              :EthernetAddressType: Dynamic
+              :PhysicalAddressType: Dynamic
+              :MACAddress: 
+              :EthernetAddress: 
+              :PhysicalAddress: 
+              :RequiredBandwidth: 0
+              :VirtualNetworkAdapterType: Synthetic
+              :VmwAdapterIndex: 
+              :LogicalNetwork: rhq
+              :VMNetwork: rhq
+              :VMNetworkServiceSetting: 
+              :VMSubnet: 
+              :PortClassification: 
+              :VirtualNetworkAdapterPortProfileSet: 
+              :LogicalSwitch: 
+              :GuestIPNetworkVirtualizationUpdatesEnabled: false
+              :MACAddressSpoofingEnabled: false
+              :MACAddressesSpoofingEnabled: false
+              :VMNetworkOptimizationEnabled: false
+              :VLanEnabled: false
+              :VLanID: 0
+              :UsesSriov: false
+              :IsUsedForHostManagement: false
+              :VirtualNetworkAdapterComplianceStatus: Compliant
+              :TemplateNicName: 
+              :VirtualNetworkAdapterComplianceErrors: []
+              :PerfNetworkKBytesRead: 0
+              :PerfNetworkKBytesWrite: 0
+              :DeviceID: 
+              :IPv4AddressType: Dynamic
+              :IPv6AddressType: Dynamic
+              :IPv4Addresses: []
+              :IPv6Addresses: []
+              :PortACL: 
+              :ObjectType: VirtualNetworkAdapter
+              :Accessibility: Public
+              :Name: cfme-hyperv-5.5.0.13-2.x86_64
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 12:22:03.937000000 -05:00
+              :ModifiedTime: 2016-06-24 20:07:15.950000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: c0d0cbc9-de86-4209-992b-f38cf63df161
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualFibreChannelAdapters: []
+          :HasVirtualFibreChannelAdapters: false
+          :VirtualFloppyDrive:
+            :ToString: cfme-hyperv-5.5.0.13-2.x86_64
+            :Props:
+              :Connection: None
+              :VirtualFloppyDisk: 
+              :ObjectType: VirtualFloppyDrive
+              :Accessibility: Public
+              :Name: cfme-hyperv-5.5.0.13-2.x86_64
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 12:22:03.933000000 -05:00
+              :ModifiedTime: 2016-06-24 20:07:15.950000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 3c74e05b-42d0-49e3-879f-ee136146a6e0
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualCOMPorts:
+          - :ToString: COM1
+            :Props:
+              :PortNumber: 1
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM1
+              :ServerConnection: *9
+              :ID: ff08771d-38c1-45c2-8fc2-f9a8f8c6bd38
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: COM2
+            :Props:
+              :PortNumber: 2
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM2
+              :ServerConnection: *9
+              :ID: 470d0d92-3673-4152-a027-6e8028e42871
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VirtualSCSIAdapters:
+          - :ToString: cfme-hyperv-5.5.0.13-2.x86_64
+            :Props:
+              :AdapterID: 6
+              :Bus: 0
+              :Shared: false
+              :SCSIControllerType: 
+              :ObjectType: VirtualSCSIAdapter
+              :Accessibility: Public
+              :Name: cfme-hyperv-5.5.0.13-2.x86_64
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 12:22:03.927000000 -05:00
+              :ModifiedTime: 2016-06-24 20:07:15.950000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 41636ac3-3012-4b66-85d8-16955a05419e
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :CapabilityProfile: 
+          :CapabilityProfileCompatibilityState:
+            :ToString: Compatible
+            :I32: 0
+          :VMCheckpoints: []
+          :HostId: 00000000-0000-0000-0000-000000000000
+          :HostType:
+            :ToString: None
+            :I32: 2
+          :HostName: 
+          :VMHost: 
+          :LibraryServer: 
+          :CloudId: 
+          :Cloud: 
+          :LibraryGroup: 
+          :GrantedToList: []
+          :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+          :UserRole: *3
+          :Owner: CFME-QE-VMM-AD\Administrator
+          :ObjectType:
+            :ToString: Template
+            :I32: 3
+          :Accessibility:
+            :ToString: Public
+            :I32: 0
+          :Name: cfme-hyperv-5.5.0.13-2.x86_64
+          :IsViewOnly: false
+          :AddedTime: 2015-12-04 12:22:03.837000000 -05:00
+          :ModifiedTime: 2016-06-24 20:07:15.943763100 -04:00
+          :Enabled: true
+          :MostRecentTask: 
+          :ServerConnection: *9
+          :ID: 77a06eb2-6b7a-4cb7-98ca-48bb00d12743
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: 
+      :vmnet:
+        :MS:
+          :VMNetwork: &23
+            :ToString: rhq
+            :Props:
+              :Name: rhq
+              :LogicalNetwork: &22
+                :ToString: rhq
+                :Props:
+                  :Name: rhq
+                  :Description: 
+                  :IsViewOnly: false
+                  :NetworkVirtualizationEnabled: false
+                  :UseGRE: false
+                  :IsPVLAN: false
+                  :SupportsExternalVMNetworkProvisioning: false
+                  :SupportsIPSubnetConfigurationOnExternalVMNetworkDefinitions: false
+                  :SupportsExternalVMNetworkDefinitionCreationWithoutIPSubnets: false
+                  :IsLogicalNetworkDefinitionIsolated: false
+                  :AllowDynamicVlanOnVnic: false
+                  :DefaultNetworkManagerForVMNetworkCreation: 
+                  :ExternalId: aafa7367-d90a-4abd-966c-289c257e10ff
+                  :LastModifiedByNetworkManager: 
+                  :ExternalSyncTime: 
+                  :ServerConnection: *9
+                  :ID: aafa7367-d90a-4abd-966c-289c257e10ff
+                  :ObjectType: LogicalNetwork
+                  :MarkedForDeletion: false
+                  :IsFullyCached: true
+              :VMSubnet: []
+              :VMNetworkGateways: []
+              :VPNConnections: []
+              :NATConnections: []
+              :RoutingDomainId: 2cfcca3a-df29-41c9-ac38-c7ef7d74ca66
+              :IsolationType:
+                :ToString: NoIsolation
+                :I32: 0
+              :UseGRE: 
+              :PAIPAddressPoolType: 
+              :CAIPAddressPoolType: 
+              :ExternalName: 
+              :NetworkEntityAccessType:
+                :ToString: VmmManaged
+                :I32: 0
+              :IsAssigned: true
+              :IsPrivateVlan: false
+              :HasGatewayConnection: false
+              :NetworkManager: 
+              :PortACL: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType:
+                :ToString: VMNetwork
+                :I32: 172
+              :Accessibility:
+                :ToString: Public
+                :I32: 0
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-07-11 15:47:15.212779700 -04:00
+              :ModifiedTime: 2015-02-20 17:13:06.460000000 -05:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 780eafa2-55b0-4a92-9d13-b8bc28eb03cb
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+      :DVDs: []
+    :346020bb-12ee-458e-aca3-1315b1965d2d:
+      :Properties:
+        :ToString: cfme-hyperv-5.5.3.4-1.x86_64
         :Props:
           :IsCustomizable: false
           :Description: 
@@ -1479,7 +1815,7 @@
             :ToString: Normal
             :I32: 0
           :ProductKeyHasValue: false
-          :GuiRunOnceCommands: 
+          :GuiRunOnceCommands: []
           :JoinDomain: 
           :JoinWorkgroup: 
           :OrgName: 
@@ -1492,7 +1828,7 @@
           :AdminPasswordHasValue: false
           :DomainAdminPasswordHasValue: false
           :TimeZone: 
-          :MergeAnswerFile: true
+          :MergeAnswerFile: false
           :OSType:
             :ToString: Other
             :I32: 2
@@ -1503,20 +1839,20 @@
           :ServerFeatures: []
           :AutoLogonCredential: 
           :AutoLogonCount: 
-          :UnattendSettings: 
+          :UnattendSettings: {}
           :DomainJoinOrganizationalUnit: 
-          :TotalVHDCapacity: 0
+          :TotalVHDCapacity: 42951106560
           :NicCount: 1
           :ApplicationProfile: 
           :SQLProfile: 
           :ComputerTierTemplate: 
           :ServiceSettingsInProductKey: []
           :VirtualizationPlatform:
-            :ToString: HyperV
-            :I32: 2
+            :ToString: Unknown
+            :I32: 0
           :Location: 
-          :CreationTime: 2016-02-22 11:51:22.789125800 -05:00
-          :OperatingSystem: &16
+          :CreationTime: 2016-04-10 16:31:19.407000000 -04:00
+          :OperatingSystem: &20
             :ToString: Unknown
             :Props:
               :Name: Unknown
@@ -1542,8 +1878,8 @@
               :IsFullyCached: true
           :HasVMAdditions: false
           :VMAddition: Not Detected
-          :NumLockEnabled: false
-          :CPUCount: 1
+          :NumLockEnabled: 
+          :CPUCount: 4
           :IsHighlyAvailable: false
           :HAVMPriority: 
           :IsDRProtectionRequired: false
@@ -1553,23 +1889,15 @@
           :ReplicationGroup: 
           :LimitCPUFunctionality: false
           :LimitCPUForMigration: false
-          :Memory: 512
-          :DynamicMemoryEnabled: true
-          :DynamicMemoryMaximumMB: 1048576
-          :DynamicMemoryBufferPercentage: 20
-          :MemoryWeight: 5000
+          :Memory: 6120
+          :DynamicMemoryEnabled: false
+          :DynamicMemoryMaximumMB: 
+          :DynamicMemoryBufferPercentage: 
+          :MemoryWeight: 
           :VirtualVideoAdapterEnabled: false
           :MonitorMaximumCount: 
           :MonitorResolutionMaximum: 
-          :BootOrder:
-          - :ToString: CD
-            :I32: 1
-          - :ToString: IdeHardDrive
-            :I32: 2
-          - :ToString: PxeBoot
-            :I32: 3
-          - :ToString: Floppy
-            :I32: 0
+          :BootOrder: 
           :FirstBootDevice: 
           :SecureBootEnabled: 
           :ComputerName: 
@@ -1629,16 +1957,7 @@
           - 
           :CustomProperty: {}
           :UndoDisksEnabled: false
-          :CPUType: &15
-            :ToString: 3.60 GHz Xeon (2 MB L2 cache)
-            :Props:
-              :Name: 3.60 GHz Xeon (2 MB L2 cache)
-              :ServerConnection: *8
-              :ID: b0957fcd-95e3-4d7e-8993-30a280f7207b
-              :IsViewOnly: false
-              :ObjectType: ProcessorType
-              :MarkedForDeletion: false
-              :IsFullyCached: true
+          :CPUType: *19
           :ExpectedCPUUtilization: 20
           :DiskIO: 0
           :NetworkUtilization: 0
@@ -1648,98 +1967,71 @@
           :CPUPerVirtualNumaNodeMaximum: 
           :MemoryPerVirtualNumaNodeMaximumMB: 
           :VirtualNumaNodesPerSocketMaximum: 
-          :DynamicMemoryMinimumMB: 32
-          :NumaIsolationRequired: false
+          :DynamicMemoryMinimumMB: 
+          :NumaIsolationRequired: 
           :Generation: 1
-          :VirtualDVDDrives:
-          - :ToString: linux_template
-            :Props:
-              :Connection: None
-              :ISOId: 
-              :ISO: 
-              :HostDrive: 
-              :BusType: IDE
-              :Bus: 1
-              :Lun: 0
-              :ISOLinked: false
-              :ObjectType: VirtualDVDDrive
-              :Accessibility: Public
-              :Name: linux_template
-              :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-22 11:51:23.110000000 -05:00
-              :ModifiedTime: 2016-02-22 11:51:23.543000000 -05:00
-              :Enabled: true
-              :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: eedd4d66-8085-4328-8a47-7009cb333107
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
+          :VirtualDVDDrives: []
           :VirtualHardDisks:
-          - &14
-            :ToString: Blank Disk - Small.vhd
+          - &21
+            :ToString: cfme-hyperv-5.5.3.4-1.x86_64.vhd
             :Props:
-              :OperatingSystem: None
+              :OperatingSystem: *20
               :VHDType: DynamicallyExpanding
               :VHDFormatType: VHD
-              :VirtualizationPlatform: HyperV
-              :MaximumSize: 17179869184
+              :VirtualizationPlatform: Unknown
+              :MaximumSize: 42951106560
               :ParentDisk: 
               :SANCopyCapable: false
               :IsCachedVhd: false
               :ComplianceStatus: 
               :Tag: 
               :HasProductKey: false
-              :Location: "\\\\Dev-scvmm2k12.cloudformswin.lab.redhat.com\\MSSCVMMLibrary\\VHDs\\Blank
-                Disk - Small.vhd"
+              :Location: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs\\cfme-hyperv-5.5.3.4-1.x86_64.vhd"
               :Release: 
               :State: Normal
-              :LibraryShareId: a1a16630-c1f6-4714-a720-cd3c8cf45406
-              :SharePath: "\\\\Dev-scvmm2k12.cloudformswin.lab.redhat.com\\MSSCVMMLibrary\\VHDs\\Blank
-                Disk - Small.vhd"
+              :LibraryShareId: 13f362dc-f853-42f0-81a8-e940303fea3f
+              :SharePath: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs\\cfme-hyperv-5.5.3.4-1.x86_64.vhd"
               :FileShare: 
-              :Directory: "\\\\Dev-scvmm2k12.cloudformswin.lab.redhat.com\\MSSCVMMLibrary\\VHDs"
-              :Size: 35328
+              :Directory: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs"
+              :Size: 2032720896
               :IsOrphaned: false
               :FamilyName: 
               :Namespace: Global
               :ReleaseTime: 
-              :HostVolumeId: 49ae08e9-88a7-4b15-9dcb-da15d89c8926
+              :HostVolumeId: 357bbc1b-bd00-4030-a237-270227a18d0c
               :HostVolume: 
               :Classification: 
-              :HostId: 261a658d-5f54-4e91-a6fa-63a563f48371
+              :HostId: c4fd75e3-5c4d-4ee7-9ed7-ce7d6657e836
               :HostType: LibraryServer
-              :HostName: Dev-scvmm2k12.cloudformswin.lab.redhat.com
+              :HostName: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :VMHost: 
-              :LibraryServer: Dev-scvmm2k12.cloudformswin.lab.redhat.com
+              :LibraryServer: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :CloudId: 
               :Cloud: 
               :LibraryGroup: 
               :GrantedToList: []
               :UserRoleID: 00000000-0000-0000-0000-000000000000
               :UserRole: 
-              :Owner: CLOUDFORMSWIN\Administrator
+              :Owner: 
               :ObjectType: VirtualHardDisk
               :Accessibility: Public
-              :Name: Blank Disk - Small.vhd
+              :Name: cfme-hyperv-5.5.3.4-1.x86_64.vhd
               :IsViewOnly: false
-              :Description: To be used as a base drive to create a new virtual machine
-                or as an additional data drive.
-              :AddedTime: 2016-01-20 15:45:53.327000000 -05:00
-              :ModifiedTime: 2016-01-20 16:31:07.600000000 -05:00
+              :Description: 
+              :AddedTime: 2016-04-10 16:31:03.853000000 -04:00
+              :ModifiedTime: 2016-06-24 20:07:07.377000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 6507ebf8-257b-415e-8469-0bb5835f5e1e
+              :ServerConnection: *9
+              :ID: d340d59a-8ae5-4d50-a54f-521bc20739fc
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualDiskDrives:
-          - :ToString: linux_template
+          - :ToString: cfme-hyperv-5.5.3.4-1.x86_64
             :Props:
-              :VirtualHardDiskId: 6507ebf8-257b-415e-8469-0bb5835f5e1e
-              :VirtualHardDisk: *14
+              :VirtualHardDiskId: d340d59a-8ae5-4d50-a54f-521bc20739fc
+              :VirtualHardDisk: *21
               :PassThroughDisk: 
               :IsVHD: true
               :HasSharedStorage: false
@@ -1749,24 +2041,24 @@
               :Lun: 0
               :PendingDiskAssociation: false
               :Classification: 
-              :VolumeType: BootAndSystem
+              :VolumeType: None
               :ObjectType: VirtualDiskDrive
               :Accessibility: Public
-              :Name: linux_template
+              :Name: cfme-hyperv-5.5.3.4-1.x86_64
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-22 11:51:22.380000000 -05:00
-              :ModifiedTime: 2016-02-22 11:51:23.540000000 -05:00
+              :AddedTime: 2016-04-10 16:31:18.367000000 -04:00
+              :ModifiedTime: 2016-06-24 20:07:15.133000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 56c29a3e-1d93-424e-97db-550f39152053
+              :ServerConnection: *9
+              :ID: 8fb69c30-3bfb-4d75-90fb-8394a1846fb9
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :ShareSCSIBus: false
           :VirtualNetworkAdapters:
-          - :ToString: linux_template
+          - :ToString: cfme-hyperv-5.5.3.4-1.x86_64
             :Props:
               :SlotId: 0
               :VirtualNetwork: 
@@ -1780,8 +2072,8 @@
               :RequiredBandwidth: 0
               :VirtualNetworkAdapterType: Synthetic
               :VmwAdapterIndex: 
-              :LogicalNetwork: 
-              :VMNetwork: 
+              :LogicalNetwork: *22
+              :VMNetwork: *23
               :VMNetworkServiceSetting: 
               :VMSubnet: 
               :PortClassification: 
@@ -1808,36 +2100,36 @@
               :PortACL: 
               :ObjectType: VirtualNetworkAdapter
               :Accessibility: Public
-              :Name: linux_template
+              :Name: cfme-hyperv-5.5.3.4-1.x86_64
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-22 11:51:23.153000000 -05:00
-              :ModifiedTime: 2016-02-22 11:51:23.543000000 -05:00
+              :AddedTime: 2016-04-10 16:31:19.537000000 -04:00
+              :ModifiedTime: 2016-06-24 20:07:15.133000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: de482f32-79fe-4689-a73a-e0c506dfa3ca
+              :ServerConnection: *9
+              :ID: 6c5702d5-6880-4b90-bc8c-232e31c2a686
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualFibreChannelAdapters: []
           :HasVirtualFibreChannelAdapters: false
           :VirtualFloppyDrive:
-            :ToString: linux_template
+            :ToString: cfme-hyperv-5.5.3.4-1.x86_64
             :Props:
               :Connection: None
               :VirtualFloppyDisk: 
               :ObjectType: VirtualFloppyDrive
               :Accessibility: Public
-              :Name: linux_template
+              :Name: cfme-hyperv-5.5.3.4-1.x86_64
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-22 11:51:23.127000000 -05:00
-              :ModifiedTime: 2016-02-22 11:51:23.543000000 -05:00
+              :AddedTime: 2016-04-10 16:31:19.530000000 -04:00
+              :ModifiedTime: 2016-06-24 20:07:15.133000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: f0d4d4e6-d608-491a-aa6a-2f2c8b017564
+              :ServerConnection: *9
+              :ID: e9d88992-71f2-4ad7-a428-0819d512ad17
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
@@ -1852,8 +2144,8 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM1
-              :ServerConnection: *8
-              :ID: 00000000-0000-0000-0000-000000000000
+              :ServerConnection: *9
+              :ID: 8979550a-48d1-4a29-9d0d-2cf811acc20b
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
@@ -1868,243 +2160,34 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM2
-              :ServerConnection: *8
-              :ID: 00000000-0000-0000-0000-000000000000
+              :ServerConnection: *9
+              :ID: 2eef7f3e-89f2-4681-b794-5326feced784
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
               :IsFullyCached: true
           :VirtualSCSIAdapters:
-          - :ToString: linux_template
+          - :ToString: cfme-hyperv-5.5.3.4-1.x86_64
             :Props:
-              :AdapterID: 7
+              :AdapterID: 6
               :Bus: 0
               :Shared: false
-              :SCSIControllerType: DefaultTypeNoType
+              :SCSIControllerType: 
               :ObjectType: VirtualSCSIAdapter
               :Accessibility: Public
-              :Name: linux_template
+              :Name: cfme-hyperv-5.5.3.4-1.x86_64
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-22 11:51:23.103000000 -05:00
-              :ModifiedTime: 2016-02-22 11:51:23.540000000 -05:00
+              :AddedTime: 2016-04-10 16:31:19.520000000 -04:00
+              :ModifiedTime: 2016-06-24 20:07:15.133000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 4271aa3c-5824-444d-81f2-70ab13b4e6fa
+              :ServerConnection: *9
+              :ID: fc9afa73-802a-49c0-bba7-38698662d548
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :CapabilityProfile: &23
-            :ToString: Hyper-V
-            :Props:
-              :Name: Hyper-V
-              :Description: The built-in fabric capability profile for Microsoft Hyper-V
-                hosts
-              :CPUCountInitial: 1
-              :CPUCountMaximum: 64
-              :CPUCountMinimum: 1
-              :CPUCompatibilityModeValue: false
-              :CPUCompatibilityModeValueCanChange: true
-              :OSCompatibilityModeValue: false
-              :OSCompatibilityModeValueCanChange: true
-              :MemoryMBInitial: 512
-              :MemoryMBMaximum: 1048576
-              :MemoryMBMinimum: 8
-              :DynamicMemoryValue: false
-              :DynamicMemoryValueCanChange: true
-              :StartupMemoryMBInitial: 512
-              :StartupMemoryMBMaximum: 1048576
-              :StartupMemoryMBMinimum: 8
-              :MaximumMemoryMBInitial: 1048576
-              :MaximumMemoryMBMaximum: 1048576
-              :MaximumMemoryMBMinimum: 8
-              :TargetMemoryBufferPercentInitial: 20
-              :TargetMemoryBufferPercentMaximum: 95
-              :TargetMemoryBufferPercentMinimum: 5
-              :VirtualDVDDriveCountInitial: 1
-              :VirtualDVDDriveCountMaximum: 4
-              :VirtualDVDDriveCountMinimum: 0
-              :SharedDVDImageFileValue: false
-              :SharedDVDImageFileValueCanChange: true
-              :VirtualHardDiskCountInitial: 0
-              :VirtualHardDiskCountMaximum: 255
-              :VirtualHardDiskCountMinimum: 0
-              :DifferencingVirtualHardDiskValue: false
-              :DifferencingVirtualHardDiskValueCanChange: true
-              :DynamicVirtualHardDiskValue: true
-              :DynamicVirtualHardDiskValueCanChange: true
-              :FixedVirtualHardDiskValue: false
-              :FixedVirtualHardDiskValueCanChange: true
-              :VirtualHardDiskSizeMBInitial: 8192
-              :VirtualHardDiskSizeMBMaximum: 67108864
-              :VirtualHardDiskSizeMBMinimum: 0
-              :NewDiskStorageClassificationValue: 00000000-0000-0000-0000-000000000000
-              :ExistDiskStorageClassificationValue: 00000000-0000-0000-0000-000000000000
-              :VirtualNetworkAdapterCountInitial: 1
-              :VirtualNetworkAdapterCountMaximum: 12
-              :VirtualNetworkAdapterCountMinimum: 0
-              :LogicalNetworkValue: 00000000-0000-0000-0000-000000000000
-              :NetworkOptimizationValue: false
-              :NetworkOptimizationValueCanChange: true
-              :VMHighlyAvailableValue: false
-              :VMHighlyAvailableValueCanChange: true
-              :FabricCapabilityType: HyperV
-              :ReadOnly: true
-              :ExpectedCPUUtilizationInitial: 0
-              :ExpectedCPUUtilizationMaximum: 999999
-              :ExpectedCPUUtilizationMinimum: 0
-              :StaticMemoryInitial: true
-              :StaticMemoryCanChange: true
-              :MemoryAmountInitial: 512
-              :MemoryAmountMaximum: 1048576
-              :MemoryAmountMinimum: 8
-              :MaximumMonitorCountInitial: 1
-              :MaximumMonitorCountMaximum: 4
-              :MaximumMonitorCountMinimum: 1
-              :MaximumHorizontalMonitorResolutionInitial: 1024
-              :MaximumHorizontalMonitorResolutionMaximum: 1920
-              :MaximumHorizontalMonitorResolutionMinimum: 1024
-              :MaximumVerticalMonitorResolutionInitial: 768
-              :MaximumVerticalMonitorResolutionMaximum: 1200
-              :MaximumVerticalMonitorResolutionMinimum: 768
-              :UseNoMediaFloppyDriveInitial: true
-              :UseNoMediaFloppyDriveCanChange: true
-              :UseExistingFloppyDriveInitial: false
-              :UseExistingFloppyDriveCanChange: false
-              :UseExistingFloppyImageFileInitial: false
-              :UseExistingFloppyImageFileCanChange: true
-              :FloppyImageFileInitial: 00000000-0000-0000-0000-000000000000
-              :UseCOM1Initial: true
-              :UseCOM1CanChange: true
-              :UseCOM1NamedPipeInitial: false
-              :UseCOM1NamedPipeCanChange: true
-              :COM1PipeNameInitial: 
-              :UseCOM1TextFileInitial: false
-              :UseCOM1TextFileCanChange: false
-              :COM1TextFileName: 
-              :UseCOM2Initial: true
-              :UseCOM2CanChange: true
-              :UseCOM2NamedPipeInitial: false
-              :UseCOM2NamedPipeCanChange: true
-              :COM2PipeNameInitial: 
-              :UseCOM2TextFileInitial: false
-              :UseCOM2TextFileCanChange: false
-              :COM2TextFileNameInitial: 
-              :UseExistingOrFirstAvailableDVDDriveChannelInitial: true
-              :UseExistingOrFirstAvailableDVDDriveChannelCanChange: true
-              :DVDDriveChannelInitial: 1
-              :DVDDriveChannelMaximum: 4
-              :DVDDriveChannelMinimum: 0
-              :UseNoMediaDVDDriveInitial: true
-              :UseNoMediaDVDDriveCanChange: true
-              :UsePhysicalDVDDriveInitial: false
-              :UsePhysicalDVDDriveCanChange: true
-              :UseExistingDVDImageFileInitial: false
-              :UseExistingDVDImageFileCanChange: true
-              :DVDImageFileInitial: 00000000-0000-0000-0000-000000000000
-              :UseFirstAvailableChannelForNewDiskInitial: true
-              :UseFirstAvailableChannelForNewDiskCanChange: false
-              :NewDiskDriveChannelInitial: 0
-              :NewDiskDriveChannelMaximum: 4
-              :NewDiskDriveChannelMinimum: 0
-              :UseExistingDiskImageFileInitial: true
-              :UseExistingDiskImageFileCanChange: true
-              :NewDiskImageFileInitial: 00000000-0000-0000-0000-000000000000
-              :NewDiskFileNameInitial: 
-              :CreateNewDiskInitial: false
-              :CreateNewDiskCanChange: true
-              :UsePassthroughDiskInitial: false
-              :UsePassthroughDiskCanChange: true
-              :UseForOperatingSystemInitial: false
-              :UseForOperatingSystemCanChange: true
-              :UseExistingOrFirstAvailableDiskDriveChannelInitial: true
-              :UseExistingOrFirstAvailableDiskDriveChannelCanChange: true
-              :ExistingDiskChannelInitial: 0
-              :ExistingDiskChannelMaximum: 4
-              :ExistingDiskChannelMinimum: 0
-              :UseExistingDiskForOperatingSystemInitial: false
-              :UseExistingDiskForOperatingSystemCanChange: true
-              :SCSIAdapterCountInitial: 1
-              :SCSIAdapterCountMaximum: 4
-              :SCSIAdapterCountMinimum: 0
-              :UseBusLogicParallelSCSIInitial: false
-              :UseBusLogicParallelSCSICanChange: false
-              :UseLSILogicParallelSCSIInitial: false
-              :UseLSILogicParallelSCSICanChange: false
-              :UseLSILogicSASSCSIInitial: false
-              :UseLSILogicSASSCSICanChange: false
-              :UseVMWareParavirtualSCSIInitial: false
-              :UseVMWareParavirtualSCSICanChange: false
-              :NetworkAdapterNameInitial: Network Adapter
-              :UseEmulatedNetworkAdapterInitial: true
-              :UseEmulatedNetworkAdapterCanChange: true
-              :UseSyntheticNetworkAdapterInitial: false
-              :UseSyntheticNetworkAdapterCanChange: true
-              :UseDynamicIPv4Initial: true
-              :UseDynamicIPv4CanChange: true
-              :UseStaticIPv4Initial: false
-              :UseStaticIPv4CanChange: true
-              :UseDynamicIPv6Initial: true
-              :UseDynamicIPv6CanChange: true
-              :UseStaticIPv6Initial: false
-              :UseStaticIPv6CanChange: true
-              :UseStaticMACAddressInitial: false
-              :UseStaticMACAddressCanChange: true
-              :StaticMACAddressInitial: 
-              :UseMACSpoofingInitial: false
-              :UseMACSpoofingCanChange: true
-              :CPUPriorityHighInitial: 10000
-              :CPUPriorityHighMaximum: 10000
-              :CPUPriorityHighMinimum: 10000
-              :CPUPriorityNormalInitial: 5000
-              :CPUPriorityNormalMaximum: 5000
-              :CPUPriorityNormalMinimum: 5000
-              :CPUPriorityLowInitial: 0
-              :CPUPriorityLowMaximum: 0
-              :CPUPriorityLowMinimum: 0
-              :CPUPriorityCustomInitial: 5000
-              :CPUPriorityCustomMaximum: 65535
-              :CPUPriorityCustomMinimum: 0
-              :MemoryPriorityHighInitial: 10000
-              :MemoryPriorityHighMaximum: 10000
-              :MemoryPriorityHighMinimum: 10000
-              :MemoryPriorityNormalInitial: 5000
-              :MemoryPriorityNormalMaximum: 5000
-              :MemoryPriorityNormalMinimum: 5000
-              :MemoryPriorityLowInitial: 0
-              :MemoryPriorityLowMaximum: 0
-              :MemoryPriorityLowMinimum: 0
-              :MemoryPriorityCustomInitial: 5000
-              :MemoryPriorityCustomMaximum: 65535
-              :MemoryPriorityCustomMinimum: 0
-              :EnableNumLockInitial: false
-              :EnableNumLockCanChange: true
-              :StartActionDoNothingInitial: false
-              :StartActionDoNothingCanChange: true
-              :StartActionAutomaticallyStartIfRunningInitial: false
-              :StartActionAutomaticallyStartIfRunningCanChange: true
-              :StartActionAlwaysStartInitial: false
-              :StartActionAlwaysStartCanChange: true
-              :StartupDelaySecondsInitial: 0
-              :StartupDelaySecondsMaximum: 2147483647
-              :StartupDelaySecondsMinimum: 0
-              :StopActionDoNothingInitial: false
-              :StopActionDoNothingCanChange: true
-              :StopActionSaveStateVMInitial: true
-              :StopActionSaveStateVMCanChange: true
-              :StopActionTurnOffVMInitial: false
-              :StopActionTurnOffVMCanChange: true
-              :StopActionShutdownVMInitial: false
-              :StopActionShutdownVMCanChange: true
-              :ServerConnection: *8
-              :ID: d1eae605-7cc0-4734-8789-bef392999d3c
-              :IsViewOnly: false
-              :ObjectType: CapabilityProfile
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :Accessibility: Public
-              :Enabled: true
+          :CapabilityProfile: 
           :CapabilityProfileCompatibilityState:
             :ToString: Compatible
             :I32: 0
@@ -2122,37 +2205,437 @@
           :GrantedToList: []
           :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
           :UserRole: *3
-          :Owner: CLOUDFORMSWIN\scvmm
+          :Owner: CFME-QE-VMM-AD\Administrator
           :ObjectType:
             :ToString: Template
             :I32: 3
           :Accessibility:
             :ToString: Public
             :I32: 0
-          :Name: linux_template
+          :Name: cfme-hyperv-5.5.3.4-1.x86_64
           :IsViewOnly: false
-          :AddedTime: 2016-02-22 11:51:22.789125800 -05:00
-          :ModifiedTime: 2016-02-22 11:51:23.536170500 -05:00
+          :AddedTime: 2016-04-10 16:31:19.407000000 -04:00
+          :ModifiedTime: 2016-06-24 20:07:15.128766800 -04:00
           :Enabled: true
           :MostRecentTask: 
-          :ServerConnection: *8
-          :ID: e8aae9d0-55af-4f72-b357-265b8fdd23e4
+          :ServerConnection: *9
+          :ID: 346020bb-12ee-458e-aca3-1315b1965d2d
           :MarkedForDeletion: false
           :IsFullyCached: true
           :MostRecentTaskIfLocal: 
       :vmnet:
         :MS:
-          :VMNetwork: 
-      :DVDs: *9
-  :vms:
-    :6673f40b-0706-4170-92a6-5fcb4d9846f6:
+          :VMNetwork: *23
+      :DVDs: []
+    :51dd8079-bcf7-4224-97b2-49871785e8da:
       :Properties:
-        :ToString: vm_linux1
+        :ToString: cfme-54402-12011420
         :Props:
-          :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\Virtual Machines\FDA2093A-D44F-40A1-BB8C-0F90FCDC1528.xml
+          :IsCustomizable: false
+          :Description: 
+          :SANCopyCapable: false
+          :Status:
+            :ToString: Normal
+            :I32: 0
+          :ProductKeyHasValue: false
+          :GuiRunOnceCommands: []
+          :JoinDomain: 
+          :JoinWorkgroup: 
+          :OrgName: 
+          :DomainAdmin: 
+          :JoinDomainRunAsAccount: 
+          :DomainAdminPasswordIsServiceSetting: false
+          :FullName: 
+          :Admin: 
+          :AdminPasswordRunAsAccount: 
+          :AdminPasswordHasValue: false
+          :DomainAdminPasswordHasValue: false
+          :TimeZone: 
+          :MergeAnswerFile: false
+          :OSType:
+            :ToString: Other
+            :I32: 2
+          :DNSDomainName: 
+          :KeyFile: 
+          :KeyString: 
+          :SysprepScript: 
+          :ServerFeatures: []
+          :AutoLogonCredential: 
+          :AutoLogonCount: 
+          :UnattendSettings: {}
+          :DomainJoinOrganizationalUnit: 
+          :TotalVHDCapacity: 42951106560
+          :NicCount: 1
+          :ApplicationProfile: 
+          :SQLProfile: 
+          :ComputerTierTemplate: 
+          :ServiceSettingsInProductKey: []
+          :VirtualizationPlatform:
+            :ToString: Unknown
+            :I32: 0
+          :Location: 
+          :CreationTime: 2016-06-03 23:48:57.723000000 -04:00
+          :OperatingSystem: *20
+          :HasVMAdditions: false
+          :VMAddition: Not Detected
+          :NumLockEnabled: 
+          :CPUCount: 4
+          :IsHighlyAvailable: false
+          :HAVMPriority: 
+          :IsDRProtectionRequired: false
+          :RecoveryPointObjective: 
+          :ProtectionProvider: 
+          :ReplicationGroupId: 
+          :ReplicationGroup: 
+          :LimitCPUFunctionality: false
+          :LimitCPUForMigration: false
+          :Memory: 10240
+          :DynamicMemoryEnabled: false
+          :DynamicMemoryMaximumMB: 
+          :DynamicMemoryBufferPercentage: 
+          :MemoryWeight: 
+          :VirtualVideoAdapterEnabled: false
+          :MonitorMaximumCount: 
+          :MonitorResolutionMaximum: 
+          :BootOrder: 
+          :FirstBootDevice: 
+          :SecureBootEnabled: 
+          :ComputerName: 
+          :UseHardwareAssistedVirtualization: false
+          :SANStatus:
+          - :ToString: TemplateVHDsNotPresentOnSANCopyCapableLuns (26150)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 26150
+              :ErrorCodeString: '26150'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : TemplateVHDsNotPresentOnSANCopyCapableLuns
+                ; Message : All template virtual hard disks are not present on SAN
+                copy capable logical units, hence template is not SAN copy capable.
+                ; Recommended Action : Bring storage pool under management if template
+                logical units are not managed or attach virtual hard disks which are
+                SAN copy capable to template and retry the operation.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: All template virtual hard disks are not present on SAN copy
+                capable logical units, hence template is not SAN copy capable.
+              :CloudProblem: All template virtual hard disks are not present on SAN
+                copy capable logical units, hence template is not SAN copy capable.
+              :RecommendedAction: Bring storage pool under management if template
+                logical units are not managed or attach virtual hard disks which are
+                SAN copy capable to template and retry the operation.
+              :RecommendedActionCLI: Bring storage pool under management if template
+                logical units are not managed or attach virtual hard disks which are
+                SAN copy capable to template and retry the operation.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters: {}
+              :Code: TemplateVHDsNotPresentOnSANCopyCapableLuns
+              :GetMessageFormatterHandler: 
+          :CostCenter: 
+          :QuotaPoint: 1
+          :IsTagEmpty: true
+          :Tag: "(none)"
+          :CustomProperties:
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          :CustomProperty: {}
+          :UndoDisksEnabled: false
+          :CPUType: *19
+          :ExpectedCPUUtilization: 20
+          :DiskIO: 0
+          :NetworkUtilization: 0
+          :RelativeWeight: 100
+          :CPUReserve: 0
+          :CPUMax: 100
+          :CPUPerVirtualNumaNodeMaximum: 
+          :MemoryPerVirtualNumaNodeMaximumMB: 
+          :VirtualNumaNodesPerSocketMaximum: 
+          :DynamicMemoryMinimumMB: 
+          :NumaIsolationRequired: 
+          :Generation: 1
+          :VirtualDVDDrives: []
+          :VirtualHardDisks:
+          - &24
+            :ToString: cfme-54402-12011420.vhd
+            :Props:
+              :OperatingSystem: *20
+              :VHDType: DynamicallyExpanding
+              :VHDFormatType: VHD
+              :VirtualizationPlatform: Unknown
+              :MaximumSize: 42951106560
+              :ParentDisk: 
+              :SANCopyCapable: false
+              :IsCachedVhd: false
+              :ComplianceStatus: 
+              :Tag: 
+              :HasProductKey: false
+              :Location: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs\\cfme-54402-12011420.vhd"
+              :Release: 
+              :State: Missing
+              :LibraryShareId: 13f362dc-f853-42f0-81a8-e940303fea3f
+              :SharePath: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs\\cfme-54402-12011420.vhd"
+              :FileShare: 
+              :Directory: "\\\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\MSSCVMMLibrary\\VHDs"
+              :Size: 2355761152
+              :IsOrphaned: false
+              :FamilyName: 
+              :Namespace: Global
+              :ReleaseTime: 
+              :HostVolumeId: 357bbc1b-bd00-4030-a237-270227a18d0c
+              :HostVolume: 
+              :Classification: 
+              :HostId: c4fd75e3-5c4d-4ee7-9ed7-ce7d6657e836
+              :HostType: LibraryServer
+              :HostName: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: 
+              :LibraryServer: scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VirtualHardDisk
+              :Accessibility: Public
+              :Name: cfme-54402-12011420.vhd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-18 16:37:27.557000000 -04:00
+              :ModifiedTime: 2016-07-11 13:20:16.367000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: d58c18ad-5827-4d91-8506-ac730ef8d424
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualDiskDrives:
+          - :ToString: cfme-54402-12011420
+            :Props:
+              :VirtualHardDiskId: d58c18ad-5827-4d91-8506-ac730ef8d424
+              :VirtualHardDisk: *24
+              :PassThroughDisk: 
+              :IsVHD: true
+              :HasSharedStorage: false
+              :CreateDiffDisk: false
+              :BusType: IDE
+              :Bus: 0
+              :Lun: 0
+              :PendingDiskAssociation: false
+              :Classification: 
+              :VolumeType: None
+              :ObjectType: VirtualDiskDrive
+              :Accessibility: Public
+              :Name: cfme-54402-12011420
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-03 23:48:56.693000000 -04:00
+              :ModifiedTime: 2016-07-11 13:20:20.723000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 4a854eae-99a0-4163-aea8-8c131e7bd2c5
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ShareSCSIBus: false
+          :VirtualNetworkAdapters:
+          - :ToString: cfme-54402-12011420
+            :Props:
+              :SlotId: 0
+              :VirtualNetwork: 
+              :VMwarePortGroup: 
+              :MACAddressType: Dynamic
+              :EthernetAddressType: Dynamic
+              :PhysicalAddressType: Dynamic
+              :MACAddress: 
+              :EthernetAddress: 
+              :PhysicalAddress: 
+              :RequiredBandwidth: 0
+              :VirtualNetworkAdapterType: Synthetic
+              :VmwAdapterIndex: 
+              :LogicalNetwork: *22
+              :VMNetwork: *23
+              :VMNetworkServiceSetting: 
+              :VMSubnet: 
+              :PortClassification: 
+              :VirtualNetworkAdapterPortProfileSet: 
+              :LogicalSwitch: 
+              :GuestIPNetworkVirtualizationUpdatesEnabled: false
+              :MACAddressSpoofingEnabled: false
+              :MACAddressesSpoofingEnabled: false
+              :VMNetworkOptimizationEnabled: false
+              :VLanEnabled: false
+              :VLanID: 0
+              :UsesSriov: false
+              :IsUsedForHostManagement: false
+              :VirtualNetworkAdapterComplianceStatus: Compliant
+              :TemplateNicName: 
+              :VirtualNetworkAdapterComplianceErrors: []
+              :PerfNetworkKBytesRead: 0
+              :PerfNetworkKBytesWrite: 0
+              :DeviceID: 
+              :IPv4AddressType: Dynamic
+              :IPv6AddressType: Dynamic
+              :IPv4Addresses: []
+              :IPv6Addresses: []
+              :PortACL: 
+              :ObjectType: VirtualNetworkAdapter
+              :Accessibility: Public
+              :Name: cfme-54402-12011420
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-03 23:48:57.850000000 -04:00
+              :ModifiedTime: 2016-07-11 13:20:20.723000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 0c0d21fd-874f-471f-8411-25cc43b3aa90
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualFibreChannelAdapters: []
+          :HasVirtualFibreChannelAdapters: false
+          :VirtualFloppyDrive:
+            :ToString: cfme-54402-12011420
+            :Props:
+              :Connection: None
+              :VirtualFloppyDisk: 
+              :ObjectType: VirtualFloppyDrive
+              :Accessibility: Public
+              :Name: cfme-54402-12011420
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-03 23:48:57.840000000 -04:00
+              :ModifiedTime: 2016-07-11 13:20:20.723000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: e1c74042-2733-4b54-961c-296bde94c58b
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualCOMPorts:
+          - :ToString: COM1
+            :Props:
+              :PortNumber: 1
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM1
+              :ServerConnection: *9
+              :ID: 95212bca-a68c-4327-bc9d-a02ab5554876
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: COM2
+            :Props:
+              :PortNumber: 2
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM2
+              :ServerConnection: *9
+              :ID: fdc710ef-4081-480e-a983-0db2788efce9
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VirtualSCSIAdapters:
+          - :ToString: cfme-54402-12011420
+            :Props:
+              :AdapterID: 6
+              :Bus: 0
+              :Shared: false
+              :SCSIControllerType: 
+              :ObjectType: VirtualSCSIAdapter
+              :Accessibility: Public
+              :Name: cfme-54402-12011420
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-03 23:48:57.833000000 -04:00
+              :ModifiedTime: 2016-07-11 13:20:20.723000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 5c3c46e4-8143-4df6-aeb4-ab8242a44816
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :CapabilityProfile: 
+          :CapabilityProfileCompatibilityState:
+            :ToString: Compatible
+            :I32: 0
+          :VMCheckpoints: []
+          :HostId: 00000000-0000-0000-0000-000000000000
+          :HostType:
+            :ToString: None
+            :I32: 2
+          :HostName: 
+          :VMHost: 
+          :LibraryServer: 
+          :CloudId: 
+          :Cloud: 
+          :LibraryGroup: 
+          :GrantedToList: []
+          :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+          :UserRole: *3
+          :Owner: CFME-QE-VMM-AD\Administrator
+          :ObjectType:
+            :ToString: Template
+            :I32: 3
+          :Accessibility:
+            :ToString: Public
+            :I32: 0
+          :Name: cfme-54402-12011420
+          :IsViewOnly: false
+          :AddedTime: 2016-06-03 23:48:57.723000000 -04:00
+          :ModifiedTime: 2016-07-11 13:20:20.719088100 -04:00
+          :Enabled: true
+          :MostRecentTask: 
+          :ServerConnection: *9
+          :ID: 51dd8079-bcf7-4224-97b2-49871785e8da
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: 
+      :vmnet:
+        :MS:
+          :VMNetwork: *23
+      :DVDs: []
+  :vms:
+    :14249d0a-0bd8-44cb-9edc-53707f66053f:
+      :Properties:
+        :ToString: WS2008R2Core-JK
+        :Props:
+          :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\Virtual Machines\6D327596-1341-4072-81F1-2658DB7F073B.xml
           :MarkedAsTemplate: false
-          :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-          :VMId: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
+          :OwnerIdentifier: 
+          :VMId: 6D327596-1341-4072-81F1-2658DB7F073B
           :VMResourceGroup: 
           :VMConfigResource: 
           :VMConfigResourceStatus:
@@ -2162,8 +2645,8 @@
           :VMResourceStatus:
             :ToString: ClusterResourceStateUnknown
             :I32: -1
-          :DiskResources: &76 []
-          :UnsupportedReason: &19
+          :DiskResources: []
+          :UnsupportedReason: &27
             :ToString: Success (0)
             :Props:
               :Exception: 
@@ -2191,25 +2674,25 @@
               :MessageParameters: {}
               :Code: Success
               :GetMessageFormatterHandler: 
-          :RefresherErrors: &77 []
+          :RefresherErrors: []
           :VirtualMachineState:
-            :ToString: Running
-            :I32: 0
-          :HostGroupPath: All Hosts\vm_linux1
-          :TotalSize: 4194304
-          :MemoryAssignedMB: 512
-          :MemoryAvailablePercentage: '0'
-          :DynamicMemoryDemandMB: 512
+            :ToString: PowerOff
+            :I32: 1
+          :HostGroupPath: All Hosts\WS2008R2Core-JK
+          :TotalSize: 2781491712
+          :MemoryAssignedMB: 0
+          :MemoryAvailablePercentage: 
+          :DynamicMemoryDemandMB: 0
           :DynamicMemoryStatus: 
           :AllocatedGPU: 
           :HasPassthroughDisk: false
           :HasSharedStorage: false
           :Status:
-            :ToString: Running
-            :I32: 0
+            :ToString: PowerOff
+            :I32: 1
           :IsOrphaned: false
           :HasSavedState: false
-          :StatusString: Running
+          :StatusString: Stopped
           :StartAction:
             :ToString: NeverAutoTurnOnVM
             :I32: 0
@@ -2218,7 +2701,7 @@
             :I32: 0
           :RunGuestAccount: 
           :DelayStart: 0
-          :BiosGuid: 5337594f-94a4-4446-b557-73dba213f6dc
+          :BiosGuid: 2c67139b-76e1-40fd-896f-407ee9efc447
           :CPUUtilization: 0
           :PerfCPUUtilization: 0
           :PerfMemory: 512
@@ -2230,9 +2713,9 @@
             :ToString: HyperV
             :I32: 2
           :ComputerNameString: Unknown
-          :CreationSource: Temporary Templateae0b700f-8f3f-4709-b7f1-55613f33b0db
+          :CreationSource: Unknown source object
           :IsUndergoingLiveMigration: false
-          :SourceObjectType: VM Template
+          :SourceObjectType: Unknown source object
           :OperatingSystemShutdownEnabled: true
           :TimeSynchronizationEnabled: true
           :DataExchangeEnabled: true
@@ -2240,7 +2723,7 @@
           :BackupEnabled: true
           :ExcludeFromPRO: false
           :FailedJobID: 
-          :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\
+          :CheckpointLocation: C:\WS2008R2Core
           :SelfServiceUserRole: 
           :PassThroughDisks: []
           :ComputerTier: 
@@ -2249,8 +2732,31 @@
           :CloudVmRoleName: 
           :UpgradeDomain: 
           :SCApplications: []
-          :LastRestoredCheckpointID: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
-          :LastRestoredVMCheckpoint: 
+          :LastRestoredCheckpointID: 8E6AA643-7EF1-4945-811D-857017D921A1
+          :LastRestoredVMCheckpoint: &26
+            :ToString: WS2008R2Core-JK - (2/17/2016 - 2:10:53 PM)
+            :Props:
+              :ParentCheckpointID: 6D327596-1341-4072-81F1-2658DB7F073B
+              :CheckpointID: 8E6AA643-7EF1-4945-811D-857017D921A1
+              :VMId: 14249d0a-0bd8-44cb-9edc-53707f66053f
+              :IsViewOnly: false
+              :CheckpointHWProfile: Microsoft.SystemCenter.VirtualMachineManager.CheckpointHardwareProfile
+              :VirtualDiskDrives:
+              - WS2008R2Core-JK - (2/17/2016 - 2:10:53 PM)
+              :VM: WS2008R2Core-JK
+              :ObjectType: VMSnapshot
+              :Accessibility: Public
+              :Name: WS2008R2Core-JK - (2/17/2016 - 2:10:53 PM)
+              :Description: 
+              :AddedTime: 2016-02-17 17:10:55.167000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.397000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: b9e5024f-eba9-4c4a-99c7-e527f245bff9
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
           :ComplianceStatus: 
           :IsFaultTolerant: false
           :DeploymentErrorInfo: 
@@ -2258,13 +2764,13 @@
           :DeploymentState:
             :ToString: Undeployed
             :I32: 0
-          :TieredPerfData: &78
-            :ToString: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+          :TieredPerfData: &47
+            :ToString: 14249d5f-0bd8-44cb-9edc-53707f66053f
             :Props:
               :IsViewOnly: false
-              :Name: 6673f45e-0706-4170-92a6-5fcb4d9846f6
-              :ServerConnection: *8
-              :ID: 6673f45e-0706-4170-92a6-5fcb4d9846f6
+              :Name: 14249d5f-0bd8-44cb-9edc-53707f66053f
+              :ServerConnection: *9
+              :ID: 14249d5f-0bd8-44cb-9edc-53707f66053f
               :ObjectType: TieredPerfData
               :MarkedForDeletion: false
               :IsFullyCached: true
@@ -2282,7 +2788,7 @@
               :PerfNetworkBytesRead: 0
               :PerfNetworkBytesWrite: 0
               :AverageDiskIO: 0
-              :data: "(TieredPerfCounterData#0) { id = 6673f45e-0706-4170-92a6-5fcb4d9846f6
+              :data: "(TieredPerfCounterData#0) { id = 14249d5f-0bd8-44cb-9edc-53707f66053f
                 }"
           :ReplicationSetting: 
           :ReplicationStatus: 
@@ -2302,80 +2808,14 @@
           :ClusterNonPossibleOwner: 
           :ClusterPreferredOwner: 
           :AvailabilitySetNames: 
-          :LiveCloningEnabled: true
-          :MostRecentTaskID: 9c32c5ad-3d6a-43c5-9c95-120296e147ce
+          :LiveCloningEnabled: false
+          :MostRecentTaskID: 6807f52e-eca6-455a-8ffa-1cd818498200
           :MostRecentTaskUIState:
             :ToString: Completed
             :I32: 5
-          :MostRecentTask: &18
-            :ToString: Refresh virtual machine
-            :Props:
-              :StepsLoaded: true
-              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Refresh virtual machine
-              :IsVisible: true
-              :Status: Completed
-              :StatusString: Completed
-              :ErrorInfo: Success (0)
-              :StartTime: 2016-02-23 19:18:07.963000000 -05:00
-              :EndTime: 2016-02-23 19:18:08.187000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Refresh virtual machine
-              :Steps:
-              - Microsoft.SystemCenter.VirtualMachineManager.Step
-              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 100
-              :Progress: 100 %
-              :WasNotifiedOfCancel: false
-              :CmdletName: "(Refresh VM - System Job)"
-              :PROTipID: 
-              :ResultObjectID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
-              :TargetObjectID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
-              :TargetObjectType: VM
-              :IsCompleted: true
-              :AreAuditRecordsAvailable: false
-              :AuditRecords: []
-              :AdditionalMessages: []
-              :Source: 
-              :Target: 
-              :ResultObjectType: VM
-              :ResultObjectTypeName: Virtual Machine
-              :ResultName: vm_linux1
-              :IsRestartable: false
-              :IsStoppable: false
-              :ServerConnection: *8
-              :ID: 9c32c5ad-3d6a-43c5-9c95-120296e147ce
-              :IsViewOnly: false
-              :ObjectType: Job
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
-          :CreationTime: 2016-02-01 13:39:24.990000000 -05:00
-          :OperatingSystem: &79
-            :ToString: CentOS Linux 6 (64 bit)
-            :Props:
-              :Name: CentOS Linux 6 (64 bit)
-              :Description: CentOS Linux 6 (64 bit)
-              :Version: 
-              :Architecture: amd64
-              :Edition: 
-              :OSType: Linux
-              :IsWindows: false
-              :ProductType: 
-              :IsCustomizationAllowed: true
-              :IsApplicationDeploymentAllowed: false
-              :RequiresAdministratorAccountNameInSysprep: false
-              :RequiresXMLSysprepFormat: false
-              :AllowsOrgNameInSysprep: false
-              :RequiresPIDInSysprep: true
-              :ServerConnection: *8
-              :ID: a095d4f1-0d8d-4c17-882e-59cfe01cf55b
-              :IsViewOnly: false
-              :ObjectType: OperatingSystem
-              :MarkedForDeletion: false
-              :IsFullyCached: true
+          :Location: C:\ProgramData\Microsoft\Windows\Hyper-V
+          :CreationTime: 2016-02-03 00:49:25.200000000 -05:00
+          :OperatingSystem: *20
           :HasVMAdditions: false
           :VMAddition: Not Detected
           :NumLockEnabled: false
@@ -2397,20 +2837,20 @@
           :VirtualVideoAdapterEnabled: false
           :MonitorMaximumCount: 
           :MonitorResolutionMaximum: 
-          :BootOrder: &80
-          - :ToString: PxeBoot
-            :I32: 3
+          :BootOrder:
           - :ToString: CD
             :I32: 1
           - :ToString: IdeHardDrive
             :I32: 2
+          - :ToString: PxeBoot
+            :I32: 3
           - :ToString: Floppy
             :I32: 0
           :FirstBootDevice: 
           :SecureBootEnabled: 
           :ComputerName: 
           :UseHardwareAssistedVirtualization: true
-          :SANStatus: &81
+          :SANStatus:
           - :ToString: DeployLUNNotFoundUsingStorageProvider (26207)
             :Props:
               :Exception: 
@@ -2419,10 +2859,10 @@
               :ErrorCodeString: '26207'
               :ErrorType: Error
               :CSMMessageString: 'Error Code : DeployLUNNotFoundUsingStorageProvider
-                ; Message : Virtual Machine vm_linux1 resides on a LUN, which is not
-                visible to any of the storage providers. ; Recommended Action : Ensure
-                that the storage provider is added to Virtual Machine Manager server.
-                Then try the operation again.'
+                ; Message : Virtual Machine WS2008R2Core-JK resides on a LUN, which
+                is not visible to any of the storage providers. ; Recommended Action
+                : Ensure that the storage provider is added to Virtual Machine Manager
+                server. Then try the operation again.'
               :IsSuccess: false
               :IsTerminating: false
               :IsConditionallyTerminating: false
@@ -2431,10 +2871,10 @@
               :DetailedErrorCode: 
               :IsMomAlert: false
               :MomAlertSeverity: Error
-              :Problem: Virtual Machine vm_linux1 resides on a LUN, which is not visible
-                to any of the storage providers.
-              :CloudProblem: Virtual Machine vm_linux1 resides on a LUN, which is
+              :Problem: Virtual Machine WS2008R2Core-JK resides on a LUN, which is
                 not visible to any of the storage providers.
+              :CloudProblem: Virtual Machine WS2008R2Core-JK resides on a LUN, which
+                is not visible to any of the storage providers.
               :RecommendedAction: Ensure that the storage provider is added to Virtual
                 Machine Manager server. Then try the operation again.
               :RecommendedActionCLI: Ensure that the storage provider is added to
@@ -2443,7 +2883,7 @@
               :DetailedSource: None
               :ExceptionDetails: 
               :MessageParameters:
-                :VMName: vm_linux1
+                :VMName: WS2008R2Core-JK
               :Code: DeployLUNNotFoundUsingStorageProvider
               :GetMessageFormatterHandler: 
           :CostCenter: 
@@ -2463,79 +2903,79 @@
           - 
           :CustomProperty: {}
           :UndoDisksEnabled: false
-          :CPUType: *15
+          :CPUType: *19
           :ExpectedCPUUtilization: 20
           :DiskIO: 0
           :NetworkUtilization: 0
           :RelativeWeight: 100
           :CPUReserve: 0
           :CPUMax: 100
-          :CPUPerVirtualNumaNodeMaximum: 4
-          :MemoryPerVirtualNumaNodeMaximumMB: 6062
+          :CPUPerVirtualNumaNodeMaximum: 8
+          :MemoryPerVirtualNumaNodeMaximumMB: 34918
           :VirtualNumaNodesPerSocketMaximum: 1
           :DynamicMemoryMinimumMB: 
-          :NumaIsolationRequired: false
+          :NumaIsolationRequired: 
           :Generation: 1
           :VirtualDVDDrives:
-          - &82
-            :ToString: vm_linux1
+          - &48
+            :ToString: WS2008R2Core-JK
             :Props:
-              :Connection: HostDrive
+              :Connection: None
               :ISOId: 
               :ISO: 
-              :HostDrive: 'F:'
+              :HostDrive: 
               :BusType: IDE
               :Bus: 1
               :Lun: 0
               :ISOLinked: false
               :ObjectType: VirtualDVDDrive
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: WS2008R2Core-JK
               :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-01 13:39:25.037000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.480000000 -05:00
+              :Description: auto-discovered
+              :AddedTime: 2016-02-03 00:49:36.727000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.393000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 13e462fb-414b-4251-a3c9-857e1098ef61
+              :ServerConnection: *9
+              :ID: 7ee21498-8bee-4d78-a459-95f5370d6b11
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualHardDisks:
-          - &17
-            :ToString: vm_linux1_disk_1
+          - &25
+            :ToString: WS2008R2Corex64Ent_5882F22A-B8DF-4D7C-BB30-F4E302D242AA
             :Props:
-              :OperatingSystem: *16
-              :VHDType: DynamicallyExpanding
-              :VHDFormatType: VHDX
+              :OperatingSystem: *20
+              :VHDType: Differencing
+              :VHDFormatType: VHD
               :VirtualizationPlatform: HyperV
-              :MaximumSize: 42949672960
-              :ParentDisk: 
+              :MaximumSize: 136365211648
+              :ParentDisk: WS2008R2Corex64Ent
               :SANCopyCapable: false
               :IsCachedVhd: false
               :ComplianceStatus: 
               :Tag: 
               :HasProductKey: false
-              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\vm_linux1_disk_1.vhdx
+              :Location: C:\Users\Public\Documents\Hyper-V\Virtual hard disks\WS2008R2Corex64Ent_5882F22A-B8DF-4D7C-BB30-F4E302D242AA.avhd
               :Release: 
               :State: Normal
               :LibraryShareId: 00000000-0000-0000-0000-000000000000
-              :SharePath: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\vm_linux1_disk_1.vhdx
+              :SharePath: C:\Users\Public\Documents\Hyper-V\Virtual hard disks\WS2008R2Corex64Ent_5882F22A-B8DF-4D7C-BB30-F4E302D242AA.avhd
               :FileShare: 
-              :Directory: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
-              :Size: 4194304
+              :Directory: C:\Users\Public\Documents\Hyper-V\Virtual hard disks
+              :Size: 98721280
               :IsOrphaned: false
               :FamilyName: 
               :Namespace: 
               :ReleaseTime: 
-              :HostVolumeId: 284c1ea0-fc51-474a-bbec-372021806117
+              :HostVolumeId: 8cf02787-8199-4754-b800-0d98dac52640
               :HostVolume:
                 :S: C:\
-              :Classification: *11
-              :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+              :Classification: *14
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
               :HostType: VMHost
-              :HostName: dell-r410-03.cloudformswin.lab.redhat.com
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :VMHost: *1
               :LibraryServer: 
               :CloudId: 
@@ -2544,27 +2984,27 @@
               :GrantedToList: []
               :UserRoleID: 00000000-0000-0000-0000-000000000000
               :UserRole: 
-              :Owner: CLOUDFORMSWIN\scvmm
+              :Owner: 
               :ObjectType: VirtualHardDisk
               :Accessibility: Internal
-              :Name: vm_linux1_disk_1
+              :Name: WS2008R2Corex64Ent_5882F22A-B8DF-4D7C-BB30-F4E302D242AA
               :IsViewOnly: false
-              :Description: vm_linux1_disk_1
-              :AddedTime: 2016-02-01 13:39:28.890000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.477000000 -05:00
+              :Description: auto-discovered
+              :AddedTime: 2016-02-17 20:43:56.567000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.390000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 34621bb0-b8e2-4dd2-a6ed-629e75683433
+              :ServerConnection: *9
+              :ID: f3e38af2-4366-4bd6-91a2-6b99f91c82eb
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualDiskDrives:
-          - &83
-            :ToString: vm_linux1
+          - &49
+            :ToString: WS2008R2Core-JK
             :Props:
-              :VirtualHardDiskId: 34621bb0-b8e2-4dd2-a6ed-629e75683433
-              :VirtualHardDisk: *17
+              :VirtualHardDiskId: f3e38af2-4366-4bd6-91a2-6b99f91c82eb
+              :VirtualHardDisk: *25
               :PassThroughDisk: 
               :IsVHD: true
               :HasSharedStorage: false
@@ -2573,41 +3013,41 @@
               :Bus: 0
               :Lun: 0
               :PendingDiskAssociation: false
-              :Classification: *11
-              :VolumeType: BootAndSystem
+              :Classification: *14
+              :VolumeType: None
               :ObjectType: VirtualDiskDrive
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: WS2008R2Core-JK
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-01 13:39:28.900000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.477000000 -05:00
+              :AddedTime: 2016-02-19 20:43:54.673000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.390000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 7aafb2b6-aa59-4831-bca7-30f3a1c17014
+              :ServerConnection: *9
+              :ID: a3b4e4d8-c27e-4e2b-9732-33a6de8c6506
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :ShareSCSIBus: false
           :VirtualNetworkAdapters:
-          - &84
-            :ToString: vm_linux1
+          - &50
+            :ToString: WS2008R2Core-JK
             :Props:
               :SlotId: 0
-              :VirtualNetwork: New Virtual Switch0
+              :VirtualNetwork: vswitch
               :VMwarePortGroup: 
               :MACAddressType: Dynamic
               :EthernetAddressType: Dynamic
               :PhysicalAddressType: Dynamic
-              :MACAddress: 00:15:5D:60:19:04
-              :EthernetAddress: 00:15:5D:60:19:04
-              :PhysicalAddress: 00:15:5D:60:19:04
+              :MACAddress: 00:15:5D:06:AC:21
+              :EthernetAddress: 00:15:5D:06:AC:21
+              :PhysicalAddress: 00:15:5D:06:AC:21
               :RequiredBandwidth: 0
               :VirtualNetworkAdapterType: Synthetic
               :VmwAdapterIndex: 
-              :LogicalNetwork: VM_Network
-              :VMNetwork: VM_Network
+              :LogicalNetwork: *22
+              :VMNetwork: *23
               :VMNetworkServiceSetting: 
               :VMSubnet: 
               :PortClassification: 
@@ -2626,7 +3066,7 @@
               :VirtualNetworkAdapterComplianceErrors: []
               :PerfNetworkKBytesRead: 0
               :PerfNetworkKBytesWrite: 0
-              :DeviceID: Microsoft:FDA2093A-D44F-40A1-BB8C-0F90FCDC1528\08F76628-21A6-4D14-989C-AD39F6FD0A02
+              :DeviceID: Microsoft:6D327596-1341-4072-81F1-2658DB7F073B\BD321C5D-D41B-4C80-8AF0-067973025A30
               :IPv4AddressType: Dynamic
               :IPv6AddressType: Dynamic
               :IPv4Addresses: []
@@ -2634,36 +3074,36 @@
               :PortACL: 
               :ObjectType: VirtualNetworkAdapter
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: WS2008R2Core-JK
               :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-23 11:49:32.300000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.480000000 -05:00
+              :Description: auto-discovered
+              :AddedTime: 2016-02-03 00:49:36.330000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.393000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 1062da4b-4642-4c4a-a10a-29a2bc6130bb
+              :ServerConnection: *9
+              :ID: d1b68d59-29b8-452e-b76a-7a9ad1ca5fdd
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualFibreChannelAdapters: []
           :HasVirtualFibreChannelAdapters: false
-          :VirtualFloppyDrive: &85
-            :ToString: vm_linux1
+          :VirtualFloppyDrive: &51
+            :ToString: WS2008R2Core-JK
             :Props:
               :Connection: None
               :VirtualFloppyDisk: 
               :ObjectType: VirtualFloppyDrive
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: WS2008R2Core-JK
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-01 13:39:25.037000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.480000000 -05:00
+              :AddedTime: 2016-02-03 00:49:25.213000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.393000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 4a40d2cc-4f72-4fb1-abe0-4b6893994685
+              :ServerConnection: *9
+              :ID: f6e8f6ce-342f-48be-bc7f-ec92652eea88
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
@@ -2678,8 +3118,8 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM1
-              :ServerConnection: *8
-              :ID: c4d1d097-0643-4965-8d01-ef5fa06ec2b7
+              :ServerConnection: *9
+              :ID: b5ea5b63-6f84-4448-96a6-a43a9a841dd1
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
@@ -2694,15 +3134,15 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM2
-              :ServerConnection: *8
-              :ID: 802aea0a-6059-4356-b1a4-6d0f6703e27b
+              :ServerConnection: *9
+              :ID: b1665dc2-6414-450d-8183-8ea29ce23681
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
               :IsFullyCached: true
           :VirtualSCSIAdapters:
-          - &86
-            :ToString: vm_linux1
+          - &52
+            :ToString: WS2008R2Core-JK
             :Props:
               :AdapterID: 255
               :Bus: 0
@@ -2710,136 +3150,69 @@
               :SCSIControllerType: DefaultTypeNoType
               :ObjectType: VirtualSCSIAdapter
               :Accessibility: Public
-              :Name: vm_linux1
+              :Name: WS2008R2Core-JK
               :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-01 13:39:25.043000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.477000000 -05:00
+              :Description: auto-discovered
+              :AddedTime: 2016-02-03 00:49:29.173000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.390000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: b4b5b43f-61c4-40ed-9531-035fd2ffdeef
+              :ServerConnection: *9
+              :ID: e0fbe5b6-b7bb-43eb-b5f2-f8bb390ed688
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :CapabilityProfile: 
-          :CapabilityProfileCompatibilityState:
-            :ToString: Compatible
-            :I32: 0
-          :VMCheckpoints: []
-          :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+          :CapabilityProfileCompatibilityState: 
+          :VMCheckpoints:
+          - *26
+          :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
           :HostType:
             :ToString: VMHost
             :I32: 9
-          :HostName: dell-r410-03.cloudformswin.lab.redhat.com
+          :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
           :VMHost: *1
           :LibraryServer: 
           :CloudId: 
           :Cloud: 
           :LibraryGroup: 
           :GrantedToList: []
-          :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
-          :UserRole: *3
-          :Owner: CLOUDFORMSWIN\scvmm
+          :UserRoleID: 00000000-0000-0000-0000-000000000000
+          :UserRole: 
+          :Owner: 
           :ObjectType:
             :ToString: VM
             :I32: 1
           :Accessibility:
             :ToString: Public
             :I32: 0
-          :Name: vm_linux1
+          :Name: WS2008R2Core-JK
           :IsViewOnly: false
           :Description: 
-          :AddedTime: 2016-02-01 13:39:24.990000000 -05:00
-          :ModifiedTime: 2016-02-29 19:18:07.470499500 -05:00
+          :AddedTime: 2016-02-03 00:49:25.200000000 -05:00
+          :ModifiedTime: 2016-07-10 18:57:04.387000000 -04:00
           :Enabled: true
-          :ServerConnection: *8
-          :ID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
+          :ServerConnection: *9
+          :ID: 14249d0a-0bd8-44cb-9edc-53707f66053f
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *18
+          :MostRecentTaskIfLocal: 
         :MS:
-          :ServicingWindows: *9
+          :ServicingWindows: *11
       :Networks: 
       :vmnet:
         :MS:
-          :VMNetwork: &22
-            :ToString: VM_Network
-            :Props:
-              :Name: VM_Network
-              :LogicalNetwork: &21
-                :ToString: VM_Network
-                :Props:
-                  :Name: VM_Network
-                  :Description: 
-                  :IsViewOnly: false
-                  :NetworkVirtualizationEnabled: true
-                  :UseGRE: true
-                  :IsPVLAN: false
-                  :SupportsExternalVMNetworkProvisioning: false
-                  :SupportsIPSubnetConfigurationOnExternalVMNetworkDefinitions: false
-                  :SupportsExternalVMNetworkDefinitionCreationWithoutIPSubnets: false
-                  :IsLogicalNetworkDefinitionIsolated: false
-                  :AllowDynamicVlanOnVnic: false
-                  :DefaultNetworkManagerForVMNetworkCreation: 
-                  :ExternalId: ddacb1ce-3450-481e-95be-6ecb1d499020
-                  :LastModifiedByNetworkManager: 
-                  :ExternalSyncTime: 
-                  :ServerConnection: *8
-                  :ID: ddacb1ce-3450-481e-95be-6ecb1d499020
-                  :ObjectType: LogicalNetwork
-                  :MarkedForDeletion: false
-                  :IsFullyCached: true
-              :VMSubnet: []
-              :VMNetworkGateways: []
-              :VPNConnections: []
-              :NATConnections: []
-              :RoutingDomainId: 50fbf692-581f-4742-ae67-41450a4bd8de
-              :IsolationType:
-                :ToString: NoIsolation
-                :I32: 0
-              :UseGRE: 
-              :PAIPAddressPoolType: 
-              :CAIPAddressPoolType: 
-              :ExternalName: 
-              :NetworkEntityAccessType:
-                :ToString: VmmManaged
-                :I32: 0
-              :IsAssigned: true
-              :IsPrivateVlan: false
-              :HasGatewayConnection: false
-              :NetworkManager: 
-              :PortACL: 
-              :GrantedToList: []
-              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
-              :UserRole: *3
-              :Owner: CLOUDFORMSWIN\Administrator
-              :ObjectType:
-                :ToString: VMNetwork
-                :I32: 172
-              :Accessibility:
-                :ToString: Public
-                :I32: 0
-              :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-29 19:59:09.447492300 -05:00
-              :ModifiedTime: 2016-02-17 11:35:32.123000000 -05:00
-              :Enabled: true
-              :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 3aa983df-43b3-40aa-8a5e-8a6a085a995b
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
-      :DVDs: *9
-    :c4425913-7043-4d2a-a229-75f051a8127b:
+          :VMNetwork: *23
+      :DVDs: []
+    :a645d581-9cb4-492a-9b68-c5b4610f4d93:
       :Properties:
-        :ToString: linux2
+        :ToString: jerrykbiker-dnd
         :Props:
-          :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2\Virtual Machines\95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84.xml
+          :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd\\Virtual
+            Machines\\D275BD15-FE85-48E3-89C4-EDDDE1EB79D9.xml"
           :MarkedAsTemplate: false
-          :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-          :VMId: 95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84
+          :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+          :VMId: D275BD15-FE85-48E3-89C4-EDDDE1EB79D9
           :VMResourceGroup: 
           :VMConfigResource: 
           :VMConfigResourceStatus:
@@ -2849,17 +3222,17 @@
           :VMResourceStatus:
             :ToString: ClusterResourceStateUnknown
             :I32: -1
-          :DiskResources: &87 []
-          :UnsupportedReason: *19
-          :RefresherErrors: &88 []
+          :DiskResources: &65 []
+          :UnsupportedReason: *27
+          :RefresherErrors: &66 []
           :VirtualMachineState:
             :ToString: Running
             :I32: 0
-          :HostGroupPath: All Hosts\linux2
-          :TotalSize: 665147392
-          :MemoryAssignedMB: 512
+          :HostGroupPath: All Hosts\jerrykbiker-dnd
+          :TotalSize: 12797134848
+          :MemoryAssignedMB: 6120
           :MemoryAvailablePercentage: '0'
-          :DynamicMemoryDemandMB: 512
+          :DynamicMemoryDemandMB: 6120
           :DynamicMemoryStatus: 
           :AllocatedGPU: 
           :HasPassthroughDisk: false
@@ -2871,17 +3244,17 @@
           :HasSavedState: false
           :StatusString: Running
           :StartAction:
-            :ToString: NeverAutoTurnOnVM
-            :I32: 0
+            :ToString: TurnOnVMIfRunningWhenVSStopped
+            :I32: 2
           :StopAction:
             :ToString: SaveVM
             :I32: 0
           :RunGuestAccount: 
           :DelayStart: 0
-          :BiosGuid: a3bd95a2-dd8d-4242-bd57-02621c4eb153
+          :BiosGuid: 3d8039e7-236b-4bb1-901d-d4735b4018f8
           :CPUUtilization: 0
-          :PerfCPUUtilization: 0
-          :PerfMemory: 512
+          :PerfCPUUtilization: 4
+          :PerfMemory: 6120
           :PerfDiskBytesRead: 0
           :PerfDiskBytesWrite: 0
           :PerfNetworkBytesRead: 0
@@ -2889,8 +3262,8 @@
           :VirtualizationPlatform:
             :ToString: HyperV
             :I32: 2
-          :ComputerNameString: Unknown
-          :CreationSource: Temporary Template1900162c-12ba-4cfa-b9f8-c2f0a3e08d43
+          :ComputerNameString: jerrykbiker-dnd
+          :CreationSource: Temporary Templatefe3719c0-3dbd-4c6b-81af-e7c4c894c34e
           :IsUndergoingLiveMigration: false
           :SourceObjectType: VM Template
           :OperatingSystemShutdownEnabled: true
@@ -2900,7 +3273,7 @@
           :BackupEnabled: true
           :ExcludeFromPRO: false
           :FailedJobID: 
-          :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
+          :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd"
           :SelfServiceUserRole: 
           :PassThroughDisks: []
           :ComputerTier: 
@@ -2909,31 +3282,8 @@
           :CloudVmRoleName: 
           :UpgradeDomain: 
           :SCApplications: []
-          :LastRestoredCheckpointID: 406845EA-0CF6-44CD-9D96-24A157DF5736
-          :LastRestoredVMCheckpoint: &24
-            :ToString: linux2 - (02/23/2016 10:35:23)
-            :Props:
-              :ParentCheckpointID: 95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84
-              :CheckpointID: 406845EA-0CF6-44CD-9D96-24A157DF5736
-              :VMId: c4425913-7043-4d2a-a229-75f051a8127b
-              :IsViewOnly: false
-              :CheckpointHWProfile: Microsoft.SystemCenter.VirtualMachineManager.CheckpointHardwareProfile
-              :VirtualDiskDrives:
-              - linux2 - (02/23/2016 10:35:23)
-              :VM: linux2
-              :ObjectType: VMSnapshot
-              :Accessibility: Public
-              :Name: linux2 - (02/23/2016 10:35:23)
-              :Description: 
-              :AddedTime: 2016-02-23 10:35:28.517000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.243000000 -05:00
-              :Enabled: true
-              :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: add88a2d-384a-4a2f-a34e-2985587a4026
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
+          :LastRestoredCheckpointID: D275BD15-FE85-48E3-89C4-EDDDE1EB79D9
+          :LastRestoredVMCheckpoint: 
           :ComplianceStatus: 
           :IsFaultTolerant: false
           :DeploymentErrorInfo: 
@@ -2941,31 +3291,31 @@
           :DeploymentState:
             :ToString: Undeployed
             :I32: 0
-          :TieredPerfData: &89
-            :ToString: c4425946-7043-4d2a-a229-75f051a8127b
+          :TieredPerfData: &67
+            :ToString: a645d5d4-9cb4-492a-9b68-c5b4610f4d93
             :Props:
               :IsViewOnly: false
-              :Name: c4425946-7043-4d2a-a229-75f051a8127b
-              :ServerConnection: *8
-              :ID: c4425946-7043-4d2a-a229-75f051a8127b
+              :Name: a645d5d4-9cb4-492a-9b68-c5b4610f4d93
+              :ServerConnection: *9
+              :ID: a645d5d4-9cb4-492a-9b68-c5b4610f4d93
               :ObjectType: TieredPerfData
               :MarkedForDeletion: false
               :IsFullyCached: true
-              :TieredCPUUtilization: 0
-              :TieredMemory: 512
+              :TieredCPUUtilization: 4
+              :TieredMemory: 6120
               :TieredDiskBytesRead: 0
               :TieredDiskBytesWrite: 0
               :TieredNetworkBytesRead: 0
               :TieredNetworkBytesWrite: 0
-              :PerfCPUUtilization: 0
-              :PerfMemoryConsumed: 512
+              :PerfCPUUtilization: 4
+              :PerfMemoryConsumed: 6120
               :PerfMemoryPressurePercent: 100
               :PerfDiskBytesRead: 0
               :PerfDiskBytesWrite: 0
               :PerfNetworkBytesRead: 0
               :PerfNetworkBytesWrite: 0
               :AverageDiskIO: 0
-              :data: "(TieredPerfCounterData#0) { id = c4425946-7043-4d2a-a229-75f051a8127b
+              :data: "(TieredPerfCounterData#0) { id = a645d5d4-9cb4-492a-9b68-c5b4610f4d93
                 }"
           :ReplicationSetting: 
           :ReplicationStatus: 
@@ -2986,36 +3336,36 @@
           :ClusterPreferredOwner: 
           :AvailabilitySetNames: 
           :LiveCloningEnabled: true
-          :MostRecentTaskID: f0cbd7d9-322b-429e-84b2-919a5cdcc979
+          :MostRecentTaskID: bf2dcff2-07ce-4fe4-81fb-c7b41ac224c1
           :MostRecentTaskUIState:
             :ToString: Completed
             :I32: 5
-          :MostRecentTask: &25
-            :ToString: Change properties of virtual machine
+          :MostRecentTask: &31
+            :ToString: Refresh Virtual Machine State
             :Props:
               :StepsLoaded: true
               :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Change properties of virtual machine
+              :Description: Refresh Virtual Machine State
               :IsVisible: true
               :Status: Completed
               :StatusString: Completed
               :ErrorInfo: Success (0)
-              :StartTime: 2016-02-23 11:21:35.097000000 -05:00
-              :EndTime: 2016-02-23 11:21:56.330000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Change properties of virtual machine
+              :StartTime: 2016-05-18 16:57:47.187000000 -04:00
+              :EndTime: 2016-05-18 16:57:47.317000000 -04:00
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :SessionOwner: CFME-QE-VMM-AD\Administrator
+              :Name: Refresh Virtual Machine State
               :Steps:
               - Microsoft.SystemCenter.VirtualMachineManager.Step
               :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
               :ProgressValue: 100
               :Progress: 100 %
               :WasNotifiedOfCancel: false
-              :CmdletName: Set-SCVirtualMachine
+              :CmdletName: "(Refresh VM State - Event Based System Job)"
               :PROTipID: 
-              :ResultObjectID: c4425913-7043-4d2a-a229-75f051a8127b
-              :TargetObjectID: c4425913-7043-4d2a-a229-75f051a8127b
+              :ResultObjectID: a645d581-9cb4-492a-9b68-c5b4610f4d93
+              :TargetObjectID: a645d581-9cb4-492a-9b68-c5b4610f4d93
               :TargetObjectType: VM
               :IsCompleted: true
               :AreAuditRecordsAvailable: false
@@ -3025,42 +3375,618 @@
               :Target: 
               :ResultObjectType: VM
               :ResultObjectTypeName: Virtual Machine
-              :ResultName: linux2
+              :ResultName: jerrykbiker-dnd
               :IsRestartable: false
               :IsStoppable: false
-              :ServerConnection: *8
-              :ID: f0cbd7d9-322b-429e-84b2-919a5cdcc979
+              :ServerConnection: *9
+              :ID: bf2dcff2-07ce-4fe4-81fb-c7b41ac224c1
               :IsViewOnly: false
               :ObjectType: Job
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
-          :CreationTime: 2016-02-22 11:52:19.483000000 -05:00
-          :OperatingSystem: &90
-            :ToString: Red Hat Enterprise Linux 7 (64 bit)
+          :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd"
+          :CreationTime: 2016-03-23 11:58:27.417000000 -04:00
+          :OperatingSystem: *28
+          :HasVMAdditions: true
+          :VMAddition: Detected
+          :NumLockEnabled: false
+          :CPUCount: 4
+          :IsHighlyAvailable: false
+          :HAVMPriority: 
+          :IsDRProtectionRequired: false
+          :RecoveryPointObjective: 
+          :ProtectionProvider: 
+          :ReplicationGroupId: 
+          :ReplicationGroup: 
+          :LimitCPUFunctionality: false
+          :LimitCPUForMigration: false
+          :Memory: 6120
+          :DynamicMemoryEnabled: false
+          :DynamicMemoryMaximumMB: 
+          :DynamicMemoryBufferPercentage: 
+          :MemoryWeight: 5000
+          :VirtualVideoAdapterEnabled: false
+          :MonitorMaximumCount: 
+          :MonitorResolutionMaximum: 
+          :BootOrder: &68
+          - :ToString: CD
+            :I32: 1
+          - :ToString: IdeHardDrive
+            :I32: 2
+          - :ToString: PxeBoot
+            :I32: 3
+          - :ToString: Floppy
+            :I32: 0
+          :FirstBootDevice: 
+          :SecureBootEnabled: 
+          :ComputerName: jerrykbiker-dnd
+          :UseHardwareAssistedVirtualization: true
+          :SANStatus: &69
+          - :ToString: CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
             :Props:
-              :Name: Red Hat Enterprise Linux 7 (64 bit)
-              :Description: Red Hat Enterprise Linux 7 (64 bit)
-              :Version: 
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 26277
+              :ErrorCodeString: '26277'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : CannotGetVolumeInfoDueToUncShareInRemoteMachine
+                ; Message : Cannot get the host volume information because the given
+                path \\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\scvmm2\jerrykbiker-dnd\
+                is a share path and not local to host of the virtual machine . ; Recommended
+                Action : '
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: Cannot get the host volume information because the given path
+                \\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\scvmm2\jerrykbiker-dnd\
+                is a share path and not local to host of the virtual machine .
+              :CloudProblem: Cannot get the host volume information because the given
+                path \\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\scvmm2\jerrykbiker-dnd\
+                is a share path and not local to host of the virtual machine .
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :FolderPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd\\"
+                :VMName: 
+              :Code: CannotGetVolumeInfoDueToUncShareInRemoteMachine
+              :GetMessageFormatterHandler: 
+          :CostCenter: 
+          :QuotaPoint: 1
+          :IsTagEmpty: true
+          :Tag: "(none)"
+          :CustomProperties:
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          - 
+          :CustomProperty: {}
+          :UndoDisksEnabled: false
+          :CPUType: *19
+          :ExpectedCPUUtilization: 20
+          :DiskIO: 0
+          :NetworkUtilization: 0
+          :RelativeWeight: 100
+          :CPUReserve: 0
+          :CPUMax: 100
+          :CPUPerVirtualNumaNodeMaximum: 8
+          :MemoryPerVirtualNumaNodeMaximumMB: 34918
+          :VirtualNumaNodesPerSocketMaximum: 1
+          :DynamicMemoryMinimumMB: 
+          :NumaIsolationRequired: false
+          :Generation: 1
+          :VirtualDVDDrives:
+          - &70
+            :ToString: jerrykbiker-dnd
+            :Props:
+              :Connection: ISOImage
+              :ISOId: 9d6efd9b-70fb-46cc-bd5d-1e093d51543e
+              :ISO: LinuxAgent
+              :HostDrive: 
+              :BusType: IDE
+              :Bus: 1
+              :Lun: 0
+              :ISOLinked: false
+              :ObjectType: VirtualDVDDrive
+              :Accessibility: Public
+              :Name: jerrykbiker-dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-23 11:59:45.783000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.377000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 9b2cf7f3-e987-408f-859c-15c507841931
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualHardDisks:
+          - &30
+            :ToString: miq-nightly-201603222000.vhd
+            :Props:
+              :OperatingSystem: *20
+              :VHDType: DynamicallyExpanding
+              :VHDFormatType: VHD
+              :VirtualizationPlatform: HyperV
+              :MaximumSize: 42951106560
+              :ParentDisk: 
+              :SANCopyCapable: false
+              :IsCachedVhd: false
+              :ComplianceStatus: 
+              :Tag: 
+              :HasProductKey: false
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd\\miq-nightly-201603222000.vhd"
+              :Release: 
+              :State: Normal
+              :LibraryShareId: 00000000-0000-0000-0000-000000000000
+              :SharePath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd\\miq-nightly-201603222000.vhd"
+              :FileShare: *29
+              :Directory: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd"
+              :Size: 12789534720
+              :IsOrphaned: false
+              :FamilyName: 
+              :Namespace: 
+              :ReleaseTime: 
+              :HostVolumeId: 
+              :HostVolume: 
+              :Classification: *8
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VirtualHardDisk
+              :Accessibility: Internal
+              :Name: miq-nightly-201603222000.vhd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-23 11:58:29.090000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.373000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 53377e76-2fad-45bf-ade6-4ea3912f83bc
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualDiskDrives:
+          - &71
+            :ToString: jerrykbiker-dnd
+            :Props:
+              :VirtualHardDiskId: 53377e76-2fad-45bf-ade6-4ea3912f83bc
+              :VirtualHardDisk: *30
+              :PassThroughDisk: 
+              :IsVHD: true
+              :HasSharedStorage: false
+              :CreateDiffDisk: false
+              :BusType: IDE
+              :Bus: 0
+              :Lun: 0
+              :PendingDiskAssociation: false
+              :Classification: *8
+              :VolumeType: None
+              :ObjectType: VirtualDiskDrive
+              :Accessibility: Public
+              :Name: jerrykbiker-dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-23 11:58:29.043000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.373000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: cbd0449b-90ff-43b9-addc-e763c5f09de9
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ShareSCSIBus: false
+          :VirtualNetworkAdapters:
+          - &72
+            :ToString: jerrykbiker-dnd
+            :Props:
+              :SlotId: 0
+              :VirtualNetwork: vswitch
+              :VMwarePortGroup: 
+              :MACAddressType: Dynamic
+              :EthernetAddressType: Dynamic
+              :PhysicalAddressType: Dynamic
+              :MACAddress: 00:15:5D:06:AC:3F
+              :EthernetAddress: 00:15:5D:06:AC:3F
+              :PhysicalAddress: 00:15:5D:06:AC:3F
+              :RequiredBandwidth: 0
+              :VirtualNetworkAdapterType: Synthetic
+              :VmwAdapterIndex: 
+              :LogicalNetwork: *22
+              :VMNetwork: *23
+              :VMNetworkServiceSetting: 
+              :VMSubnet: 
+              :PortClassification: 
+              :VirtualNetworkAdapterPortProfileSet: 
+              :LogicalSwitch: 
+              :GuestIPNetworkVirtualizationUpdatesEnabled: false
+              :MACAddressSpoofingEnabled: false
+              :MACAddressesSpoofingEnabled: false
+              :VMNetworkOptimizationEnabled: false
+              :VLanEnabled: false
+              :VLanID: 0
+              :UsesSriov: false
+              :IsUsedForHostManagement: false
+              :VirtualNetworkAdapterComplianceStatus: Compliant
+              :TemplateNicName: 
+              :VirtualNetworkAdapterComplianceErrors: []
+              :PerfNetworkKBytesRead: 0
+              :PerfNetworkKBytesWrite: 0
+              :DeviceID: Microsoft:D275BD15-FE85-48E3-89C4-EDDDE1EB79D9\0AA9AAC4-2916-4C87-BC00-863264399DC9
+              :IPv4AddressType: Dynamic
+              :IPv6AddressType: Dynamic
+              :IPv4Addresses: []
+              :IPv6Addresses: []
+              :PortACL: 
+              :ObjectType: VirtualNetworkAdapter
+              :Accessibility: Public
+              :Name: jerrykbiker-dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-23 11:58:27.577000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.380000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 7c07b9a3-bf39-420a-a8db-5dd2988efdbc
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualFibreChannelAdapters: []
+          :HasVirtualFibreChannelAdapters: false
+          :VirtualFloppyDrive: &73
+            :ToString: jerrykbiker-dnd
+            :Props:
+              :Connection: None
+              :VirtualFloppyDisk: 
+              :ObjectType: VirtualFloppyDrive
+              :Accessibility: Public
+              :Name: jerrykbiker-dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-23 11:58:27.570000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.380000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 640dd0ab-7e07-42f4-a291-95598c1bfa74
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :VirtualCOMPorts:
+          - :ToString: COM1
+            :Props:
+              :PortNumber: 1
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM1
+              :ServerConnection: *9
+              :ID: c45d4307-8a5b-4970-8702-b7a2c426fa99
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: COM2
+            :Props:
+              :PortNumber: 2
+              :Connection: None
+              :HostPort: 
+              :VMHostCOMPort: 
+              :WaitForModem: 
+              :TextFile: 
+              :NamedPipe: 
+              :Name: COM2
+              :ServerConnection: *9
+              :ID: fe2d176b-1bf7-4272-a240-9faa8ca4cbe1
+              :IsViewOnly: false
+              :ObjectType: None
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VirtualSCSIAdapters:
+          - &74
+            :ToString: jerrykbiker-dnd
+            :Props:
+              :AdapterID: 255
+              :Bus: 0
+              :Shared: false
+              :SCSIControllerType: DefaultTypeNoType
+              :ObjectType: VirtualSCSIAdapter
+              :Accessibility: Public
+              :Name: jerrykbiker-dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-23 11:58:27.560000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.373000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 7436b06a-4512-43b9-a7f8-a73f2bb90e29
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :CapabilityProfile: 
+          :CapabilityProfileCompatibilityState:
+            :ToString: Compatible
+            :I32: 0
+          :VMCheckpoints: []
+          :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+          :HostType:
+            :ToString: VMHost
+            :I32: 9
+          :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :VMHost: *1
+          :LibraryServer: 
+          :CloudId: 
+          :Cloud: 
+          :LibraryGroup: 
+          :GrantedToList: []
+          :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+          :UserRole: *3
+          :Owner: CFME-QE-VMM-AD\Administrator
+          :ObjectType:
+            :ToString: VM
+            :I32: 1
+          :Accessibility:
+            :ToString: Public
+            :I32: 0
+          :Name: jerrykbiker-dnd
+          :IsViewOnly: false
+          :Description: 
+          :AddedTime: 2016-03-23 11:58:27.417000000 -04:00
+          :ModifiedTime: 2016-07-10 18:57:09.364784100 -04:00
+          :Enabled: true
+          :ServerConnection: *9
+          :ID: a645d581-9cb4-492a-9b68-c5b4610f4d93
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: *31
+        :MS:
+          :ServicingWindows: *11
+      :Networks: 
+      :vmnet:
+        :MS:
+          :VMNetwork: *23
+      :DVDs:
+      - :MS:
+          :ID: 9d6efd9b-70fb-46cc-bd5d-1e093d51543e
+          :Name: LinuxAgent
+          :SharePath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd\\LinuxAgent.iso"
+          :Size: 7600128
+    :685f8061-9903-4dd0-9a91-874255a68a23:
+      :Properties:
+        :ToString: DualDVDa
+        :Props:
+          :VMCPath: C:\DualDVDa\Virtual Machines\445AE267-8448-4654-B7AB-71339F16B626.xml
+          :MarkedAsTemplate: false
+          :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+          :VMId: 445AE267-8448-4654-B7AB-71339F16B626
+          :VMResourceGroup: 
+          :VMConfigResource: 
+          :VMConfigResourceStatus:
+            :ToString: ClusterResourceStateUnknown
+            :I32: -1
+          :VMResource: 
+          :VMResourceStatus:
+            :ToString: ClusterResourceStateUnknown
+            :I32: -1
+          :DiskResources: &53 []
+          :UnsupportedReason: *27
+          :RefresherErrors: &54 []
+          :VirtualMachineState:
+            :ToString: Running
+            :I32: 0
+          :HostGroupPath: All Hosts\DualDVDa
+          :TotalSize: 10216880128
+          :MemoryAssignedMB: 2048
+          :MemoryAvailablePercentage: '0'
+          :DynamicMemoryDemandMB: 2048
+          :DynamicMemoryStatus: 
+          :AllocatedGPU: 
+          :HasPassthroughDisk: false
+          :HasSharedStorage: false
+          :Status:
+            :ToString: Running
+            :I32: 0
+          :IsOrphaned: false
+          :HasSavedState: false
+          :StatusString: Running
+          :StartAction:
+            :ToString: TurnOnVMIfRunningWhenVSStopped
+            :I32: 2
+          :StopAction:
+            :ToString: SaveVM
+            :I32: 0
+          :RunGuestAccount: 
+          :DelayStart: 0
+          :BiosGuid: c63a8f5e-b320-4d1a-9bb8-4dfd185be0e7
+          :CPUUtilization: 0
+          :PerfCPUUtilization: 0
+          :PerfMemory: 2048
+          :PerfDiskBytesRead: 0
+          :PerfDiskBytesWrite: 0
+          :PerfNetworkBytesRead: 0
+          :PerfNetworkBytesWrite: 0
+          :VirtualizationPlatform:
+            :ToString: HyperV
+            :I32: 2
+          :ComputerNameString: WIN-AQTG41U5HJC
+          :CreationSource: Win12SCoreTemplate
+          :IsUndergoingLiveMigration: false
+          :SourceObjectType: VM Template
+          :OperatingSystemShutdownEnabled: true
+          :TimeSynchronizationEnabled: true
+          :DataExchangeEnabled: true
+          :HeartbeatEnabled: true
+          :BackupEnabled: true
+          :ExcludeFromPRO: false
+          :FailedJobID: 
+          :CheckpointLocation: C:\DualDVDa
+          :SelfServiceUserRole: 
+          :PassThroughDisks: []
+          :ComputerTier: 
+          :ConnectToAddresses: []
+          :CloudVmRoleId: 
+          :CloudVmRoleName: 
+          :UpgradeDomain: 
+          :SCApplications: []
+          :LastRestoredCheckpointID: 445AE267-8448-4654-B7AB-71339F16B626
+          :LastRestoredVMCheckpoint: 
+          :ComplianceStatus: 
+          :IsFaultTolerant: false
+          :DeploymentErrorInfo: 
+          :ServiceDeploymentErrorMessage: 
+          :DeploymentState:
+            :ToString: Undeployed
+            :I32: 0
+          :TieredPerfData: &55
+            :ToString: 685f8034-9903-4dd0-9a91-874255a68a23
+            :Props:
+              :IsViewOnly: false
+              :Name: 685f8034-9903-4dd0-9a91-874255a68a23
+              :ServerConnection: *9
+              :ID: 685f8034-9903-4dd0-9a91-874255a68a23
+              :ObjectType: TieredPerfData
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :TieredCPUUtilization: 0
+              :TieredMemory: 2048
+              :TieredDiskBytesRead: 0
+              :TieredDiskBytesWrite: 0
+              :TieredNetworkBytesRead: 0
+              :TieredNetworkBytesWrite: 0
+              :PerfCPUUtilization: 0
+              :PerfMemoryConsumed: 2048
+              :PerfMemoryPressurePercent: 100
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :AverageDiskIO: 0
+              :data: "(TieredPerfCounterData#0) { id = 685f8034-9903-4dd0-9a91-874255a68a23
+                }"
+          :ReplicationSetting: 
+          :ReplicationStatus: 
+          :IsRecoveryVM: false
+          :IsPrimaryVM: false
+          :IsTestReplicaVM: false
+          :ReplicationState: 
+          :ReplicationHealth: 
+          :ReplicationMode: 
+          :LastReplicationTime: 
+          :IsDREnabled: false
+          :DRState:
+            :ToString: Disabled
+            :I32: 0
+          :DRErrors: []
+          :HasDRError: false
+          :ClusterNonPossibleOwner: 
+          :ClusterPreferredOwner: 
+          :AvailabilitySetNames: 
+          :LiveCloningEnabled: true
+          :MostRecentTaskID: a7abd456-07f6-4290-b1ba-0c580e454f19
+          :MostRecentTaskUIState:
+            :ToString: Completed
+            :I32: 5
+          :MostRecentTask: &33
+            :ToString: Refresh virtual machine
+            :Props:
+              :StepsLoaded: true
+              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :Description: Refresh virtual machine
+              :IsVisible: true
+              :Status: Completed
+              :StatusString: Completed
+              :ErrorInfo: Success (0)
+              :StartTime: 2016-07-08 11:04:35.410000000 -04:00
+              :EndTime: 2016-07-08 11:04:40.077000000 -04:00
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :SessionOwner: CFME-QE-VMM-AD\Administrator
+              :Name: Refresh virtual machine
+              :Steps:
+              - Microsoft.SystemCenter.VirtualMachineManager.Step
+              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :ProgressValue: 100
+              :Progress: 100 %
+              :WasNotifiedOfCancel: false
+              :CmdletName: Read-SCVirtualMachine
+              :PROTipID: 
+              :ResultObjectID: 685f8061-9903-4dd0-9a91-874255a68a23
+              :TargetObjectID: 685f8061-9903-4dd0-9a91-874255a68a23
+              :TargetObjectType: VM
+              :IsCompleted: true
+              :AreAuditRecordsAvailable: false
+              :AuditRecords: []
+              :AdditionalMessages: []
+              :Source: 
+              :Target: 
+              :ResultObjectType: VM
+              :ResultObjectTypeName: Virtual Machine
+              :ResultName: DualDVDa
+              :IsRestartable: false
+              :IsStoppable: false
+              :ServerConnection: *9
+              :ID: a7abd456-07f6-4290-b1ba-0c580e454f19
+              :IsViewOnly: false
+              :ObjectType: Job
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :Location: C:\DualDVDa
+          :CreationTime: 2016-06-24 12:45:54.603000000 -04:00
+          :OperatingSystem: &56
+            :ToString: Windows Server 2012 R2 Standard
+            :Props:
+              :Name: Windows Server 2012 R2 Standard
+              :Description: Windows Server 2012 R2 Standard
+              :Version: '6.3'
               :Architecture: amd64
-              :Edition: 
-              :OSType: Linux
-              :IsWindows: false
-              :ProductType: 
+              :Edition: Standard
+              :OSType: Windows
+              :IsWindows: true
+              :ProductType: VER_NT_SERVER
               :IsCustomizationAllowed: true
-              :IsApplicationDeploymentAllowed: false
+              :IsApplicationDeploymentAllowed: true
               :RequiresAdministratorAccountNameInSysprep: false
-              :RequiresXMLSysprepFormat: false
+              :RequiresXMLSysprepFormat: true
               :AllowsOrgNameInSysprep: false
-              :RequiresPIDInSysprep: true
-              :ServerConnection: *8
-              :ID: 5ee4aa4b-e087-4fb1-856e-da9ed885b904
+              :RequiresPIDInSysprep: false
+              :ServerConnection: *9
+              :ID: 50b66974-c64a-4a06-b05a-7e6610c579a2
               :IsViewOnly: false
               :ObjectType: OperatingSystem
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :HasVMAdditions: false
-          :VMAddition: Not Detected
+          :HasVMAdditions: true
+          :VMAddition: 6.3.9600.16384
           :NumLockEnabled: false
           :CPUCount: 1
           :IsHighlyAvailable: false
@@ -3072,15 +3998,15 @@
           :ReplicationGroup: 
           :LimitCPUFunctionality: false
           :LimitCPUForMigration: false
-          :Memory: 512
-          :DynamicMemoryEnabled: true
-          :DynamicMemoryMaximumMB: 1048576
-          :DynamicMemoryBufferPercentage: 20
+          :Memory: 2048
+          :DynamicMemoryEnabled: false
+          :DynamicMemoryMaximumMB: 
+          :DynamicMemoryBufferPercentage: 
           :MemoryWeight: 5000
           :VirtualVideoAdapterEnabled: false
           :MonitorMaximumCount: 
           :MonitorResolutionMaximum: 
-          :BootOrder: &91
+          :BootOrder: &57
           - :ToString: CD
             :I32: 1
           - :ToString: IdeHardDrive
@@ -3091,9 +4017,9 @@
             :I32: 0
           :FirstBootDevice: 
           :SecureBootEnabled: 
-          :ComputerName: 
+          :ComputerName: WIN-AQTG41U5HJC
           :UseHardwareAssistedVirtualization: true
-          :SANStatus: &92
+          :SANStatus: &58
           - :ToString: DeployLUNNotFoundUsingStorageProvider (26207)
             :Props:
               :Exception: 
@@ -3102,7 +4028,7 @@
               :ErrorCodeString: '26207'
               :ErrorType: Error
               :CSMMessageString: 'Error Code : DeployLUNNotFoundUsingStorageProvider
-                ; Message : Virtual Machine linux2 resides on a LUN, which is not
+                ; Message : Virtual Machine DualDVDa resides on a LUN, which is not
                 visible to any of the storage providers. ; Recommended Action : Ensure
                 that the storage provider is added to Virtual Machine Manager server.
                 Then try the operation again.'
@@ -3114,9 +4040,9 @@
               :DetailedErrorCode: 
               :IsMomAlert: false
               :MomAlertSeverity: Error
-              :Problem: Virtual Machine linux2 resides on a LUN, which is not visible
+              :Problem: Virtual Machine DualDVDa resides on a LUN, which is not visible
                 to any of the storage providers.
-              :CloudProblem: Virtual Machine linux2 resides on a LUN, which is not
+              :CloudProblem: Virtual Machine DualDVDa resides on a LUN, which is not
                 visible to any of the storage providers.
               :RecommendedAction: Ensure that the storage provider is added to Virtual
                 Machine Manager server. Then try the operation again.
@@ -3126,7 +4052,7 @@
               :DetailedSource: None
               :ExceptionDetails: 
               :MessageParameters:
-                :VMName: linux2
+                :VMName: DualDVDa
               :Code: DeployLUNNotFoundUsingStorageProvider
               :GetMessageFormatterHandler: 
           :CostCenter: 
@@ -3146,7 +4072,7 @@
           - 
           :CustomProperty: {}
           :UndoDisksEnabled: false
-          :CPUType: *15
+          :CPUType: *19
           :ExpectedCPUUtilization: 20
           :DiskIO: 0
           :NetworkUtilization: 0
@@ -3154,18 +4080,18 @@
           :CPUReserve: 0
           :CPUMax: 100
           :CPUPerVirtualNumaNodeMaximum: 8
-          :MemoryPerVirtualNumaNodeMaximumMB: 63140
+          :MemoryPerVirtualNumaNodeMaximumMB: 34918
           :VirtualNumaNodesPerSocketMaximum: 1
-          :DynamicMemoryMinimumMB: 32
-          :NumaIsolationRequired: false
+          :DynamicMemoryMinimumMB: 
+          :NumaIsolationRequired: 
           :Generation: 1
           :VirtualDVDDrives:
-          - &93
-            :ToString: linux2
+          - &59
+            :ToString: DualDVDa
             :Props:
               :Connection: ISOImage
-              :ISOId: b7da3b77-25ad-4ab6-8999-20fef973e176
-              :ISO: CentOS-7-x86_64-Minimal-1511.iso
+              :ISOId: 005bf420-ddbb-46a6-bf46-b4c1ed3c18bb
+              :ISO: en_office_professional_plus_2016_x005F_x86_x005F_x64_dvd_6962141
               :HostDrive: 
               :BusType: IDE
               :Bus: 1
@@ -3173,54 +4099,77 @@
               :ISOLinked: false
               :ObjectType: VirtualDVDDrive
               :Accessibility: Public
-              :Name: linux2
+              :Name: DualDVDa
               :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-22 11:52:19.583000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
+              :Description: auto-discovered
+              :AddedTime: 2016-06-24 12:45:54.747000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.023000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: e466dac1-19b1-43cf-9aaa-8c3f3ce28df1
+              :ServerConnection: *9
+              :ID: d0695eaa-1525-433e-a2a5-feae5aa2f04a
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          - &60
+            :ToString: DualDVDa
+            :Props:
+              :Connection: ISOImage
+              :ISOId: c5760f67-6d30-4916-bb79-3d80a0bb8e07
+              :ISO: en_visio_professional_2016_x005F_x86_x005F_x64_dvd_6962139
+              :HostDrive: 
+              :BusType: IDE
+              :Bus: 1
+              :Lun: 1
+              :ISOLinked: false
+              :ObjectType: VirtualDVDDrive
+              :Accessibility: Public
+              :Name: DualDVDa
+              :IsViewOnly: false
+              :Description: auto-discovered
+              :AddedTime: 2016-06-24 14:02:29.523000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.023000000 -04:00
+              :Enabled: true
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 8e948ca0-45a6-425a-afe0-70787f54587e
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualHardDisks:
-          - &20
-            :ToString: Blank Disk - Small_77376D2F-3967-476A-942A-6314A3337EEC
+          - &32
+            :ToString: SmallWin12Template
             :Props:
-              :OperatingSystem: *16
-              :VHDType: Differencing
-              :VHDFormatType: VHD
+              :OperatingSystem: *20
+              :VHDType: DynamicallyExpanding
+              :VHDFormatType: VHDX
               :VirtualizationPlatform: HyperV
-              :MaximumSize: 17179869184
-              :ParentDisk: Blank Disk - Small.vhd
+              :MaximumSize: 32212254720
+              :ParentDisk: 
               :SANCopyCapable: false
               :IsCachedVhd: false
               :ComplianceStatus: 
               :Tag: 
               :HasProductKey: false
-              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2\Blank Disk
-                - Small_77376D2F-3967-476A-942A-6314A3337EEC.avhd
+              :Location: C:\DualDVDa\SmallWin12Template.vhdx
               :Release: 
               :State: Normal
               :LibraryShareId: 00000000-0000-0000-0000-000000000000
-              :SharePath: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2\Blank Disk
-                - Small_77376D2F-3967-476A-942A-6314A3337EEC.avhd
+              :SharePath: C:\DualDVDa\SmallWin12Template.vhdx
               :FileShare: 
-              :Directory: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
-              :Size: 110592
+              :Directory: C:\DualDVDa
+              :Size: 5372903424
               :IsOrphaned: false
               :FamilyName: 
               :Namespace: 
               :ReleaseTime: 
-              :HostVolumeId: 284c1ea0-fc51-474a-bbec-372021806117
+              :HostVolumeId: 8cf02787-8199-4754-b800-0d98dac52640
               :HostVolume:
                 :S: C:\
-              :Classification: *11
-              :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+              :Classification: *14
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
               :HostType: VMHost
-              :HostName: dell-r410-03.cloudformswin.lab.redhat.com
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :VMHost: *1
               :LibraryServer: 
               :CloudId: 
@@ -3232,24 +4181,24 @@
               :Owner: 
               :ObjectType: VirtualHardDisk
               :Accessibility: Internal
-              :Name: Blank Disk - Small_77376D2F-3967-476A-942A-6314A3337EEC
+              :Name: SmallWin12Template
               :IsViewOnly: false
               :Description: auto-discovered
-              :AddedTime: 2016-02-23 10:35:36.247000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.237000000 -05:00
+              :AddedTime: 2016-06-24 12:45:55.837000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.020000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 566be4aa-5ea9-417c-ac8a-a7c75262584f
+              :ServerConnection: *9
+              :ID: d986b343-ccd4-4ebe-b93b-6722a43eaf6b
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualDiskDrives:
-          - &94
-            :ToString: linux2
+          - &61
+            :ToString: DualDVDa
             :Props:
-              :VirtualHardDiskId: 566be4aa-5ea9-417c-ac8a-a7c75262584f
-              :VirtualHardDisk: *20
+              :VirtualHardDiskId: d986b343-ccd4-4ebe-b93b-6722a43eaf6b
+              :VirtualHardDisk: *32
               :PassThroughDisk: 
               :IsVHD: true
               :HasSharedStorage: false
@@ -3258,41 +4207,41 @@
               :Bus: 0
               :Lun: 0
               :PendingDiskAssociation: false
-              :Classification: *11
-              :VolumeType: BootAndSystem
+              :Classification: *14
+              :VolumeType: None
               :ObjectType: VirtualDiskDrive
               :Accessibility: Public
-              :Name: linux2
+              :Name: DualDVDa
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-23 10:35:36.307000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.237000000 -05:00
+              :AddedTime: 2016-06-24 12:45:55.823000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.020000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 8f6f5c5a-75d4-4e29-84b3-462957907cb9
+              :ServerConnection: *9
+              :ID: 8ffe2d90-6ee6-4caf-801f-e24a94edf449
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :ShareSCSIBus: false
           :VirtualNetworkAdapters:
-          - &95
-            :ToString: linux2
+          - &62
+            :ToString: DualDVDa
             :Props:
               :SlotId: 0
-              :VirtualNetwork: New Virtual Switch0
+              :VirtualNetwork: vswitch
               :VMwarePortGroup: 
               :MACAddressType: Dynamic
               :EthernetAddressType: Dynamic
               :PhysicalAddressType: Dynamic
-              :MACAddress: 00:15:5D:60:19:03
-              :EthernetAddress: 00:15:5D:60:19:03
-              :PhysicalAddress: 00:15:5D:60:19:03
+              :MACAddress: 00:15:5D:06:AC:D1
+              :EthernetAddress: 00:15:5D:06:AC:D1
+              :PhysicalAddress: 00:15:5D:06:AC:D1
               :RequiredBandwidth: 0
               :VirtualNetworkAdapterType: Synthetic
               :VmwAdapterIndex: 
-              :LogicalNetwork: *21
-              :VMNetwork: *22
+              :LogicalNetwork: *22
+              :VMNetwork: *23
               :VMNetworkServiceSetting: 
               :VMSubnet: 
               :PortClassification: 
@@ -3311,44 +4260,47 @@
               :VirtualNetworkAdapterComplianceErrors: []
               :PerfNetworkKBytesRead: 0
               :PerfNetworkKBytesWrite: 0
-              :DeviceID: Microsoft:95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84\8AC7272A-5922-4B7F-80D6-8A073C4346AF
+              :DeviceID: Microsoft:445AE267-8448-4654-B7AB-71339F16B626\25DAF439-874C-4CAF-BF98-89A379783955
               :IPv4AddressType: Dynamic
               :IPv6AddressType: Dynamic
-              :IPv4Addresses: []
-              :IPv6Addresses: []
+              :IPv4Addresses:
+              - 10.16.6.197
+              :IPv6Addresses:
+              - fe80::55ce:ef06:7636:514b
+              - 2620:52:0:1007:55ce:ef06:7636:514b
               :PortACL: 
               :ObjectType: VirtualNetworkAdapter
               :Accessibility: Public
-              :Name: linux2
+              :Name: DualDVDa
               :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-22 11:52:19.587000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
+              :Description: auto-discovered
+              :AddedTime: 2016-06-24 12:45:54.763000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.027000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 690f1412-9e45-46da-ad6d-c189c6db205d
+              :ServerConnection: *9
+              :ID: 70b4a2d8-90be-4eef-bf73-fec3cfb90df3
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualFibreChannelAdapters: []
           :HasVirtualFibreChannelAdapters: false
-          :VirtualFloppyDrive: &96
-            :ToString: linux2
+          :VirtualFloppyDrive: &63
+            :ToString: DualDVDa
             :Props:
               :Connection: None
               :VirtualFloppyDisk: 
               :ObjectType: VirtualFloppyDrive
               :Accessibility: Public
-              :Name: linux2
+              :Name: DualDVDa
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-22 11:52:19.587000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
+              :AddedTime: 2016-06-24 12:45:54.753000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.023000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: bb634cfe-216b-44bc-a9bd-a9ba68160e61
+              :ServerConnection: *9
+              :ID: e346c5f7-3ab3-4a98-baff-244a5defbfc0
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
@@ -3363,8 +4315,8 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM1
-              :ServerConnection: *8
-              :ID: cd0cdd03-767e-4898-a58d-7f88b8612731
+              :ServerConnection: *9
+              :ID: e6669441-1b25-4878-a82d-ebc51a56678e
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
@@ -3379,15 +4331,15 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM2
-              :ServerConnection: *8
-              :ID: d440417e-9e39-462f-8672-6614906c5c94
+              :ServerConnection: *9
+              :ID: f74b02f9-035d-46d7-8269-93f56bf544ac
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
               :IsFullyCached: true
           :VirtualSCSIAdapters:
-          - &97
-            :ToString: linux2
+          - &64
+            :ToString: DualDVDa
             :Props:
               :AdapterID: 255
               :Bus: 0
@@ -3395,29 +4347,28 @@
               :SCSIControllerType: DefaultTypeNoType
               :ObjectType: VirtualSCSIAdapter
               :Accessibility: Public
-              :Name: linux2
+              :Name: DualDVDa
               :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-22 11:52:19.583000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.237000000 -05:00
+              :Description: auto-discovered
+              :AddedTime: 2016-06-24 12:45:54.730000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.020000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 5d4a67fc-4e86-4821-b1a8-4a2e11e8dd4c
+              :ServerConnection: *9
+              :ID: fc4095c2-4882-4039-85c6-997021e25344
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :CapabilityProfile: *23
+          :CapabilityProfile: 
           :CapabilityProfileCompatibilityState:
             :ToString: Compatible
             :I32: 0
-          :VMCheckpoints:
-          - *24
-          :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+          :VMCheckpoints: []
+          :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
           :HostType:
             :ToString: VMHost
             :I32: 9
-          :HostName: dell-r410-03.cloudformswin.lab.redhat.com
+          :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
           :VMHost: *1
           :LibraryServer: 
           :CloudId: 
@@ -3426,119 +4377,50 @@
           :GrantedToList: []
           :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
           :UserRole: *3
-          :Owner: CLOUDFORMSWIN\scvmm
+          :Owner: CFME-QE-VMM-AD\Administrator
           :ObjectType:
             :ToString: VM
             :I32: 1
           :Accessibility:
             :ToString: Public
             :I32: 0
-          :Name: linux2
+          :Name: DualDVDa
           :IsViewOnly: false
           :Description: 
-          :AddedTime: 2016-02-22 11:52:19.483000000 -05:00
-          :ModifiedTime: 2016-02-29 19:18:07.230000000 -05:00
+          :AddedTime: 2016-06-24 12:45:54.603000000 -04:00
+          :ModifiedTime: 2016-07-10 18:57:08.013783100 -04:00
           :Enabled: true
-          :ServerConnection: *8
-          :ID: c4425913-7043-4d2a-a229-75f051a8127b
+          :ServerConnection: *9
+          :ID: 685f8061-9903-4dd0-9a91-874255a68a23
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *25
+          :MostRecentTaskIfLocal: *33
         :MS:
-          :ServicingWindows: *9
-      :Networks: 
+          :ServicingWindows: *11
+      :Networks: 10.16.6.197
       :vmnet:
         :MS:
-          :VMNetwork: *22
+          :VMNetwork: *23
       :DVDs:
-        :ToString: CentOS-7-x86_64-Minimal-1511.iso
-        :Props:
-          :Release: 
-          :State:
-            :ToString: Normal
-            :I32: 0
-          :LibraryShareId: 00000000-0000-0000-0000-000000000000
-          :SharePath: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2\CentOS-7-x86_64-Minimal-1511.iso
-          :FileShare: 
-          :Directory: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
-          :Size: 632291328
-          :IsOrphaned: false
-          :FamilyName: 
-          :Namespace: 
-          :ReleaseTime: 
-          :HostVolumeId: 284c1ea0-fc51-474a-bbec-372021806117
-          :HostVolume: &98
-            :ToString: C:\
-            :Props:
-              :Name: C:\
-              :StorageVolumeID: 3d0c4879-d6cf-11e5-80b3-806e6f6e6963
-              :ObjectID: "\\\\?\\Volume{3d0c4879-d6cf-11e5-80b3-806e6f6e6963}\\"
-              :HostVolumeID: 3d0c4879-d6cf-11e5-80b3-806e6f6e6963
-              :MountPoints:
-              - C:\
-              :Capacity: 299630587904
-              :FreeSpace: 267202084864
-              :VolumeLabel: 
-              :FileSystem: NTFS
-              :IsSANMigrationPossible: false
-              :IsClustered: false
-              :IsClusterSharedVolume: false
-              :InUse: false
-              :VMHost: *1
-              :IsAvailableForPlacement: true
-              :HostDiskID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-              :StorageDiskID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-              :HostDisk: *2
-              :StorageDisk: *2
-              :Classification: *11
-              :StoragePool: 
-              :ServerConnection: *8
-              :ID: 284c1ea0-fc51-474a-bbec-372021806117
-              :IsViewOnly: false
-              :ObjectType: VMHostVolume
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :Classification: *11
-          :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-          :HostType:
-            :ToString: VMHost
-            :I32: 9
-          :HostName: dell-r410-03.cloudformswin.lab.redhat.com
-          :VMHost: *1
-          :LibraryServer: 
-          :CloudId: 
-          :Cloud: 
-          :LibraryGroup: 
-          :GrantedToList: []
-          :UserRoleID: 00000000-0000-0000-0000-000000000000
-          :UserRole: 
-          :Owner: 
-          :ObjectType:
-            :ToString: ISO
-            :I32: 6
-          :Accessibility:
-            :ToString: Internal
-            :I32: 1
-          :Name: CentOS-7-x86_64-Minimal-1511.iso
-          :IsViewOnly: false
-          :Description: 
-          :AddedTime: 2016-02-23 11:21:35.710000000 -05:00
-          :ModifiedTime: 2016-02-29 19:18:07.240000000 -05:00
-          :Enabled: true
-          :MostRecentTask: 
-          :ServerConnection: *8
-          :ID: b7da3b77-25ad-4ab6-8999-20fef973e176
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-          :MostRecentTaskIfLocal: 
-    :3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297:
+      - :MS:
+          :ID: 005bf420-ddbb-46a6-bf46-b4c1ed3c18bb
+          :Name: en_office_professional_plus_2016_x005F_x86_x005F_x64_dvd_6962141
+          :SharePath: C:\tmp\en_office_professional_plus_2016_x005F_x86_x005F_x64_dvd_6962141.iso
+          :Size: 2421989376
+      - :MS:
+          :ID: c5760f67-6d30-4916-bb79-3d80a0bb8e07
+          :Name: en_visio_professional_2016_x005F_x86_x005F_x64_dvd_6962139
+          :SharePath: C:\tmp\en_visio_professional_2016_x005F_x86_x005F_x64_dvd_6962139.iso
+          :Size: 2421987328
+    :d5593afa-d38c-4593-9732-f377c36e8bdc:
       :Properties:
-        :ToString: testing_provisioning
+        :ToString: CFME-56011-JT
         :Props:
-          :VMCPath: C:\testing_provisioning\Virtual Machines\1998F65F-E02F-439B-8A5B-CD750F068020.xml
+          :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT\\Virtual
+            Machines\\944C26BF-9DA2-4AD7-AE13-8AA1CF5A8E0F.xml"
           :MarkedAsTemplate: false
-          :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-          :VMId: 1998F65F-E02F-439B-8A5B-CD750F068020
+          :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+          :VMId: 944C26BF-9DA2-4AD7-AE13-8AA1CF5A8E0F
           :VMResourceGroup: 
           :VMConfigResource: 
           :VMConfigResourceStatus:
@@ -3548,14 +4430,14 @@
           :VMResourceStatus:
             :ToString: ClusterResourceStateUnknown
             :I32: -1
-          :DiskResources: &59 []
-          :UnsupportedReason: *19
-          :RefresherErrors: &60 []
+          :DiskResources: []
+          :UnsupportedReason: *27
+          :RefresherErrors: []
           :VirtualMachineState:
             :ToString: PowerOff
             :I32: 1
-          :HostGroupPath: All Hosts\testing_provisioning
-          :TotalSize: 35328
+          :HostGroupPath: All Hosts\CFME-56011-JT
+          :TotalSize: 5359607808
           :MemoryAssignedMB: 0
           :MemoryAvailablePercentage: 
           :DynamicMemoryDemandMB: 0
@@ -3577,10 +4459,10 @@
             :I32: 0
           :RunGuestAccount: 
           :DelayStart: 0
-          :BiosGuid: 44f2407c-cd50-4ad6-8041-208a81441f4a
+          :BiosGuid: 1f49a2be-f97b-436b-b34a-b4a78a46ce7e
           :CPUUtilization: 0
           :PerfCPUUtilization: 0
-          :PerfMemory: 0
+          :PerfMemory: 10240
           :PerfDiskBytesRead: 0
           :PerfDiskBytesWrite: 0
           :PerfNetworkBytesRead: 0
@@ -3588,8 +4470,8 @@
           :VirtualizationPlatform:
             :ToString: HyperV
             :I32: 2
-          :ComputerNameString: Unknown
-          :CreationSource: linux_template
+          :ComputerNameString: localhost
+          :CreationSource: Temporary Template6368a08c-2e85-40c5-b38e-0d8e60c9c650
           :IsUndergoingLiveMigration: false
           :SourceObjectType: VM Template
           :OperatingSystemShutdownEnabled: true
@@ -3599,7 +4481,7 @@
           :BackupEnabled: true
           :ExcludeFromPRO: false
           :FailedJobID: 
-          :CheckpointLocation: C:\testing_provisioning
+          :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT"
           :SelfServiceUserRole: 
           :PassThroughDisks: []
           :ComputerTier: 
@@ -3608,7 +4490,7 @@
           :CloudVmRoleName: 
           :UpgradeDomain: 
           :SCApplications: []
-          :LastRestoredCheckpointID: 1998F65F-E02F-439B-8A5B-CD750F068020
+          :LastRestoredCheckpointID: 944C26BF-9DA2-4AD7-AE13-8AA1CF5A8E0F
           :LastRestoredVMCheckpoint: 
           :ComplianceStatus: 
           :IsFaultTolerant: false
@@ -3617,31 +4499,31 @@
           :DeploymentState:
             :ToString: Undeployed
             :I32: 0
-          :TieredPerfData: &61
-            :ToString: 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
+          :TieredPerfData: &75
+            :ToString: d5593aaf-d38c-4593-9732-f377c36e8bdc
             :Props:
               :IsViewOnly: false
-              :Name: 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
-              :ServerConnection: *8
-              :ID: 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
+              :Name: d5593aaf-d38c-4593-9732-f377c36e8bdc
+              :ServerConnection: *9
+              :ID: d5593aaf-d38c-4593-9732-f377c36e8bdc
               :ObjectType: TieredPerfData
               :MarkedForDeletion: false
               :IsFullyCached: true
               :TieredCPUUtilization: 0
-              :TieredMemory: 0
+              :TieredMemory: 10240
               :TieredDiskBytesRead: 0
               :TieredDiskBytesWrite: 0
               :TieredNetworkBytesRead: 0
               :TieredNetworkBytesWrite: 0
               :PerfCPUUtilization: 0
-              :PerfMemoryConsumed: 0
+              :PerfMemoryConsumed: 10240
               :PerfMemoryPressurePercent: 100
               :PerfDiskBytesRead: 0
               :PerfDiskBytesWrite: 0
               :PerfNetworkBytesRead: 0
               :PerfNetworkBytesWrite: 0
               :AverageDiskIO: 0
-              :data: "(TieredPerfCounterData#0) { id = 3ddc6b2f-1709-4c2f-9f0f-ecc1d39aa297
+              :data: "(TieredPerfCounterData#0) { id = d5593aaf-d38c-4593-9732-f377c36e8bdc
                 }"
           :ReplicationSetting: 
           :ReplicationStatus: 
@@ -3662,36 +4544,36 @@
           :ClusterPreferredOwner: 
           :AvailabilitySetNames: 
           :LiveCloningEnabled: false
-          :MostRecentTaskID: 2e688429-c7cb-49c9-a577-06fb8ed48763
+          :MostRecentTaskID: fdc572bd-cb9a-473b-8a79-a6c8b69dfea4
           :MostRecentTaskUIState:
             :ToString: Completed
             :I32: 5
-          :MostRecentTask: &27
-            :ToString: Refresh virtual machine
+          :MostRecentTask: &35
+            :ToString: Shut down virtual machine
             :Props:
               :StepsLoaded: true
               :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Refresh virtual machine
+              :Description: Shut down virtual machine
               :IsVisible: true
               :Status: Completed
               :StatusString: Completed
               :ErrorInfo: Success (0)
-              :StartTime: 2016-02-27 06:58:42.970000000 -05:00
-              :EndTime: 2016-02-27 06:58:46.940000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Refresh virtual machine
+              :StartTime: 2016-06-28 12:21:26.687000000 -04:00
+              :EndTime: 2016-06-28 12:22:21.777000000 -04:00
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :SessionOwner: CFME-QE-VMM-AD\Administrator
+              :Name: Shut down virtual machine
               :Steps:
               - Microsoft.SystemCenter.VirtualMachineManager.Step
               :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
               :ProgressValue: 100
               :Progress: 100 %
               :WasNotifiedOfCancel: false
-              :CmdletName: "(Refresh VM - System Job)"
+              :CmdletName: Stop-SCVirtualMachine
               :PROTipID: 
-              :ResultObjectID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
-              :TargetObjectID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
+              :ResultObjectID: d5593afa-d38c-4593-9732-f377c36e8bdc
+              :TargetObjectID: d5593afa-d38c-4593-9732-f377c36e8bdc
               :TargetObjectType: VM
               :IsCompleted: true
               :AreAuditRecordsAvailable: false
@@ -3701,22 +4583,22 @@
               :Target: 
               :ResultObjectType: VM
               :ResultObjectTypeName: Virtual Machine
-              :ResultName: testing_provisioning
+              :ResultName: CFME-56011-JT
               :IsRestartable: false
               :IsStoppable: false
-              :ServerConnection: *8
-              :ID: 2e688429-c7cb-49c9-a577-06fb8ed48763
+              :ServerConnection: *9
+              :ID: fdc572bd-cb9a-473b-8a79-a6c8b69dfea4
               :IsViewOnly: false
               :ObjectType: Job
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :Location: C:\testing_provisioning
-          :CreationTime: 2016-02-26 13:42:16.017000000 -05:00
-          :OperatingSystem: *16
-          :HasVMAdditions: false
-          :VMAddition: Not Detected
+          :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT"
+          :CreationTime: 2016-06-15 13:56:26.440000000 -04:00
+          :OperatingSystem: *28
+          :HasVMAdditions: true
+          :VMAddition: '3.1'
           :NumLockEnabled: false
-          :CPUCount: 1
+          :CPUCount: 4
           :IsHighlyAvailable: false
           :HAVMPriority: 
           :IsDRProtectionRequired: false
@@ -3726,15 +4608,15 @@
           :ReplicationGroup: 
           :LimitCPUFunctionality: false
           :LimitCPUForMigration: false
-          :Memory: 1024
-          :DynamicMemoryEnabled: true
-          :DynamicMemoryMaximumMB: 4096
-          :DynamicMemoryBufferPercentage: 20
+          :Memory: 10240
+          :DynamicMemoryEnabled: false
+          :DynamicMemoryMaximumMB: 
+          :DynamicMemoryBufferPercentage: 
           :MemoryWeight: 5000
           :VirtualVideoAdapterEnabled: false
           :MonitorMaximumCount: 
           :MonitorResolutionMaximum: 
-          :BootOrder: &62
+          :BootOrder:
           - :ToString: CD
             :I32: 1
           - :ToString: IdeHardDrive
@@ -3745,21 +4627,21 @@
             :I32: 0
           :FirstBootDevice: 
           :SecureBootEnabled: 
-          :ComputerName: 
+          :ComputerName: localhost
           :UseHardwareAssistedVirtualization: true
-          :SANStatus: &63
-          - :ToString: DeployLUNNotFoundUsingStorageProvider (26207)
+          :SANStatus:
+          - :ToString: CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
             :Props:
               :Exception: 
               :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 26207
-              :ErrorCodeString: '26207'
+              :DisplayableErrorCode: 26277
+              :ErrorCodeString: '26277'
               :ErrorType: Error
-              :CSMMessageString: 'Error Code : DeployLUNNotFoundUsingStorageProvider
-                ; Message : Virtual Machine testing_provisioning resides on a LUN,
-                which is not visible to any of the storage providers. ; Recommended
-                Action : Ensure that the storage provider is added to Virtual Machine
-                Manager server. Then try the operation again.'
+              :CSMMessageString: 'Error Code : CannotGetVolumeInfoDueToUncShareInRemoteMachine
+                ; Message : Cannot get the host volume information because the given
+                path \\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\scvmm2\CFME-56011-JT\
+                is a share path and not local to host of the virtual machine . ; Recommended
+                Action : '
               :IsSuccess: false
               :IsTerminating: false
               :IsConditionallyTerminating: false
@@ -3768,20 +4650,21 @@
               :DetailedErrorCode: 
               :IsMomAlert: false
               :MomAlertSeverity: Error
-              :Problem: Virtual Machine testing_provisioning resides on a LUN, which
-                is not visible to any of the storage providers.
-              :CloudProblem: Virtual Machine testing_provisioning resides on a LUN,
-                which is not visible to any of the storage providers.
-              :RecommendedAction: Ensure that the storage provider is added to Virtual
-                Machine Manager server. Then try the operation again.
-              :RecommendedActionCLI: Ensure that the storage provider is added to
-                Virtual Machine Manager server. Then try the operation again.
+              :Problem: Cannot get the host volume information because the given path
+                \\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\scvmm2\CFME-56011-JT\
+                is a share path and not local to host of the virtual machine .
+              :CloudProblem: Cannot get the host volume information because the given
+                path \\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\scvmm2\CFME-56011-JT\
+                is a share path and not local to host of the virtual machine .
+              :RecommendedAction: 
+              :RecommendedActionCLI: 
               :DetailedCode: 0
               :DetailedSource: None
               :ExceptionDetails: 
               :MessageParameters:
-                :VMName: testing_provisioning
-              :Code: DeployLUNNotFoundUsingStorageProvider
+                :FolderPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT\\"
+                :VMName: 
+              :Code: CannotGetVolumeInfoDueToUncShareInRemoteMachine
               :GetMessageFormatterHandler: 
           :CostCenter: 
           :QuotaPoint: 1
@@ -3800,7 +4683,7 @@
           - 
           :CustomProperty: {}
           :UndoDisksEnabled: false
-          :CPUType: *15
+          :CPUType: *19
           :ExpectedCPUUtilization: 20
           :DiskIO: 0
           :NetworkUtilization: 0
@@ -3808,72 +4691,46 @@
           :CPUReserve: 0
           :CPUMax: 100
           :CPUPerVirtualNumaNodeMaximum: 8
-          :MemoryPerVirtualNumaNodeMaximumMB: 63140
+          :MemoryPerVirtualNumaNodeMaximumMB: 34918
           :VirtualNumaNodesPerSocketMaximum: 1
-          :DynamicMemoryMinimumMB: 1024
+          :DynamicMemoryMinimumMB: 
           :NumaIsolationRequired: false
           :Generation: 1
-          :VirtualDVDDrives:
-          - &64
-            :ToString: testing_provisioning
-            :Props:
-              :Connection: None
-              :ISOId: 
-              :ISO: 
-              :HostDrive: 
-              :BusType: IDE
-              :Bus: 1
-              :Lun: 0
-              :ISOLinked: false
-              :ObjectType: VirtualDVDDrive
-              :Accessibility: Public
-              :Name: testing_provisioning
-              :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-26 13:42:16.057000000 -05:00
-              :ModifiedTime: 2016-02-29 06:58:47.093000000 -05:00
-              :Enabled: true
-              :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: e5440b3f-e6f4-4659-a573-9d8e93b3f4b1
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
+          :VirtualDVDDrives: []
           :VirtualHardDisks:
-          - &26
-            :ToString: Blank Disk - Small.vhd
+          - &34
+            :ToString: cfme-56011-06151559.vhd
             :Props:
-              :OperatingSystem: *16
+              :OperatingSystem: *20
               :VHDType: DynamicallyExpanding
               :VHDFormatType: VHD
               :VirtualizationPlatform: HyperV
-              :MaximumSize: 17179869184
+              :MaximumSize: 42951106560
               :ParentDisk: 
               :SANCopyCapable: false
               :IsCachedVhd: false
               :ComplianceStatus: 
               :Tag: 
               :HasProductKey: false
-              :Location: C:\testing_provisioning\Blank Disk - Small.vhd
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT\\cfme-56011-06151559.vhd"
               :Release: 
               :State: Normal
               :LibraryShareId: 00000000-0000-0000-0000-000000000000
-              :SharePath: C:\testing_provisioning\Blank Disk - Small.vhd
-              :FileShare: 
-              :Directory: C:\testing_provisioning
-              :Size: 35328
+              :SharePath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT\\cfme-56011-06151559.vhd"
+              :FileShare: *29
+              :Directory: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT"
+              :Size: 5359607808
               :IsOrphaned: false
               :FamilyName: 
               :Namespace: 
               :ReleaseTime: 
-              :HostVolumeId: 1c00651a-ca2a-4676-976b-55875305a89f
-              :HostVolume:
-                :S: C:\
-              :Classification: *11
-              :HostId: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
+              :HostVolumeId: 
+              :HostVolume: 
+              :Classification: *8
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
               :HostType: VMHost
-              :HostName: dell-r410-01.cloudformswin.lab.redhat.com
-              :VMHost: *10
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
               :LibraryServer: 
               :CloudId: 
               :Cloud: 
@@ -3884,25 +4741,24 @@
               :Owner: 
               :ObjectType: VirtualHardDisk
               :Accessibility: Internal
-              :Name: Blank Disk - Small.vhd
+              :Name: cfme-56011-06151559.vhd
               :IsViewOnly: false
-              :Description: To be used as a base drive to create a new virtual machine
-                or as an additional data drive.
-              :AddedTime: 2016-02-26 13:42:16.843000000 -05:00
-              :ModifiedTime: 2016-02-29 06:58:47.090000000 -05:00
+              :Description: 
+              :AddedTime: 2016-06-15 13:56:29.717000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:10.030000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 77e12b95-986d-4001-95fa-6dfa25a72067
+              :ServerConnection: *9
+              :ID: febcbf05-e75f-4039-8521-840091483ad8
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualDiskDrives:
-          - &65
-            :ToString: testing_provisioning
+          - &76
+            :ToString: CFME-56011-JT
             :Props:
-              :VirtualHardDiskId: 77e12b95-986d-4001-95fa-6dfa25a72067
-              :VirtualHardDisk: *26
+              :VirtualHardDiskId: febcbf05-e75f-4039-8521-840091483ad8
+              :VirtualHardDisk: *34
               :PassThroughDisk: 
               :IsVHD: true
               :HasSharedStorage: false
@@ -3911,42 +4767,41 @@
               :Bus: 0
               :Lun: 0
               :PendingDiskAssociation: false
-              :Classification: *11
-              :VolumeType: BootAndSystem
+              :Classification: *8
+              :VolumeType: None
               :ObjectType: VirtualDiskDrive
               :Accessibility: Public
-              :Name: testing_provisioning
+              :Name: CFME-56011-JT
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-26 13:42:16.837000000 -05:00
-              :ModifiedTime: 2016-02-29 06:58:47.090000000 -05:00
+              :AddedTime: 2016-06-15 13:56:29.673000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:10.030000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 48df8938-5c34-45b9-9f55-c18f09a6730b
+              :ServerConnection: *9
+              :ID: cef5d603-fd60-452d-9196-8f6c8f663a76
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :ShareSCSIBus: false
           :VirtualNetworkAdapters:
-          - &66
-            :ToString: testing_provisioning
+          - &77
+            :ToString: CFME-56011-JT
             :Props:
               :SlotId: 0
-              :VirtualNetwork: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
-                #33 - Virtual Switch'
+              :VirtualNetwork: vswitch
               :VMwarePortGroup: 
               :MACAddressType: Dynamic
               :EthernetAddressType: Dynamic
               :PhysicalAddressType: Dynamic
-              :MACAddress: '00:00:00:00:00:00'
-              :EthernetAddress: '00:00:00:00:00:00'
-              :PhysicalAddress: '00:00:00:00:00:00'
+              :MACAddress: 00:15:5D:06:AC:C0
+              :EthernetAddress: 00:15:5D:06:AC:C0
+              :PhysicalAddress: 00:15:5D:06:AC:C0
               :RequiredBandwidth: 0
               :VirtualNetworkAdapterType: Synthetic
               :VmwAdapterIndex: 
-              :LogicalNetwork: *21
-              :VMNetwork: *22
+              :LogicalNetwork: *22
+              :VMNetwork: *23
               :VMNetworkServiceSetting: 
               :VMSubnet: 
               :PortClassification: 
@@ -3965,44 +4820,47 @@
               :VirtualNetworkAdapterComplianceErrors: []
               :PerfNetworkKBytesRead: 0
               :PerfNetworkKBytesWrite: 0
-              :DeviceID: Microsoft:1998F65F-E02F-439B-8A5B-CD750F068020\2BAF313D-BD78-46AD-8442-B91F7030F42D
+              :DeviceID: Microsoft:944C26BF-9DA2-4AD7-AE13-8AA1CF5A8E0F\E25EDFD3-0A42-4529-83C4-568C3D4D3233
               :IPv4AddressType: Dynamic
               :IPv6AddressType: Dynamic
-              :IPv4Addresses: []
-              :IPv6Addresses: []
+              :IPv4Addresses:
+              - 10.16.7.187
+              :IPv6Addresses:
+              - 2620:52:0:1007:215:5dff:fe06:acc0
+              - fe80::215:5dff:fe06:acc0
               :PortACL: 
               :ObjectType: VirtualNetworkAdapter
               :Accessibility: Public
-              :Name: testing_provisioning
+              :Name: CFME-56011-JT
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-26 13:42:16.057000000 -05:00
-              :ModifiedTime: 2016-02-29 06:58:47.093000000 -05:00
+              :AddedTime: 2016-06-15 13:56:26.573000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:10.033000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: b04144e0-46dd-49ea-a434-5e39e13a2997
+              :ServerConnection: *9
+              :ID: 17256440-76e3-40a9-ac8d-bc505398f15c
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
           :VirtualFibreChannelAdapters: []
           :HasVirtualFibreChannelAdapters: false
-          :VirtualFloppyDrive: &67
-            :ToString: testing_provisioning
+          :VirtualFloppyDrive: &78
+            :ToString: CFME-56011-JT
             :Props:
               :Connection: None
               :VirtualFloppyDisk: 
               :ObjectType: VirtualFloppyDrive
               :Accessibility: Public
-              :Name: testing_provisioning
+              :Name: CFME-56011-JT
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-26 13:42:16.057000000 -05:00
-              :ModifiedTime: 2016-02-29 06:58:47.093000000 -05:00
+              :AddedTime: 2016-06-15 13:56:26.563000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:10.033000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: d3297030-93fa-4076-b96c-f8cd17695657
+              :ServerConnection: *9
+              :ID: 57d66b50-62d7-4fca-8807-198aaf6bf76a
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
@@ -4017,8 +4875,8 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM1
-              :ServerConnection: *8
-              :ID: d6367962-b5d7-4034-af9f-5ccd451f87bf
+              :ServerConnection: *9
+              :ID: 436fb896-3df4-460c-892e-39512d9dca27
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
@@ -4033,15 +4891,15 @@
               :TextFile: 
               :NamedPipe: 
               :Name: COM2
-              :ServerConnection: *8
-              :ID: b32ce2d2-c534-42f5-8bb3-fd2880a2dc02
+              :ServerConnection: *9
+              :ID: 0a28a448-18d6-4e88-ba3e-6ea1156d1532
               :IsViewOnly: false
               :ObjectType: None
               :MarkedForDeletion: false
               :IsFullyCached: true
           :VirtualSCSIAdapters:
-          - &68
-            :ToString: testing_provisioning
+          - &79
+            :ToString: CFME-56011-JT
             :Props:
               :AdapterID: 255
               :Bus: 0
@@ -4049,29 +4907,27 @@
               :SCSIControllerType: DefaultTypeNoType
               :ObjectType: VirtualSCSIAdapter
               :Accessibility: Public
-              :Name: testing_provisioning
+              :Name: CFME-56011-JT
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-26 13:42:16.053000000 -05:00
-              :ModifiedTime: 2016-02-29 06:58:47.090000000 -05:00
+              :AddedTime: 2016-06-15 13:56:26.557000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:10.030000000 -04:00
               :Enabled: true
               :MostRecentTask: 
-              :ServerConnection: *8
-              :ID: 299f46f3-c0e9-4c83-a5c3-32f7c08022e1
+              :ServerConnection: *9
+              :ID: 97422318-1210-4f9c-acfa-5af12a374f1d
               :MarkedForDeletion: false
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :CapabilityProfile: *23
-          :CapabilityProfileCompatibilityState:
-            :ToString: Compatible
-            :I32: 0
+          :CapabilityProfile: 
+          :CapabilityProfileCompatibilityState: 
           :VMCheckpoints: []
-          :HostId: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
+          :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
           :HostType:
             :ToString: VMHost
             :I32: 9
-          :HostName: dell-r410-01.cloudformswin.lab.redhat.com
-          :VMHost: *10
+          :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :VMHost: *1
           :LibraryServer: 
           :CloudId: 
           :Cloud: 
@@ -4079,1206 +4935,99 @@
           :GrantedToList: []
           :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
           :UserRole: *3
-          :Owner: CLOUDFORMSWIN\scvmm
+          :Owner: CFME-QE-VMM-AD\Administrator
           :ObjectType:
             :ToString: VM
             :I32: 1
           :Accessibility:
             :ToString: Public
             :I32: 0
-          :Name: testing_provisioning
+          :Name: CFME-56011-JT
           :IsViewOnly: false
           :Description: 
-          :AddedTime: 2016-02-26 13:42:16.017000000 -05:00
-          :ModifiedTime: 2016-02-29 06:58:47.087000000 -05:00
+          :AddedTime: 2016-06-15 13:56:26.440000000 -04:00
+          :ModifiedTime: 2016-07-10 18:57:10.023000000 -04:00
           :Enabled: true
-          :ServerConnection: *8
-          :ID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
+          :ServerConnection: *9
+          :ID: d5593afa-d38c-4593-9732-f377c36e8bdc
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *27
+          :MostRecentTaskIfLocal: *35
         :MS:
-          :ServicingWindows: *9
-      :Networks: 
+          :ServicingWindows: *11
+      :Networks: 10.16.7.187
       :vmnet:
         :MS:
-          :VMNetwork: *22
-      :DVDs: *9
+          :VMNetwork: *23
+      :DVDs: []
   :hosts:
-    :21ae0784-db30-48f2-bdd5-08dfe01b6929:
+    :18060bb0-05b9-40fb-b1e3-dfccb8d85c6b:
       :Properties:
-        :ToString: cfme-esx-55-03
+        :ToString: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
         :Props:
-          :RunAsAccount: *28
-          :MostRecentTaskID: 8b7045ef-e923-4ee4-85fa-6a26eaf3a8dd
+          :RunAsAccount: *36
+          :MostRecentTaskID: 22c8bd5f-b9ad-4028-96fd-32eb2c5b014b
           :MostRecentTaskUIState:
-            :ToString: Failed
-            :I32: 3
-          :MostRecentTask: &40
-            :ToString: Add virtual machine host
+            :ToString: SucceedWithInfo
+            :I32: 6
+          :MostRecentTask: &80
+            :ToString: Refresh virtual machine properties
             :Props:
               :StepsLoaded: true
               :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Add virtual machine host
+              :Description: Refresh virtual machine properties
               :IsVisible: true
-              :Status: Failed
-              :StatusString: Failed
-              :ErrorInfo: FailedWithCriticalException (20413)
-              :StartTime: 2016-02-24 11:48:21.207000000 -05:00
-              :EndTime: 2016-02-24 11:48:28.650000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Add virtual machine host
+              :Status: SucceedWithInfo
+              :StatusString: Completed w/ Info
+              :ErrorInfo: Success (0)
+              :StartTime: 2016-06-23 17:21:30.177000000 -04:00
+              :EndTime: 2016-06-23 17:21:59.850000000 -04:00
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :SessionOwner: CFME-QE-VMM-AD\Administrator
+              :Name: Refresh virtual machine properties
               :Steps:
               - Microsoft.SystemCenter.VirtualMachineManager.Step
               :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 66
-              :Progress: 66 %
+              :ProgressValue: 100
+              :Progress: 100 %
               :WasNotifiedOfCancel: false
-              :CmdletName: Add-SCVMHostCluster
+              :CmdletName: "(Refresh VM Properties - System Job)"
               :PROTipID: 
-              :ResultObjectID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
-              :TargetObjectID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
+              :ResultObjectID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :TargetObjectID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
               :TargetObjectType: VMHost
               :IsCompleted: true
               :AreAuditRecordsAvailable: false
               :AuditRecords: []
-              :AdditionalMessages: []
+              :AdditionalMessages:
+              - 'HostAgentFileNotFound (2903); HR: 0x80070002'
+              - FailedToUpdateVM (23234); 0
               :Source: 
               :Target: 
               :ResultObjectType: VMHost
               :ResultObjectTypeName: Host
-              :ResultName: cfme-esx-55-03
-              :IsRestartable: true
-              :IsStoppable: false
-              :ServerConnection: *8
-              :ID: 8b7045ef-e923-4ee4-85fa-6a26eaf3a8dd
-              :IsViewOnly: false
-              :ObjectType: Job
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :OverallStateString: Adding...
-          :OverallState:
-            :ToString: Adding
-            :By: 3
-          :CommunicationStateString: Connecting...
-          :CommunicationState:
-            :ToString: Connecting
-            :By: 3
-          :Name: cfme-esx-55-03
-          :FullyQualifiedDomainName: cfme-esx-55-03
-          :ComputerName: cfme-esx-55-03
-          :DomainName: cfme-esx-55-03
-          :Description: 
-          :RemoteUserName: localhost\root
-          :OverrideHostGroupReserves: false
-          :CPUPercentageReserve: 10
-          :NetworkPercentageReserve: 0
-          :DiskSpaceReserveMB: 10240
-          :MaxDiskIOReservation: 10000
-          :MemoryReserveMB: 2048
-          :VMPaths: *29
-          :BaseDiskPaths: *30
-          :PROEnabled: false
-          :MaintenanceHost: false
-          :AvailableForPlacement: true
-          :IsEmbedded: false
-          :CredentialsNeeded: true
-          :PausedForNetworkIncompatibility: false
-          :LogicalProcessorCount: 0
-          :PhysicalCPUCount: 0
-          :CoresPerCPU: 0
-          :L2CacheSize: 0
-          :L3CacheSize: 0
-          :BusSpeed: 0
-          :ProcessorSpeed: 0
-          :ProcessorModel: 
-          :ProcessorManufacturer: 
-          :ProcessorArchitecture: 0
-          :ProcessorFamily: 
-          :CpuUtilization: 0
-          :TotalMemory: 0
-          :AvailableMemory: 0
-          :OperatingSystem: *16
-          :OperatingSystemVersion: '0.0'
-          :DVDDrives: 
-          :DVDDriveList: []
-          :VirtualizationPlatformString: VMware ESX Server
-          :VirtualizationPlatform:
-            :ToString: VMWareESX
-            :I32: 4
-          :VirtualizationPlatformDetail: VMware ESX Server
-          :IsVirtualizationSoftwareDetailUnknown: false
-          :IsViridianHost: false
-          :SupportsLiveMigration: false
-          :FloppyDrives: 
-          :FloppyDriveList: []
-          :VMHostGroup: *13
-          :HostCluster: &43
-            :ToString: CFME-ESX55-Cluster
-            :Props:
-              :Name: CFME-ESX55-Cluster
-              :ClusterName: CFME-ESX55-Cluster
-              :DomainName: 
-              :Description: 
-              :HostGroup: *13
-              :ClusterReserve: 1
-              :ClusterReserveState: Unknown
-              :ClusterReserveDetails: 
-              :CustomProperty: {}
-              :IsVMwareHAEnabled: false
-              :IsVMwareDrsEnabled: false
-              :AvailableStorageNode: 
-              :Nodes:
-              - *31
-              - *32
-              - *33
-              - *34
-              :VMwareResourcePool: 
-              :VirtualizationPlatform: VMWareVC
-              :HostGroupID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
-              :AvailableVolumes: []
-              :SharedVolumes: []
-              :RegisteredStorageFileShares: []
-              :RefresherErrors: *35
-              :IPAddresses: []
-              :QuorumDiskResourceName: 
-              :ValidationResult: TestNotRun
-              :ValidationReportPath: 
-              :ClusterCoreResources: *36
-              :VMHostManagementCredential: *28
-              :ServerConnection: *8
-              :ID: d9a2261c-7c46-4e0f-83c1-44d779d71594
-              :IsViewOnly: false
-              :ObjectType: HostCluster
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :RemoteConnectEnabled: true
-          :RemoteConnectPort: 5900
-          :SecureRemoteConnectEnabled: false
-          :VMRCCertificateAvailable: false
-          :EnableLiveMigration: false
-          :LiveMigrationMaximum: 0
-          :LiveStorageMigrationMaximum: 0
-          :UseAnyMigrationSubnet: false
-          :MigrationSubnet: *37
-          :MigrationSubnetUserManaged: *38
-          :MigrationAuthProtocol:
-            :ToString: CredSSP
-            :By: 0
-          :MigrationPerformanceOption:
-            :ToString: Standard
-            :By: 0
-          :SslTcpPort: 443
-          :SslCertificateHash: 
-          :SshTcpPort: 22
-          :SshPublicKeyHash: 
-          :SshPublicKey: 
-          :IsRemoteFXRoleInstalled: false
-          :IsCPUSLAT: false
-          :IsNumaSpanningEnabled: 
-          :GPUMemoryTotalMB: 
-          :GPUMemoryAvailableMB: 
-          :ClusterNodeStatus:
-            :ToString: Unknown
-            :By: 7
-          :TimeZone: 
-          :HyperVState:
-            :ToString: Unknown
-            :By: 7
-          :HyperVStateString: Unknown
-          :HyperVVersion: '0.0'
-          :HyperVVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :PerimeterNetworkHost: false
-          :NonTrustedDomainHost: false
-          :MaximumMemoryPerVM: 0
-          :MinimumMemoryPerVM: 0
-          :SuggestedMaximumMemoryPerVM: 0
-          :ModifiedTime: 2016-02-24 11:48:26.253000000 -05:00
-          :Agent: &39
-            :ToString: cfme-esx-55-03
-            :Props:
-              :StateString: Responding
-              :RoleString: Host
-              :State: Responding
-              :VersionState: NotApplicable
-              :VersionStateString: Not Applicable
-              :MarkedForDeletion: false
-              :Name: cfme-esx-55-03
-              :MostRecentTaskID: 
-              :MostRecentTaskUIState: 
-              :MostRecentTask: 
-              :FullyQualifiedDomainName: cfme-esx-55-03
-              :FQDN: cfme-esx-55-03
-              :ComputerName: cfme-esx-55-03
-              :Description: 
-              :AgentVersion: '0.0'
-              :Role: Host
-              :UpdatedDate: 2016-02-24 11:48:21.367000000 -05:00
-              :ComplianceStatus: 
-              :ServerConnection: *8
-              :ID: 702b7fd5-6fe3-4e23-8391-f401d72e5e84
-              :IsViewOnly: false
-              :ObjectType: AgentServer
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
-          :ManagedComputer: *39
-          :VMs: []
-          :Disks: []
-          :GPUs: []
-          :InstalledVirtualSwitchExtensions: []
-          :DiskVolumes: []
-          :RegisteredStorageFileShares: []
-          :FibreChannelHbas: []
-          :FibreChannelVirtualSANs: []
-          :SASHbas: []
-          :InternetSCSIHbas: []
-          :VMwareResourcePool: 
-          :IsConfiguredForOutOfBandManagement: false
-          :PhysicalMachine:
-            :ToString: ''
-            :Props:
-              :Name: 
-              :BMCType: None
-              :BMCCustomConfigurationProvider: 
-              :BMCAddress: 
-              :BMCPort: 
-              :RunAsAccount: 
-              :SMBiosGUID: 
-              :ComputerPowerState: Unknown
-              :SystemEventLog: []
-              :ServerConnection: *8
-              :ID: 235e556e-3287-4c95-9f9f-d9182dd1eeb8
-              :IsViewOnly: false
-              :ObjectType: PhysicalMachine
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :HealthMonitors: []
-          :RemoteStorageTotalCapacity: 0
-          :RemoteStorageAvailableCapacity: 0
-          :LocalStorageTotalCapacity: 0
-          :LocalStorageAvailableCapacity: 0
-          :TotalStorageCapacity: 0
-          :AvailableStorageCapacity: 0
-          :UsedStorageCapacity: 0
-          :IsDedicatedToNetworkVirtualizationGateway: false
-          :FibreChannelWorldWidePortNameMinimum: 
-          :FibreChannelWorldWidePortNameMaximum: 
-          :FibreChannelWorldWideNodeName: 
-          :VMConnectCertificateThumbprint: 
-          :Custom1: 
-          :Custom2: 
-          :Custom3: 
-          :Custom4: 
-          :Custom5: 
-          :Custom6: 
-          :Custom7: 
-          :Custom8: 
-          :Custom9: 
-          :Custom10: 
-          :CustomProperty: {}
-          :FibreChannelSANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :ISCSISANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :NPIVFibreChannelSANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :CertificateRequest: 
-          :ComputerState:
-            :ToString: Adding
-            :By: 0
-          :VirtualizationManager: 
-          :ServerConnection: *8
-          :ID: 21ae0784-db30-48f2-bdd5-08dfe01b6929
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHost
-            :I32: 9
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-          :MostRecentTaskIfLocal: *40
-        :MS:
-          :FQDN: cfme-esx-55-03
-          :LogicalCPUCount: 0
-          :CPUSpeed: 0
-          :CPUModel: 
-          :CPUManufacturer: 
-          :CPUArchitecture: 0
-          :CPUFamily: 
-          :VMRCEnabled: true
-          :VMRCPort: 5900
-          :SecureVMRCEnabled: false
-          :VirtualServerState:
-            :ToString: Unknown
-            :By: 7
-          :VirtualServerStateString: Unknown
-          :VirtualServerVersion: '0.0'
-          :VirtualServerVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :ServicingWindows: *9
-      :NetworkAdapters: []
-      :VirtualSwitch: []
-    :79fc4dfd-6a87-4840-8836-4f1096a56a75:
-      :Properties:
-        :ToString: cfme-esx-55-04
-        :Props:
-          :RunAsAccount: *28
-          :MostRecentTaskID: 1a5ce85a-e208-4da0-a9a7-8374846fc94a
-          :MostRecentTaskUIState:
-            :ToString: Failed
-            :I32: 3
-          :MostRecentTask: &47
-            :ToString: Add virtual machine host
-            :Props:
-              :StepsLoaded: true
-              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Add virtual machine host
-              :IsVisible: true
-              :Status: Failed
-              :StatusString: Failed
-              :ErrorInfo: FailedWithCriticalException (20413)
-              :StartTime: 2016-02-24 11:48:21.160000000 -05:00
-              :EndTime: 2016-02-24 11:48:27.723000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Add virtual machine host
-              :Steps:
-              - Microsoft.SystemCenter.VirtualMachineManager.Step
-              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 66
-              :Progress: 66 %
-              :WasNotifiedOfCancel: false
-              :CmdletName: Add-SCVMHostCluster
-              :PROTipID: 
-              :ResultObjectID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
-              :TargetObjectID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
-              :TargetObjectType: VMHost
-              :IsCompleted: true
-              :AreAuditRecordsAvailable: false
-              :AuditRecords: []
-              :AdditionalMessages: []
-              :Source: 
-              :Target: 
-              :ResultObjectType: VMHost
-              :ResultObjectTypeName: Host
-              :ResultName: cfme-esx-55-04
-              :IsRestartable: true
-              :IsStoppable: false
-              :ServerConnection: *8
-              :ID: 1a5ce85a-e208-4da0-a9a7-8374846fc94a
-              :IsViewOnly: false
-              :ObjectType: Job
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :OverallStateString: Adding...
-          :OverallState:
-            :ToString: Adding
-            :By: 3
-          :CommunicationStateString: Connecting...
-          :CommunicationState:
-            :ToString: Connecting
-            :By: 3
-          :Name: cfme-esx-55-04
-          :FullyQualifiedDomainName: cfme-esx-55-04
-          :ComputerName: cfme-esx-55-04
-          :DomainName: cfme-esx-55-04
-          :Description: 
-          :RemoteUserName: localhost\root
-          :OverrideHostGroupReserves: false
-          :CPUPercentageReserve: 10
-          :NetworkPercentageReserve: 0
-          :DiskSpaceReserveMB: 10240
-          :MaxDiskIOReservation: 10000
-          :MemoryReserveMB: 2048
-          :VMPaths: *41
-          :BaseDiskPaths: *42
-          :PROEnabled: false
-          :MaintenanceHost: false
-          :AvailableForPlacement: true
-          :IsEmbedded: false
-          :CredentialsNeeded: true
-          :PausedForNetworkIncompatibility: false
-          :LogicalProcessorCount: 0
-          :PhysicalCPUCount: 0
-          :CoresPerCPU: 0
-          :L2CacheSize: 0
-          :L3CacheSize: 0
-          :BusSpeed: 0
-          :ProcessorSpeed: 0
-          :ProcessorModel: 
-          :ProcessorManufacturer: 
-          :ProcessorArchitecture: 0
-          :ProcessorFamily: 
-          :CpuUtilization: 0
-          :TotalMemory: 0
-          :AvailableMemory: 0
-          :OperatingSystem: *16
-          :OperatingSystemVersion: '0.0'
-          :DVDDrives: 
-          :DVDDriveList: []
-          :VirtualizationPlatformString: VMware ESX Server
-          :VirtualizationPlatform:
-            :ToString: VMWareESX
-            :I32: 4
-          :VirtualizationPlatformDetail: VMware ESX Server
-          :IsVirtualizationSoftwareDetailUnknown: false
-          :IsViridianHost: false
-          :SupportsLiveMigration: false
-          :FloppyDrives: 
-          :FloppyDriveList: []
-          :VMHostGroup: *13
-          :HostCluster: *43
-          :RemoteConnectEnabled: true
-          :RemoteConnectPort: 5900
-          :SecureRemoteConnectEnabled: false
-          :VMRCCertificateAvailable: false
-          :EnableLiveMigration: false
-          :LiveMigrationMaximum: 0
-          :LiveStorageMigrationMaximum: 0
-          :UseAnyMigrationSubnet: false
-          :MigrationSubnet: *44
-          :MigrationSubnetUserManaged: *45
-          :MigrationAuthProtocol:
-            :ToString: CredSSP
-            :By: 0
-          :MigrationPerformanceOption:
-            :ToString: Standard
-            :By: 0
-          :SslTcpPort: 443
-          :SslCertificateHash: 
-          :SshTcpPort: 22
-          :SshPublicKeyHash: 
-          :SshPublicKey: 
-          :IsRemoteFXRoleInstalled: false
-          :IsCPUSLAT: false
-          :IsNumaSpanningEnabled: 
-          :GPUMemoryTotalMB: 
-          :GPUMemoryAvailableMB: 
-          :ClusterNodeStatus:
-            :ToString: Unknown
-            :By: 7
-          :TimeZone: 
-          :HyperVState:
-            :ToString: Unknown
-            :By: 7
-          :HyperVStateString: Unknown
-          :HyperVVersion: '0.0'
-          :HyperVVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :PerimeterNetworkHost: false
-          :NonTrustedDomainHost: false
-          :MaximumMemoryPerVM: 0
-          :MinimumMemoryPerVM: 0
-          :SuggestedMaximumMemoryPerVM: 0
-          :ModifiedTime: 2016-02-24 11:48:22.863000000 -05:00
-          :Agent: &46
-            :ToString: cfme-esx-55-04
-            :Props:
-              :StateString: Responding
-              :RoleString: Host
-              :State: Responding
-              :VersionState: NotApplicable
-              :VersionStateString: Not Applicable
-              :MarkedForDeletion: false
-              :Name: cfme-esx-55-04
-              :MostRecentTaskID: 
-              :MostRecentTaskUIState: 
-              :MostRecentTask: 
-              :FullyQualifiedDomainName: cfme-esx-55-04
-              :FQDN: cfme-esx-55-04
-              :ComputerName: cfme-esx-55-04
-              :Description: 
-              :AgentVersion: '0.0'
-              :Role: Host
-              :UpdatedDate: 2016-02-24 11:48:21.327000000 -05:00
-              :ComplianceStatus: 
-              :ServerConnection: *8
-              :ID: 12e73edd-5efd-4b9a-95ab-19ca601d7be1
-              :IsViewOnly: false
-              :ObjectType: AgentServer
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
-          :ManagedComputer: *46
-          :VMs: []
-          :Disks: []
-          :GPUs: []
-          :InstalledVirtualSwitchExtensions: []
-          :DiskVolumes: []
-          :RegisteredStorageFileShares: []
-          :FibreChannelHbas: []
-          :FibreChannelVirtualSANs: []
-          :SASHbas: []
-          :InternetSCSIHbas: []
-          :VMwareResourcePool: 
-          :IsConfiguredForOutOfBandManagement: false
-          :PhysicalMachine:
-            :ToString: ''
-            :Props:
-              :Name: 
-              :BMCType: None
-              :BMCCustomConfigurationProvider: 
-              :BMCAddress: 
-              :BMCPort: 
-              :RunAsAccount: 
-              :SMBiosGUID: 
-              :ComputerPowerState: Unknown
-              :SystemEventLog: []
-              :ServerConnection: *8
-              :ID: 57bdf3fa-97cb-4fa7-b6ab-c8580cb9ba92
-              :IsViewOnly: false
-              :ObjectType: PhysicalMachine
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :HealthMonitors: []
-          :RemoteStorageTotalCapacity: 0
-          :RemoteStorageAvailableCapacity: 0
-          :LocalStorageTotalCapacity: 0
-          :LocalStorageAvailableCapacity: 0
-          :TotalStorageCapacity: 0
-          :AvailableStorageCapacity: 0
-          :UsedStorageCapacity: 0
-          :IsDedicatedToNetworkVirtualizationGateway: false
-          :FibreChannelWorldWidePortNameMinimum: 
-          :FibreChannelWorldWidePortNameMaximum: 
-          :FibreChannelWorldWideNodeName: 
-          :VMConnectCertificateThumbprint: 
-          :Custom1: 
-          :Custom2: 
-          :Custom3: 
-          :Custom4: 
-          :Custom5: 
-          :Custom6: 
-          :Custom7: 
-          :Custom8: 
-          :Custom9: 
-          :Custom10: 
-          :CustomProperty: {}
-          :FibreChannelSANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :ISCSISANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :NPIVFibreChannelSANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :CertificateRequest: 
-          :ComputerState:
-            :ToString: Adding
-            :By: 0
-          :VirtualizationManager: 
-          :ServerConnection: *8
-          :ID: 79fc4dfd-6a87-4840-8836-4f1096a56a75
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHost
-            :I32: 9
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-          :MostRecentTaskIfLocal: *47
-        :MS:
-          :FQDN: cfme-esx-55-04
-          :LogicalCPUCount: 0
-          :CPUSpeed: 0
-          :CPUModel: 
-          :CPUManufacturer: 
-          :CPUArchitecture: 0
-          :CPUFamily: 
-          :VMRCEnabled: true
-          :VMRCPort: 5900
-          :SecureVMRCEnabled: false
-          :VirtualServerState:
-            :ToString: Unknown
-            :By: 7
-          :VirtualServerStateString: Unknown
-          :VirtualServerVersion: '0.0'
-          :VirtualServerVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :ServicingWindows: *9
-      :NetworkAdapters: []
-      :VirtualSwitch: []
-    :d4c780ae-2251-44f7-b624-111bd25e7400:
-      :Properties:
-        :ToString: cfme-esx-55-02
-        :Props:
-          :RunAsAccount: *28
-          :MostRecentTaskID: af5b8a7e-da60-4b62-837c-c1e876328410
-          :MostRecentTaskUIState:
-            :ToString: Failed
-            :I32: 3
-          :MostRecentTask: &53
-            :ToString: Add virtual machine host
-            :Props:
-              :StepsLoaded: true
-              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Add virtual machine host
-              :IsVisible: true
-              :Status: Failed
-              :StatusString: Failed
-              :ErrorInfo: FailedWithCriticalException (20413)
-              :StartTime: 2016-02-24 11:48:21.263000000 -05:00
-              :EndTime: 2016-02-24 11:48:30.253000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Add virtual machine host
-              :Steps:
-              - Microsoft.SystemCenter.VirtualMachineManager.Step
-              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 66
-              :Progress: 66 %
-              :WasNotifiedOfCancel: false
-              :CmdletName: Add-SCVMHostCluster
-              :PROTipID: 
-              :ResultObjectID: d4c780ae-2251-44f7-b624-111bd25e7400
-              :TargetObjectID: d4c780ae-2251-44f7-b624-111bd25e7400
-              :TargetObjectType: VMHost
-              :IsCompleted: true
-              :AreAuditRecordsAvailable: false
-              :AuditRecords: []
-              :AdditionalMessages: []
-              :Source: 
-              :Target: 
-              :ResultObjectType: VMHost
-              :ResultObjectTypeName: Host
-              :ResultName: cfme-esx-55-02
-              :IsRestartable: true
-              :IsStoppable: false
-              :ServerConnection: *8
-              :ID: af5b8a7e-da60-4b62-837c-c1e876328410
-              :IsViewOnly: false
-              :ObjectType: Job
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :OverallStateString: Adding...
-          :OverallState:
-            :ToString: Adding
-            :By: 3
-          :CommunicationStateString: Connecting...
-          :CommunicationState:
-            :ToString: Connecting
-            :By: 3
-          :Name: cfme-esx-55-02
-          :FullyQualifiedDomainName: cfme-esx-55-02
-          :ComputerName: cfme-esx-55-02
-          :DomainName: cfme-esx-55-02
-          :Description: 
-          :RemoteUserName: localhost\root
-          :OverrideHostGroupReserves: false
-          :CPUPercentageReserve: 10
-          :NetworkPercentageReserve: 0
-          :DiskSpaceReserveMB: 10240
-          :MaxDiskIOReservation: 10000
-          :MemoryReserveMB: 2048
-          :VMPaths: *48
-          :BaseDiskPaths: *49
-          :PROEnabled: false
-          :MaintenanceHost: false
-          :AvailableForPlacement: true
-          :IsEmbedded: false
-          :CredentialsNeeded: true
-          :PausedForNetworkIncompatibility: false
-          :LogicalProcessorCount: 0
-          :PhysicalCPUCount: 0
-          :CoresPerCPU: 0
-          :L2CacheSize: 0
-          :L3CacheSize: 0
-          :BusSpeed: 0
-          :ProcessorSpeed: 0
-          :ProcessorModel: 
-          :ProcessorManufacturer: 
-          :ProcessorArchitecture: 0
-          :ProcessorFamily: 
-          :CpuUtilization: 0
-          :TotalMemory: 0
-          :AvailableMemory: 0
-          :OperatingSystem: *16
-          :OperatingSystemVersion: '0.0'
-          :DVDDrives: 
-          :DVDDriveList: []
-          :VirtualizationPlatformString: VMware ESX Server
-          :VirtualizationPlatform:
-            :ToString: VMWareESX
-            :I32: 4
-          :VirtualizationPlatformDetail: VMware ESX Server
-          :IsVirtualizationSoftwareDetailUnknown: false
-          :IsViridianHost: false
-          :SupportsLiveMigration: false
-          :FloppyDrives: 
-          :FloppyDriveList: []
-          :VMHostGroup: *13
-          :HostCluster: *43
-          :RemoteConnectEnabled: true
-          :RemoteConnectPort: 5900
-          :SecureRemoteConnectEnabled: false
-          :VMRCCertificateAvailable: false
-          :EnableLiveMigration: false
-          :LiveMigrationMaximum: 0
-          :LiveStorageMigrationMaximum: 0
-          :UseAnyMigrationSubnet: false
-          :MigrationSubnet: *50
-          :MigrationSubnetUserManaged: *51
-          :MigrationAuthProtocol:
-            :ToString: CredSSP
-            :By: 0
-          :MigrationPerformanceOption:
-            :ToString: Standard
-            :By: 0
-          :SslTcpPort: 443
-          :SslCertificateHash: 
-          :SshTcpPort: 22
-          :SshPublicKeyHash: 
-          :SshPublicKey: 
-          :IsRemoteFXRoleInstalled: false
-          :IsCPUSLAT: false
-          :IsNumaSpanningEnabled: 
-          :GPUMemoryTotalMB: 
-          :GPUMemoryAvailableMB: 
-          :ClusterNodeStatus:
-            :ToString: Unknown
-            :By: 7
-          :TimeZone: 
-          :HyperVState:
-            :ToString: Unknown
-            :By: 7
-          :HyperVStateString: Unknown
-          :HyperVVersion: '0.0'
-          :HyperVVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :PerimeterNetworkHost: false
-          :NonTrustedDomainHost: false
-          :MaximumMemoryPerVM: 0
-          :MinimumMemoryPerVM: 0
-          :SuggestedMaximumMemoryPerVM: 0
-          :ModifiedTime: 2016-02-24 11:48:27.520000000 -05:00
-          :Agent: &52
-            :ToString: cfme-esx-55-02
-            :Props:
-              :StateString: Responding
-              :RoleString: Host
-              :State: Responding
-              :VersionState: NotApplicable
-              :VersionStateString: Not Applicable
-              :MarkedForDeletion: false
-              :Name: cfme-esx-55-02
-              :MostRecentTaskID: 
-              :MostRecentTaskUIState: 
-              :MostRecentTask: 
-              :FullyQualifiedDomainName: cfme-esx-55-02
-              :FQDN: cfme-esx-55-02
-              :ComputerName: cfme-esx-55-02
-              :Description: 
-              :AgentVersion: '0.0'
-              :Role: Host
-              :UpdatedDate: 2016-02-24 11:48:21.430000000 -05:00
-              :ComplianceStatus: 
-              :ServerConnection: *8
-              :ID: 0dcd1d21-c08c-47db-b590-54ae757a20e6
-              :IsViewOnly: false
-              :ObjectType: AgentServer
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
-          :ManagedComputer: *52
-          :VMs: []
-          :Disks: []
-          :GPUs: []
-          :InstalledVirtualSwitchExtensions: []
-          :DiskVolumes: []
-          :RegisteredStorageFileShares: []
-          :FibreChannelHbas: []
-          :FibreChannelVirtualSANs: []
-          :SASHbas: []
-          :InternetSCSIHbas: []
-          :VMwareResourcePool: 
-          :IsConfiguredForOutOfBandManagement: false
-          :PhysicalMachine:
-            :ToString: ''
-            :Props:
-              :Name: 
-              :BMCType: None
-              :BMCCustomConfigurationProvider: 
-              :BMCAddress: 
-              :BMCPort: 
-              :RunAsAccount: 
-              :SMBiosGUID: 
-              :ComputerPowerState: Unknown
-              :SystemEventLog: []
-              :ServerConnection: *8
-              :ID: 7df87cde-7567-41ca-b292-fa6547fc436b
-              :IsViewOnly: false
-              :ObjectType: PhysicalMachine
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :HealthMonitors: []
-          :RemoteStorageTotalCapacity: 0
-          :RemoteStorageAvailableCapacity: 0
-          :LocalStorageTotalCapacity: 0
-          :LocalStorageAvailableCapacity: 0
-          :TotalStorageCapacity: 0
-          :AvailableStorageCapacity: 0
-          :UsedStorageCapacity: 0
-          :IsDedicatedToNetworkVirtualizationGateway: false
-          :FibreChannelWorldWidePortNameMinimum: 
-          :FibreChannelWorldWidePortNameMaximum: 
-          :FibreChannelWorldWideNodeName: 
-          :VMConnectCertificateThumbprint: 
-          :Custom1: 
-          :Custom2: 
-          :Custom3: 
-          :Custom4: 
-          :Custom5: 
-          :Custom6: 
-          :Custom7: 
-          :Custom8: 
-          :Custom9: 
-          :Custom10: 
-          :CustomProperty: {}
-          :FibreChannelSANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :ISCSISANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :NPIVFibreChannelSANStatus:
-            :ToString: SANNotConfigured (1245)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1245
-              :ErrorCodeString: '1245'
-              :ErrorType: Info
-              :CSMMessageString: 'Error Code : SANNotConfigured ; Message : SAN is
-                not configured for this server. ; Recommended Action : '
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: SAN is not configured for this server.
-              :CloudProblem: SAN is not configured for this server.
-              :RecommendedAction: 
-              :RecommendedActionCLI: 
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters: {}
-              :Code: SANNotConfigured
-              :GetMessageFormatterHandler: 
-          :CertificateRequest: 
-          :ComputerState:
-            :ToString: Adding
-            :By: 0
-          :VirtualizationManager: 
-          :ServerConnection: *8
-          :ID: d4c780ae-2251-44f7-b624-111bd25e7400
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHost
-            :I32: 9
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-          :MostRecentTaskIfLocal: *53
-        :MS:
-          :FQDN: cfme-esx-55-02
-          :LogicalCPUCount: 0
-          :CPUSpeed: 0
-          :CPUModel: 
-          :CPUManufacturer: 
-          :CPUArchitecture: 0
-          :CPUFamily: 
-          :VMRCEnabled: true
-          :VMRCPort: 5900
-          :SecureVMRCEnabled: false
-          :VirtualServerState:
-            :ToString: Unknown
-            :By: 7
-          :VirtualServerStateString: Unknown
-          :VirtualServerVersion: '0.0'
-          :VirtualServerVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :ServicingWindows: *9
-      :NetworkAdapters: []
-      :VirtualSwitch: []
-    :7805b0eb-dffa-4f62-b38d-c6fa624b0ee9:
-      :Properties:
-        :ToString: dell-r410-01.cloudformswin.lab.redhat.com
-        :Props:
-          :RunAsAccount: 
-          :MostRecentTaskID: 06be14e2-b6f3-4f53-a7e6-1124908f1d2c
-          :MostRecentTaskUIState:
-            :ToString: Failed
-            :I32: 3
-          :MostRecentTask: &69
-            :ToString: Refresh Performance Data
-            :Props:
-              :StepsLoaded: true
-              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Refresh Performance Data
-              :IsVisible: true
-              :Status: Failed
-              :StatusString: Failed
-              :ErrorInfo: 'HostAgentFail (2912); HR: 0x80070576'
-              :StartTime: 2016-02-26 21:03:46.440000000 -05:00
-              :EndTime: 2016-02-26 21:03:46.450000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Refresh Performance Data
-              :Steps:
-              - Microsoft.SystemCenter.VirtualMachineManager.Step
-              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 0
-              :Progress: 0 %
-              :WasNotifiedOfCancel: false
-              :CmdletName: Performance Data Refresher (System Job)
-              :PROTipID: 
-              :ResultObjectID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :TargetObjectID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :TargetObjectType: VMHost
-              :IsCompleted: true
-              :AreAuditRecordsAvailable: false
-              :AuditRecords: []
-              :AdditionalMessages: []
-              :Source: 
-              :Target: 
-              :ResultObjectType: VMHost
-              :ResultObjectTypeName: Host
-              :ResultName: dell-r410-01.cloudformswin.lab.redhat.com
+              :ResultName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :IsRestartable: false
               :IsStoppable: false
-              :ServerConnection: *8
-              :ID: 06be14e2-b6f3-4f53-a7e6-1124908f1d2c
+              :ServerConnection: *9
+              :ID: 22c8bd5f-b9ad-4028-96fd-32eb2c5b014b
               :IsViewOnly: false
               :ObjectType: Job
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :OverallStateString: OK
+          :OverallStateString: Needs Attention
           :OverallState:
-            :ToString: OK
-            :By: 0
+            :ToString: NeedsAttention
+            :By: 2
           :CommunicationStateString: Responding
           :CommunicationState:
             :ToString: Responding
             :By: 0
-          :Name: dell-r410-01.cloudformswin.lab.redhat.com
-          :FullyQualifiedDomainName: dell-r410-01.cloudformswin.lab.redhat.com
-          :ComputerName: dell-r410-01
-          :DomainName: cloudformswin.lab.redhat.com
+          :Name: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :FullyQualifiedDomainName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :ComputerName: qeblade33
+          :DomainName: cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
           :Description: 
           :RemoteUserName: 
           :OverrideHostGroupReserves: false
@@ -5287,8 +5036,8 @@
           :DiskSpaceReserveMB: 10240
           :MaxDiskIOReservation: 10000
           :MemoryReserveMB: 2048
-          :VMPaths: *54
-          :BaseDiskPaths: *55
+          :VMPaths: *37
+          :BaseDiskPaths: *38
           :PROEnabled: false
           :MaintenanceHost: false
           :AvailableForPlacement: true
@@ -5298,21 +5047,21 @@
           :LogicalProcessorCount: 16
           :PhysicalCPUCount: 2
           :CoresPerCPU: 8
-          :L2CacheSize: 2048
-          :L3CacheSize: 12288
-          :BusSpeed: 5860
-          :ProcessorSpeed: 2394
+          :L2CacheSize: 256
+          :L3CacheSize: 8192
+          :BusSpeed: 4800
+          :ProcessorSpeed: 2133
           :ProcessorModel: Xeon
           :ProcessorManufacturer: Intel
           :ProcessorArchitecture: 9
           :ProcessorFamily: '179'
-          :CpuUtilization: 0
-          :TotalMemory: 137425408000
-          :AvailableMemory: 127532
+          :CpuUtilization: 11
+          :TotalMemory: 77297573888
+          :AvailableMemory: 20920
           :OperatingSystem:
-            :ToString: 'Microsoft Windows Server 2012 R2 Datacenter '
+            :ToString: 'Microsoft Windows Server 2012 R2 Standard '
             :Props:
-              :Name: 'Microsoft Windows Server 2012 R2 Datacenter '
+              :Name: 'Microsoft Windows Server 2012 R2 Standard '
               :Description: 
               :Version: 6.3.9600
               :Architecture: amd64
@@ -5327,16 +5076,14 @@
               :AllowsOrgNameInSysprep: false
               :RequiresPIDInSysprep: true
               :ServerConnection: 
-              :ID: d9e77efb-d99a-40d8-8e85-939b3fcb1638
+              :ID: d41665a1-ca05-4432-9cb5-6fb810260c21
               :IsViewOnly: false
               :ObjectType: OperatingSystem
               :MarkedForDeletion: false
               :IsFullyCached: true
           :OperatingSystemVersion: 6.3.9600
-          :DVDDrives: F:;G:;
-          :DVDDriveList:
-          - F
-          - G
+          :DVDDrives: 
+          :DVDDriveList: []
           :VirtualizationPlatformString: Microsoft Hyper-V
           :VirtualizationPlatform:
             :ToString: HyperV
@@ -5347,8 +5094,58 @@
           :SupportsLiveMigration: true
           :FloppyDrives: 
           :FloppyDriveList: []
-          :VMHostGroup: *13
-          :HostCluster: 
+          :VMHostGroup: *39
+          :HostCluster: &85
+            :ToString: hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :Props:
+              :Name: hyperv_cluster.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :ClusterName: hyperv_cluster
+              :DomainName: cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :Description: 
+              :HostGroup: *39
+              :ClusterReserve: 1
+              :ClusterReserveState: OK
+              :ClusterReserveDetails: 
+              :CustomProperty: {}
+              :IsVMwareHAEnabled: false
+              :IsVMwareDrsEnabled: false
+              :AvailableStorageNode: *1
+              :Nodes:
+              - *12
+              - *1
+              :VMwareResourcePool: 
+              :VirtualizationPlatform: HyperV
+              :HostGroupID: 0e3ba228-a059-46be-aa41-2f5cf0f4b96e
+              :AvailableVolumes: []
+              :SharedVolumes:
+              - *40
+              - *41
+              :RegisteredStorageFileShares:
+              - *29
+              :RefresherErrors: *42
+              :IPAddresses:
+              - :ToString: 10.16.4.55
+                :Props:
+                  :Address: 923013130
+                  :AddressFamily: InterNetwork
+                  :IsIPv6Multicast: false
+                  :IsIPv6LinkLocal: false
+                  :IsIPv6SiteLocal: false
+                  :IsIPv6Teredo: false
+                  :IsIPv4MappedToIPv6: false
+                :MS:
+                  :IPAddressToString: 10.16.4.55
+              :QuorumDiskResourceName: 
+              :ValidationResult: TestNotRun
+              :ValidationReportPath: 
+              :ClusterCoreResources: *43
+              :VMHostManagementCredential: *36
+              :ServerConnection: *9
+              :ID: 8e830204-6448-4817-b220-34af48ccf8ca
+              :IsViewOnly: false
+              :ObjectType: HostCluster
+              :MarkedForDeletion: false
+              :IsFullyCached: true
           :RemoteConnectEnabled: true
           :RemoteConnectPort: 2179
           :SecureRemoteConnectEnabled: false
@@ -5356,9 +5153,9 @@
           :EnableLiveMigration: true
           :LiveMigrationMaximum: 2
           :LiveStorageMigrationMaximum: 2
-          :UseAnyMigrationSubnet: true
-          :MigrationSubnet: *56
-          :MigrationSubnetUserManaged: *57
+          :UseAnyMigrationSubnet: false
+          :MigrationSubnet: *44
+          :MigrationSubnetUserManaged: *45
           :MigrationAuthProtocol:
             :ToString: CredSSP
             :By: 0
@@ -5376,9 +5173,9 @@
           :GPUMemoryTotalMB: 
           :GPUMemoryAvailableMB: 
           :ClusterNodeStatus:
-            :ToString: Unknown
-            :By: 7
-          :TimeZone: -300
+            :ToString: Running
+            :By: 3
+          :TimeZone: -420
           :HyperVState:
             :ToString: Running
             :By: 3
@@ -5392,53 +5189,53 @@
           :MaximumMemoryPerVM: 1048576
           :MinimumMemoryPerVM: 32
           :SuggestedMaximumMemoryPerVM: 512
-          :ModifiedTime: 2016-02-29 19:51:46.917145200 -05:00
-          :Agent: &58
-            :ToString: dell-r410-01.cloudformswin.lab.redhat.com
+          :ModifiedTime: 2016-07-11 15:46:42.450779800 -04:00
+          :Agent: &46
+            :ToString: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
             :Props:
               :StateString: Responding
               :RoleString: Host
               :State: Responding
-              :VersionState: UpToDate
-              :VersionStateString: Up-to-date
+              :VersionState: UpgradeAvailable
+              :VersionStateString: Upgrade Available
               :MarkedForDeletion: false
-              :Name: dell-r410-01.cloudformswin.lab.redhat.com
+              :Name: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :MostRecentTaskID: 
               :MostRecentTaskUIState: 
               :MostRecentTask: 
-              :FullyQualifiedDomainName: dell-r410-01.cloudformswin.lab.redhat.com
-              :FQDN: dell-r410-01.cloudformswin.lab.redhat.com
-              :ComputerName: dell-r410-01
+              :FullyQualifiedDomainName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :FQDN: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :ComputerName: qeblade33
               :Description: 
-              :AgentVersion: 3.2.8145.0
+              :AgentVersion: 3.2.8117.0
               :Role: Host
-              :UpdatedDate: 2016-02-22 09:22:22.073000000 -05:00
+              :UpdatedDate: 2016-05-18 16:54:26.073000000 -04:00
               :ComplianceStatus: 
-              :ServerConnection: *8
-              :ID: cceb9149-9138-4bfd-ba8d-12ed505b6764
+              :ServerConnection: *9
+              :ID: 54990107-5319-4ad2-a71d-cb7f7b17c986
               :IsViewOnly: false
               :ObjectType: AgentServer
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :ManagedComputer: *58
+          :ManagedComputer: *46
           :VMs:
-          - :ToString: testing_provisioning
+          - :ToString: SCVMM16
             :Props:
-              :VMCPath: C:\testing_provisioning\Virtual Machines\1998F65F-E02F-439B-8A5B-CD750F068020.xml
+              :VMCPath: C:\tmp\SCVMM16\Virtual Machines\F0E6D5D6-BA51-40DF-9652-D6E81837D25F.xml
               :MarkedAsTemplate: false
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :VMId: 1998F65F-E02F-439B-8A5B-CD750F068020
+              :OwnerIdentifier: 
+              :VMId: F0E6D5D6-BA51-40DF-9652-D6E81837D25F
               :VMResourceGroup: 
               :VMConfigResource: 
               :VMConfigResourceStatus: ClusterResourceStateUnknown
               :VMResource: 
               :VMResourceStatus: ClusterResourceStateUnknown
-              :DiskResources: *59
-              :UnsupportedReason: *19
-              :RefresherErrors: *60
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
               :VirtualMachineState: PowerOff
-              :HostGroupPath: All Hosts\testing_provisioning
-              :TotalSize: 35328
+              :HostGroupPath: All Hosts\SCVMM16
+              :TotalSize: 10640949248
               :MemoryAssignedMB: 0
               :MemoryAvailablePercentage: 
               :DynamicMemoryDemandMB: 0
@@ -5454,7 +5251,7 @@
               :StopAction: SaveVM
               :RunGuestAccount: 
               :DelayStart: 0
-              :BiosGuid: 44f2407c-cd50-4ad6-8041-208a81441f4a
+              :BiosGuid: 86ec0b4b-b3b6-4415-94fb-9c2dc3711466
               :CPUUtilization: 0
               :PerfCPUUtilization: 0
               :PerfMemory: 0
@@ -5464,9 +5261,9 @@
               :PerfNetworkBytesWrite: 0
               :VirtualizationPlatform: HyperV
               :ComputerNameString: Unknown
-              :CreationSource: linux_template
+              :CreationSource: Unknown source object
               :IsUndergoingLiveMigration: false
-              :SourceObjectType: VM Template
+              :SourceObjectType: Unknown source object
               :OperatingSystemShutdownEnabled: true
               :TimeSynchronizationEnabled: true
               :DataExchangeEnabled: true
@@ -5474,7 +5271,7 @@
               :BackupEnabled: true
               :ExcludeFromPRO: false
               :FailedJobID: 
-              :CheckpointLocation: C:\testing_provisioning
+              :CheckpointLocation: C:\tmp\SCVMM16
               :SelfServiceUserRole: 
               :PassThroughDisks: []
               :ComputerTier: 
@@ -5483,14 +5280,14 @@
               :CloudVmRoleName: 
               :UpgradeDomain: 
               :SCApplications: []
-              :LastRestoredCheckpointID: 1998F65F-E02F-439B-8A5B-CD750F068020
+              :LastRestoredCheckpointID: F0E6D5D6-BA51-40DF-9652-D6E81837D25F
               :LastRestoredVMCheckpoint: 
               :ComplianceStatus: 
               :IsFaultTolerant: false
               :DeploymentErrorInfo: 
               :ServiceDeploymentErrorMessage: 
               :DeploymentState: Undeployed
-              :TieredPerfData: *61
+              :TieredPerfData: fd02403c-e5c6-4446-b26e-03a1ae1b9d8f
               :ReplicationSetting: 
               :ReplicationStatus: 
               :IsRecoveryVM: false
@@ -5508,1890 +5305,11 @@
               :ClusterPreferredOwner: 
               :AvailabilitySetNames: 
               :LiveCloningEnabled: false
-              :MostRecentTaskID: 2e688429-c7cb-49c9-a577-06fb8ed48763
+              :MostRecentTaskID: f14b4b37-2954-4bfa-b7a1-11ab92f89919
               :MostRecentTaskUIState: Completed
-              :MostRecentTask: *27
-              :Location: C:\testing_provisioning
-              :CreationTime: 2016-02-26 13:42:16.017000000 -05:00
-              :OperatingSystem: *16
-              :HasVMAdditions: false
-              :VMAddition: Not Detected
-              :NumLockEnabled: false
-              :CPUCount: 1
-              :IsHighlyAvailable: false
-              :HAVMPriority: 
-              :IsDRProtectionRequired: false
-              :RecoveryPointObjective: 
-              :ProtectionProvider: 
-              :ReplicationGroupId: 
-              :ReplicationGroup: 
-              :LimitCPUFunctionality: false
-              :LimitCPUForMigration: false
-              :Memory: 1024
-              :DynamicMemoryEnabled: true
-              :DynamicMemoryMaximumMB: 4096
-              :DynamicMemoryBufferPercentage: 20
-              :MemoryWeight: 5000
-              :VirtualVideoAdapterEnabled: false
-              :MonitorMaximumCount: 
-              :MonitorResolutionMaximum: 
-              :BootOrder: *62
-              :FirstBootDevice: 
-              :SecureBootEnabled: 
-              :ComputerName: 
-              :UseHardwareAssistedVirtualization: true
-              :SANStatus: *63
-              :CostCenter: 
-              :QuotaPoint: 1
-              :IsTagEmpty: false
-              :Tag: "(none)"
-              :CustomProperties:
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              :CustomProperty: {}
-              :UndoDisksEnabled: false
-              :CPUType: *15
-              :ExpectedCPUUtilization: 20
-              :DiskIO: 0
-              :NetworkUtilization: 0
-              :RelativeWeight: 100
-              :CPUReserve: 0
-              :CPUMax: 100
-              :CPUPerVirtualNumaNodeMaximum: 8
-              :MemoryPerVirtualNumaNodeMaximumMB: 63140
-              :VirtualNumaNodesPerSocketMaximum: 1
-              :DynamicMemoryMinimumMB: 1024
-              :NumaIsolationRequired: false
-              :Generation: 1
-              :VirtualDVDDrives:
-              - *64
-              :VirtualHardDisks:
-              - *26
-              :VirtualDiskDrives:
-              - *65
-              :ShareSCSIBus: false
-              :VirtualNetworkAdapters:
-              - *66
-              :VirtualFibreChannelAdapters: []
-              :HasVirtualFibreChannelAdapters: false
-              :VirtualFloppyDrive: *67
-              :VirtualCOMPorts:
-              - COM1
-              - COM2
-              :VirtualSCSIAdapters:
-              - *68
-              :CapabilityProfile: *23
-              :CapabilityProfileCompatibilityState: Compatible
-              :VMCheckpoints: []
-              :HostId: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :HostType: VMHost
-              :HostName: dell-r410-01.cloudformswin.lab.redhat.com
-              :VMHost: *10
-              :LibraryServer: 
-              :CloudId: 
-              :Cloud: 
-              :LibraryGroup: 
-              :GrantedToList: []
-              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
-              :UserRole: *3
-              :Owner: CLOUDFORMSWIN\scvmm
-              :ObjectType: VM
-              :Accessibility: Public
-              :Name: testing_provisioning
-              :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-26 13:42:16.017000000 -05:00
-              :ModifiedTime: 2016-02-29 06:58:47.087000000 -05:00
-              :Enabled: true
-              :ServerConnection: *8
-              :ID: 3ddc6b7a-1709-4c2f-9f0f-ecc1d39aa297
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: *27
-            :MS:
-              :ServicingWindows: *9
-          :Disks:
-          - :ToString: "\\\\.\\PHYSICALDRIVE1"
-            :Props:
-              :Name: "\\\\.\\PHYSICALDRIVE1"
-              :Signature: 0
-              :UniqueID: '0'
-              :Capacity: 0
-              :AvailableCapacity: 0
-              :PhysicallyAvailableCapacity: 0
-              :DeviceID: "\\\\.\\PHYSICALDRIVE1"
-              :Index: 1
-              :IsClustered: false
-              :IsSanAttached: false
-              :IsPassThroughCapable: false
-              :ClusterDisk: 
-              :VMHost: *10
-              :LibraryServer: 
-              :DiskID: a2aae001-de04-4980-b974-55678e0e35f1
-              :Location: 
-              :SMLunId: USBSTOR\DISK&VEN_IDRAC&PROD_LCDRIVE&REV_0323\7&2D5DFC65&0&20080519&0:dell-r410-01
-              :SMLunIdFormat: 1
-              :SMLunIdNamespace: 1
-              :Bus: 0
-              :Lun: 0
-              :Port: 
-              :Target: 0
-              :StorageLogicalUnit: 
-              :Classification: *11
-              :DiskVolumes: []
-              :PartitionStyle: Unknown
-              :DiskStatus: Unknown
-              :IsViewOnly: false
-              :ServerConnection: *8
-              :ID: a2aae001-de04-4980-b974-55678e0e35f1
-              :ObjectType: VMHostDisk
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - *12
-          - :ToString: "\\\\.\\PHYSICALDRIVE2"
-            :Props:
-              :Name: "\\\\.\\PHYSICALDRIVE2"
-              :Signature: 0
-              :UniqueID: '0'
-              :Capacity: 0
-              :AvailableCapacity: 0
-              :PhysicallyAvailableCapacity: 0
-              :DeviceID: "\\\\.\\PHYSICALDRIVE2"
-              :Index: 2
-              :IsClustered: false
-              :IsSanAttached: false
-              :IsPassThroughCapable: false
-              :ClusterDisk: 
-              :VMHost: *10
-              :LibraryServer: 
-              :DiskID: 98fbfe0e-7629-4926-8f85-e01747f7d36f
-              :Location: 
-              :SMLunId: USBSTOR\DISK&VEN_IDRAC&PROD_VIRTUAL_FLOPPY&REV_0323\7&379531CB&0&20080519&1:dell-r410-01
-              :SMLunIdFormat: 1
-              :SMLunIdNamespace: 1
-              :Bus: 0
-              :Lun: 0
-              :Port: 
-              :Target: 0
-              :StorageLogicalUnit: 
-              :Classification: *11
-              :DiskVolumes: []
-              :PartitionStyle: Unknown
-              :DiskStatus: Unknown
-              :IsViewOnly: false
-              :ServerConnection: *8
-              :ID: 98fbfe0e-7629-4926-8f85-e01747f7d36f
-              :ObjectType: VMHostDisk
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :GPUs: []
-          :InstalledVirtualSwitchExtensions:
-          - :ToString: Microsoft Windows Filtering Platform
-            :Props:
-              :Name: Microsoft Windows Filtering Platform
-              :HostID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :Description: WFP vSwitch Extension LightWeight Filter for Hyper-V Virtual
-                Switch Filtering
-              :VirtualSwitchExtensionType: Filter
-              :DriverId: e7c3b2f0-f3c5-48df-af2b-10fed6d72e7a
-              :Version: 6.3.9600.18086
-              :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: 5ee3dc6e-c3a4-4248-9556-6c258edd450a
-              :IsViewOnly: false
-              :ObjectType: InstalledVirtualSwitchExtension
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Microsoft VMM DHCPv4 Server Switch Extension
-            :Props:
-              :Name: Microsoft VMM DHCPv4 Server Switch Extension
-              :HostID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :Description: Microsoft System Center Virtual Machine Manager DHCP Server
-              :VirtualSwitchExtensionType: Filter
-              :DriverId: 0d37c9f0-ea6c-47a0-9c42-4baeba3768d1
-              :Version: 24.0.1.0
-              :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: 71a35132-df8e-486e-95af-badf0887971e
-              :IsViewOnly: false
-              :ObjectType: InstalledVirtualSwitchExtension
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Microsoft Virtual Ethernet Switch Native Extension
-            :Props:
-              :Name: Microsoft Virtual Ethernet Switch Native Extension
-              :HostID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :Description: Provides built-in features that may be configured on a
-                switch or port
-              :VirtualSwitchExtensionType: Native
-              :DriverId: 11ec6134-128a-4a23-b12f-164184b48348
-              :Version: 6.3.9600.18005
-              :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: a2ac3e8f-9392-4642-860c-c91531de1250
-              :IsViewOnly: false
-              :ObjectType: InstalledVirtualSwitchExtension
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Microsoft NDIS Capture
-            :Props:
-              :Name: Microsoft NDIS Capture
-              :HostID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :Description: Microsoft NDIS Packet Capture Filter Driver
-              :VirtualSwitchExtensionType: Monitoring
-              :DriverId: ea24cd6c-d17a-4348-9190-09f0d5be83dd
-              :Version: 6.3.9600.16384
-              :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: 2076db4b-0d76-4a1b-bf4b-d0a7e932e7ea
-              :IsViewOnly: false
-              :ObjectType: InstalledVirtualSwitchExtension
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :DiskVolumes:
-          - :ToString: C:\
-            :Props:
-              :Name: C:\
-              :StorageVolumeID: 219c146f-cad3-11e5-80b3-806e6f6e6963
-              :ObjectID: 
-              :HostVolumeID: 219c146f-cad3-11e5-80b3-806e6f6e6963
-              :MountPoints:
-              - C:\
-              :Capacity: 499738734592
-              :FreeSpace: 463193792512
-              :VolumeLabel: 
-              :FileSystem: 
-              :IsSANMigrationPossible: false
-              :IsClustered: false
-              :IsClusterSharedVolume: false
-              :InUse: false
-              :VMHost: *10
-              :IsAvailableForPlacement: true
-              :HostDiskID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
-              :StorageDiskID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
-              :HostDisk: *12
-              :StorageDisk: *12
-              :Classification: *11
-              :StoragePool: 
-              :ServerConnection: *8
-              :ID: 1c00651a-ca2a-4676-976b-55875305a89f
-              :IsViewOnly: false
-              :ObjectType: VMHostVolume
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: "\\\\?\\Volume{219c146e-cad3-11e5-80b3-806e6f6e6963}\\"
-            :Props:
-              :Name: "\\\\?\\Volume{219c146e-cad3-11e5-80b3-806e6f6e6963}\\"
-              :StorageVolumeID: 219c146e-cad3-11e5-80b3-806e6f6e6963
-              :ObjectID: 
-              :HostVolumeID: 219c146e-cad3-11e5-80b3-806e6f6e6963
-              :MountPoints:
-              - "\\\\?\\Volume{219c146e-cad3-11e5-80b3-806e6f6e6963}\\"
-              :Capacity: 366997504
-              :FreeSpace: 75644928
-              :VolumeLabel: System Reserved
-              :FileSystem: 
-              :IsSANMigrationPossible: false
-              :IsClustered: false
-              :IsClusterSharedVolume: false
-              :InUse: false
-              :VMHost: *10
-              :IsAvailableForPlacement: true
-              :HostDiskID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
-              :StorageDiskID: 2437e277-2827-48a1-ba3a-c42dd40f17e7
-              :HostDisk: *12
-              :StorageDisk: *12
-              :Classification: *11
-              :StoragePool: 
-              :ServerConnection: *8
-              :ID: 0b67af43-9d08-48d4-b418-f99c0cef0bf7
-              :IsViewOnly: false
-              :ObjectType: VMHostVolume
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :RegisteredStorageFileShares: []
-          :FibreChannelHbas: []
-          :FibreChannelVirtualSANs: []
-          :SASHbas:
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 3
-              :LocalSASAddress: 5D4AE5207D3F9203
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.930000000 -05:00
-              :ServerConnection: *8
-              :ID: 45056b73-029c-478f-aac7-1bc58bb7f65e
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 1
-              :LocalSASAddress: 5D4AE5207D3F9201
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.910000000 -05:00
-              :ServerConnection: *8
-              :ID: 19106a9f-674e-46de-ac0b-46344054a28c
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 5
-              :LocalSASAddress: 5D4AE5207D3F9205
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.953000000 -05:00
-              :ServerConnection: *8
-              :ID: 5a93ae04-0b4f-49ca-b67a-7ed0650395fd
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 0
-              :LocalSASAddress: 5D4AE5207D3F9200
-              :AttachedSASAddress: '1221000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.897000000 -05:00
-              :ServerConnection: *8
-              :ID: 7507a153-717a-4005-a398-b32c470898ef
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 4
-              :LocalSASAddress: 5D4AE5207D3F9204
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.943000000 -05:00
-              :ServerConnection: *8
-              :ID: 055b7786-9bea-4fca-aaea-c195490d9960
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 6
-              :LocalSASAddress: 5D4AE5207D3F9206
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.963000000 -05:00
-              :ServerConnection: *8
-              :ID: 13fc58a7-bf5f-4327-a18c-d34759607655
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 7
-              :LocalSASAddress: 5D4AE5207D3F9207
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.973000000 -05:00
-              :ServerConnection: *8
-              :ID: 5e9a41c3-b05c-436a-b675-e2faa0b37338
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 2
-              :LocalSASAddress: 5D4AE5207D3F9202
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *10
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:35:45.920000000 -05:00
-              :ServerConnection: *8
-              :ID: 50a1cc33-df0e-4e51-93f5-fa97fdbeafb1
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :InternetSCSIHbas: []
-          :VMwareResourcePool: 
-          :IsConfiguredForOutOfBandManagement: false
-          :PhysicalMachine:
-            :ToString: 4c4c4544-0031-5210-8050-c2c04f4b5331
-            :Props:
-              :Name: 4c4c4544-0031-5210-8050-c2c04f4b5331
-              :BMCType: None
-              :BMCCustomConfigurationProvider: 
-              :BMCAddress: 
-              :BMCPort: 
-              :RunAsAccount: 
-              :SMBiosGUID: 4c4c4544-0031-5210-8050-c2c04f4b5331
-              :ComputerPowerState: Unknown
-              :SystemEventLog: []
-              :ServerConnection: *8
-              :ID: 55eb714f-a929-44b9-adb1-c9f12e7e54cc
-              :IsViewOnly: false
-              :ObjectType: PhysicalMachine
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :HealthMonitors:
-          - :ToString: Hyper-V Virtual Machine Management Service
-            :Props:
-              :ParentID: d676ac10-b472-4fcf-b7b3-cb7b93870177
-              :Name: Hyper-V Virtual Machine Management Service
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-22 09:22:22.893000000 -05:00
-              :ServerConnection: *8
-              :ID: 02b0ecf8-392c-411b-a31b-0485afe004d4
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Host Agent Overall
-            :Props:
-              :ParentID: 907f9cc8-4377-4244-b5e4-b27b9f080b4a
-              :Name: Host Agent Overall
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: 
-              :UpdatedDate: 2016-02-22 09:22:22.887000000 -05:00
-              :ServerConnection: *8
-              :ID: 4d9037dd-5993-4c7a-b199-15074ab66fd7
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Hyper-V Role Version
-            :Props:
-              :ParentID: d676ac10-b472-4fcf-b7b3-cb7b93870177
-              :Name: Hyper-V Role Version
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-22 09:22:22.897000000 -05:00
-              :ServerConnection: *8
-              :ID: cbfb3236-a9aa-4363-88ab-438007e1c018
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Network
-            :Props:
-              :ParentID: 907f9cc8-4377-4244-b5e4-b27b9f080b4a
-              :Name: Network
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-22 09:22:22.887000000 -05:00
-              :ServerConnection: *8
-              :ID: 7e2be21d-8ea5-4ebd-bdef-6b861cf2ac5f
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Host Agent Service
-            :Props:
-              :ParentID: 4d9037dd-5993-4c7a-b199-15074ab66fd7
-              :Name: Host Agent Service
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-22 09:22:22.890000000 -05:00
-              :ServerConnection: *8
-              :ID: b023b069-eb9e-4212-ad7d-85f899e4b523
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Host Agent Version
-            :Props:
-              :ParentID: 4d9037dd-5993-4c7a-b199-15074ab66fd7
-              :Name: Host Agent Version
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-22 09:22:22.890000000 -05:00
-              :ServerConnection: *8
-              :ID: 844d8bb9-43c6-4acc-929e-8649c17b8961
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Overall
-            :Props:
-              :ParentID: 
-              :Name: Overall
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: 
-              :UpdatedDate: 2016-02-22 09:22:22.887000000 -05:00
-              :ServerConnection: *8
-              :ID: 907f9cc8-4377-4244-b5e4-b27b9f080b4a
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: WMI Performance Counter
-            :Props:
-              :ParentID: 4d9037dd-5993-4c7a-b199-15074ab66fd7
-              :Name: WMI Performance Counter
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-22 09:22:22.890000000 -05:00
-              :ServerConnection: *8
-              :ID: 0bcdf63e-571d-4340-ba22-c966b9a6bd4e
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Hyper-V Role Overall
-            :Props:
-              :ParentID: 907f9cc8-4377-4244-b5e4-b27b9f080b4a
-              :Name: Hyper-V Role Overall
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: 
-              :UpdatedDate: 2016-02-22 09:22:22.890000000 -05:00
-              :ServerConnection: *8
-              :ID: d676ac10-b472-4fcf-b7b3-cb7b93870177
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: WinRM
-            :Props:
-              :ParentID: 907f9cc8-4377-4244-b5e4-b27b9f080b4a
-              :Name: WinRM
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-22 09:22:22.887000000 -05:00
-              :ServerConnection: *8
-              :ID: cefed282-0a57-4716-91db-e8034f46252b
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :RemoteStorageTotalCapacity: 0
-          :RemoteStorageAvailableCapacity: 0
-          :LocalStorageTotalCapacity: 500107862016
-          :LocalStorageAvailableCapacity: 463269437440
-          :TotalStorageCapacity: 500107862016
-          :AvailableStorageCapacity: 463269437440
-          :UsedStorageCapacity: 36838424576
-          :IsDedicatedToNetworkVirtualizationGateway: false
-          :FibreChannelWorldWidePortNameMinimum: C003FF831E9E0000
-          :FibreChannelWorldWidePortNameMaximum: C003FF831E9EFFFF
-          :FibreChannelWorldWideNodeName: C003FF0000FFFF00
-          :VMConnectCertificateThumbprint: 
-          :Custom1: 
-          :Custom2: 
-          :Custom3: 
-          :Custom4: 
-          :Custom5: 
-          :Custom6: 
-          :Custom7: 
-          :Custom8: 
-          :Custom9: 
-          :Custom10: 
-          :CustomProperty: {}
-          :FibreChannelSANStatus:
-            :ToString: DeployTargetDoesNotHaveHBA (1204)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1204
-              :ErrorCodeString: '1204'
-              :ErrorType: Error
-              :CSMMessageString: 'Error Code : DeployTargetDoesNotHaveHBA ; Message
-                : The server dell-r410-01.cloudformswin.lab.redhat.com does not contain
-                any host bus adapter (HBA) ports. Fibre Channel SAN transfer cannot
-                be used. ; Recommended Action : Transfer the virtual machine over
-                the LAN.'
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: The server dell-r410-01.cloudformswin.lab.redhat.com does
-                not contain any host bus adapter (HBA) ports. Fibre Channel SAN transfer
-                cannot be used.
-              :CloudProblem: The server does not contain any host bus adapter (HBA)
-                ports. Fibre Channel SAN transfer cannot be used.
-              :RecommendedAction: Transfer the virtual machine over the LAN.
-              :RecommendedActionCLI: Transfer the virtual machine over the LAN.
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters:
-                :VMHostName: dell-r410-01.cloudformswin.lab.redhat.com
-              :Code: DeployTargetDoesNotHaveHBA
-              :GetMessageFormatterHandler: 
-          :ISCSISANStatus:
-            :ToString: DeployTargetDoesNotHaveIscsiInitiator (1231)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1231
-              :ErrorCodeString: '1231'
-              :ErrorType: Error
-              :CSMMessageString: 'Error Code : DeployTargetDoesNotHaveIscsiInitiator
-                ; Message : The server dell-r410-01.cloudformswin.lab.redhat.com does
-                not have the Microsoft iSCSI Initiator installed. iSCSI SAN transfer
-                cannot be used. ; Recommended Action : Transfer the virtual machine
-                over the LAN.'
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: The server dell-r410-01.cloudformswin.lab.redhat.com does
-                not have the Microsoft iSCSI Initiator installed. iSCSI SAN transfer
-                cannot be used.
-              :CloudProblem: The server does not have the Microsoft iSCSI Initiator
-                installed. iSCSI SAN transfer cannot be used.
-              :RecommendedAction: Transfer the virtual machine over the LAN.
-              :RecommendedActionCLI: Transfer the virtual machine over the LAN.
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters:
-                :VMHostName: dell-r410-01.cloudformswin.lab.redhat.com
-              :Code: DeployTargetDoesNotHaveIscsiInitiator
-              :GetMessageFormatterHandler: 
-          :NPIVFibreChannelSANStatus:
-            :ToString: DeployHostIsNotNPIVCapable (1252)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1252
-              :ErrorCodeString: '1252'
-              :ErrorType: Error
-              :CSMMessageString: 'Error Code : DeployHostIsNotNPIVCapable ; Message
-                : The server dell-r410-01.cloudformswin.lab.redhat.com does not have
-                an HBA which supports NPIV. ; Recommended Action : If server dell-r410-01.cloudformswin.lab.redhat.com
-                contains an HBA that supports NPIV, ensure that the right version
-                of firmware and driver are installed, or transfer the virtual machine
-                over the LAN.'
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: The server dell-r410-01.cloudformswin.lab.redhat.com does
-                not have an HBA which supports NPIV.
-              :CloudProblem: The server does not have an HBA which supports NPIV.
-              :RecommendedAction: If server dell-r410-01.cloudformswin.lab.redhat.com
-                contains an HBA that supports NPIV, ensure that the right version
-                of firmware and driver are installed, or transfer the virtual machine
-                over the LAN.
-              :RecommendedActionCLI: If server dell-r410-01.cloudformswin.lab.redhat.com
-                contains an HBA that supports NPIV, ensure that the right version
-                of firmware and driver are installed, or transfer the virtual machine
-                over the LAN.
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters:
-                :VMHostName: dell-r410-01.cloudformswin.lab.redhat.com
-              :Code: DeployHostIsNotNPIVCapable
-              :GetMessageFormatterHandler: 
-          :CertificateRequest: 
-          :ComputerState:
-            :ToString: Responding
-            :By: 2
-          :VirtualizationManager: 
-          :ServerConnection: *8
-          :ID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHost
-            :I32: 9
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-          :MostRecentTaskIfLocal: *69
-        :MS:
-          :FQDN: dell-r410-01.cloudformswin.lab.redhat.com
-          :LogicalCPUCount: 16
-          :CPUSpeed: 2394
-          :CPUModel: Xeon
-          :CPUManufacturer: Intel
-          :CPUArchitecture: 9
-          :CPUFamily: '179'
-          :VMRCEnabled: true
-          :VMRCPort: 2179
-          :SecureVMRCEnabled: false
-          :VirtualServerState:
-            :ToString: Running
-            :By: 3
-          :VirtualServerStateString: Running
-          :VirtualServerVersion: 6.3.9600.17787
-          :VirtualServerVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :ServicingWindows: *9
-      :NetworkAdapters:
-      - :ToString: 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
-          #33'
-        :Props:
-          :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33'
-          :IPAddresses:
-          - :ToString: 10.8.96.23
-            :Props:
-              :Address: 392169482
-              :AddressFamily: InterNetwork
-              :IsIPv6Multicast: false
-              :IsIPv6LinkLocal: false
-              :IsIPv6SiteLocal: false
-              :IsIPv6Teredo: false
-              :IsIPv4MappedToIPv6: false
-            :MS:
-              :IPAddressToString: 10.8.96.23
-          - :ToString: fe80::29fb:5b39:3533:3516
-            :Props:
-              :AddressFamily: InterNetworkV6
-              :ScopeId: 0
-              :IsIPv6Multicast: false
-              :IsIPv6LinkLocal: true
-              :IsIPv6SiteLocal: false
-              :IsIPv6Teredo: false
-              :IsIPv4MappedToIPv6: false
-            :MS:
-              :IPAddressToString: fe80::29fb:5b39:3533:3516
-          :DHCPEnabled: true
-          :IPSubnets:
-          - :ToString: 10.8.96.0/22
-            :Props:
-              :NetworkAddress: 10.8.96.0
-              :AddressRangeEnd: 10.8.99.255
-              :AddressFamily: IPv4
-              :PrefixLength: 22
-              :SubnetMask: 255.255.252.0
-              :FirstAddressInSubnet: 10.8.96.1
-              :LastAddressInSubnet: 10.8.99.254
-          - :ToString: fe80::/64
-            :Props:
-              :NetworkAddress: 'fe80::'
-              :AddressRangeEnd: fe80::ffff:ffff:ffff:ffff
-              :AddressFamily: IPv6
-              :PrefixLength: 64
-              :SubnetMask: 'ffff:ffff:ffff:ffff::'
-              :FirstAddressInSubnet: fe80::1
-              :LastAddressInSubnet: fe80::ffff:ffff:ffff:fffe
-          :DefaultIPGateways:
-          - :ToString: 10.8.99.254
-            :Props:
-              :Address: 4267902986
-              :AddressFamily: InterNetwork
-              :IsIPv6Multicast: false
-              :IsIPv6LinkLocal: false
-              :IsIPv6SiteLocal: false
-              :IsIPv6Teredo: false
-              :IsIPv4MappedToIPv6: false
-            :MS:
-              :IPAddressToString: 10.8.99.254
-          :MacAddress: D4:AE:52:6A:02:43
-          :PhysicalAddress: D4:AE:52:6A:02:43
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: &70
-            :ToString: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33
-              - Virtual Switch'
-            :Props:
-              :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33 -
-                Virtual Switch'
-              :HighlyAvailable: false
-              :HostBoundVlanId: 0
-              :NetworkOptimizationCapable: false
-              :NetworkOptimizationAvailable: false
-              :BoundToVMHost: true
-              :Description: 
-              :LogicalNetworks:
-              - *21
-              :VMHostNetworkAdapters:
-              - 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
-                #33'
-              :VMHost: *10
-              :LogicalSwitch: 
-              :LogicalSwitchComplianceStatus: NotAnInstanceOfLogicalSwitch
-              :LogicalSwitchComplianceErrors: []
-              :VMwarePortGroups: []
-              :VMHostID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-              :ServerConnection: *8
-              :ID: ba598ad6-436f-4b13-821f-39c69217619f
-              :IsViewOnly: false
-              :ObjectType: VirtualNetwork
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :NetworkSwitchPort: 
-          :UplinkPortProfileSet: 
-          :VLanTags: []
-          :UsableVLanTags:
-          - 0
-          :VLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :DesiredVLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :VLanEnabled: true
-          :ConnectionState:
-            :ToString: Connected
-            :I32: 0
-          :ConnectionName: Ethernet 2
-          :Description: 
-          :PrimaryDNSSuffix: cloudforms.lab.eng.rdu2.redhat.com
-          :MaxBandwidth: 1000
-          :VMHost: *10
-          :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :UsableVlanMode:
-            :ToString: Trunk
-            :I32: 1
-          :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
-          :UnassignedVLans: []
-          :AvailableForPlacement: true
-          :IsAvailableForHA: true
-          :UsedForManagement: true
-          :LogicalNetworkCompliance:
-            :ToString: Compliant
-            :I32: 1
-          :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 1, device 0, function 0
-          :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: 40aa1cc5-3261-4741-b690-2d49869c3a5a
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHostNetworkAdapter
-            :I32: 12
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-      - :ToString: 'Ethernet - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
-          #34'
-        :Props:
-          :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #34'
-          :IPAddresses: []
-          :DHCPEnabled: true
-          :IPSubnets: []
-          :DefaultIPGateways: []
-          :MacAddress: D4:AE:52:6A:02:44
-          :PhysicalAddress: D4:AE:52:6A:02:44
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: 
-          :NetworkSwitchPort: 
-          :UplinkPortProfileSet: 
-          :VLanTags: []
-          :UsableVLanTags:
-          - 0
-          :VLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :DesiredVLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :VLanEnabled: true
-          :ConnectionState:
-            :ToString: MediaDisconnected
-            :I32: 4
-          :ConnectionName: Ethernet
-          :Description: 
-          :PrimaryDNSSuffix: 
-          :MaxBandwidth: 0
-          :VMHost: *10
-          :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :UsableVlanMode:
-            :ToString: Trunk
-            :I32: 1
-          :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
-          :UnassignedVLans: []
-          :AvailableForPlacement: true
-          :IsAvailableForHA: true
-          :UsedForManagement: false
-          :LogicalNetworkCompliance:
-            :ToString: Compliant
-            :I32: 1
-          :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 1, device 0, function 1
-          :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: d0632785-b5cf-4258-9237-4378aa15b538
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHostNetworkAdapter
-            :I32: 12
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-      - :ToString: 'Ethernet 3 - Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client)
-          #35'
-        :Props:
-          :Name: 'Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client) #35'
-          :IPAddresses: []
-          :DHCPEnabled: true
-          :IPSubnets: []
-          :DefaultIPGateways: []
-          :MacAddress: 00:10:18:CD:8D:88
-          :PhysicalAddress: 00:10:18:CD:8D:88
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: 
-          :NetworkSwitchPort: 
-          :UplinkPortProfileSet: 
-          :VLanTags: []
-          :UsableVLanTags:
-          - 0
-          :VLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :DesiredVLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :VLanEnabled: true
-          :ConnectionState:
-            :ToString: MediaDisconnected
-            :I32: 4
-          :ConnectionName: Ethernet 3
-          :Description: 
-          :PrimaryDNSSuffix: 
-          :MaxBandwidth: 0
-          :VMHost: *10
-          :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :UsableVlanMode:
-            :ToString: Trunk
-            :I32: 1
-          :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
-          :UnassignedVLans: []
-          :AvailableForPlacement: true
-          :IsAvailableForHA: true
-          :UsedForManagement: false
-          :LogicalNetworkCompliance:
-            :ToString: Compliant
-            :I32: 1
-          :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 3, device 0, function 0
-          :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: 366ed811-f732-43e8-b1f2-8aa1f091aea9
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHostNetworkAdapter
-            :I32: 12
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-      - :ToString: 'Ethernet 4 - Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client)
-          #36'
-        :Props:
-          :Name: 'Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client) #36'
-          :IPAddresses: []
-          :DHCPEnabled: true
-          :IPSubnets: []
-          :DefaultIPGateways: []
-          :MacAddress: 00:10:18:CD:8D:8A
-          :PhysicalAddress: 00:10:18:CD:8D:8A
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: 
-          :NetworkSwitchPort: 
-          :UplinkPortProfileSet: 
-          :VLanTags: []
-          :UsableVLanTags:
-          - 0
-          :VLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :DesiredVLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :VLanEnabled: true
-          :ConnectionState:
-            :ToString: MediaDisconnected
-            :I32: 4
-          :ConnectionName: Ethernet 4
-          :Description: 
-          :PrimaryDNSSuffix: 
-          :MaxBandwidth: 0
-          :VMHost: *10
-          :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :UsableVlanMode:
-            :ToString: Trunk
-            :I32: 1
-          :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
-          :UnassignedVLans: []
-          :AvailableForPlacement: true
-          :IsAvailableForHA: true
-          :UsedForManagement: false
-          :LogicalNetworkCompliance:
-            :ToString: Compliant
-            :I32: 1
-          :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 3, device 0, function 1
-          :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: ff70f228-63df-434b-94a6-f77075332529
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHostNetworkAdapter
-            :I32: 12
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-      :VirtualSwitch:
-      - :ToString: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33 - Virtual
-          Switch'
-        :Props:
-          :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33 - Virtual
-            Switch'
-          :HighlyAvailable: false
-          :HostBoundVlanId: 0
-          :NetworkOptimizationCapable: false
-          :NetworkOptimizationAvailable: false
-          :BoundToVMHost: true
-          :Description: 
-          :LogicalNetworks:
-          - *21
-          :VMHostNetworkAdapters:
-          - :ToString: 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD
-              Client) #33'
-            :Props:
-              :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33'
-              :IPAddresses:
-              - :ToString: 10.8.96.23
-                :Props:
-                  :Address: 392169482
-                  :AddressFamily: InterNetwork
-                  :IsIPv6Multicast: false
-                  :IsIPv6LinkLocal: false
-                  :IsIPv6SiteLocal: false
-                  :IsIPv6Teredo: false
-                  :IsIPv4MappedToIPv6: false
-                :MS:
-                  :IPAddressToString: 10.8.96.23
-              - :ToString: fe80::29fb:5b39:3533:3516
-                :Props:
-                  :AddressFamily: InterNetworkV6
-                  :ScopeId: 0
-                  :IsIPv6Multicast: false
-                  :IsIPv6LinkLocal: true
-                  :IsIPv6SiteLocal: false
-                  :IsIPv6Teredo: false
-                  :IsIPv4MappedToIPv6: false
-                :MS:
-                  :IPAddressToString: fe80::29fb:5b39:3533:3516
-              :DHCPEnabled: true
-              :IPSubnets:
-              - 10.8.96.0/22
-              - fe80::/64
-              :DefaultIPGateways:
-              - :ToString: 10.8.99.254
-                :Props:
-                  :Address: 4267902986
-                  :AddressFamily: InterNetwork
-                  :IsIPv6Multicast: false
-                  :IsIPv6LinkLocal: false
-                  :IsIPv6SiteLocal: false
-                  :IsIPv6Teredo: false
-                  :IsIPv4MappedToIPv6: false
-                :MS:
-                  :IPAddressToString: 10.8.99.254
-              :MacAddress: D4:AE:52:6A:02:43
-              :PhysicalAddress: D4:AE:52:6A:02:43
-              :NetworkLocation: VM_Network
-              :VirtualNetwork: *70
-              :NetworkSwitchPort: 
-              :UplinkPortProfileSet: 
-              :VLanTags: []
-              :UsableVLanTags:
-              - 0
-              :VLanMode: Trunk
-              :DesiredVLanMode: Trunk
-              :VLanEnabled: true
-              :ConnectionState: Connected
-              :ConnectionName: Ethernet 2
-              :Description: 
-              :PrimaryDNSSuffix: cloudforms.lab.eng.rdu2.redhat.com
-              :MaxBandwidth: 1000
-              :VMHost: *10
-              :LogicalNetworkMap:
-                ! '':
-                - '0'
-              :UsableVlanMode: Trunk
-              :ModelAccessibleSubnetVLans:
-                ! '':
-                - '0'
-              :LogicalNetworks:
-              - *21
-              :SubnetVLans:
-              - '0'
-              :UnassignedVLans: []
-              :AvailableForPlacement: true
-              :IsAvailableForHA: true
-              :UsedForManagement: true
-              :LogicalNetworkCompliance: Compliant
-              :LogicalNetworkComplianceErrors: []
-              :BDFLocationInformation: PCI bus 1, device 0, function 0
-              :NetworkVirtualizationEnabled: true
-              :ServerConnection: *8
-              :ID: 40aa1cc5-3261-4741-b690-2d49869c3a5a
-              :IsViewOnly: false
-              :ObjectType: VMHostNetworkAdapter
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :VMHost: *10
-          :LogicalSwitch: 
-          :LogicalSwitchComplianceStatus:
-            :ToString: NotAnInstanceOfLogicalSwitch
-            :I32: 0
-          :LogicalSwitchComplianceErrors: []
-          :VMwarePortGroups: []
-          :VMHostID: 7805b0eb-dffa-4f62-b38d-c6fa624b0ee9
-          :ServerConnection: *8
-          :ID: ba598ad6-436f-4b13-821f-39c69217619f
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VirtualNetwork
-            :I32: 15
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-    :6a2c5120-2931-4cc2-a445-8d28dfc73e03:
-      :Properties:
-        :ToString: dell-r410-03.cloudformswin.lab.redhat.com
-        :Props:
-          :RunAsAccount: 
-          :MostRecentTaskID: a45a922f-7815-46bd-9116-b47ad83ffc1f
-          :MostRecentTaskUIState:
-            :ToString: Failed
-            :I32: 3
-          :MostRecentTask: &99
-            :ToString: Refresh Performance Data
-            :Props:
-              :StepsLoaded: true
-              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Refresh Performance Data
-              :IsVisible: true
-              :Status: Failed
-              :StatusString: Failed
-              :ErrorInfo: 'HostAgentFail (2912); HR: 0x80070576'
-              :StartTime: 2016-02-26 21:05:07.510000000 -05:00
-              :EndTime: 2016-02-26 21:05:07.530000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Refresh Performance Data
-              :Steps:
-              - Microsoft.SystemCenter.VirtualMachineManager.Step
-              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 0
-              :Progress: 0 %
-              :WasNotifiedOfCancel: false
-              :CmdletName: Performance Data Refresher (System Job)
-              :PROTipID: 
-              :ResultObjectID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-              :TargetObjectID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-              :TargetObjectType: VMHost
-              :IsCompleted: true
-              :AreAuditRecordsAvailable: false
-              :AuditRecords: []
-              :AdditionalMessages: []
-              :Source: 
-              :Target: 
-              :ResultObjectType: VMHost
-              :ResultObjectTypeName: Host
-              :ResultName: dell-r410-03.cloudformswin.lab.redhat.com
-              :IsRestartable: false
-              :IsStoppable: false
-              :ServerConnection: *8
-              :ID: a45a922f-7815-46bd-9116-b47ad83ffc1f
-              :IsViewOnly: false
-              :ObjectType: Job
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :OverallStateString: OK
-          :OverallState:
-            :ToString: OK
-            :By: 0
-          :CommunicationStateString: Responding
-          :CommunicationState:
-            :ToString: Responding
-            :By: 0
-          :Name: dell-r410-03.cloudformswin.lab.redhat.com
-          :FullyQualifiedDomainName: dell-r410-03.cloudformswin.lab.redhat.com
-          :ComputerName: dell-r410-03
-          :DomainName: cloudformswin.lab.redhat.com
-          :Description: 
-          :RemoteUserName: 
-          :OverrideHostGroupReserves: false
-          :CPUPercentageReserve: 10
-          :NetworkPercentageReserve: 0
-          :DiskSpaceReserveMB: 10240
-          :MaxDiskIOReservation: 10000
-          :MemoryReserveMB: 2048
-          :VMPaths: *71
-          :BaseDiskPaths: *72
-          :PROEnabled: false
-          :MaintenanceHost: false
-          :AvailableForPlacement: true
-          :IsEmbedded: false
-          :CredentialsNeeded: false
-          :PausedForNetworkIncompatibility: false
-          :LogicalProcessorCount: 16
-          :PhysicalCPUCount: 2
-          :CoresPerCPU: 8
-          :L2CacheSize: 2048
-          :L3CacheSize: 12288
-          :BusSpeed: 5860
-          :ProcessorSpeed: 2394
-          :ProcessorModel: Xeon
-          :ProcessorManufacturer: Intel
-          :ProcessorArchitecture: 9
-          :ProcessorFamily: '179'
-          :CpuUtilization: 0
-          :TotalMemory: 137425408000
-          :AvailableMemory: 127010
-          :OperatingSystem:
-            :ToString: 'Microsoft Windows Server 2012 R2 Datacenter '
-            :Props:
-              :Name: 'Microsoft Windows Server 2012 R2 Datacenter '
-              :Description: 
-              :Version: 6.3.9600
-              :Architecture: amd64
-              :Edition: Standard
-              :OSType: Windows
-              :IsWindows: false
-              :ProductType: 
-              :IsCustomizationAllowed: false
-              :IsApplicationDeploymentAllowed: false
-              :RequiresAdministratorAccountNameInSysprep: false
-              :RequiresXMLSysprepFormat: true
-              :AllowsOrgNameInSysprep: false
-              :RequiresPIDInSysprep: true
-              :ServerConnection: 
-              :ID: d57123c4-cc5b-4dbe-992c-ca1ad6fd42ba
-              :IsViewOnly: false
-              :ObjectType: OperatingSystem
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :OperatingSystemVersion: 6.3.9600
-          :DVDDrives: F:;G:;
-          :DVDDriveList:
-          - F
-          - G
-          :VirtualizationPlatformString: Microsoft Hyper-V
-          :VirtualizationPlatform:
-            :ToString: HyperV
-            :I32: 2
-          :VirtualizationPlatformDetail: Microsoft Hyper-V
-          :IsVirtualizationSoftwareDetailUnknown: false
-          :IsViridianHost: true
-          :SupportsLiveMigration: false
-          :FloppyDrives: 
-          :FloppyDriveList: []
-          :VMHostGroup: *13
-          :HostCluster: 
-          :RemoteConnectEnabled: true
-          :RemoteConnectPort: 2179
-          :SecureRemoteConnectEnabled: false
-          :VMRCCertificateAvailable: false
-          :EnableLiveMigration: false
-          :LiveMigrationMaximum: 2
-          :LiveStorageMigrationMaximum: 2
-          :UseAnyMigrationSubnet: false
-          :MigrationSubnet: *73
-          :MigrationSubnetUserManaged: *74
-          :MigrationAuthProtocol:
-            :ToString: CredSSP
-            :By: 0
-          :MigrationPerformanceOption:
-            :ToString: UseCompression
-            :By: 1
-          :SslTcpPort: 5985
-          :SslCertificateHash: 
-          :SshTcpPort: 0
-          :SshPublicKeyHash: 
-          :SshPublicKey: 
-          :IsRemoteFXRoleInstalled: false
-          :IsCPUSLAT: true
-          :IsNumaSpanningEnabled: true
-          :GPUMemoryTotalMB: 
-          :GPUMemoryAvailableMB: 
-          :ClusterNodeStatus:
-            :ToString: Unknown
-            :By: 7
-          :TimeZone: -300
-          :HyperVState:
-            :ToString: Running
-            :By: 3
-          :HyperVStateString: Running
-          :HyperVVersion: 6.3.9600.17787
-          :HyperVVersionState:
-            :ToString: UpToDate
-            :By: 0
-          :PerimeterNetworkHost: false
-          :NonTrustedDomainHost: false
-          :MaximumMemoryPerVM: 1048576
-          :MinimumMemoryPerVM: 32
-          :SuggestedMaximumMemoryPerVM: 512
-          :ModifiedTime: 2016-02-29 19:53:09.520876000 -05:00
-          :Agent: &75
-            :ToString: dell-r410-03.cloudformswin.lab.redhat.com
-            :Props:
-              :StateString: Responding
-              :RoleString: Host
-              :State: Responding
-              :VersionState: UpToDate
-              :VersionStateString: Up-to-date
-              :MarkedForDeletion: false
-              :Name: dell-r410-03.cloudformswin.lab.redhat.com
-              :MostRecentTaskID: 
-              :MostRecentTaskUIState: 
-              :MostRecentTask: 
-              :FullyQualifiedDomainName: dell-r410-03.cloudformswin.lab.redhat.com
-              :FQDN: dell-r410-03.cloudformswin.lab.redhat.com
-              :ComputerName: dell-r410-03
-              :Description: 
-              :AgentVersion: 3.2.8145.0
-              :Role: Host
-              :UpdatedDate: 2016-02-20 06:00:07.757000000 -05:00
-              :ComplianceStatus: 
-              :ServerConnection: *8
-              :ID: 69da0411-247e-49bb-96fd-99a74788ef7e
-              :IsViewOnly: false
-              :ObjectType: AgentServer
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: 
-          :ManagedComputer: *75
-          :VMs:
-          - :ToString: vm_linux1
-            :Props:
-              :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\Virtual
-                Machines\FDA2093A-D44F-40A1-BB8C-0F90FCDC1528.xml
-              :MarkedAsTemplate: false
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :VMId: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
-              :VMResourceGroup: 
-              :VMConfigResource: 
-              :VMConfigResourceStatus: ClusterResourceStateUnknown
-              :VMResource: 
-              :VMResourceStatus: ClusterResourceStateUnknown
-              :DiskResources: *76
-              :UnsupportedReason: *19
-              :RefresherErrors: *77
-              :VirtualMachineState: Running
-              :HostGroupPath: All Hosts\vm_linux1
-              :TotalSize: 4194304
-              :MemoryAssignedMB: 512
-              :MemoryAvailablePercentage: '0'
-              :DynamicMemoryDemandMB: 512
-              :DynamicMemoryStatus: 
-              :AllocatedGPU: 
-              :HasPassthroughDisk: false
-              :HasSharedStorage: false
-              :Status: Running
-              :IsOrphaned: false
-              :HasSavedState: false
-              :StatusString: Running
-              :StartAction: NeverAutoTurnOnVM
-              :StopAction: SaveVM
-              :RunGuestAccount: 
-              :DelayStart: 0
-              :BiosGuid: 5337594f-94a4-4446-b557-73dba213f6dc
-              :CPUUtilization: 0
-              :PerfCPUUtilization: 0
-              :PerfMemory: 512
-              :PerfDiskBytesRead: 0
-              :PerfDiskBytesWrite: 0
-              :PerfNetworkBytesRead: 0
-              :PerfNetworkBytesWrite: 0
-              :VirtualizationPlatform: HyperV
-              :ComputerNameString: Unknown
-              :CreationSource: Temporary Templateae0b700f-8f3f-4709-b7f1-55613f33b0db
-              :IsUndergoingLiveMigration: false
-              :SourceObjectType: VM Template
-              :OperatingSystemShutdownEnabled: true
-              :TimeSynchronizationEnabled: true
-              :DataExchangeEnabled: true
-              :HeartbeatEnabled: true
-              :BackupEnabled: true
-              :ExcludeFromPRO: false
-              :FailedJobID: 
-              :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1\
-              :SelfServiceUserRole: 
-              :PassThroughDisks: []
-              :ComputerTier: 
-              :ConnectToAddresses: []
-              :CloudVmRoleId: 
-              :CloudVmRoleName: 
-              :UpgradeDomain: 
-              :SCApplications: []
-              :LastRestoredCheckpointID: FDA2093A-D44F-40A1-BB8C-0F90FCDC1528
-              :LastRestoredVMCheckpoint: 
-              :ComplianceStatus: 
-              :IsFaultTolerant: false
-              :DeploymentErrorInfo: 
-              :ServiceDeploymentErrorMessage: 
-              :DeploymentState: Undeployed
-              :TieredPerfData: *78
-              :ReplicationSetting: 
-              :ReplicationStatus: 
-              :IsRecoveryVM: false
-              :IsPrimaryVM: false
-              :IsTestReplicaVM: false
-              :ReplicationState: 
-              :ReplicationHealth: 
-              :ReplicationMode: 
-              :LastReplicationTime: 
-              :IsDREnabled: false
-              :DRState: Disabled
-              :DRErrors: []
-              :HasDRError: false
-              :ClusterNonPossibleOwner: 
-              :ClusterPreferredOwner: 
-              :AvailabilitySetNames: 
-              :LiveCloningEnabled: true
-              :MostRecentTaskID: 9c32c5ad-3d6a-43c5-9c95-120296e147ce
-              :MostRecentTaskUIState: Completed
-              :MostRecentTask: *18
-              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\vm_linux1
-              :CreationTime: 2016-02-01 13:39:24.990000000 -05:00
-              :OperatingSystem: *79
-              :HasVMAdditions: false
-              :VMAddition: Not Detected
-              :NumLockEnabled: false
-              :CPUCount: 1
-              :IsHighlyAvailable: false
-              :HAVMPriority: 
-              :IsDRProtectionRequired: false
-              :RecoveryPointObjective: 
-              :ProtectionProvider: 
-              :ReplicationGroupId: 
-              :ReplicationGroup: 
-              :LimitCPUFunctionality: false
-              :LimitCPUForMigration: false
-              :Memory: 512
-              :DynamicMemoryEnabled: false
-              :DynamicMemoryMaximumMB: 
-              :DynamicMemoryBufferPercentage: 
-              :MemoryWeight: 5000
-              :VirtualVideoAdapterEnabled: false
-              :MonitorMaximumCount: 
-              :MonitorResolutionMaximum: 
-              :BootOrder: *80
-              :FirstBootDevice: 
-              :SecureBootEnabled: 
-              :ComputerName: 
-              :UseHardwareAssistedVirtualization: true
-              :SANStatus: *81
-              :CostCenter: 
-              :QuotaPoint: 1
-              :IsTagEmpty: false
-              :Tag: "(none)"
-              :CustomProperties:
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              - 
-              :CustomProperty: {}
-              :UndoDisksEnabled: false
-              :CPUType: *15
-              :ExpectedCPUUtilization: 20
-              :DiskIO: 0
-              :NetworkUtilization: 0
-              :RelativeWeight: 100
-              :CPUReserve: 0
-              :CPUMax: 100
-              :CPUPerVirtualNumaNodeMaximum: 4
-              :MemoryPerVirtualNumaNodeMaximumMB: 6062
-              :VirtualNumaNodesPerSocketMaximum: 1
-              :DynamicMemoryMinimumMB: 
-              :NumaIsolationRequired: false
-              :Generation: 1
-              :VirtualDVDDrives:
-              - *82
-              :VirtualHardDisks:
-              - *17
-              :VirtualDiskDrives:
-              - *83
-              :ShareSCSIBus: false
-              :VirtualNetworkAdapters:
-              - *84
-              :VirtualFibreChannelAdapters: []
-              :HasVirtualFibreChannelAdapters: false
-              :VirtualFloppyDrive: *85
-              :VirtualCOMPorts:
-              - COM1
-              - COM2
-              :VirtualSCSIAdapters:
-              - *86
-              :CapabilityProfile: 
-              :CapabilityProfileCompatibilityState: Compatible
-              :VMCheckpoints: []
-              :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-              :HostType: VMHost
-              :HostName: dell-r410-03.cloudformswin.lab.redhat.com
-              :VMHost: *1
-              :LibraryServer: 
-              :CloudId: 
-              :Cloud: 
-              :LibraryGroup: 
-              :GrantedToList: []
-              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
-              :UserRole: *3
-              :Owner: CLOUDFORMSWIN\scvmm
-              :ObjectType: VM
-              :Accessibility: Public
-              :Name: vm_linux1
-              :IsViewOnly: false
-              :Description: 
-              :AddedTime: 2016-02-01 13:39:24.990000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.470499500 -05:00
-              :Enabled: true
-              :ServerConnection: *8
-              :ID: 6673f40b-0706-4170-92a6-5fcb4d9846f6
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-              :MostRecentTaskIfLocal: *18
-            :MS:
-              :ServicingWindows: *9
-          - :ToString: linux2
-            :Props:
-              :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2\Virtual Machines\95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84.xml
-              :MarkedAsTemplate: false
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :VMId: 95412AD4-2CBF-4FAF-AE4B-0C56C30D1B84
-              :VMResourceGroup: 
-              :VMConfigResource: 
-              :VMConfigResourceStatus: ClusterResourceStateUnknown
-              :VMResource: 
-              :VMResourceStatus: ClusterResourceStateUnknown
-              :DiskResources: *87
-              :UnsupportedReason: *19
-              :RefresherErrors: *88
-              :VirtualMachineState: Running
-              :HostGroupPath: All Hosts\linux2
-              :TotalSize: 665147392
-              :MemoryAssignedMB: 512
-              :MemoryAvailablePercentage: '0'
-              :DynamicMemoryDemandMB: 512
-              :DynamicMemoryStatus: 
-              :AllocatedGPU: 
-              :HasPassthroughDisk: false
-              :HasSharedStorage: false
-              :Status: Running
-              :IsOrphaned: false
-              :HasSavedState: false
-              :StatusString: Running
-              :StartAction: NeverAutoTurnOnVM
-              :StopAction: SaveVM
-              :RunGuestAccount: 
-              :DelayStart: 0
-              :BiosGuid: a3bd95a2-dd8d-4242-bd57-02621c4eb153
-              :CPUUtilization: 0
-              :PerfCPUUtilization: 0
-              :PerfMemory: 512
-              :PerfDiskBytesRead: 0
-              :PerfDiskBytesWrite: 0
-              :PerfNetworkBytesRead: 0
-              :PerfNetworkBytesWrite: 0
-              :VirtualizationPlatform: HyperV
-              :ComputerNameString: Unknown
-              :CreationSource: Temporary Template1900162c-12ba-4cfa-b9f8-c2f0a3e08d43
-              :IsUndergoingLiveMigration: false
-              :SourceObjectType: VM Template
-              :OperatingSystemShutdownEnabled: true
-              :TimeSynchronizationEnabled: true
-              :DataExchangeEnabled: true
-              :HeartbeatEnabled: true
-              :BackupEnabled: true
-              :ExcludeFromPRO: false
-              :FailedJobID: 
-              :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
-              :SelfServiceUserRole: 
-              :PassThroughDisks: []
-              :ComputerTier: 
-              :ConnectToAddresses: []
-              :CloudVmRoleId: 
-              :CloudVmRoleName: 
-              :UpgradeDomain: 
-              :SCApplications: []
-              :LastRestoredCheckpointID: 406845EA-0CF6-44CD-9D96-24A157DF5736
-              :LastRestoredVMCheckpoint: *24
-              :ComplianceStatus: 
-              :IsFaultTolerant: false
-              :DeploymentErrorInfo: 
-              :ServiceDeploymentErrorMessage: 
-              :DeploymentState: Undeployed
-              :TieredPerfData: *89
-              :ReplicationSetting: 
-              :ReplicationStatus: 
-              :IsRecoveryVM: false
-              :IsPrimaryVM: false
-              :IsTestReplicaVM: false
-              :ReplicationState: 
-              :ReplicationHealth: 
-              :ReplicationMode: 
-              :LastReplicationTime: 
-              :IsDREnabled: false
-              :DRState: Disabled
-              :DRErrors: []
-              :HasDRError: false
-              :ClusterNonPossibleOwner: 
-              :ClusterPreferredOwner: 
-              :AvailabilitySetNames: 
-              :LiveCloningEnabled: true
-              :MostRecentTaskID: f0cbd7d9-322b-429e-84b2-919a5cdcc979
-              :MostRecentTaskUIState: Completed
-              :MostRecentTask: *25
-              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V\linux2
-              :CreationTime: 2016-02-22 11:52:19.483000000 -05:00
-              :OperatingSystem: *90
+              :Location: C:\tmp\SCVMM16
+              :CreationTime: 2016-03-18 13:46:10.160000000 -04:00
+              :OperatingSystem: *20
               :HasVMAdditions: false
               :VMAddition: Not Detected
               :NumLockEnabled: false
@@ -7413,12 +5331,17 @@
               :VirtualVideoAdapterEnabled: false
               :MonitorMaximumCount: 
               :MonitorResolutionMaximum: 
-              :BootOrder: *91
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
               :FirstBootDevice: 
               :SecureBootEnabled: 
               :ComputerName: 
               :UseHardwareAssistedVirtualization: true
-              :SANStatus: *92
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
               :CostCenter: 
               :QuotaPoint: 1
               :IsTagEmpty: false
@@ -7436,7 +5359,7 @@
               - 
               :CustomProperty: {}
               :UndoDisksEnabled: false
-              :CPUType: *15
+              :CPUType: *19
               :ExpectedCPUUtilization: 20
               :DiskIO: 0
               :NetworkUtilization: 0
@@ -7444,35 +5367,639 @@
               :CPUReserve: 0
               :CPUMax: 100
               :CPUPerVirtualNumaNodeMaximum: 8
-              :MemoryPerVirtualNumaNodeMaximumMB: 63140
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
               :VirtualNumaNodesPerSocketMaximum: 1
-              :DynamicMemoryMinimumMB: 32
-              :NumaIsolationRequired: false
+              :DynamicMemoryMinimumMB: 512
+              :NumaIsolationRequired: 
               :Generation: 1
               :VirtualDVDDrives:
-              - *93
+              - SCVMM16
               :VirtualHardDisks:
-              - *20
+              - SCVMM16
               :VirtualDiskDrives:
-              - *94
+              - SCVMM16
               :ShareSCSIBus: false
               :VirtualNetworkAdapters:
-              - *95
+              - SCVMM16
               :VirtualFibreChannelAdapters: []
               :HasVirtualFibreChannelAdapters: false
-              :VirtualFloppyDrive: *96
+              :VirtualFloppyDrive: SCVMM16
               :VirtualCOMPorts:
               - COM1
               - COM2
               :VirtualSCSIAdapters:
-              - *97
-              :CapabilityProfile: *23
+              - SCVMM16
+              :CapabilityProfile: 
               :CapabilityProfileCompatibilityState: Compatible
-              :VMCheckpoints:
-              - *24
-              :HostId: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
               :HostType: VMHost
-              :HostName: dell-r410-03.cloudformswin.lab.redhat.com
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: SCVMM16
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-18 13:46:10.160000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:03.934783400 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: fd024069-e5c6-4446-b26e-03a1ae1b9d8f
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: WS2008R2Core
+            :Props:
+              :VMCPath: C:\WS2008R2Core\Virtual Machines\F36C31F0-A138-4F24-8F56-10A3BFBD7D14.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: F36C31F0-A138-4F24-8F56-10A3BFBD7D14
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\WS2008R2Core
+              :TotalSize: 2684928512
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: NeverAutoTurnOnVM
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 2c67139b-76e1-40fd-896f-407ee9efc447
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 512
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\WS2008R2Core
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 16FF0C08-04D3-4BEE-9E74-34393E087F4A
+              :LastRestoredVMCheckpoint: WS2008R2Core - (6/10/2016 - 8:41:12 AM)
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: f9d6d644-d835-4f95-ae3d-152eb43652f1
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 41a87ed5-c82b-47cc-825b-15e534102ffb
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: C:\WS2008R2Core
+              :CreationTime: 2015-12-04 19:04:25.937000000 -05:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 512
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - WS2008R2Core
+              :VirtualHardDisks:
+              - WS2008R2Corex64Ent_C02F48D6-ED11-4F67-B77C-B9EC821A4A3E
+              :VirtualDiskDrives:
+              - WS2008R2Core
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - WS2008R2Core
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: WS2008R2Core
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - WS2008R2Core
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints:
+              - WS2008R2Core - (6/10/2016 - 8:41:12 AM)
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: WS2008R2Core
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:25.937000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:03.923000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: f9d6d611-d835-4f95-ae3d-152eb43652f1
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: proxy-cfme-dnd
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\proxy-cfme\\Virtual Machines\\94BCEFC0-8C3E-4E68-B15D-41A719D80042.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 94BCEFC0-8C3E-4E68-B15D-41A719D80042
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors:
+              - FileInUNCPathNotAccessibleFromCluster (13932); 0
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\proxy-cfme-dnd
+              :TotalSize: 6267774976
+              :MemoryAssignedMB: 4096
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 4096
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: UnsupportedSharedFiles
+              :IsOrphaned: false
+              :HasSavedState: true
+              :StatusString: Unsupported VM Configuration
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 7419610f-ed9d-4fff-ac66-649bd8bd6eb5
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 4096
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2\\proxy-cfme"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 94BCEFC0-8C3E-4E68-B15D-41A719D80042
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 93b5aac3-2a28-4371-b440-1579c6b92c12
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 14a0a0ec-4f74-403c-a542-0c29fe9d3ab7
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Discover Network Configuration Change
+              :Location: "\\\\CFME_HYPERV\\scvmm2\\proxy-cfme"
+              :CreationTime: 2016-03-31 12:44:02.793000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 4096
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployVMNonSANDisk (1209)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - proxy-cfme
+              :VirtualHardDisks:
+              - proxy-cfme
+              :VirtualDiskDrives:
+              - proxy-cfme
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - proxy-cfme
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: proxy-cfme
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - proxy-cfme
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: proxy-cfme-dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-31 12:44:02.793000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:04.080000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 93b5aa96-2a28-4371-b440-1579c6b92c12
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Discover Network Configuration Change
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-56012-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56012-JT\\Virtual
+                Machines\\B39939EB-645A-4C23-A74E-AAC52E9A1033.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: B39939EB-645A-4C23-A74E-AAC52E9A1033
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\CFME-56012-JT
+              :TotalSize: 3240968192
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 66367949-bcec-44b8-b4eb-8199798750b0
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: cfme56012jt
+              :CreationSource: Temporary Template5fcd58ce-4d2b-4d47-bcab-ce1a30948066
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56012-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: B39939EB-645A-4C23-A74E-AAC52E9A1033
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 959321ab-2a9b-4acc-ae5e-1bad7320e37e
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 8fb13af2-0eaf-43a3-8bc2-8dfe451405a3
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56012-JT"
+              :CreationTime: 2016-06-22 12:31:16.310000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: cfme56012jt
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-56012-06221512.vhd
+              :VirtualDiskDrives:
+              - CFME-56012-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-56012-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-56012-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-56012-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :VMHost: *1
               :LibraryServer: 
               :CloudId: 
@@ -7481,32 +6008,4452 @@
               :GrantedToList: []
               :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
               :UserRole: *3
-              :Owner: CLOUDFORMSWIN\scvmm
+              :Owner: CFME-QE-VMM-AD\Administrator
               :ObjectType: VM
               :Accessibility: Public
-              :Name: linux2
+              :Name: CFME-56012-JT
               :IsViewOnly: false
               :Description: 
-              :AddedTime: 2016-02-22 11:52:19.483000000 -05:00
-              :ModifiedTime: 2016-02-29 19:18:07.230000000 -05:00
+              :AddedTime: 2016-06-22 12:31:16.310000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:03.763000000 -04:00
               :Enabled: true
-              :ServerConnection: *8
-              :ID: c4425913-7043-4d2a-a229-75f051a8127b
+              :ServerConnection: *9
+              :ID: 959321fe-2a9b-4acc-ae5e-1bad7320e37e
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: taigotest
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\taigotest\\Virtual Machines\\63DEA6C5-A1EC-4558-834C-988D0A7BDDD3.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 63DEA6C5-A1EC-4558-834C-988D0A7BDDD3
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Saved
+              :HostGroupPath: All Hosts\taigotest
+              :TotalSize: 15050919936
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Saved
+              :IsOrphaned: false
+              :HasSavedState: true
+              :StatusString: Saved State
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 779f38cf-76d4-4cc4-8adb-b12d3180307e
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2\\taigotest"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 9CFE68F1-A9BE-4A8F-A253-6160BDB6F74F
+              :LastRestoredVMCheckpoint: taigotest - (9/11/2015 - 12:55:58 PM)
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 78c28225-e00c-4099-9971-2dc260996276
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: d65e3a96-6df0-40f0-9960-471046455716
+              :MostRecentTaskUIState: Completed
+              :Location: "\\\\CFME_HYPERV\\scvmm2\\taigotest"
+              :CreationTime: 2015-12-04 19:04:31.523000000 -05:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - taigotest
+              :VirtualHardDisks:
+              - taigotest_D907A587-00BD-45A8-ACC9-1B141E788007
+              :VirtualDiskDrives:
+              - taigotest
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - taigotest
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: taigotest
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - taigotest
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints:
+              - taigotest - (9/11/2015 - 12:55:58 PM)
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: taigotest
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:31.523000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.380000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 78c28270-e00c-4099-9971-2dc260996276
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-5541-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5541-JT\\Virtual
+                Machines\\D4F9E1A9-0C16-4B20-A605-BFE88B350334.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: D4F9E1A9-0C16-4B20-A605-BFE88B350334
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\CFME-5541-JT
+              :TotalSize: 9265459200
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: NeverAutoTurnOnVM
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: bb949dda-f81b-4aee-a932-2df01de44310
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Templatee2c0ab56-7323-45d7-8c98-801f72a2b2fc
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5541-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: D4F9E1A9-0C16-4B20-A605-BFE88B350334
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: efcdc0b4-3b55-4868-aa59-2e0ca4ed87c3
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 43d4ac83-84dc-4088-aa8d-f34a11baebc4
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5541-JT"
+              :CreationTime: 2016-05-13 13:48:45.020000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-hyperv-5.5.4.1-1.x86_64.vhd
+              :VirtualDiskDrives:
+              - CFME-5541-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-5541-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-5541-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-5541-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-5541-JT
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-05-13 13:48:45.020000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:03.753000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: efcdc0e1-3b55-4868-aa59-2e0ca4ed87c3
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: HV2016CTP4
+            :Props:
+              :VMCPath: C:\tmp\HV2016CTP4\Virtual Machines\7CF28F62-CF55-42A1-85F4-349188C5AA60.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 7CF28F62-CF55-42A1-85F4-349188C5AA60
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\HV2016CTP4
+              :TotalSize: 6513754112
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: a7a56ed0-9456-4d38-84c5-7da4fa46527e
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 0
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\tmp\HV2016CTP4
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 7CF28F62-CF55-42A1-85F4-349188C5AA60
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 2694313f-b6a3-4d7a-88da-332ff16427bc
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 278202b6-e6de-4cca-b139-fc564e3ad6c3
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: C:\tmp\HV2016CTP4
+              :CreationTime: 2016-03-18 12:42:28.533000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 4096
+              :DynamicMemoryEnabled: true
+              :DynamicMemoryMaximumMB: 1048576
+              :DynamicMemoryBufferPercentage: 20
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 512
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - HV2016CTP4
+              :VirtualHardDisks:
+              - HV2016CTP4
+              :VirtualDiskDrives:
+              - HV2016CTP4
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - HV2016CTP4
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: HV2016CTP4
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - HV2016CTP4
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: HV2016CTP4
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-18 12:42:28.533000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:03.900783900 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 2694316a-b6a3-4d7a-88da-332ff16427bc
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: WIN7-5609-JT
+            :Props:
+              :VMCPath: C:\WIN7-5609-JT\Virtual Machines\42187D80-5F67-40A8-8883-8F3746BF3350.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 42187D80-5F67-40A8-8883-8F3746BF3350
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\WIN7-5609-JT
+              :TotalSize: 14432600064
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: NeverAutoTurnOnVM
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: d7452cbc-51fe-4a62-af97-6c714b081b81
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 1024
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Win7SmallTemplate
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\WIN7-5609-JT
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 42187D80-5F67-40A8-8883-8F3746BF3350
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: d195db3f-ff8e-4ecc-a31e-530f83d7c57b
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: de510f8b-becc-4778-8ad1-d21c1159c543
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: C:\WIN7-5609-JT
+              :CreationTime: 2016-06-03 16:29:50.590000000 -04:00
+              :OperatingSystem: 64-bit edition of Windows 7
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 1024
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives:
+              - WIN7-5609-JT
+              :VirtualHardDisks:
+              - Win7SmallTemplate.vhdx
+              :VirtualDiskDrives:
+              - WIN7-5609-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - WIN7-5609-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: WIN7-5609-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - WIN7-5609-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: WIN7-5609-JT
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-03 16:29:50.590000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:03.784780600 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: d195db6a-ff8e-4ecc-a31e-530f83d7c57b
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: WS2008R2Core-JK
+            :Props:
+              :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\Virtual Machines\6D327596-1341-4072-81F1-2658DB7F073B.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 6D327596-1341-4072-81F1-2658DB7F073B
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\WS2008R2Core-JK
+              :TotalSize: 2781491712
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: NeverAutoTurnOnVM
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 2c67139b-76e1-40fd-896f-407ee9efc447
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 512
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\WS2008R2Core
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 8E6AA643-7EF1-4945-811D-857017D921A1
+              :LastRestoredVMCheckpoint: *26
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: *47
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 6807f52e-eca6-455a-8ffa-1cd818498200
+              :MostRecentTaskUIState: Completed
+              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :CreationTime: 2016-02-03 00:49:25.200000000 -05:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 512
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - *48
+              :VirtualHardDisks:
+              - *25
+              :VirtualDiskDrives:
+              - *49
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - *50
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: *51
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - *52
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints:
+              - *26
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: WS2008R2Core-JK
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-02-03 00:49:25.200000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:04.387000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 14249d0a-0bd8-44cb-9edc-53707f66053f
               :MarkedForDeletion: false
               :IsFullyCached: true
-              :MostRecentTaskIfLocal: *25
+              :MostRecentTaskIfLocal: 
             :MS:
-              :ServicingWindows: *9
+              :ServicingWindows: *11
+          - :ToString: Win7SmallTmpl
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Win7SmallTmpl\\Virtual Machines\\88F30778-FC0A-434D-BC50-7BF1A70BFCB0.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 88F30778-FC0A-434D-BC50-7BF1A70BFCB0
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\Win7SmallTmpl
+              :TotalSize: 14432600064
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 0b54120b-45e6-4687-aca6-8a36b0b5d55c
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 2048
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2\\Win7SmallTmpl"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 88F30778-FC0A-434D-BC50-7BF1A70BFCB0
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: d63b8de8-70ea-4301-92ba-59271fd6ddfb
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: f445ddc6-eda0-4cc1-bba7-e50ebe1d8f5e
+              :MostRecentTaskUIState: Completed
+              :Location: "\\\\CFME_HYPERV\\scvmm2\\Win7SmallTmpl"
+              :CreationTime: 2016-01-11 12:03:18.867000000 -05:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 2
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 2048
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - Win7SmallTmpl
+              :VirtualHardDisks:
+              - Win7SmallTmpl
+              :VirtualDiskDrives:
+              - Win7SmallTmpl
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - Win7SmallTmpl
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: Win7SmallTmpl
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - Win7SmallTmpl
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: Win7SmallTmpl
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-01-11 12:03:18.867000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:03.567000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: d63b8dbd-70ea-4301-92ba-59271fd6ddfb
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-5610-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5610-JT\\Virtual
+                Machines\\CC5D2230-7D1A-4C31-8C17-48F4F10AFBEF.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: CC5D2230-7D1A-4C31-8C17-48F4F10AFBEF
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\CFME-5610-JT
+              :TotalSize: 5332340736
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: c03189c2-04fd-4c1a-8e0f-bea265ce4c55
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Templateb3288d3d-64d4-4883-aad8-d818e8bee8d6
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5610-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: CC5D2230-7D1A-4C31-8C17-48F4F10AFBEF
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 049030ba-930e-45c2-ac4f-5be12bd947d3
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 8dbadcc7-3597-491b-9256-7f0a5fcd25c9
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5610-JT"
+              :CreationTime: 2016-06-08 09:04:25.187000000 -04:00
+              :OperatingSystem: *28
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-56010-06071823.vhd
+              :VirtualDiskDrives:
+              - CFME-5610-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-5610-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-5610-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-5610-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-5610-JT
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-08 09:04:25.187000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:06.663783500 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 049030ef-930e-45c2-ac4f-5be12bd947d3
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: Local33SSATest
+            :Props:
+              :VMCPath: C:\Local33SSATest\Virtual Machines\EDB47A93-808F-4315-9104-5FAF00678001.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: EDB47A93-808F-4315-9104-5FAF00678001
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\Local33SSATest
+              :TotalSize: 19297992704
+              :MemoryAssignedMB: 1024
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 1024
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: NeverAutoTurnOnVM
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 61ac3145-845c-4925-833e-b962bf8cc879
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 1024
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: lssa-PC
+              :CreationSource: Win7SmallTemplate
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\Local33SSATest
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: EDB47A93-808F-4315-9104-5FAF00678001
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 2e9bca61-d8d1-4cd2-a89a-69ada9da384f
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: 6cf11f49-25e3-40a4-abd0-3050f0390d71
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: C:\Local33SSATest
+              :CreationTime: 2016-06-23 14:49:09.860000000 -04:00
+              :OperatingSystem: 64-bit edition of Windows 7
+              :HasVMAdditions: true
+              :VMAddition: 6.1.7601.17514
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 1024
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: lssa-PC
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives:
+              - Local33SSATest
+              :VirtualHardDisks:
+              - Win7SmallTemplate.vhdx
+              :VirtualDiskDrives:
+              - Local33SSATest
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - Local33SSATest
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: Local33SSATest
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - Local33SSATest
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: Local33SSATest
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-23 14:49:09.860000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:07.273000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 2e9bca34-d8d1-4cd2-a89a-69ada9da384f
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-56012b
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56012b\\Virtual
+                Machines\\3A024B43-C737-4210-A303-FE28F4339795.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 3A024B43-C737-4210-A303-FE28F4339795
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\CFME-56012b
+              :TotalSize: 3175940096
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: bf9e716d-05bb-4444-b452-735309aa23a8
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Template0ee2609f-0633-4465-b761-8e6e15910beb
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56012b"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 3A024B43-C737-4210-A303-FE28F4339795
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 6cef5f93-a2ca-4d44-9c57-6d76ac9fe0da
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 932d3f73-fd67-4eae-8742-a4a09a13a1f0
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56012b"
+              :CreationTime: 2016-06-22 14:41:03.940000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-56012-06221512.vhd
+              :VirtualDiskDrives:
+              - CFME-56012b
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-56012b
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-56012b
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-56012b
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-56012b
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-22 14:41:03.940000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:06.707000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 6cef5fc6-a2ca-4d44-9c57-6d76ac9fe0da
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: Ubu1404LTS
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Ubu1404LTS\\Virtual Machines\\FD6EDF3B-FD36-4605-8CC0-B411537A361B.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: FD6EDF3B-FD36-4605-8CC0-B411537A361B
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\Ubu1404LTS
+              :TotalSize: 6547308544
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 48cdec24-ba12-47e1-b28e-aeca6da88cee
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 0
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: cfmeqe-Virtual-Machine
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2\\Ubu1404LTS"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: FD6EDF3B-FD36-4605-8CC0-B411537A361B
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: fd5e7a44-5b41-4f21-8b19-82ee6b40d3ed
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 704c25f8-74ad-435a-9d65-2b70de2a6e39
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\CFME_HYPERV\\scvmm2\\Ubu1404LTS"
+              :CreationTime: 2016-03-30 12:29:18.410000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 512
+              :DynamicMemoryEnabled: true
+              :DynamicMemoryMaximumMB: 1048576
+              :DynamicMemoryBufferPercentage: 20
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: cfmeqe-Virtual-Machine
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 512
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - Ubu1404LTS
+              :VirtualHardDisks:
+              - Ubu1404LTS
+              :VirtualDiskDrives:
+              - Ubu1404LTS
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - Ubu1404LTS
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: Ubu1404LTS
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - Ubu1404LTS
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: Ubu1404LTS
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-30 12:29:18.410000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:06.740000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: fd5e7a11-5b41-4f21-8b19-82ee6b40d3ed
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-5550-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5550-JT\\Virtual
+                Machines\\B2F6CAE5-558F-42FF-A1E8-C55DD3E673C4.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: B2F6CAE5-558F-42FF-A1E8-C55DD3E673C4
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\CFME-5550-JT
+              :TotalSize: 2053697536
+              :MemoryAssignedMB: 8192
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 8192
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 3b012738-1609-4798-a12a-58134b16a522
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Template62f49a3c-e1eb-4eee-92bc-69714054e27d
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5550-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: B2F6CAE5-558F-42FF-A1E8-C55DD3E673C4
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 01eb2472-0f9d-42e9-8ac7-84799b1b5a76
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: 379a4a2e-a90e-46e9-87a0-ad1cc1702fe4
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5550-JT"
+              :CreationTime: 2016-07-05 12:59:20.287000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-55500-06291244.vhd
+              :VirtualDiskDrives:
+              - CFME-5550-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-5550-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-5550-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-5550-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-5550-JT
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-07-05 12:59:20.287000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:07.000000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 01eb2427-0f9d-42e9-8ac7-84799b1b5a76
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: DualDVDa
+            :Props:
+              :VMCPath: C:\DualDVDa\Virtual Machines\445AE267-8448-4654-B7AB-71339F16B626.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 445AE267-8448-4654-B7AB-71339F16B626
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: *53
+              :UnsupportedReason: *27
+              :RefresherErrors: *54
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\DualDVDa
+              :TotalSize: 10216880128
+              :MemoryAssignedMB: 2048
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 2048
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: c63a8f5e-b320-4d1a-9bb8-4dfd185be0e7
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 2048
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: WIN-AQTG41U5HJC
+              :CreationSource: Win12SCoreTemplate
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\DualDVDa
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 445AE267-8448-4654-B7AB-71339F16B626
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: *55
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: a7abd456-07f6-4290-b1ba-0c580e454f19
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: *33
+              :Location: C:\DualDVDa
+              :CreationTime: 2016-06-24 12:45:54.603000000 -04:00
+              :OperatingSystem: *56
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 2048
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder: *57
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: WIN-AQTG41U5HJC
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus: *58
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - *59
+              - *60
+              :VirtualHardDisks:
+              - *32
+              :VirtualDiskDrives:
+              - *61
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - *62
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: *63
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - *64
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: DualDVDa
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-24 12:45:54.603000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:08.013783100 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 685f8061-9903-4dd0-9a91-874255a68a23
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: *33
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: PERF-56010a
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\PERF-56010a\\Virtual
+                Machines\\00D02297-D351-4D82-B623-5FA4D740D615.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 00D02297-D351-4D82-B623-5FA4D740D615
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\PERF-56010a
+              :TotalSize: 61156950528
+              :MemoryAssignedMB: 10240
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 10240
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: d6e1f7e1-45c3-440f-8c69-187ce0421a7a
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Templatefad3cdcf-7db1-49cb-9f65-41e448133237
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\PERF-56010a"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 00D02297-D351-4D82-B623-5FA4D740D615
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 7b790199-7d84-4b6f-a047-8b5a40511214
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: 8f0d9bc4-8584-49ed-b828-e562f33f7cbb
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\PERF-56010a"
+              :CreationTime: 2016-06-08 13:28:11.960000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-56010-06071823.vhd
+              - New Virtual Hard Disk
+              :VirtualDiskDrives:
+              - PERF-56010a
+              - PERF-56010a
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - PERF-56010a
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: PERF-56010a
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - PERF-56010a
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: PERF-56010a
+              :IsViewOnly: false
+              :Description: Machine for installing Alex's performance code.
+              :AddedTime: 2016-06-08 13:28:11.960000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:07.197000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 7b7901cc-7d84-4b6f-a047-8b5a40511214
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: scvmm-sp1-1
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\scvmm-sp1-1\\Virtual Machines\\87E98D3C-3BDA-43BE-9D05-A8993FEF0108.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 87E98D3C-3BDA-43BE-9D05-A8993FEF0108
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\scvmm-sp1-1
+              :TotalSize: 54067351040
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 18cf5d93-e47b-4f9f-b0c0-bd174fb3059d
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 4096
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: scvmm-sp1.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2\\scvmm-sp1-1\\"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: A79F2809-D0A9-4AD0-91A4-4939DAD8AD02
+              :LastRestoredVMCheckpoint: scvmm-sp1 - (8/26/2015 - 2:01:14 PM)
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: c7fb09bf-9836-432d-aece-9a68a56f929b
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 5800d0e8-a3a1-42c8-9057-cfb19258c6bb
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\CFME_HYPERV\\scvmm2\\scvmm-sp1-1"
+              :CreationTime: 2015-12-04 19:04:40.987000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows Server 2012 Datacenter
+              :HasVMAdditions: true
+              :VMAddition: 6.2.9200.16384
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 4096
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 10000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: scvmm-sp1.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - scvmm-sp1-1
+              :VirtualHardDisks:
+              - SC2012_SP1_SCVMM_EVALVHD_F2A2083A-906E-4EB5-8DF5-0903C064F1C3
+              :VirtualDiskDrives:
+              - scvmm-sp1-1
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - scvmm-sp1-1
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: scvmm-sp1-1
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - scvmm-sp1-1
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints:
+              - scvmm-sp1 - (8/26/2015 - 2:01:14 PM)
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: scvmm-sp1-1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:40.987000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:08.107000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: c7fb09ea-9836-432d-aece-9a68a56f929b
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: cluster-storage
+            :Props:
+              :VMCPath: C:\cluster-storage\Virtual Machines\7BE3BCEF-676D-4D66-9691-CF96613FBE73.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 7BE3BCEF-676D-4D66-9691-CF96613FBE73
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\cluster-storage
+              :TotalSize: 33521262592
+              :MemoryAssignedMB: 2048
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 2048
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 76f22f4c-baa8-407e-812e-c6ae90fc5d51
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 2048
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: ClusterStore.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\cluster-storage
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: AED29147-1E9F-4994-A9E4-48553E676AA6
+              :LastRestoredVMCheckpoint: cluster-storage - (5/26/2016 - 9:38:59 AM)
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 792e0075-0ddd-4d8f-a5ae-9ea557c5ee18
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: 413e0a99-af75-4234-bbe5-86b07e08b56c
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: C:\cluster-storage
+              :CreationTime: 2015-12-04 19:04:43.633000000 -05:00
+              :OperatingSystem: Windows Server 2012 R2 Datacenter
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 2048
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: ClusterStore.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - cluster-storage
+              :VirtualHardDisks:
+              - vm_ws2012s_346DBD7E-CE54-4901-8014-AF65C74ED609
+              :VirtualDiskDrives:
+              - cluster-storage
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - cluster-storage
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: cluster-storage
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - cluster-storage
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints:
+              - cluster-storage - (11/5/2015 - 6:36:33 AM)
+              - cluster-storage - (5/26/2016 - 9:38:59 AM)
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: cluster-storage
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:43.633000000 -05:00
+              :ModifiedTime: 2016-07-10 18:57:09.017783700 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 792e0020-0ddd-4d8f-a5ae-9ea557c5ee18
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: WS16CTP4
+            :Props:
+              :VMCPath: C:\tmp\WS16CTP4\Virtual Machines\993F7DE3-45C5-445D-9AA3-D7B3985CAE8E.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 993F7DE3-45C5-445D-9AA3-D7B3985CAE8E
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\WS16CTP4
+              :TotalSize: 14499708928
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: c40049d1-4bd3-487b-900c-549a7d3d8b26
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: WIN-IMHVN91K6FF
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\tmp\WS16CTP4
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 993F7DE3-45C5-445D-9AA3-D7B3985CAE8E
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 215d23dd-62bb-48b8-b979-af9faade48e0
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: f96ce8b8-3546-4d39-88fb-f19433c3968d
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: C:\tmp\WS16CTP4
+              :CreationTime: 2016-03-18 13:40:42.797000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: 10.0.10011.16384
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: WIN-IMHVN91K6FF
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - WS16CTP4
+              :VirtualHardDisks:
+              - WS16CTP4
+              :VirtualDiskDrives:
+              - WS16CTP4
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - WS16CTP4
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: WS16CTP4
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - WS16CTP4
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: WS16CTP4
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-18 13:40:42.797000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:07.673000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 215d2388-62bb-48b8-b979-af9faade48e0
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: jerrykbiker-dnd
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd\\Virtual
+                Machines\\D275BD15-FE85-48E3-89C4-EDDDE1EB79D9.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: D275BD15-FE85-48E3-89C4-EDDDE1EB79D9
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: *65
+              :UnsupportedReason: *27
+              :RefresherErrors: *66
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\jerrykbiker-dnd
+              :TotalSize: 12797134848
+              :MemoryAssignedMB: 6120
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 6120
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 3d8039e7-236b-4bb1-901d-d4735b4018f8
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 4
+              :PerfMemory: 6120
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: jerrykbiker-dnd
+              :CreationSource: Temporary Templatefe3719c0-3dbd-4c6b-81af-e7c4c894c34e
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: D275BD15-FE85-48E3-89C4-EDDDE1EB79D9
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: *67
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: bf2dcff2-07ce-4fe4-81fb-c7b41ac224c1
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: *31
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\jerrykbiker-dnd"
+              :CreationTime: 2016-03-23 11:58:27.417000000 -04:00
+              :OperatingSystem: *28
+              :HasVMAdditions: true
+              :VMAddition: Detected
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 6120
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder: *68
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: jerrykbiker-dnd
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus: *69
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives:
+              - *70
+              :VirtualHardDisks:
+              - *30
+              :VirtualDiskDrives:
+              - *71
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - *72
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: *73
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - *74
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: jerrykbiker-dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-03-23 11:58:27.417000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.364784100 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: a645d581-9cb4-492a-9b68-c5b4610f4d93
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: *31
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-5609-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5609-JT\\Virtual
+                Machines\\C3639F13-2891-42C0-AD2E-708F427C5795.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: C3639F13-2891-42C0-AD2E-708F427C5795
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\CFME-5609-JT
+              :TotalSize: 3144474624
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 13045ae6-fc36-4395-bc25-9849d95b8549
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Template36fc1410-943a-4e9b-a60d-f7670aa9b586
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5609-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: C3639F13-2891-42C0-AD2E-708F427C5795
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: d19902fc-3430-4c70-93e0-da49844bb47c
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 6160ead2-2500-4276-b987-381672b732c7
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5609-JT"
+              :CreationTime: 2016-06-03 12:40:12.857000000 -04:00
+              :OperatingSystem: *28
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-56009-0601163.vhd
+              :VirtualDiskDrives:
+              - CFME-5609-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-5609-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-5609-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-5609-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-5609-JT
+              :IsViewOnly: false
+              :Description: RC2
+              :AddedTime: 2016-06-03 12:40:12.857000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.483000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: d19902a9-3430-4c70-93e0-da49844bb47c
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-5540-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5540-JT\\Virtual
+                Machines\\AEA3049A-4E24-463F-B396-4A5F5608E7B8.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: AEA3049A-4E24-463F-B396-4A5F5608E7B8
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\CFME-5540-JT
+              :TotalSize: 9424888832
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: NeverAutoTurnOnVM
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 0c8e5a33-081c-4a16-8a96-63baa15107dd
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Template87bc1df5-bca8-479d-8c17-ab32142eed95
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5540-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: AEA3049A-4E24-463F-B396-4A5F5608E7B8
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 60947654-60a3-47b7-a69b-dac728cadc48
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: b15384d2-9ace-4be5-9a62-747590373456
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-5540-JT"
+              :CreationTime: 2016-04-27 19:53:15.353000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-hyperv-5.5.4.0-1.x86_64.vhd
+              :VirtualDiskDrives:
+              - CFME-5540-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-5540-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-5540-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-5540-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-5540-JT
+              :IsViewOnly: false
+              :Description: Ongoing Test VM
+              :AddedTime: 2016-04-27 19:53:15.353000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.647784200 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 60947601-60a3-47b7-a69b-dac728cadc48
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: MIQ-627-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\MIQ-627-JT\\Virtual
+                Machines\\C5397701-BE74-4C19-B7FA-0A9A8BF972FC.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: C5397701-BE74-4C19-B7FA-0A9A8BF972FC
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\MIQ-627-JT
+              :TotalSize: 5420441600
+              :MemoryAssignedMB: 10240
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 10240
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 6a73b6f3-eb99-41a2-846f-3fa63d1404dc
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Template81f3d910-350f-4d30-9a52-1cd0c98c0c69
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\MIQ-627-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: C5397701-BE74-4C19-B7FA-0A9A8BF972FC
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: c57d098e-2e12-49e2-a8e6-deaaf5149ede
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: f764cf9d-17ec-4411-bc85-e8d8f8d9501e
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\MIQ-627-JT"
+              :CreationTime: 2016-06-28 12:24:34.893000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - miq-nightly-201606272000.vhd
+              :VirtualDiskDrives:
+              - MIQ-627-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - MIQ-627-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: MIQ-627-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - MIQ-627-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: MIQ-627-JT
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-28 12:24:34.893000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:09.660784400 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: c57d09db-2e12-49e2-a8e6-deaaf5149ede
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-56013-JT
+            :Props:
+              :VMCPath: C:\CFME-56013-JT\Virtual Machines\83E5699F-EBCE-45AE-8267-799FD7C1DF6B.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 83E5699F-EBCE-45AE-8267-799FD7C1DF6B
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\CFME-56013-JT
+              :TotalSize: 8260677120
+              :MemoryAssignedMB: 8192
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 8192
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: e0c0bf72-b448-4697-af42-c82c13b4bdd4
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Template490b5fea-84b9-40aa-bb60-cb6cf4a14aa0
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\CFME-56013-JT
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 83E5699F-EBCE-45AE-8267-799FD7C1DF6B
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: c350d242-6031-4823-b3ce-e3dabdb38885
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: f2be5c41-7601-454f-89ce-122ee8720886
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: C:\CFME-56013-JT
+              :CreationTime: 2016-06-24 20:13:06.063000000 -04:00
+              :OperatingSystem: *28
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives:
+              - CFME-56013-JT
+              :VirtualHardDisks:
+              - cfme-hyperv-5.6.0.13-1.x86_64.vhd
+              :VirtualDiskDrives:
+              - CFME-56013-JT
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - CFME-56013-JT
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: CFME-56013-JT
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - CFME-56013-JT
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-56013-JT
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-24 20:13:06.063000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:10.373000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: c350d217-6031-4823-b3ce-e3dabdb38885
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: CFME-56011-JT
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT\\Virtual
+                Machines\\944C26BF-9DA2-4AD7-AE13-8AA1CF5A8E0F.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 944C26BF-9DA2-4AD7-AE13-8AA1CF5A8E0F
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\CFME-56011-JT
+              :TotalSize: 5359607808
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 1f49a2be-f97b-436b-b34a-b4a78a46ce7e
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: Temporary Template6368a08c-2e85-40c5-b38e-0d8e60c9c650
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 944C26BF-9DA2-4AD7-AE13-8AA1CF5A8E0F
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: *75
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: fdc572bd-cb9a-473b-8a79-a6c8b69dfea4
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: *35
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\CFME-56011-JT"
+              :CreationTime: 2016-06-15 13:56:26.440000000 -04:00
+              :OperatingSystem: *28
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - *34
+              :VirtualDiskDrives:
+              - *76
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - *77
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: *78
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - *79
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :HostType: VMHost
+              :HostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *1
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: CFME-56011-JT
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-15 13:56:26.440000000 -04:00
+              :ModifiedTime: 2016-07-10 18:57:10.023000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: d5593afa-d38c-4593-9732-f377c36e8bdc
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: *35
+            :MS:
+              :ServicingWindows: *11
           :Disks:
+          - *15
           - *2
+          - *10
           - :ToString: "\\\\.\\PHYSICALDRIVE1"
             :Props:
               :Name: "\\\\.\\PHYSICALDRIVE1"
-              :Signature: 0
-              :UniqueID: '0'
-              :Capacity: 0
+              :Signature: 2015661737
+              :UniqueID: '2015661737'
+              :Capacity: 500107862016
               :AvailableCapacity: 0
-              :PhysicallyAvailableCapacity: 0
+              :PhysicallyAvailableCapacity: 500107862016
               :DeviceID: "\\\\.\\PHYSICALDRIVE1"
               :Index: 1
               :IsClustered: false
@@ -7515,106 +10462,55 @@
               :ClusterDisk: 
               :VMHost: *1
               :LibraryServer: 
-              :DiskID: 23d6471f-7201-4053-828c-cfaac29f248e
+              :DiskID: e83472da-4856-460e-a835-e17bcf80d40b
               :Location: 
-              :SMLunId: USBSTOR\DISK&VEN_IDRAC&PROD_LCDRIVE&REV_0323\7&2D5DFC65&0&20080519&0:dell-r410-03
-              :SMLunIdFormat: 1
-              :SMLunIdNamespace: 1
+              :SMLunId: 5000C50034A7B913
+              :SMLunIdFormat: 9
+              :SMLunIdNamespace: 2
               :Bus: 0
               :Lun: 0
               :Port: 
-              :Target: 0
+              :Target: 2
               :StorageLogicalUnit: 
-              :Classification: *11
+              :Classification: *14
               :DiskVolumes: []
-              :PartitionStyle: Unknown
-              :DiskStatus: Unknown
+              :PartitionStyle: MasterBootRecord
+              :DiskStatus: Online
               :IsViewOnly: false
-              :ServerConnection: *8
-              :ID: 23d6471f-7201-4053-828c-cfaac29f248e
-              :ObjectType: VMHostDisk
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: "\\\\.\\PHYSICALDRIVE2"
-            :Props:
-              :Name: "\\\\.\\PHYSICALDRIVE2"
-              :Signature: 0
-              :UniqueID: '0'
-              :Capacity: 0
-              :AvailableCapacity: 0
-              :PhysicallyAvailableCapacity: 0
-              :DeviceID: "\\\\.\\PHYSICALDRIVE2"
-              :Index: 2
-              :IsClustered: false
-              :IsSanAttached: false
-              :IsPassThroughCapable: false
-              :ClusterDisk: 
-              :VMHost: *1
-              :LibraryServer: 
-              :DiskID: b296141f-52d3-41ff-8143-ea12d0244db2
-              :Location: 
-              :SMLunId: USBSTOR\DISK&VEN_IDRAC&PROD_VIRTUAL_FLOPPY&REV_0323\7&379531CB&0&20080519&1:dell-r410-03
-              :SMLunIdFormat: 1
-              :SMLunIdNamespace: 1
-              :Bus: 0
-              :Lun: 0
-              :Port: 
-              :Target: 0
-              :StorageLogicalUnit: 
-              :Classification: *11
-              :DiskVolumes: []
-              :PartitionStyle: Unknown
-              :DiskStatus: Unknown
-              :IsViewOnly: false
-              :ServerConnection: *8
-              :ID: b296141f-52d3-41ff-8143-ea12d0244db2
+              :ServerConnection: *9
+              :ID: e83472da-4856-460e-a835-e17bcf80d40b
               :ObjectType: VMHostDisk
               :MarkedForDeletion: false
               :IsFullyCached: true
           :GPUs: []
           :InstalledVirtualSwitchExtensions:
+          - :ToString: Microsoft Virtual Ethernet Switch Native Extension
+            :Props:
+              :Name: Microsoft Virtual Ethernet Switch Native Extension
+              :HostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :Description: Provides built-in features that may be configured on a
+                switch or port
+              :VirtualSwitchExtensionType: Native
+              :DriverId: 11ec6134-128a-4a23-b12f-164184b48348
+              :Version: 6.3.9600.18258
+              :Vendor: Microsoft
+              :ServerConnection: *9
+              :ID: cf37110d-9b6d-4c88-8be1-56dbf4ef5a62
+              :IsViewOnly: false
+              :ObjectType: InstalledVirtualSwitchExtension
+              :MarkedForDeletion: false
+              :IsFullyCached: true
           - :ToString: Microsoft VMM DHCPv4 Server Switch Extension
             :Props:
               :Name: Microsoft VMM DHCPv4 Server Switch Extension
-              :HostID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+              :HostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
               :Description: Microsoft System Center Virtual Machine Manager DHCP Server
               :VirtualSwitchExtensionType: Filter
               :DriverId: 0d37c9f0-ea6c-47a0-9c42-4baeba3768d1
               :Version: 24.0.1.0
               :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: fe840a7c-dd75-4991-8a39-af63f4ffb156
-              :IsViewOnly: false
-              :ObjectType: InstalledVirtualSwitchExtension
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Microsoft NDIS Capture
-            :Props:
-              :Name: Microsoft NDIS Capture
-              :HostID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-              :Description: Microsoft NDIS Packet Capture Filter Driver
-              :VirtualSwitchExtensionType: Monitoring
-              :DriverId: ea24cd6c-d17a-4348-9190-09f0d5be83dd
-              :Version: 6.3.9600.16384
-              :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: 3a4c95a2-db42-48b8-8bb7-bae9b183c153
-              :IsViewOnly: false
-              :ObjectType: InstalledVirtualSwitchExtension
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Microsoft Virtual Ethernet Switch Native Extension
-            :Props:
-              :Name: Microsoft Virtual Ethernet Switch Native Extension
-              :HostID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-              :Description: Provides built-in features that may be configured on a
-                switch or port
-              :VirtualSwitchExtensionType: Native
-              :DriverId: 11ec6134-128a-4a23-b12f-164184b48348
-              :Version: 6.3.9600.18005
-              :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: 6ea936cf-8779-4700-812f-be5263a7b6b9
+              :ServerConnection: *9
+              :ID: e30b57bf-41cb-44a0-9c09-7daf165e9150
               :IsViewOnly: false
               :ObjectType: InstalledVirtualSwitchExtension
               :MarkedForDeletion: false
@@ -7622,31 +10518,75 @@
           - :ToString: Microsoft Windows Filtering Platform
             :Props:
               :Name: Microsoft Windows Filtering Platform
-              :HostID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+              :HostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
               :Description: WFP vSwitch Extension LightWeight Filter for Hyper-V Virtual
                 Switch Filtering
               :VirtualSwitchExtensionType: Filter
               :DriverId: e7c3b2f0-f3c5-48df-af2b-10fed6d72e7a
-              :Version: 6.3.9600.18086
+              :Version: 6.3.9600.18229
               :Vendor: Microsoft
-              :ServerConnection: *8
-              :ID: a146fd69-eaac-4f7c-a7dc-d6e5a84dc4bb
+              :ServerConnection: *9
+              :ID: 68b8d463-aa44-40e9-9bfb-b94d4cfe12bb
+              :IsViewOnly: false
+              :ObjectType: InstalledVirtualSwitchExtension
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Microsoft NDIS Capture
+            :Props:
+              :Name: Microsoft NDIS Capture
+              :HostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :Description: Microsoft NDIS Packet Capture Filter Driver
+              :VirtualSwitchExtensionType: Monitoring
+              :DriverId: ea24cd6c-d17a-4348-9190-09f0d5be83dd
+              :Version: 6.3.9600.16384
+              :Vendor: Microsoft
+              :ServerConnection: *9
+              :ID: e134dff5-bbeb-478e-88c5-c6342a4cf90d
               :IsViewOnly: false
               :ObjectType: InstalledVirtualSwitchExtension
               :MarkedForDeletion: false
               :IsFullyCached: true
           :DiskVolumes:
-          - *98
-          - :ToString: "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
+          - :ToString: C:\
             :Props:
-              :Name: "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
-              :StorageVolumeID: 3d0c4878-d6cf-11e5-80b3-806e6f6e6963
-              :ObjectID: "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
-              :HostVolumeID: 3d0c4878-d6cf-11e5-80b3-806e6f6e6963
+              :Name: C:\
+              :StorageVolumeID: b58fecc2-c453-11e4-80b4-806e6f6e6963
+              :ObjectID: "\\\\?\\Volume{b58fecc2-c453-11e4-80b4-806e6f6e6963}\\"
+              :HostVolumeID: b58fecc2-c453-11e4-80b4-806e6f6e6963
               :MountPoints:
-              - "\\\\?\\Volume{3d0c4878-d6cf-11e5-80b3-806e6f6e6963}\\"
+              - C:\
+              :Capacity: 499738734592
+              :FreeSpace: 153622286336
+              :VolumeLabel: 
+              :FileSystem: NTFS
+              :IsSANMigrationPossible: false
+              :IsClustered: false
+              :IsClusterSharedVolume: false
+              :InUse: false
+              :VMHost: *1
+              :IsAvailableForPlacement: true
+              :HostDiskID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+              :StorageDiskID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+              :HostDisk: *15
+              :StorageDisk: *15
+              :Classification: *14
+              :StoragePool: 
+              :ServerConnection: *9
+              :ID: 8cf02787-8199-4754-b800-0d98dac52640
+              :IsViewOnly: false
+              :ObjectType: VMHostVolume
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: "\\\\?\\Volume{b58fecc1-c453-11e4-80b4-806e6f6e6963}\\"
+            :Props:
+              :Name: "\\\\?\\Volume{b58fecc1-c453-11e4-80b4-806e6f6e6963}\\"
+              :StorageVolumeID: b58fecc1-c453-11e4-80b4-806e6f6e6963
+              :ObjectID: "\\\\?\\Volume{b58fecc1-c453-11e4-80b4-806e6f6e6963}\\"
+              :HostVolumeID: b58fecc1-c453-11e4-80b4-806e6f6e6963
+              :MountPoints:
+              - "\\\\?\\Volume{b58fecc1-c453-11e4-80b4-806e6f6e6963}\\"
               :Capacity: 366997504
-              :FreeSpace: 75780096
+              :FreeSpace: 77737984
               :VolumeLabel: System Reserved
               :FileSystem: NTFS
               :IsSANMigrationPossible: false
@@ -7655,382 +10595,387 @@
               :InUse: false
               :VMHost: *1
               :IsAvailableForPlacement: true
-              :HostDiskID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-              :StorageDiskID: f3ff951a-45bd-4dd4-bc3a-297cbb68f6f4
-              :HostDisk: *2
-              :StorageDisk: *2
-              :Classification: *11
+              :HostDiskID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+              :StorageDiskID: bc3d758d-83ef-405b-a935-6a6d8a5e3b2e
+              :HostDisk: *15
+              :StorageDisk: *15
+              :Classification: *14
               :StoragePool: 
-              :ServerConnection: *8
-              :ID: c7723821-9706-4fe6-bbf1-c7c1766f0e02
+              :ServerConnection: *9
+              :ID: 3846dd68-ed09-485c-a3d8-554ea2a4338c
               :IsViewOnly: false
               :ObjectType: VMHostVolume
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :RegisteredStorageFileShares: []
+          - :ToString: C:\ClusterStorage\netapp_crud_vol
+            :Props:
+              :Name: C:\ClusterStorage\netapp_crud_vol
+              :StorageVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+              :ObjectID: "\\\\?\\Volume{cadbe3e4-e781-44aa-95ff-e6d4708bdc09}\\"
+              :HostVolumeID: cadbe3e4-e781-44aa-95ff-e6d4708bdc09
+              :MountPoints:
+              - C:\ClusterStorage\netapp_crud_vol
+              :Capacity: 268470042624
+              :FreeSpace: 65260634112
+              :VolumeLabel: csv_cluster1
+              :FileSystem: CSVFS
+              :IsSANMigrationPossible: false
+              :IsClustered: true
+              :IsClusterSharedVolume: true
+              :InUse: false
+              :VMHost: *1
+              :IsAvailableForPlacement: true
+              :HostDiskID: 787f92b3-03d9-4df9-84d1-a9b80612af4b
+              :StorageDiskID: 787f92b3-03d9-4df9-84d1-a9b80612af4b
+              :HostDisk: *10
+              :StorageDisk: *10
+              :Classification: *8
+              :StoragePool: 
+              :ServerConnection: *9
+              :ID: df15d6c7-79a2-4740-a630-8627e1f25957
+              :IsViewOnly: false
+              :ObjectType: VMHostVolume
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+            :Props:
+              :Name: C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+              :StorageVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
+              :ObjectID: "\\\\?\\Volume{cd0c3151-b540-4d65-87f9-ac3156ae703f}\\"
+              :HostVolumeID: cd0c3151-b540-4d65-87f9-ac3156ae703f
+              :MountPoints:
+              - C:\ClusterStorage\CLUSP04 Prod Volume 3-1
+              :Capacity: 563757445120
+              :FreeSpace: 462748672000
+              :VolumeLabel: CSV-NA-Disk
+              :FileSystem: CSVFS
+              :IsSANMigrationPossible: false
+              :IsClustered: true
+              :IsClusterSharedVolume: true
+              :InUse: false
+              :VMHost: *1
+              :IsAvailableForPlacement: true
+              :HostDiskID: 1a044003-9f71-4191-9263-9b3641479a48
+              :StorageDiskID: 1a044003-9f71-4191-9263-9b3641479a48
+              :HostDisk: *2
+              :StorageDisk: *2
+              :Classification: *8
+              :StoragePool: 
+              :ServerConnection: *9
+              :ID: 15fb039d-027a-4113-8504-a37fd0994dca
+              :IsViewOnly: false
+              :ObjectType: VMHostVolume
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :RegisteredStorageFileShares:
+          - *29
           :FibreChannelHbas: []
           :FibreChannelVirtualSANs: []
           :SASHbas:
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 0
-              :LocalSASAddress: 5782BCB0788B4C00
-              :AttachedSASAddress: 50000393B8426D36
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *1
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.923000000 -05:00
-              :ServerConnection: *8
-              :ID: 5b2b1dac-fd59-49a5-ad51-02e8eb5a5948
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 6
-              :LocalSASAddress: 5782BCB0788B4C06
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *1
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.983000000 -05:00
-              :ServerConnection: *8
-              :ID: 6c160fac-fe9d-4fc8-b8b2-03c16b27e9ed
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 7
-              :LocalSASAddress: 5782BCB0788B4C07
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *1
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.993000000 -05:00
-              :ServerConnection: *8
-              :ID: 77755ae5-45bd-44a1-85e3-362a05fa935f
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 2
-              :LocalSASAddress: 5782BCB0788B4C02
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *1
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.943000000 -05:00
-              :ServerConnection: *8
-              :ID: f237e81e-5390-48a4-be6a-379324fbc503
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 1
-              :LocalSASAddress: 5782BCB0788B4C01
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *1
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.933000000 -05:00
-              :ServerConnection: *8
-              :ID: 137c551f-bc10-468e-9cd6-71e6898bde8a
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-            :Props:
-              :PortNumber: 4
-              :LocalSASAddress: 5782BCB0788B4C04
-              :AttachedSASAddress: '0000000000000000'
-              :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Manufacturer: LSI Corporation
-              :DriverName: lsi_sas
-              :SerialNumber: 
-              :VMHost: *1
-              :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.963000000 -05:00
-              :ServerConnection: *8
-              :ID: f3dbd95e-d003-409b-b6e7-c94bc54ca94f
-              :IsViewOnly: false
-              :ObjectType: HostSASHba
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
             :Props:
               :PortNumber: 3
-              :LocalSASAddress: 5782BCB0788B4C03
+              :LocalSASAddress: 5005076B08B09E1F
               :AttachedSASAddress: '0000000000000000'
               :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
               :Manufacturer: LSI Corporation
               :DriverName: lsi_sas
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.953000000 -05:00
-              :ServerConnection: *8
-              :ID: ee1a2ac4-7015-4e29-af03-d3b371e82ee4
+              :ModifiedTime: 2016-07-11 15:41:29.413000000 -04:00
+              :ServerConnection: *9
+              :ID: b2340652-45fb-48f2-b51f-2ea89abd8b61
               :IsViewOnly: false
               :ObjectType: HostSASHba
               :MarkedForDeletion: false
               :IsFullyCached: true
-          - :ToString: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
             :Props:
-              :PortNumber: 5
-              :LocalSASAddress: 5782BCB0788B4C05
-              :AttachedSASAddress: '0000000000000000'
+              :PortNumber: 0
+              :LocalSASAddress: 5005076B08B09E1C
+              :AttachedSASAddress: 5000C50034A77565
               :PortType: SASDevice
-              :Name: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
-              :Model: SAS6IR
-              :InstanceName: PCI\VEN_1000&DEV_0058&SUBSYS_1F0F1028&REV_08\4&1cfce22b&0&0018_0
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
               :Manufacturer: LSI Corporation
               :DriverName: lsi_sas
               :SerialNumber: 
               :VMHost: *1
               :LibraryServer: 
-              :ModifiedTime: 2016-02-29 19:30:01.973000000 -05:00
-              :ServerConnection: *8
-              :ID: 8e8fe4e5-ff94-4d2a-aa97-fbe27a460fc2
+              :ModifiedTime: 2016-07-11 15:41:29.333000000 -04:00
+              :ServerConnection: *9
+              :ID: b6c16b37-93c1-4058-beed-35156cc56670
               :IsViewOnly: false
               :ObjectType: HostSASHba
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :InternetSCSIHbas: []
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :Props:
+              :PortNumber: 1
+              :LocalSASAddress: 5005076B08B09E1D
+              :AttachedSASAddress: 5000C50034A7B911
+              :PortType: SASDevice
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Manufacturer: LSI Corporation
+              :DriverName: lsi_sas
+              :SerialNumber: 
+              :VMHost: *1
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:29.363000000 -04:00
+              :ServerConnection: *9
+              :ID: 4c648dd4-3d04-41ae-951d-9ea1ec67590e
+              :IsViewOnly: false
+              :ObjectType: HostSASHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :Props:
+              :PortNumber: 2
+              :LocalSASAddress: 5005076B08B09E1E
+              :AttachedSASAddress: '0000000000000000'
+              :PortType: SASDevice
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Manufacturer: LSI Corporation
+              :DriverName: lsi_sas
+              :SerialNumber: 
+              :VMHost: *1
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:29.390000000 -04:00
+              :ServerConnection: *9
+              :ID: d6ca1068-4aca-4255-98d4-e7cf5acbb221
+              :IsViewOnly: false
+              :ObjectType: HostSASHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :InternetSCSIHbas:
+          - :ToString: ROOT\ISCSIPRT\0000_0
+            :Props:
+              :ISCSINodeName: iqn.1991-05.com.microsoft:qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :IsSoftwareBased: true
+              :Targets:
+              - iqn.1992-08.com.netapp:sn.b1e1a51c450811e585a200a098861b10:vs.5
+              - iqn.1992-08.com.netapp:sn.6ff1d45251c111e59bb500a098861bb2:vs.7
+              :Portals:
+              - 10.16.4.8
+              - 10.16.4.20
+              - 10.16.4.2
+              - 10.16.4.5
+              :Name: ROOT\ISCSIPRT\0000_0
+              :Model: iSCSI Initiator
+              :InstanceName: ROOT\ISCSIPRT\0000_0
+              :Manufacturer: Microsoft Corporation
+              :DriverName: msiscsi.sys
+              :SerialNumber: MSFT-05-1991
+              :VMHost: *1
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:29.510000000 -04:00
+              :ServerConnection: *9
+              :ID: d537bc36-b914-4508-8c6d-eb79ae19277f
+              :IsViewOnly: false
+              :ObjectType: HostInternetSCSIHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
           :VMwareResourcePool: 
           :IsConfiguredForOutOfBandManagement: false
           :PhysicalMachine:
-            :ToString: 4c4c4544-0038-3810-8053-cac04f585231
+            :ToString: 463b9e30-9f60-e011-8346-5cf3fc1c83ec
             :Props:
-              :Name: 4c4c4544-0038-3810-8053-cac04f585231
+              :Name: 463b9e30-9f60-e011-8346-5cf3fc1c83ec
               :BMCType: None
               :BMCCustomConfigurationProvider: 
               :BMCAddress: 
               :BMCPort: 
               :RunAsAccount: 
-              :SMBiosGUID: 4c4c4544-0038-3810-8053-cac04f585231
+              :SMBiosGUID: 463b9e30-9f60-e011-8346-5cf3fc1c83ec
               :ComputerPowerState: Unknown
               :SystemEventLog: []
-              :ServerConnection: *8
-              :ID: 5f2cf6a4-f6d5-48d5-a3cb-41d34ffff6d0
+              :ServerConnection: *9
+              :ID: 13b9e4c4-7315-4183-803e-5aafcdec86c3
               :IsViewOnly: false
               :ObjectType: PhysicalMachine
               :MarkedForDeletion: false
               :IsFullyCached: true
           :HealthMonitors:
-          - :ToString: Overall
-            :Props:
-              :ParentID: 
-              :Name: Overall
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: 
-              :UpdatedDate: 2016-02-19 16:50:25.583000000 -05:00
-              :ServerConnection: *8
-              :ID: ab17848b-357a-4cc4-81a5-2cade3766e8a
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Hyper-V Role Version
-            :Props:
-              :ParentID: 824aeb5f-3e53-42e4-9461-7e929624b0a4
-              :Name: Hyper-V Role Version
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-19 16:50:25.593000000 -05:00
-              :ServerConnection: *8
-              :ID: d7334e8c-28ee-4d56-a824-4e12e198f8e0
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: WMI Performance Counter
-            :Props:
-              :ParentID: 3966e17b-55e4-41c0-a66a-d4f8c8d8a8e8
-              :Name: WMI Performance Counter
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-19 16:50:25.587000000 -05:00
-              :ServerConnection: *8
-              :ID: 38d69525-f117-4d60-aaa1-544aaf1db533
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Host Agent Service
-            :Props:
-              :ParentID: 3966e17b-55e4-41c0-a66a-d4f8c8d8a8e8
-              :Name: Host Agent Service
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-19 16:50:25.587000000 -05:00
-              :ServerConnection: *8
-              :ID: 91dadbda-201b-4fd2-bbee-6a71c40d4256
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Hyper-V Role Overall
-            :Props:
-              :ParentID: ab17848b-357a-4cc4-81a5-2cade3766e8a
-              :Name: Hyper-V Role Overall
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: 
-              :UpdatedDate: 2016-02-19 16:50:25.587000000 -05:00
-              :ServerConnection: *8
-              :ID: 824aeb5f-3e53-42e4-9461-7e929624b0a4
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Hyper-V Virtual Machine Management Service
-            :Props:
-              :ParentID: 824aeb5f-3e53-42e4-9461-7e929624b0a4
-              :Name: Hyper-V Virtual Machine Management Service
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-19 16:50:25.590000000 -05:00
-              :ServerConnection: *8
-              :ID: 57ceb3dd-5bc4-4275-b34b-bc09f23e581f
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          - :ToString: Network
-            :Props:
-              :ParentID: ab17848b-357a-4cc4-81a5-2cade3766e8a
-              :Name: Network
-              :IsRemediationAvailable: false
-              :RemediationDescription: 
-              :State: Healthy
-              :StateString: OK
-              :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-19 16:50:25.583000000 -05:00
-              :ServerConnection: *8
-              :ID: 17b0f562-d68f-41be-bc6f-c2c3b3b0793f
-              :IsViewOnly: false
-              :ObjectType: HealthMonitor
-              :MarkedForDeletion: false
-              :IsFullyCached: true
           - :ToString: WinRM
             :Props:
-              :ParentID: ab17848b-357a-4cc4-81a5-2cade3766e8a
+              :ParentID: fcaeb0f0-a909-49a9-bc69-9fb060c2abaa
               :Name: WinRM
               :IsRemediationAvailable: false
               :RemediationDescription: 
               :State: Healthy
               :StateString: OK
               :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-19 16:50:25.583000000 -05:00
-              :ServerConnection: *8
-              :ID: 8c1f52cd-efd5-4aff-95b6-d1b9c9f0ac69
+              :UpdatedDate: 2016-07-11 15:41:42.620000000 -04:00
+              :ServerConnection: *9
+              :ID: e45c7ead-aa06-491c-bb65-0225151d2e58
               :IsViewOnly: false
               :ObjectType: HealthMonitor
               :MarkedForDeletion: false
               :IsFullyCached: true
-          - :ToString: Host Agent Overall
+          - :ToString: Hyper-V Role Version
             :Props:
-              :ParentID: ab17848b-357a-4cc4-81a5-2cade3766e8a
-              :Name: Host Agent Overall
+              :ParentID: a57f3e31-e848-4dfa-94a6-a5cccd20fbb9
+              :Name: Hyper-V Role Version
               :IsRemediationAvailable: false
               :RemediationDescription: 
               :State: Healthy
               :StateString: OK
-              :LastKnownError: 
-              :UpdatedDate: 2016-02-19 16:50:25.583000000 -05:00
-              :ServerConnection: *8
-              :ID: 3966e17b-55e4-41c0-a66a-d4f8c8d8a8e8
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.633000000 -04:00
+              :ServerConnection: *9
+              :ID: 560debfe-07e9-4204-882f-432691ff48b1
               :IsViewOnly: false
               :ObjectType: HealthMonitor
               :MarkedForDeletion: false
               :IsFullyCached: true
           - :ToString: Host Agent Version
             :Props:
-              :ParentID: 3966e17b-55e4-41c0-a66a-d4f8c8d8a8e8
+              :ParentID: 479c3b0e-a2bc-4686-9f30-a0ad6c4d1c25
               :Name: Host Agent Version
+              :IsRemediationAvailable: true
+              :RemediationDescription: We would try to upgrade VMM agent from 3.2.8117.0
+                to latest version.
+              :State: Warning
+              :StateString: Warning
+              :LastKnownError: HMAgentVersionUpgradeAvailable (20510)
+              :UpdatedDate: 2016-07-11 15:41:42.623000000 -04:00
+              :ServerConnection: *9
+              :ID: cc481b3c-de6d-4523-88f8-5885602718ce
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Host Agent Service
+            :Props:
+              :ParentID: 479c3b0e-a2bc-4686-9f30-a0ad6c4d1c25
+              :Name: Host Agent Service
               :IsRemediationAvailable: false
               :RemediationDescription: 
               :State: Healthy
               :StateString: OK
               :LastKnownError: Success (0)
-              :UpdatedDate: 2016-02-19 16:50:25.587000000 -05:00
-              :ServerConnection: *8
-              :ID: e5ae52a4-f23d-42df-ae60-ef9c8d39630e
+              :UpdatedDate: 2016-07-11 15:41:42.623000000 -04:00
+              :ServerConnection: *9
+              :ID: bfdbaa83-ac9a-4986-ba2b-67be96f353a8
               :IsViewOnly: false
               :ObjectType: HealthMonitor
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :RemoteStorageTotalCapacity: 0
-          :RemoteStorageAvailableCapacity: 0
-          :LocalStorageTotalCapacity: 300000000000
-          :LocalStorageAvailableCapacity: 267277864960
-          :TotalStorageCapacity: 300000000000
-          :AvailableStorageCapacity: 267277864960
-          :UsedStorageCapacity: 32722135040
+          - :ToString: WMI Performance Counter
+            :Props:
+              :ParentID: 479c3b0e-a2bc-4686-9f30-a0ad6c4d1c25
+              :Name: WMI Performance Counter
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.623000000 -04:00
+              :ServerConnection: *9
+              :ID: 6f3ea137-22dd-433e-a7d1-7f8c6dd2316f
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Overall
+            :Props:
+              :ParentID: 
+              :Name: Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Warning
+              :StateString: Warning
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:41:42.620000000 -04:00
+              :ServerConnection: *9
+              :ID: fcaeb0f0-a909-49a9-bc69-9fb060c2abaa
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Host Agent Overall
+            :Props:
+              :ParentID: fcaeb0f0-a909-49a9-bc69-9fb060c2abaa
+              :Name: Host Agent Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Warning
+              :StateString: Warning
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:41:42.623000000 -04:00
+              :ServerConnection: *9
+              :ID: 479c3b0e-a2bc-4686-9f30-a0ad6c4d1c25
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Role Overall
+            :Props:
+              :ParentID: fcaeb0f0-a909-49a9-bc69-9fb060c2abaa
+              :Name: Hyper-V Role Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:41:42.627000000 -04:00
+              :ServerConnection: *9
+              :ID: a57f3e31-e848-4dfa-94a6-a5cccd20fbb9
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Virtual Machine Management Service
+            :Props:
+              :ParentID: a57f3e31-e848-4dfa-94a6-a5cccd20fbb9
+              :Name: Hyper-V Virtual Machine Management Service
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.630000000 -04:00
+              :ServerConnection: *9
+              :ID: aa0347f9-0e93-49a9-ae56-cd4738fd8155
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Network
+            :Props:
+              :ParentID: fcaeb0f0-a909-49a9-bc69-9fb060c2abaa
+              :Name: Network
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.620000000 -04:00
+              :ServerConnection: *9
+              :ID: 7e4cf16e-66ef-43cf-ae2c-fdfc6f60fb7c
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :RemoteStorageTotalCapacity: 832233830400
+          :RemoteStorageAvailableCapacity: 528009306112
+          :LocalStorageTotalCapacity: 1000215724032
+          :LocalStorageAvailableCapacity: 153700024320
+          :TotalStorageCapacity: 1832449554432
+          :AvailableStorageCapacity: 681709330432
+          :UsedStorageCapacity: 1150740224000
           :IsDedicatedToNetworkVirtualizationGateway: false
-          :FibreChannelWorldWidePortNameMinimum: C003FF3CB93B0000
-          :FibreChannelWorldWidePortNameMaximum: C003FF3CB93BFFFF
+          :FibreChannelWorldWidePortNameMinimum: C003FFDA8ADA0000
+          :FibreChannelWorldWidePortNameMaximum: C003FFDA8ADAFFFF
           :FibreChannelWorldWideNodeName: C003FF0000FFFF00
           :VMConnectCertificateThumbprint: 
           :Custom1: 
@@ -8053,43 +10998,8 @@
               :ErrorCodeString: '1204'
               :ErrorType: Error
               :CSMMessageString: 'Error Code : DeployTargetDoesNotHaveHBA ; Message
-                : The server dell-r410-03.cloudformswin.lab.redhat.com does not contain
-                any host bus adapter (HBA) ports. Fibre Channel SAN transfer cannot
-                be used. ; Recommended Action : Transfer the virtual machine over
-                the LAN.'
-              :IsSuccess: false
-              :IsTerminating: false
-              :IsConditionallyTerminating: false
-              :IsDeploymentBlocker: false
-              :ShowDetailedError: false
-              :DetailedErrorCode: 
-              :IsMomAlert: false
-              :MomAlertSeverity: Error
-              :Problem: The server dell-r410-03.cloudformswin.lab.redhat.com does
+                : The server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com does
                 not contain any host bus adapter (HBA) ports. Fibre Channel SAN transfer
-                cannot be used.
-              :CloudProblem: The server does not contain any host bus adapter (HBA)
-                ports. Fibre Channel SAN transfer cannot be used.
-              :RecommendedAction: Transfer the virtual machine over the LAN.
-              :RecommendedActionCLI: Transfer the virtual machine over the LAN.
-              :DetailedCode: 0
-              :DetailedSource: None
-              :ExceptionDetails: 
-              :MessageParameters:
-                :VMHostName: dell-r410-03.cloudformswin.lab.redhat.com
-              :Code: DeployTargetDoesNotHaveHBA
-              :GetMessageFormatterHandler: 
-          :ISCSISANStatus:
-            :ToString: DeployTargetDoesNotHaveIscsiInitiator (1231)
-            :Props:
-              :Exception: 
-              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
-              :DisplayableErrorCode: 1231
-              :ErrorCodeString: '1231'
-              :ErrorType: Error
-              :CSMMessageString: 'Error Code : DeployTargetDoesNotHaveIscsiInitiator
-                ; Message : The server dell-r410-03.cloudformswin.lab.redhat.com does
-                not have the Microsoft iSCSI Initiator installed. iSCSI SAN transfer
                 cannot be used. ; Recommended Action : Transfer the virtual machine
                 over the LAN.'
               :IsSuccess: false
@@ -8100,19 +11010,54 @@
               :DetailedErrorCode: 
               :IsMomAlert: false
               :MomAlertSeverity: Error
-              :Problem: The server dell-r410-03.cloudformswin.lab.redhat.com does
-                not have the Microsoft iSCSI Initiator installed. iSCSI SAN transfer
-                cannot be used.
-              :CloudProblem: The server does not have the Microsoft iSCSI Initiator
-                installed. iSCSI SAN transfer cannot be used.
+              :Problem: The server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not contain any host bus adapter (HBA) ports. Fibre Channel SAN
+                transfer cannot be used.
+              :CloudProblem: The server does not contain any host bus adapter (HBA)
+                ports. Fibre Channel SAN transfer cannot be used.
               :RecommendedAction: Transfer the virtual machine over the LAN.
               :RecommendedActionCLI: Transfer the virtual machine over the LAN.
               :DetailedCode: 0
               :DetailedSource: None
               :ExceptionDetails: 
               :MessageParameters:
-                :VMHostName: dell-r410-03.cloudformswin.lab.redhat.com
-              :Code: DeployTargetDoesNotHaveIscsiInitiator
+                :VMHostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :Code: DeployTargetDoesNotHaveHBA
+              :GetMessageFormatterHandler: 
+          :ISCSISANStatus:
+            :ToString: DeployHostDoesNotHaveMPIO (1253)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1253
+              :ErrorCodeString: '1253'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : DeployHostDoesNotHaveMPIO ; Message
+                : SAN operations cannot be performed because the server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not have a Microsoft MPIO feature installed. ; Recommended Action
+                : Install MPIO feature on the server and claim all MPIO capable paths.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN operations cannot be performed because the server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not have a Microsoft MPIO feature installed.
+              :CloudProblem: SAN operations cannot be performed because the server
+                does not have a Microsoft MPIO feature installed.
+              :RecommendedAction: Install MPIO feature on the server and claim all
+                MPIO capable paths.
+              :RecommendedActionCLI: Install MPIO feature on the server and claim
+                all MPIO capable paths.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :VMHostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :Code: DeployHostDoesNotHaveMPIO
               :GetMessageFormatterHandler: 
           :NPIVFibreChannelSANStatus:
             :ToString: DeployHostIsNotNPIVCapable (1252)
@@ -8123,11 +11068,11 @@
               :ErrorCodeString: '1252'
               :ErrorType: Error
               :CSMMessageString: 'Error Code : DeployHostIsNotNPIVCapable ; Message
-                : The server dell-r410-03.cloudformswin.lab.redhat.com does not have
-                an HBA which supports NPIV. ; Recommended Action : If server dell-r410-03.cloudformswin.lab.redhat.com
-                contains an HBA that supports NPIV, ensure that the right version
-                of firmware and driver are installed, or transfer the virtual machine
-                over the LAN.'
+                : The server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com does
+                not have an HBA which supports NPIV. ; Recommended Action : If server
+                qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com contains an HBA
+                that supports NPIV, ensure that the right version of firmware and
+                driver are installed, or transfer the virtual machine over the LAN.'
               :IsSuccess: false
               :IsTerminating: false
               :IsConditionallyTerminating: false
@@ -8136,14 +11081,14 @@
               :DetailedErrorCode: 
               :IsMomAlert: false
               :MomAlertSeverity: Error
-              :Problem: The server dell-r410-03.cloudformswin.lab.redhat.com does
-                not have an HBA which supports NPIV.
+              :Problem: The server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not have an HBA which supports NPIV.
               :CloudProblem: The server does not have an HBA which supports NPIV.
-              :RecommendedAction: If server dell-r410-03.cloudformswin.lab.redhat.com
+              :RecommendedAction: If server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
                 contains an HBA that supports NPIV, ensure that the right version
                 of firmware and driver are installed, or transfer the virtual machine
                 over the LAN.
-              :RecommendedActionCLI: If server dell-r410-03.cloudformswin.lab.redhat.com
+              :RecommendedActionCLI: If server qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
                 contains an HBA that supports NPIV, ensure that the right version
                 of firmware and driver are installed, or transfer the virtual machine
                 over the LAN.
@@ -8151,7 +11096,7 @@
               :DetailedSource: None
               :ExceptionDetails: 
               :MessageParameters:
-                :VMHostName: dell-r410-03.cloudformswin.lab.redhat.com
+                :VMHostName: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
               :Code: DeployHostIsNotNPIVCapable
               :GetMessageFormatterHandler: 
           :CertificateRequest: 
@@ -8159,19 +11104,19 @@
             :ToString: Responding
             :By: 2
           :VirtualizationManager: 
-          :ServerConnection: *8
-          :ID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
+          :ServerConnection: *9
+          :ID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
           :IsViewOnly: false
           :ObjectType:
             :ToString: VMHost
             :I32: 9
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *99
+          :MostRecentTaskIfLocal: *80
         :MS:
-          :FQDN: dell-r410-03.cloudformswin.lab.redhat.com
+          :FQDN: qeblade33.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
           :LogicalCPUCount: 16
-          :CPUSpeed: 2394
+          :CPUSpeed: 2133
           :CPUModel: Xeon
           :CPUManufacturer: Intel
           :CPUArchitecture: 9
@@ -8187,196 +11132,15 @@
           :VirtualServerVersionState:
             :ToString: UpToDate
             :By: 0
-          :ServicingWindows: *9
+          :ServicingWindows: *11
       :NetworkAdapters:
-      - :ToString: 'Ethernet - Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client)
-          #35'
+      - :ToString: Local Area Connection - IBM USB Remote NDIS Network Device
         :Props:
-          :Name: 'Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client) #35'
-          :IPAddresses: []
-          :DHCPEnabled: true
-          :IPSubnets: []
-          :DefaultIPGateways: []
-          :MacAddress: 00:10:18:CD:8D:54
-          :PhysicalAddress: 00:10:18:CD:8D:54
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: 
-          :NetworkSwitchPort: 
-          :UplinkPortProfileSet: 
-          :VLanTags: []
-          :UsableVLanTags:
-          - 0
-          :VLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :DesiredVLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :VLanEnabled: true
-          :ConnectionState:
-            :ToString: MediaDisconnected
-            :I32: 4
-          :ConnectionName: Ethernet
-          :Description: 
-          :PrimaryDNSSuffix: 
-          :MaxBandwidth: 0
-          :VMHost: *1
-          :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :UsableVlanMode:
-            :ToString: Trunk
-            :I32: 1
-          :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
-          :UnassignedVLans: []
-          :AvailableForPlacement: true
-          :IsAvailableForHA: true
-          :UsedForManagement: false
-          :LogicalNetworkCompliance:
-            :ToString: Compliant
-            :I32: 1
-          :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 3, device 0, function 0
-          :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: f1555e77-1cbe-4e48-8a9c-033cb31b0c60
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHostNetworkAdapter
-            :I32: 12
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-      - :ToString: 'Ethernet 4 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
-          #34'
-        :Props:
-          :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #34'
-          :IPAddresses: []
-          :DHCPEnabled: true
-          :IPSubnets: []
-          :DefaultIPGateways: []
-          :MacAddress: 78:2B:CB:40:7B:A5
-          :PhysicalAddress: 78:2B:CB:40:7B:A5
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: 
-          :NetworkSwitchPort: 
-          :UplinkPortProfileSet: 
-          :VLanTags: []
-          :UsableVLanTags:
-          - 0
-          :VLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :DesiredVLanMode:
-            :ToString: Trunk
-            :I32: 1
-          :VLanEnabled: true
-          :ConnectionState:
-            :ToString: MediaDisconnected
-            :I32: 4
-          :ConnectionName: Ethernet 4
-          :Description: 
-          :PrimaryDNSSuffix: 
-          :MaxBandwidth: 0
-          :VMHost: *1
-          :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :UsableVlanMode:
-            :ToString: Trunk
-            :I32: 1
-          :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
-          :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
-          :UnassignedVLans: []
-          :AvailableForPlacement: true
-          :IsAvailableForHA: true
-          :UsedForManagement: false
-          :LogicalNetworkCompliance:
-            :ToString: Compliant
-            :I32: 1
-          :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 1, device 0, function 1
-          :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: da9ab8ec-f3e2-4359-be22-5b68596ae49f
-          :IsViewOnly: false
-          :ObjectType:
-            :ToString: VMHostNetworkAdapter
-            :I32: 12
-          :MarkedForDeletion: false
-          :IsFullyCached: true
-      - :ToString: 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
-          #33'
-        :Props:
-          :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33'
+          :Name: IBM USB Remote NDIS Network Device
           :IPAddresses:
-          - :ToString: 10.8.96.25
+          - :ToString: 11.1.1.2
             :Props:
-              :Address: 425723914
+              :Address: 33620235
               :AddressFamily: InterNetwork
               :IsIPv6Multicast: false
               :IsIPv6LinkLocal: false
@@ -8384,8 +11148,8 @@
               :IsIPv6Teredo: false
               :IsIPv4MappedToIPv6: false
             :MS:
-              :IPAddressToString: 10.8.96.25
-          - :ToString: fe80::7102:f721:e03b:7e51
+              :IPAddressToString: 11.1.1.2
+          - :ToString: fe80::99f4:615:b8da:1611
             :Props:
               :AddressFamily: InterNetworkV6
               :ScopeId: 0
@@ -8395,18 +11159,18 @@
               :IsIPv6Teredo: false
               :IsIPv4MappedToIPv6: false
             :MS:
-              :IPAddressToString: fe80::7102:f721:e03b:7e51
-          :DHCPEnabled: true
+              :IPAddressToString: fe80::99f4:615:b8da:1611
+          :DHCPEnabled: false
           :IPSubnets:
-          - :ToString: 10.8.96.0/22
+          - :ToString: 11.1.1.0/24
             :Props:
-              :NetworkAddress: 10.8.96.0
-              :AddressRangeEnd: 10.8.99.255
+              :NetworkAddress: 11.1.1.0
+              :AddressRangeEnd: 11.1.1.255
               :AddressFamily: IPv4
-              :PrefixLength: 22
-              :SubnetMask: 255.255.252.0
-              :FirstAddressInSubnet: 10.8.96.1
-              :LastAddressInSubnet: 10.8.99.254
+              :PrefixLength: 24
+              :SubnetMask: 255.255.255.0
+              :FirstAddressInSubnet: 11.1.1.1
+              :LastAddressInSubnet: 11.1.1.254
           - :ToString: fe80::/64
             :Props:
               :NetworkAddress: 'fe80::'
@@ -8416,10 +11180,98 @@
               :SubnetMask: 'ffff:ffff:ffff:ffff::'
               :FirstAddressInSubnet: fe80::1
               :LastAddressInSubnet: fe80::ffff:ffff:ffff:fffe
-          :DefaultIPGateways:
-          - :ToString: 10.8.99.254
+          :DefaultIPGateways: []
+          :MacAddress: 5E:F3:FC:1E:E4:AF
+          :PhysicalAddress: 5E:F3:FC:1E:E4:AF
+          :NetworkLocation: 
+          :VirtualNetwork: 
+          :NetworkSwitchPort: 
+          :UplinkPortProfileSet: 
+          :VLanTags: []
+          :UsableVLanTags: []
+          :VLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :DesiredVLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :VLanEnabled: true
+          :ConnectionState:
+            :ToString: Connected
+            :I32: 0
+          :ConnectionName: Local Area Connection
+          :Description: 
+          :PrimaryDNSSuffix: 
+          :MaxBandwidth: 9
+          :VMHost: *1
+          :LogicalNetworkMap: {}
+          :UsableVlanMode:
+            :ToString: Trunk
+            :I32: 1
+          :ModelAccessibleSubnetVLans: {}
+          :LogicalNetworks: []
+          :SubnetVLans: []
+          :UnassignedVLans: []
+          :AvailableForPlacement: true
+          :IsAvailableForHA: true
+          :UsedForManagement: false
+          :LogicalNetworkCompliance:
+            :ToString: NonCompliant
+            :I32: 3
+          :LogicalNetworkComplianceErrors:
+          - :ToString: HostNetworkAdapterNoLogicalNetwork (13706)
             :Props:
-              :Address: 4267902986
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 13706
+              :ErrorCodeString: '13706'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : HostNetworkAdapterNoLogicalNetwork
+                ; Message : The host network adapter (IBM USB Remote NDIS Network
+                Device) is not associated with any logical networks. ; Recommended
+                Action : Specify the logical networks to which the host network adapter
+                has access.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: The host network adapter (IBM USB Remote NDIS Network Device)
+                is not associated with any logical networks.
+              :CloudProblem: The host network adapter (*) is not associated with any
+                logical networks.
+              :RecommendedAction: Specify the logical networks to which the host network
+                adapter has access.
+              :RecommendedActionCLI: Specify the logical networks to which the host
+                network adapter has access.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :Name: IBM USB Remote NDIS Network Device
+              :Code: HostNetworkAdapterNoLogicalNetwork
+              :GetMessageFormatterHandler: 
+          :BDFLocationInformation: Port_#0002.Hub_#0001
+          :NetworkVirtualizationEnabled: true
+          :ServerConnection: *9
+          :ID: 09eab928-fb82-435d-ae48-4bb6b9d7f684
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHostNetworkAdapter
+            :I32: 12
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+      - :ToString: 'Ethernet - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+          #51'
+        :Props:
+          :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #51'
+          :IPAddresses:
+          - :ToString: 10.16.4.54
+            :Props:
+              :Address: 906235914
               :AddressFamily: InterNetwork
               :IsIPv6Multicast: false
               :IsIPv6LinkLocal: false
@@ -8427,33 +11279,182 @@
               :IsIPv6Teredo: false
               :IsIPv4MappedToIPv6: false
             :MS:
-              :IPAddressToString: 10.8.99.254
-          :MacAddress: 78:2B:CB:40:7B:A4
-          :PhysicalAddress: 78:2B:CB:40:7B:A4
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: &100
-            :ToString: New Virtual Switch0
+              :IPAddressToString: 10.16.4.54
+          :DHCPEnabled: true
+          :IPSubnets:
+          - :ToString: 10.16.4.0/22
             :Props:
-              :Name: New Virtual Switch0
-              :HighlyAvailable: false
+              :NetworkAddress: 10.16.4.0
+              :AddressRangeEnd: 10.16.7.255
+              :AddressFamily: IPv4
+              :PrefixLength: 22
+              :SubnetMask: 255.255.252.0
+              :FirstAddressInSubnet: 10.16.4.1
+              :LastAddressInSubnet: 10.16.7.254
+          :DefaultIPGateways:
+          - :ToString: 10.16.7.254
+            :Props:
+              :Address: 4261875722
+              :AddressFamily: InterNetwork
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: false
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: 10.16.7.254
+          :MacAddress: 5C:F3:FC:1C:83:EC
+          :PhysicalAddress: 5C:F3:FC:1C:83:EC
+          :NetworkLocation: rhq
+          :VirtualNetwork: &82
+            :ToString: vswitch
+            :Props:
+              :Name: vswitch
+              :HighlyAvailable: true
               :HostBoundVlanId: 0
               :NetworkOptimizationCapable: false
               :NetworkOptimizationAvailable: false
               :BoundToVMHost: true
               :Description: 
               :LogicalNetworks:
-              - *21
+              - *22
               :VMHostNetworkAdapters:
-              - 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client)
-                #33'
+              - 'Ethernet - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+                #51'
               :VMHost: *1
               :LogicalSwitch: 
               :LogicalSwitchComplianceStatus: NotAnInstanceOfLogicalSwitch
               :LogicalSwitchComplianceErrors: []
               :VMwarePortGroups: []
-              :VMHostID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-              :ServerConnection: *8
-              :ID: 545b4e5d-c756-4046-8aab-84c8650398a8
+              :VMHostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :ServerConnection: *9
+              :ID: 35269705-1f7d-4203-ba2a-7ecf4f589128
+              :IsViewOnly: false
+              :ObjectType: VirtualNetwork
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :NetworkSwitchPort: 
+          :UplinkPortProfileSet: 
+          :VLanTags: []
+          :UsableVLanTags:
+          - 0
+          :VLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :DesiredVLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :VLanEnabled: true
+          :ConnectionState:
+            :ToString: Connected
+            :I32: 0
+          :ConnectionName: Ethernet
+          :Description: 
+          :PrimaryDNSSuffix: rhq.lab.eng.bos.redhat.com
+          :MaxBandwidth: 1000
+          :VMHost: *1
+          :LogicalNetworkMap:
+            ! '': []
+          :UsableVlanMode:
+            :ToString: Trunk
+            :I32: 1
+          :ModelAccessibleSubnetVLans:
+            ! '': []
+          :LogicalNetworks:
+          - *22
+          :SubnetVLans: []
+          :UnassignedVLans: []
+          :AvailableForPlacement: true
+          :IsAvailableForHA: true
+          :UsedForManagement: true
+          :LogicalNetworkCompliance:
+            :ToString: Compliant
+            :I32: 1
+          :LogicalNetworkComplianceErrors: []
+          :BDFLocationInformation: PCI bus 16, device 0, function 0
+          :NetworkVirtualizationEnabled: true
+          :ServerConnection: *9
+          :ID: e65d26a8-5826-4a9e-bf62-5f2baa5ba609
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHostNetworkAdapter
+            :I32: 12
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+      - :ToString: 'Ethernet 2 - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+          #52'
+        :Props:
+          :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #52'
+          :IPAddresses:
+          - :ToString: 169.254.181.81
+            :Props:
+              :Address: 1370881705
+              :AddressFamily: InterNetwork
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: false
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: 169.254.181.81
+          - :ToString: fe80::345a:45bf:224c:b551
+            :Props:
+              :AddressFamily: InterNetworkV6
+              :ScopeId: 0
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: true
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: fe80::345a:45bf:224c:b551
+          :DHCPEnabled: true
+          :IPSubnets:
+          - :ToString: 169.254.0.0/16
+            :Props:
+              :NetworkAddress: 169.254.0.0
+              :AddressRangeEnd: 169.254.255.255
+              :AddressFamily: IPv4
+              :PrefixLength: 16
+              :SubnetMask: 255.255.0.0
+              :FirstAddressInSubnet: 169.254.0.1
+              :LastAddressInSubnet: 169.254.255.254
+          - :ToString: fe80::/64
+            :Props:
+              :NetworkAddress: 'fe80::'
+              :AddressRangeEnd: fe80::ffff:ffff:ffff:ffff
+              :AddressFamily: IPv6
+              :PrefixLength: 64
+              :SubnetMask: 'ffff:ffff:ffff:ffff::'
+              :FirstAddressInSubnet: fe80::1
+              :LastAddressInSubnet: fe80::ffff:ffff:ffff:fffe
+          :DefaultIPGateways: []
+          :MacAddress: 5C:F3:FC:1C:83:EE
+          :PhysicalAddress: 5C:F3:FC:1C:83:EE
+          :NetworkLocation: hyperv_clus_netwk
+          :VirtualNetwork: &81
+            :ToString: hyperv_clus_netwk
+            :Props:
+              :Name: hyperv_clus_netwk
+              :HighlyAvailable: true
+              :HostBoundVlanId: 0
+              :NetworkOptimizationCapable: false
+              :NetworkOptimizationAvailable: false
+              :BoundToVMHost: true
+              :Description: 
+              :LogicalNetworks:
+              - hyperv_clus_netwk
+              :VMHostNetworkAdapters:
+              - 'Ethernet 2 - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+                #52'
+              :VMHost: *1
+              :LogicalSwitch: 
+              :LogicalSwitchComplianceStatus: NotAnInstanceOfLogicalSwitch
+              :LogicalSwitchComplianceErrors: []
+              :VMwarePortGroups: []
+              :VMHostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+              :ServerConnection: *9
+              :ID: 4b83bcdb-5137-4db4-8de5-4772830db115
               :IsViewOnly: false
               :ObjectType: VirtualNetwork
               :MarkedForDeletion: false
@@ -8475,79 +11476,5148 @@
             :I32: 0
           :ConnectionName: Ethernet 2
           :Description: 
-          :PrimaryDNSSuffix: cloudforms.lab.eng.rdu2.redhat.com
+          :PrimaryDNSSuffix: 
           :MaxBandwidth: 1000
           :VMHost: *1
           :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
+            ? ! ":\n                                    \n                                    hyperv_clus_netwk\n
+              \                                   \n                                      hyperv_clus_netwk\n
+              \                                     \n                                      false\n
+              \                                     false\n                                      false\n
+              \                                     false\n                                      false\n
+              \                                     false\n                                      false\n
+              \                                     false\n                                      false\n
+              \                                     \n                                      8f76e937-2f9a-409e-a166-e547add6056f\n
+              \                                     \n                                      \n
+              \                                     \n                                      8f76e937-2f9a-409e-a166-e547add6056f\n
+              \                                     LogicalNetwork\n                                      false\n
+              \                                     true\n                                    \n
+              \                                 "
+            : []
           :UsableVlanMode:
             :ToString: Trunk
             :I32: 1
           :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
+            ! '': []
           :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
+          - 
+          :SubnetVLans: []
           :UnassignedVLans: []
           :AvailableForPlacement: true
           :IsAvailableForHA: true
-          :UsedForManagement: true
+          :UsedForManagement: false
           :LogicalNetworkCompliance:
             :ToString: Compliant
             :I32: 1
           :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 1, device 0, function 0
+          :BDFLocationInformation: PCI bus 16, device 0, function 1
           :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: dbc6b0bf-7aa9-411e-8a80-8628dda8d7fe
+          :ServerConnection: *9
+          :ID: 8df3efb3-ccfb-4bb0-b688-80a3a09a378d
           :IsViewOnly: false
           :ObjectType:
             :ToString: VMHostNetworkAdapter
             :I32: 12
           :MarkedForDeletion: false
           :IsFullyCached: true
-      - :ToString: 'Ethernet 3 - Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client)
-          #36'
+      :VirtualSwitch:
+      - :ToString: hyperv_clus_netwk
         :Props:
-          :Name: 'Broadcom BCM5709C NetXtreme II GigE (NDIS VBD Client) #36'
-          :IPAddresses: []
+          :Name: hyperv_clus_netwk
+          :HighlyAvailable: true
+          :HostBoundVlanId: 0
+          :NetworkOptimizationCapable: false
+          :NetworkOptimizationAvailable: false
+          :BoundToVMHost: true
+          :Description: 
+          :LogicalNetworks:
+          - 
+          :VMHostNetworkAdapters:
+          - :ToString: 'Ethernet 2 - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD
+              Client) #52'
+            :Props:
+              :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #52'
+              :IPAddresses:
+              - :ToString: 169.254.181.81
+                :Props:
+                  :Address: 1370881705
+                  :AddressFamily: InterNetwork
+                  :IsIPv6Multicast: false
+                  :IsIPv6LinkLocal: false
+                  :IsIPv6SiteLocal: false
+                  :IsIPv6Teredo: false
+                  :IsIPv4MappedToIPv6: false
+                :MS:
+                  :IPAddressToString: 169.254.181.81
+              - :ToString: fe80::345a:45bf:224c:b551
+                :Props:
+                  :AddressFamily: InterNetworkV6
+                  :ScopeId: 0
+                  :IsIPv6Multicast: false
+                  :IsIPv6LinkLocal: true
+                  :IsIPv6SiteLocal: false
+                  :IsIPv6Teredo: false
+                  :IsIPv4MappedToIPv6: false
+                :MS:
+                  :IPAddressToString: fe80::345a:45bf:224c:b551
+              :DHCPEnabled: true
+              :IPSubnets:
+              - 169.254.0.0/16
+              - fe80::/64
+              :DefaultIPGateways: []
+              :MacAddress: 5C:F3:FC:1C:83:EE
+              :PhysicalAddress: 5C:F3:FC:1C:83:EE
+              :NetworkLocation: hyperv_clus_netwk
+              :VirtualNetwork: *81
+              :NetworkSwitchPort: 
+              :UplinkPortProfileSet: 
+              :VLanTags: []
+              :UsableVLanTags:
+              - 0
+              :VLanMode: Trunk
+              :DesiredVLanMode: Trunk
+              :VLanEnabled: true
+              :ConnectionState: Connected
+              :ConnectionName: Ethernet 2
+              :Description: 
+              :PrimaryDNSSuffix: 
+              :MaxBandwidth: 1000
+              :VMHost: *1
+              :LogicalNetworkMap:
+                ! '': []
+              :UsableVlanMode: Trunk
+              :ModelAccessibleSubnetVLans:
+                ! '': []
+              :LogicalNetworks:
+              - 
+              :SubnetVLans: []
+              :UnassignedVLans: []
+              :AvailableForPlacement: true
+              :IsAvailableForHA: true
+              :UsedForManagement: false
+              :LogicalNetworkCompliance: Compliant
+              :LogicalNetworkComplianceErrors: []
+              :BDFLocationInformation: PCI bus 16, device 0, function 1
+              :NetworkVirtualizationEnabled: true
+              :ServerConnection: *9
+              :ID: 8df3efb3-ccfb-4bb0-b688-80a3a09a378d
+              :IsViewOnly: false
+              :ObjectType: VMHostNetworkAdapter
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VMHost: *1
+          :LogicalSwitch: 
+          :LogicalSwitchComplianceStatus:
+            :ToString: NotAnInstanceOfLogicalSwitch
+            :I32: 0
+          :LogicalSwitchComplianceErrors: []
+          :VMwarePortGroups: []
+          :VMHostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+          :ServerConnection: *9
+          :ID: 4b83bcdb-5137-4db4-8de5-4772830db115
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VirtualNetwork
+            :I32: 15
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+      - :ToString: vswitch
+        :Props:
+          :Name: vswitch
+          :HighlyAvailable: true
+          :HostBoundVlanId: 0
+          :NetworkOptimizationCapable: false
+          :NetworkOptimizationAvailable: false
+          :BoundToVMHost: true
+          :Description: 
+          :LogicalNetworks:
+          - *22
+          :VMHostNetworkAdapters:
+          - :ToString: 'Ethernet - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+              #51'
+            :Props:
+              :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #51'
+              :IPAddresses:
+              - :ToString: 10.16.4.54
+                :Props:
+                  :Address: 906235914
+                  :AddressFamily: InterNetwork
+                  :IsIPv6Multicast: false
+                  :IsIPv6LinkLocal: false
+                  :IsIPv6SiteLocal: false
+                  :IsIPv6Teredo: false
+                  :IsIPv4MappedToIPv6: false
+                :MS:
+                  :IPAddressToString: 10.16.4.54
+              :DHCPEnabled: true
+              :IPSubnets:
+              - 10.16.4.0/22
+              :DefaultIPGateways:
+              - :ToString: 10.16.7.254
+                :Props:
+                  :Address: 4261875722
+                  :AddressFamily: InterNetwork
+                  :IsIPv6Multicast: false
+                  :IsIPv6LinkLocal: false
+                  :IsIPv6SiteLocal: false
+                  :IsIPv6Teredo: false
+                  :IsIPv4MappedToIPv6: false
+                :MS:
+                  :IPAddressToString: 10.16.7.254
+              :MacAddress: 5C:F3:FC:1C:83:EC
+              :PhysicalAddress: 5C:F3:FC:1C:83:EC
+              :NetworkLocation: rhq
+              :VirtualNetwork: *82
+              :NetworkSwitchPort: 
+              :UplinkPortProfileSet: 
+              :VLanTags: []
+              :UsableVLanTags:
+              - 0
+              :VLanMode: Trunk
+              :DesiredVLanMode: Trunk
+              :VLanEnabled: true
+              :ConnectionState: Connected
+              :ConnectionName: Ethernet
+              :Description: 
+              :PrimaryDNSSuffix: rhq.lab.eng.bos.redhat.com
+              :MaxBandwidth: 1000
+              :VMHost: *1
+              :LogicalNetworkMap:
+                ! '': []
+              :UsableVlanMode: Trunk
+              :ModelAccessibleSubnetVLans:
+                ! '': []
+              :LogicalNetworks:
+              - *22
+              :SubnetVLans: []
+              :UnassignedVLans: []
+              :AvailableForPlacement: true
+              :IsAvailableForHA: true
+              :UsedForManagement: true
+              :LogicalNetworkCompliance: Compliant
+              :LogicalNetworkComplianceErrors: []
+              :BDFLocationInformation: PCI bus 16, device 0, function 0
+              :NetworkVirtualizationEnabled: true
+              :ServerConnection: *9
+              :ID: e65d26a8-5826-4a9e-bf62-5f2baa5ba609
+              :IsViewOnly: false
+              :ObjectType: VMHostNetworkAdapter
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VMHost: *1
+          :LogicalSwitch: 
+          :LogicalSwitchComplianceStatus:
+            :ToString: NotAnInstanceOfLogicalSwitch
+            :I32: 0
+          :LogicalSwitchComplianceErrors: []
+          :VMwarePortGroups: []
+          :VMHostID: 18060bb0-05b9-40fb-b1e3-dfccb8d85c6b
+          :ServerConnection: *9
+          :ID: 35269705-1f7d-4203-ba2a-7ecf4f589128
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VirtualNetwork
+            :I32: 15
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+    :64e80126-006c-4efd-a00c-c1c4e9ee9d17:
+      :Properties:
+        :ToString: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+        :Props:
+          :RunAsAccount: *36
+          :MostRecentTaskID: 0a930a4f-3baf-4fcd-a037-bf266517ddbe
+          :MostRecentTaskUIState:
+            :ToString: Completed
+            :I32: 5
+          :MostRecentTask: &89
+            :ToString: Refresh virtual machine properties
+            :Props:
+              :StepsLoaded: true
+              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :Description: Refresh virtual machine properties
+              :IsVisible: true
+              :Status: Completed
+              :StatusString: Completed
+              :ErrorInfo: Success (0)
+              :StartTime: 2016-06-23 17:21:03.503000000 -04:00
+              :EndTime: 2016-06-23 17:21:12.173000000 -04:00
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :SessionOwner: CFME-QE-VMM-AD\Administrator
+              :Name: Refresh virtual machine properties
+              :Steps:
+              - Microsoft.SystemCenter.VirtualMachineManager.Step
+              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
+              :ProgressValue: 100
+              :Progress: 100 %
+              :WasNotifiedOfCancel: false
+              :CmdletName: "(Refresh VM Properties - System Job)"
+              :PROTipID: 
+              :ResultObjectID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :TargetObjectID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :TargetObjectType: VMHost
+              :IsCompleted: true
+              :AreAuditRecordsAvailable: false
+              :AuditRecords: []
+              :AdditionalMessages: []
+              :Source: 
+              :Target: 
+              :ResultObjectType: VMHost
+              :ResultObjectTypeName: Host
+              :ResultName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :IsRestartable: false
+              :IsStoppable: false
+              :ServerConnection: *9
+              :ID: 0a930a4f-3baf-4fcd-a037-bf266517ddbe
+              :IsViewOnly: false
+              :ObjectType: Job
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :OverallStateString: Needs Attention
+          :OverallState:
+            :ToString: NeedsAttention
+            :By: 2
+          :CommunicationStateString: Responding
+          :CommunicationState:
+            :ToString: Responding
+            :By: 0
+          :Name: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :FullyQualifiedDomainName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :ComputerName: qeblade26
+          :DomainName: cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :Description: 
+          :RemoteUserName: 
+          :OverrideHostGroupReserves: false
+          :CPUPercentageReserve: 10
+          :NetworkPercentageReserve: 0
+          :DiskSpaceReserveMB: 10240
+          :MaxDiskIOReservation: 10000
+          :MemoryReserveMB: 2048
+          :VMPaths: *83
+          :BaseDiskPaths: *84
+          :PROEnabled: false
+          :MaintenanceHost: false
+          :AvailableForPlacement: true
+          :IsEmbedded: false
+          :CredentialsNeeded: false
+          :PausedForNetworkIncompatibility: false
+          :LogicalProcessorCount: 8
+          :PhysicalCPUCount: 2
+          :CoresPerCPU: 4
+          :L2CacheSize: 256
+          :L3CacheSize: 8192
+          :BusSpeed: 4800
+          :ProcessorSpeed: 2133
+          :ProcessorModel: Xeon
+          :ProcessorManufacturer: Intel
+          :ProcessorArchitecture: 9
+          :ProcessorFamily: '179'
+          :CpuUtilization: 27
+          :TotalMemory: 77297573888
+          :AvailableMemory: 39698
+          :OperatingSystem:
+            :ToString: 'Microsoft Windows Server 2012 R2 Standard '
+            :Props:
+              :Name: 'Microsoft Windows Server 2012 R2 Standard '
+              :Description: 
+              :Version: 6.3.9600
+              :Architecture: amd64
+              :Edition: Standard
+              :OSType: Windows
+              :IsWindows: false
+              :ProductType: 
+              :IsCustomizationAllowed: false
+              :IsApplicationDeploymentAllowed: false
+              :RequiresAdministratorAccountNameInSysprep: false
+              :RequiresXMLSysprepFormat: true
+              :AllowsOrgNameInSysprep: false
+              :RequiresPIDInSysprep: true
+              :ServerConnection: 
+              :ID: d6f39351-faad-403a-a98e-cecb52e990a3
+              :IsViewOnly: false
+              :ObjectType: OperatingSystem
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :OperatingSystemVersion: 6.3.9600
+          :DVDDrives: 
+          :DVDDriveList: []
+          :VirtualizationPlatformString: Microsoft Hyper-V
+          :VirtualizationPlatform:
+            :ToString: HyperV
+            :I32: 2
+          :VirtualizationPlatformDetail: Microsoft Hyper-V
+          :IsVirtualizationSoftwareDetailUnknown: false
+          :IsViridianHost: true
+          :SupportsLiveMigration: true
+          :FloppyDrives: 
+          :FloppyDriveList: []
+          :VMHostGroup: *39
+          :HostCluster: *85
+          :RemoteConnectEnabled: true
+          :RemoteConnectPort: 2179
+          :SecureRemoteConnectEnabled: false
+          :VMRCCertificateAvailable: false
+          :EnableLiveMigration: true
+          :LiveMigrationMaximum: 2
+          :LiveStorageMigrationMaximum: 2
+          :UseAnyMigrationSubnet: false
+          :MigrationSubnet: *86
+          :MigrationSubnetUserManaged: *87
+          :MigrationAuthProtocol:
+            :ToString: CredSSP
+            :By: 0
+          :MigrationPerformanceOption:
+            :ToString: UseCompression
+            :By: 1
+          :SslTcpPort: 5985
+          :SslCertificateHash: 
+          :SshTcpPort: 0
+          :SshPublicKeyHash: 
+          :SshPublicKey: 
+          :IsRemoteFXRoleInstalled: false
+          :IsCPUSLAT: true
+          :IsNumaSpanningEnabled: true
+          :GPUMemoryTotalMB: 
+          :GPUMemoryAvailableMB: 
+          :ClusterNodeStatus:
+            :ToString: Running
+            :By: 3
+          :TimeZone: -240
+          :HyperVState:
+            :ToString: Running
+            :By: 3
+          :HyperVStateString: Running
+          :HyperVVersion: 6.3.9600.17787
+          :HyperVVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :PerimeterNetworkHost: false
+          :NonTrustedDomainHost: false
+          :MaximumMemoryPerVM: 1048576
+          :MinimumMemoryPerVM: 32
+          :SuggestedMaximumMemoryPerVM: 512
+          :ModifiedTime: 2016-07-11 15:44:15.927780100 -04:00
+          :Agent: &88
+            :ToString: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+            :Props:
+              :StateString: Responding
+              :RoleString: Host
+              :State: Responding
+              :VersionState: UpgradeAvailable
+              :VersionStateString: Upgrade Available
+              :MarkedForDeletion: false
+              :Name: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :MostRecentTaskID: 
+              :MostRecentTaskUIState: 
+              :MostRecentTask: 
+              :FullyQualifiedDomainName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :FQDN: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :ComputerName: qeblade26
+              :Description: 
+              :AgentVersion: 3.2.8117.0
+              :Role: Host
+              :UpdatedDate: 2015-12-04 19:02:45.067000000 -05:00
+              :ComplianceStatus: 
+              :ServerConnection: *9
+              :ID: 5698bd37-073c-4f72-a8fd-f8382defd167
+              :IsViewOnly: false
+              :ObjectType: AgentServer
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :ManagedComputer: *88
+          :VMs:
+          - :ToString: lcouzens_rr99
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\s_appl_downstream-56z_160615_LI6Ch44V\\Virtual
+                Machines\\DB9B0A50-9360-46B0-9CC1-CED5EF75A1AC.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: DB9B0A50-9360-46B0-9CC1-CED5EF75A1AC
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\lcouzens_rr99
+              :TotalSize: 2158580736
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 977a91c9-1ed0-4a37-a052-6184779d766d
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\s_appl_downstream-56z_160615_LI6Ch44V"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: DB9B0A50-9360-46B0-9CC1-CED5EF75A1AC
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: f62b1c24-9b3c-4e36-a629-021791e3da45
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 
+              :MostRecentTaskUIState: 
+              :MostRecentTask: 
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\s_appl_downstream-56z_160615_LI6Ch44V"
+              :CreationTime: 2016-06-23 17:15:53.833000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-56011-06151559
+              :VirtualDiskDrives:
+              - lcouzens_rr99
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - lcouzens_rr99
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: lcouzens_rr99
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - lcouzens_rr99
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: lcouzens_rr99
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-23 17:15:53.833000000 -04:00
+              :ModifiedTime: 2016-07-11 12:03:46.477000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: f62b1c71-9b3c-4e36-a629-021791e3da45
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: LargeWin12DTemplate
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Virtual Machines\\8834B4A8-481E-43FC-AAF0-7BE0DFAF2AC5.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 8834B4A8-481E-43FC-AAF0-7BE0DFAF2AC5
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\LargeWin12DTemplate
+              :TotalSize: 9902751744
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 49609853-23fa-44e3-8d7d-0587e8462795
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: WIN-NN41QP1TR71
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 8834B4A8-481E-43FC-AAF0-7BE0DFAF2AC5
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: fcbd69e6-3b7c-498b-b2c4-044621ffff3e
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 7fcc54df-8cb2-4fac-8433-71a8f074541f
+              :MostRecentTaskUIState: Completed
+              :Location: "\\\\CFME_HYPERV\\scvmm2"
+              :CreationTime: 2016-01-24 00:03:28.000000000 -05:00
+              :OperatingSystem: Windows Server 2012 R2 Datacenter
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: WIN-NN41QP1TR71
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - LargeWin12DTemplate
+              :VirtualHardDisks:
+              - LargeWin12DTemplate
+              :VirtualDiskDrives:
+              - LargeWin12DTemplate
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - LargeWin12DTemplate
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: LargeWin12DTemplate
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - LargeWin12DTemplate
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: LargeWin12DTemplate
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-01-24 00:03:28.000000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:46.767000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: fcbd69b3-3b7c-498b-b2c4-044621ffff3e
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: scvmm-sp1
+            :Props:
+              :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\Virtual Machines\75CF4109-8A7E-4F0B-A43D-9E4E66CD3C7B.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 75CF4109-8A7E-4F0B-A43D-9E4E66CD3C7B
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\scvmm-sp1
+              :TotalSize: 88119497728
+              :MemoryAssignedMB: 8192
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 8192
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 18cf5d93-e47b-4f9f-b0c0-bd174fb3059d
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 20
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: scvmm-sp1.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 75CF4109-8A7E-4F0B-A43D-9E4E66CD3C7B
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 67b113b6-e1c0-452a-bd3d-0da97d82ac64
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: 59ba585a-8069-407c-946b-272cd8fc90fb
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :CreationTime: 2015-12-04 19:04:14.473000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows Server 2012 Datacenter
+              :HasVMAdditions: true
+              :VMAddition: 6.2.9200.16384
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 10000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: scvmm-sp1.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - scvmm-sp1
+              :VirtualHardDisks:
+              - SC2012_SP1_SCVMM_EVALVHD
+              :VirtualDiskDrives:
+              - scvmm-sp1
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - scvmm-sp1
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: scvmm-sp1
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - scvmm-sp1
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: scvmm-sp1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:14.473000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:46.464300900 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 67b113e3-e1c0-452a-bd3d-0da97d82ac64
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: scvmm2
+            :Props:
+              :VMCPath: C:\scvmm2\Virtual Machines\18FD7270-3DC6-4518-92D4-347C9232FB4C.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 18FD7270-3DC6-4518-92D4-347C9232FB4C
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\scvmm2
+              :TotalSize: 564134817792
+              :MemoryAssignedMB: 10240
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 10240
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: fe4feed0-0c2f-4924-a442-5bc619013ba6
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\scvmm2
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: DFCAF40D-AE8E-4612-80BC-041C66D9C61D
+              :LastRestoredVMCheckpoint: scvmm2__EVM_SNAPSHOT
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 366f288d-89f8-4257-8112-138a62c435e8
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: 37925a09-4511-44e7-ad54-19d4355383e4
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Discover Network Configuration Change
+              :Location: C:\scvmm2
+              :CreationTime: 2015-12-04 19:04:36.697000000 -05:00
+              :OperatingSystem: Windows Server 2012 R2 Datacenter
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 8
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 10000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: SCVMM2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - scvmm2
+              :VirtualHardDisks:
+              - SC2012_R2_VMM_EVALVHD - Copy_0BED6EB3-D1E0-4189-B79B-5F3D187C6C15
+              :VirtualDiskDrives:
+              - scvmm2
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - scvmm2
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: scvmm2
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - scvmm2
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints:
+              - scvmm2 - (12/7/2015 - 11:22:44 PM)
+              - scvmm2 - (2/22/2016 - 1:05:23 PM)
+              - scvmm2__EVM_SNAPSHOT
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: scvmm2
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:36.697000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:48.417000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 366f28d8-89f8-4257-8112-138a62c435e8
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Discover Network Configuration Change
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: dajo-dsl
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Virtual Machines\\6FF2C9BE-46C1-4853-AB52-D32FC05052DE.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 6FF2C9BE-46C1-4853-AB52-D32FC05052DE
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\dajo-dsl
+              :TotalSize: 255989760
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 0b9e4936-fd8c-4b58-aba9-fb77ef94a551
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 128
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 5EAE39ED-6CDD-4B8B-B028-F5D66884FD93
+              :LastRestoredVMCheckpoint: dajo-dsl - (4/14/2016 - 11:38:11 PM)
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: c024bb17-2ffe-48eb-98e1-2767fe9826b5
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: c0e103b3-2c57-4f52-b41b-3fccfc460fef
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\CFME_HYPERV\\scvmm2"
+              :CreationTime: 2016-04-14 14:40:32.787000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 128
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - dajo-dsl
+              :VirtualHardDisks:
+              - dajo-dsl_D656E7B9-CF61-4B31-B6A3-834E1BAB9CF7
+              :VirtualDiskDrives:
+              - dajo-dsl
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - dajo-dsl
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: dajo-dsl
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - dajo-dsl
+              - dajo-dsl
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints:
+              - dajo-dsl - (4/14/2016 - 11:38:11 PM)
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: dajo-dsl
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-04-14 14:40:32.787000000 -04:00
+              :ModifiedTime: 2016-07-11 12:03:46.863302400 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: c024bb42-2ffe-48eb-98e1-2767fe9826b5
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: SmallWin12Template
+            :Props:
+              :VMCPath: C:\SmallWin12Template\Virtual Machines\6D37D03D-12C4-4085-BB74-7C9C27C737D5.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 6D37D03D-12C4-4085-BB74-7C9C27C737D5
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\SmallWin12Template
+              :TotalSize: 5372903424
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 7a572a51-4c46-4986-9aaf-f60d45f80990
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 0
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: WIN-AQTG41U5HJC
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\SmallWin12Template
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 6D37D03D-12C4-4085-BB74-7C9C27C737D5
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 603d527e-1ef9-4f5b-8530-2de4fac45ea4
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 0e7be20e-2030-42d2-a8a4-4a74644bc2df
+              :MostRecentTaskUIState: Completed
+              :Location: C:\SmallWin12Template
+              :CreationTime: 2016-01-22 18:21:51.913000000 -05:00
+              :OperatingSystem: *56
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 512
+              :DynamicMemoryEnabled: true
+              :DynamicMemoryMaximumMB: 1048576
+              :DynamicMemoryBufferPercentage: 20
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: WIN-AQTG41U5HJC
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 512
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - SmallWin12Template
+              :VirtualHardDisks:
+              - SmallWin12Template
+              :VirtualDiskDrives:
+              - SmallWin12Template
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - SmallWin12Template
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: SmallWin12Template
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - SmallWin12Template
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: SmallWin12Template
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-01-22 18:21:51.913000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:46.473000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 603d522b-1ef9-4f5b-8530-2de4fac45ea4
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: ws2008r2d-sp1-26
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Virtual Machines\\1E720F8C-18CE-4BC7-AFBD-F78588B8D8B4.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 1E720F8C-18CE-4BC7-AFBD-F78588B8D8B4
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\ws2008r2d-sp1-26
+              :TotalSize: 21411921920
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: f9353582-237a-459b-a00d-058e25ac243f
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 2048
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: WIN-SAP1NK95697
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 1E720F8C-18CE-4BC7-AFBD-F78588B8D8B4
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 8764e369-a1a8-456a-bd3c-4eef63a7ac6b
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: cc1f2173-8efe-4505-ae88-8a8d9c7315f0
+              :MostRecentTaskUIState: Completed
+              :Location: "\\\\CFME_HYPERV\\scvmm2"
+              :CreationTime: 2015-12-04 19:04:34.477000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows Server 2008 R2 Datacenter
+              :HasVMAdditions: true
+              :VMAddition: 6.1.7601.17514
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 2048
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: WIN-SAP1NK95697
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - ws2008r2d-sp1-26
+              :VirtualHardDisks:
+              - ws2008r2d-sp1-26
+              :VirtualDiskDrives:
+              - ws2008r2d-sp1-26
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - ws2008r2d-sp1-26
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: ws2008r2d-sp1-26
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - ws2008r2d-sp1-26
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: ws2008r2d-sp1-26
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:34.477000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:46.617299000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 8764e33c-a1a8-456a-bd3c-4eef63a7ac6b
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: s_appl_downstream-56z_160624_OsNx9fCt
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\s_appl_downstream-56z_160624_OsNx9fCt\\Virtual
+                Machines\\8BF372AB-9342-4773-B72D-3723FC0F1A1D.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 8BF372AB-9342-4773-B72D-3723FC0F1A1D
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\s_appl_downstream-56z_160624_OsNx9fCt
+              :TotalSize: 2083064832
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Missing
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Missing
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: d87d7902-59fc-4f90-84cd-2c37cb4de928
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: cfme-56013-06242325
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\s_appl_downstream-56z_160624_OsNx9fCt"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 8BF372AB-9342-4773-B72D-3723FC0F1A1D
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 551041e7-7ef2-46b2-8e05-5259e236c3ea
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 5b43fadb-860e-4e1d-a3bb-5a31e2d98812
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Discover Virtual Machine Removed
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\s_appl_downstream-56z_160624_OsNx9fCt"
+              :CreationTime: 2016-06-24 22:35:35.653000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - cfme-56013-06242325.vhd
+              :VirtualDiskDrives:
+              - s_appl_downstream-56z_160624_OsNx9fCt
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - s_appl_downstream-56z_160624_OsNx9fCt
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: s_appl_downstream-56z_160624_OsNx9fCt
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - s_appl_downstream-56z_160624_OsNx9fCt
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: s_appl_downstream-56z_160624_OsNx9fCt
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-24 22:35:35.653000000 -04:00
+              :ModifiedTime: 2016-06-28 12:23:00.377000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 551041b2-7ef2-46b2-8e05-5259e236c3ea
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Discover Virtual Machine Removed
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: SmallWin7Template
+            :Props:
+              :VMCPath: C:\SmallWin7Template\Virtual Machines\552BA517-BDC4-40E2-B547-833046023EBA.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 552BA517-BDC4-40E2-B547-833046023EBA
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\SmallWin7Template
+              :TotalSize: 8353284096
+              :MemoryAssignedMB: 512
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 512
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: UnderTemplateCreation
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Sysprepping...
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: b7e5c38d-5be1-49b8-a6a9-f3d67adaaed7
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 16
+              :PerfMemory: 512
+              :PerfDiskBytesRead: 7811325
+              :PerfDiskBytesWrite: 256444
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: cfmeqe-0122
+              :CreationSource: SmallWin7Template
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Virtual Machine
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 79a48fbd-2d90-4223-9993-78b8adf1bd71
+              :CheckpointLocation: C:\SmallWin7Template\
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 552BA517-BDC4-40E2-B547-833046023EBA
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 79068a94-d519-460c-a2d6-621bf0d48661
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: fbd9c6da-5fcd-4d3a-813c-53521dc851be
+              :MostRecentTaskUIState: Completed
+              :Location: C:\SmallWin7Template
+              :CreationTime: 2016-01-22 18:04:01.600000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows 7
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 512
+              :DynamicMemoryEnabled: true
+              :DynamicMemoryMaximumMB: 1048576
+              :DynamicMemoryBufferPercentage: 20
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: cfmeqe-0122
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 512
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - SmallWin7Template
+              :VirtualHardDisks:
+              - SmallWin7Template
+              :VirtualDiskDrives:
+              - SmallWin7Template
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - SmallWin7Template
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: SmallWin7Template
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - SmallWin7Template
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: SmallWin7Template
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-01-22 18:04:01.600000000 -05:00
+              :ModifiedTime: 2016-01-22 18:17:10.590000000 -05:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 79068ac1-d519-460c-a2d6-621bf0d48661
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: jt_dnd_w12r2d_scvmm_dev
+            :Props:
+              :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\Virtual Machines\BF4D7ACA-C2B9-4BC7-9802-E4A7CA3A3A26.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: BF4D7ACA-C2B9-4BC7-9802-E4A7CA3A3A26
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\jt_dnd_w12r2d_scvmm_dev
+              :TotalSize: 45000687616
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 7ac9a112-6ec7-4d1b-b0c2-f4e88fbec6a2
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 5000
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: JTSC12RVMM.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: BF4D7ACA-C2B9-4BC7-9802-E4A7CA3A3A26
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 0863954e-9f1a-41c8-acca-67b32e0dc9e7
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 19736e30-8609-4b6a-88a8-4a4b9590ac02
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :CreationTime: 2015-12-04 19:04:31.853000000 -05:00
+              :OperatingSystem: Windows Server 2012 R2 Datacenter
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 2
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 5000
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: JTSC12RVMM.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - jt_dnd_w12r2d_scvmm_dev
+              :VirtualHardDisks:
+              - jt_w12r2d_scvmm_dev
+              :VirtualDiskDrives:
+              - jt_dnd_w12r2d_scvmm_dev
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - jt_dnd_w12r2d_scvmm_dev
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: jt_dnd_w12r2d_scvmm_dev
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - jt_dnd_w12r2d_scvmm_dev
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: jt_dnd_w12r2d_scvmm_dev
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:31.853000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:46.437000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 0863951b-9f1a-41c8-acca-67b32e0dc9e7
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: django-win7-jt
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\SCVMM2\\django-win7-jt\\Virtual Machines\\5B2885F6-57CF-4037-B7F2-DF5223B6C105.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 5B2885F6-57CF-4037-B7F2-DF5223B6C105
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Saved
+              :HostGroupPath: All Hosts\django-win7-jt
+              :TotalSize: 99314700288
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Saved
+              :IsOrphaned: false
+              :HasSavedState: true
+              :StatusString: Saved State
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 8e4fa9c1-dabc-4473-91dc-c14ff8f7c03f
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: django-cfme
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\SCVMM2\\django-win7-jt"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 5B2885F6-57CF-4037-B7F2-DF5223B6C105
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: a918f98e-b034-4e95-93ad-7a69105fa1fb
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: eacbda8d-796f-4d9a-81f3-1ecde8881a78
+              :MostRecentTaskUIState: Completed
+              :Location: "\\\\CFME_HYPERV\\SCVMM2\\django-win7-jt"
+              :CreationTime: 2015-12-04 19:04:37.353000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows 7
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: django-cfme
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - django-win7-jt
+              :VirtualHardDisks:
+              - django-win7-jt
+              :VirtualDiskDrives:
+              - django-win7-jt
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - django-win7-jt
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: django-win7-jt
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - django-win7-jt
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: django-win7-jt
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:37.353000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:47.041376700 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: a918f9db-b034-4e95-93ad-7a69105fa1fb
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: ws12r2dc-2DVDs
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Virtual Machines\\3DA306DC-48B8-4EC7-829B-B0B458293FAB.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 3DA306DC-48B8-4EC7-829B-B0B458293FAB
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\ws12r2dc-2DVDs
+              :TotalSize: 13187066669
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 67582faa-5b0e-4322-b447-9934db76b9e5
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 2048
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 85D12C23-D8F7-4C7B-82FD-06DCB2EE08BD
+              :LastRestoredVMCheckpoint: ws12r2dc-2DVDs - (11/23/2015 14:24:12)
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 4a1756fa-3c1f-4437-bbfc-7cfb08bc81ff
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 88b23a95-acaf-4484-838c-2d84538f474e
+              :MostRecentTaskUIState: SucceedWithInfo
+              :MostRecentTask: Refresh virtual machine
+              :Location: "\\\\CFME_HYPERV\\scvmm2"
+              :CreationTime: 2015-12-04 19:04:34.803000000 -05:00
+              :OperatingSystem: Windows Server 2012 R2 Datacenter
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 2048
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives:
+              - ws12r2dc-2DVDs
+              - ws12r2dc-2DVDs
+              :VirtualHardDisks:
+              - ws12r2dc-07_600E9306-94A1-4710-AB5D-C044DB6C7E8F
+              :VirtualDiskDrives:
+              - ws12r2dc-2DVDs
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - ws12r2dc-2DVDs
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: ws12r2dc-2DVDs
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - ws12r2dc-2DVDs
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints:
+              - ws12r2dc-2DVDs - (11/23/2015 14:24:12)
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: ws12r2dc-2DVDs
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:34.803000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:47.387299500 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 4a1756af-3c1f-4437-bbfc-7cfb08bc81ff
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: Centos-Test1
+            :Props:
+              :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\Virtual Machines\D1545281-6ED4-4C34-B88F-C002D07BF836.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: D1545281-6ED4-4C34-B88F-C002D07BF836
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\Centos-Test1
+              :TotalSize: 2319450112
+              :MemoryAssignedMB: 2048
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 2048
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: UpdateFailed
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Update Failed
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: b7528c71-b106-42dd-90b2-85c3fc71d7af
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 2048
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 58b0f640-a287-4149-8f89-62b0782ee07e
+              :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: D1545281-6ED4-4C34-B88F-C002D07BF836
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: b91e9f90-d8e2-4627-a05c-826e2ebd4a54
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: 58b0f640-a287-4149-8f89-62b0782ee07e
+              :MostRecentTaskUIState: Failed
+              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :CreationTime: 2015-12-04 19:04:27.090000000 -05:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 2048
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - Centos-Test1
+              :VirtualHardDisks:
+              - Centos-Test1
+              :VirtualDiskDrives:
+              - Centos-Test1
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - Centos-Test1
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: Centos-Test1
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - Centos-Test1
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: Centos-Test1
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:27.090000000 -05:00
+              :ModifiedTime: 2016-04-06 16:47:39.650000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: b91e9fc5-d8e2-4627-a05c-826e2ebd4a54
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: miq-nightly-201606272000
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\miq-nightly-201606272000\\Virtual
+                Machines\\36905DFD-9B32-46C1-9EFC-8A33110EEB03.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 36905DFD-9B32-46C1-9EFC-8A33110EEB03
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\miq-nightly-201606272000
+              :TotalSize: 4228975104
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 76b89280-d16d-421c-9b28-858b2cc1cb47
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 10240
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: localhost
+              :CreationSource: miq-nightly-201606272000
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\miq-nightly-201606272000"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 36905DFD-9B32-46C1-9EFC-8A33110EEB03
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 5971054c-d7dc-400f-81d5-93494fba159e
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: e371ae34-7149-4c59-86de-80c62e9eb954
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh Virtual Machine State
+              :Location: "\\\\cfme_hyperv.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\\scvmm2\\miq-nightly-201606272000"
+              :CreationTime: 2016-06-28 16:13:12.790000000 -04:00
+              :OperatingSystem: *20
+              :HasVMAdditions: true
+              :VMAddition: '3.1'
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 10240
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: localhost
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives: []
+              :VirtualHardDisks:
+              - miq-nightly-201606272000.vhd
+              :VirtualDiskDrives:
+              - miq-nightly-201606272000
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - miq-nightly-201606272000
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: miq-nightly-201606272000
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - miq-nightly-201606272000
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: miq-nightly-201606272000
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-06-28 16:13:12.790000000 -04:00
+              :ModifiedTime: 2016-07-11 12:03:49.280000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 59710519-d7dc-400f-81d5-93494fba159e
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh Virtual Machine State
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: cfme-vmm-ad-bu-DND
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv\\scvmm2\\Virtual Machines\\66B26EB2-BA55-4F89-9AAF-270D48CDDED2.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 66B26EB2-BA55-4F89-9AAF-270D48CDDED2
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\cfme-vmm-ad-bu-DND
+              :TotalSize: 25337790464
+              :MemoryAssignedMB: 8192
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 8192
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 40aa7ca1-9b42-4de2-b26a-739f873670eb
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: cfme-qe-vmm-ad2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv\\scvmm2"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 66B26EB2-BA55-4F89-9AAF-270D48CDDED2
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 6e77c30d-5141-4b47-851d-a3ff666eefce
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: 88bb7f1b-4926-4476-9547-c6ed086a5126
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Discover Network Configuration Change
+              :Location: "\\\\cfme_hyperv\\scvmm2"
+              :CreationTime: 2016-04-25 13:10:28.123000000 -04:00
+              :OperatingSystem: *56
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: cfme-qe-vmm-ad2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - cfme-vmm-ad-bu-DND
+              :VirtualHardDisks:
+              - cfme-vmm-ad-bu-DND
+              :VirtualDiskDrives:
+              - cfme-vmm-ad-bu-DND
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - cfme-vmm-ad-bu-DND
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: cfme-vmm-ad-bu-DND
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - cfme-vmm-ad-bu-DND
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: cfme-vmm-ad-bu-DND
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-04-25 13:10:28.123000000 -04:00
+              :ModifiedTime: 2016-07-11 12:03:49.277000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 6e77c358-5141-4b47-851d-a3ff666eefce
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Discover Network Configuration Change
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: Engineering - win10ent64
+            :Props:
+              :VMCPath: "\\\\cfme_hyperv\\scvmm2\\win10ent64\\Virtual Machines\\901F9A0F-38F3-40F5-ABF5-70A26427A5E2.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 901F9A0F-38F3-40F5-ABF5-70A26427A5E2
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\Engineering - win10ent64
+              :TotalSize: 14701035520
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: b184b96b-c1e5-4e61-a923-73b712b4c20a
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 2048
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: win10ent64.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :CreationSource: win10ent64
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Virtual Machine
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\cfme_hyperv\\scvmm2\\win10ent64"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 901F9A0F-38F3-40F5-ABF5-70A26427A5E2
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 99eed994-015f-494c-aea5-a7924ab47d57
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: f8338b35-42b8-42e4-b82b-a974ea29aabd
+              :MostRecentTaskUIState: Completed
+              :Location: "\\\\cfme_hyperv\\scvmm2\\win10ent64"
+              :CreationTime: 2015-12-14 12:40:27.300000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows 10
+              :HasVMAdditions: true
+              :VMAddition: 10.0.10011.16384
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 2048
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: win10ent64.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 8
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - win10ent64
+              :VirtualHardDisks:
+              - WIN10ENT64
+              :VirtualDiskDrives:
+              - Engineering - win10ent64
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - Engineering - win10ent64
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: win10ent64
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - Engineering - win10ent64
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: Engineering - win10ent64
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-14 12:40:27.300000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:49.744301400 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 99eed9c1-015f-494c-aea5-a7924ab47d57
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: SmallWin7Template
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Virtual Machines\\00C2348C-0A04-43DA-A4E7-BF6AA2ECD848.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 00C2348C-0A04-43DA-A4E7-BF6AA2ECD848
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\SmallWin7Template
+              :TotalSize: 10165223424
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: UnderTemplateCreation
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Sysprepping...
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: b7e5c38d-5be1-49b8-a6a9-f3d67adaaed7
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 0
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: cfmeqe-0122
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: c6c966e6-4ab7-498b-800a-7255cfcbd54b
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 00C2348C-0A04-43DA-A4E7-BF6AA2ECD848
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: f5d85d3b-2679-4481-b5a6-cbe3e809e668
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: e71b3db6-b8cc-4dae-af3b-9dd13aa9ab47
+              :MostRecentTaskUIState: Completed
+              :Location: "\\\\CFME_HYPERV\\scvmm2"
+              :CreationTime: 2016-01-22 16:58:15.393000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows 7
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 1
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 512
+              :DynamicMemoryEnabled: true
+              :DynamicMemoryMaximumMB: 1048576
+              :DynamicMemoryBufferPercentage: 20
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: cfmeqe-0122
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 512
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - SmallWin7Template
+              :VirtualHardDisks:
+              - SmallWin7Template
+              :VirtualDiskDrives:
+              - SmallWin7Template
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - SmallWin7Template
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: SmallWin7Template
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - SmallWin7Template
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: SmallWin7Template
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2016-01-22 16:58:15.393000000 -05:00
+              :ModifiedTime: 2016-02-03 21:56:37.303000000 -05:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: f5d85d6e-2679-4481-b5a6-cbe3e809e668
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: smis_netapp_dnd
+            :Props:
+              :VMCPath: "\\\\CFME_HYPERV\\scvmm2\\Virtual Machines\\898784DF-3292-42A8-97F3-189646A1D452.xml"
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: 898784DF-3292-42A8-97F3-189646A1D452
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: Running
+              :HostGroupPath: All Hosts\smis_netapp_dnd
+              :TotalSize: 32182894592
+              :MemoryAssignedMB: 4096
+              :MemoryAvailablePercentage: '0'
+              :DynamicMemoryDemandMB: 4096
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: Running
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Running
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 25fbdd5a-8594-465c-b5b1-cec70ee78e59
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 4096
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: SMIS-PC
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: "\\\\CFME_HYPERV\\scvmm2"
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 898784DF-3292-42A8-97F3-189646A1D452
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 0d300372-f062-4743-8db4-cc2e8ee1b410
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: true
+              :MostRecentTaskID: b66b2cbb-0282-439e-9b75-61ac54e6405f
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: "\\\\CFME_HYPERV\\scvmm2"
+              :CreationTime: 2015-12-04 19:03:59.053000000 -05:00
+              :OperatingSystem: 64-bit edition of Windows 7
+              :HasVMAdditions: true
+              :VMAddition: 6.3.9600.16384
+              :NumLockEnabled: false
+              :CPUCount: 2
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 4096
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: SMIS-PC
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - CannotGetVolumeInfoDueToUncShareInRemoteMachine (26277)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - smis_netapp_dnd
+              :VirtualHardDisks:
+              - smis_netapp_dnd
+              :VirtualDiskDrives:
+              - smis_netapp_dnd
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - smis_netapp_dnd
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: smis_netapp_dnd
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - smis_netapp_dnd
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: smis_netapp_dnd
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:03:59.053000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:49.560000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 0d300327-f062-4743-8db4-cc2e8ee1b410
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: jt_dnd_w12r2d_dev
+            :Props:
+              :VMCPath: C:\ProgramData\Microsoft\Windows\Hyper-V\Virtual Machines\AD76A4D4-46D6-4F5C-AC14-62368D0BD2DC.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: 
+              :VMId: AD76A4D4-46D6-4F5C-AC14-62368D0BD2DC
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\jt_dnd_w12r2d_dev
+              :TotalSize: 69965185024
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: TurnOnVMIfRunningWhenVSStopped
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 3b0657b5-f3f3-497e-b48e-68736ea85e93
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 8192
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: Unknown
+              :CreationSource: Unknown source object
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: Unknown source object
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: AD76A4D4-46D6-4F5C-AC14-62368D0BD2DC
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: 206ee9bc-cb80-4a39-bc59-ec55ebc2fd21
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: da29c738-680e-4b5c-8acb-4cf4ad4ef4d0
+              :MostRecentTaskUIState: Completed
+              :Location: C:\ProgramData\Microsoft\Windows\Hyper-V
+              :CreationTime: 2015-12-04 19:04:30.430000000 -05:00
+              :OperatingSystem: *20
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 8192
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 7500
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: 
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: false
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: 
+              :Generation: 1
+              :VirtualDVDDrives:
+              - jt_dnd_w12r2d_dev
+              :VirtualHardDisks:
+              - jt_w12r2d_dev
+              :VirtualDiskDrives:
+              - jt_dnd_w12r2d_dev
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - jt_dnd_w12r2d_dev
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: jt_dnd_w12r2d_dev
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - jt_dnd_w12r2d_dev
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: 
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 00000000-0000-0000-0000-000000000000
+              :UserRole: 
+              :Owner: 
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: jt_dnd_w12r2d_dev
+              :IsViewOnly: false
+              :Description: 
+              :AddedTime: 2015-12-04 19:04:30.430000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:49.113000000 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: 206ee9e9-cb80-4a39-bc59-ec55ebc2fd21
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: 
+            :MS:
+              :ServicingWindows: *11
+          - :ToString: SmallLinuxVM
+            :Props:
+              :VMCPath: C:\SmallLinuxVM\Virtual Machines\5E461C0E-DF94-4AA0-99EC-C07A91BC65E9.xml
+              :MarkedAsTemplate: false
+              :OwnerIdentifier: S-1-5-21-2991069696-1967981014-2582041260-500
+              :VMId: 5E461C0E-DF94-4AA0-99EC-C07A91BC65E9
+              :VMResourceGroup: 
+              :VMConfigResource: 
+              :VMConfigResourceStatus: ClusterResourceStateUnknown
+              :VMResource: 
+              :VMResourceStatus: ClusterResourceStateUnknown
+              :DiskResources: []
+              :UnsupportedReason: *27
+              :RefresherErrors: []
+              :VirtualMachineState: PowerOff
+              :HostGroupPath: All Hosts\SmallLinuxVM
+              :TotalSize: 1910265856
+              :MemoryAssignedMB: 0
+              :MemoryAvailablePercentage: 
+              :DynamicMemoryDemandMB: 0
+              :DynamicMemoryStatus: 
+              :AllocatedGPU: 
+              :HasPassthroughDisk: false
+              :HasSharedStorage: false
+              :Status: PowerOff
+              :IsOrphaned: false
+              :HasSavedState: false
+              :StatusString: Stopped
+              :StartAction: NeverAutoTurnOnVM
+              :StopAction: SaveVM
+              :RunGuestAccount: 
+              :DelayStart: 0
+              :BiosGuid: 2968575c-2e73-4874-870e-2a09778332a9
+              :CPUUtilization: 0
+              :PerfCPUUtilization: 0
+              :PerfMemory: 6120
+              :PerfDiskBytesRead: 0
+              :PerfDiskBytesWrite: 0
+              :PerfNetworkBytesRead: 0
+              :PerfNetworkBytesWrite: 0
+              :VirtualizationPlatform: HyperV
+              :ComputerNameString: SmallLinuxVM
+              :CreationSource: Temporary Template983a25b7-7732-4d78-8bf9-63fd2804a85f
+              :IsUndergoingLiveMigration: false
+              :SourceObjectType: VM Template
+              :OperatingSystemShutdownEnabled: true
+              :TimeSynchronizationEnabled: true
+              :DataExchangeEnabled: true
+              :HeartbeatEnabled: true
+              :BackupEnabled: true
+              :ExcludeFromPRO: false
+              :FailedJobID: 
+              :CheckpointLocation: C:\SmallLinuxVM
+              :SelfServiceUserRole: 
+              :PassThroughDisks: []
+              :ComputerTier: 
+              :ConnectToAddresses: []
+              :CloudVmRoleId: 
+              :CloudVmRoleName: 
+              :UpgradeDomain: 
+              :SCApplications: []
+              :LastRestoredCheckpointID: 5E461C0E-DF94-4AA0-99EC-C07A91BC65E9
+              :LastRestoredVMCheckpoint: 
+              :ComplianceStatus: 
+              :IsFaultTolerant: false
+              :DeploymentErrorInfo: 
+              :ServiceDeploymentErrorMessage: 
+              :DeploymentState: Undeployed
+              :TieredPerfData: f83d9135-aed4-427a-b460-ef0f93f171c8
+              :ReplicationSetting: 
+              :ReplicationStatus: 
+              :IsRecoveryVM: false
+              :IsPrimaryVM: false
+              :IsTestReplicaVM: false
+              :ReplicationState: 
+              :ReplicationHealth: 
+              :ReplicationMode: 
+              :LastReplicationTime: 
+              :IsDREnabled: false
+              :DRState: Disabled
+              :DRErrors: []
+              :HasDRError: false
+              :ClusterNonPossibleOwner: 
+              :ClusterPreferredOwner: 
+              :AvailabilitySetNames: 
+              :LiveCloningEnabled: false
+              :MostRecentTaskID: e3c3a0ee-615b-455a-bc03-44c07f727273
+              :MostRecentTaskUIState: Completed
+              :MostRecentTask: Refresh virtual machine
+              :Location: C:\SmallLinuxVM
+              :CreationTime: 2016-01-21 12:51:41.580000000 -05:00
+              :OperatingSystem: *28
+              :HasVMAdditions: false
+              :VMAddition: Not Detected
+              :NumLockEnabled: false
+              :CPUCount: 4
+              :IsHighlyAvailable: false
+              :HAVMPriority: 
+              :IsDRProtectionRequired: false
+              :RecoveryPointObjective: 
+              :ProtectionProvider: 
+              :ReplicationGroupId: 
+              :ReplicationGroup: 
+              :LimitCPUFunctionality: false
+              :LimitCPUForMigration: false
+              :Memory: 6120
+              :DynamicMemoryEnabled: false
+              :DynamicMemoryMaximumMB: 
+              :DynamicMemoryBufferPercentage: 
+              :MemoryWeight: 5000
+              :VirtualVideoAdapterEnabled: false
+              :MonitorMaximumCount: 
+              :MonitorResolutionMaximum: 
+              :BootOrder:
+              - CD
+              - IdeHardDrive
+              - PxeBoot
+              - Floppy
+              :FirstBootDevice: 
+              :SecureBootEnabled: 
+              :ComputerName: SmallLinuxVM
+              :UseHardwareAssistedVirtualization: true
+              :SANStatus:
+              - DeployLUNNotFoundUsingStorageProvider (26207)
+              :CostCenter: 
+              :QuotaPoint: 1
+              :IsTagEmpty: true
+              :Tag: "(none)"
+              :CustomProperties:
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              - 
+              :CustomProperty: {}
+              :UndoDisksEnabled: false
+              :CPUType: *19
+              :ExpectedCPUUtilization: 20
+              :DiskIO: 0
+              :NetworkUtilization: 0
+              :RelativeWeight: 100
+              :CPUReserve: 0
+              :CPUMax: 100
+              :CPUPerVirtualNumaNodeMaximum: 4
+              :MemoryPerVirtualNumaNodeMaximumMB: 34918
+              :VirtualNumaNodesPerSocketMaximum: 1
+              :DynamicMemoryMinimumMB: 
+              :NumaIsolationRequired: false
+              :Generation: 1
+              :VirtualDVDDrives:
+              - SmallLinuxVM
+              :VirtualHardDisks:
+              - cfme-hyperv-5.5.0.13-2.x86_64.vhd
+              :VirtualDiskDrives:
+              - SmallLinuxVM
+              :ShareSCSIBus: false
+              :VirtualNetworkAdapters:
+              - SmallLinuxVM
+              :VirtualFibreChannelAdapters: []
+              :HasVirtualFibreChannelAdapters: false
+              :VirtualFloppyDrive: SmallLinuxVM
+              :VirtualCOMPorts:
+              - COM1
+              - COM2
+              :VirtualSCSIAdapters:
+              - SmallLinuxVM
+              :CapabilityProfile: 
+              :CapabilityProfileCompatibilityState: Compatible
+              :VMCheckpoints: []
+              :HostId: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :HostType: VMHost
+              :HostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :VMHost: *12
+              :LibraryServer: 
+              :CloudId: 
+              :Cloud: 
+              :LibraryGroup: 
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: VM
+              :Accessibility: Public
+              :Name: SmallLinuxVM
+              :IsViewOnly: false
+              :Description: SmallLinuxVM
+              :AddedTime: 2016-01-21 12:51:41.580000000 -05:00
+              :ModifiedTime: 2016-07-11 12:03:49.388303400 -04:00
+              :Enabled: true
+              :ServerConnection: *9
+              :ID: f83d9160-aed4-427a-b460-ef0f93f171c8
+              :MarkedForDeletion: false
+              :IsFullyCached: false
+              :MostRecentTaskIfLocal: Refresh virtual machine
+            :MS:
+              :ServicingWindows: *11
+          :Disks:
+          - *16
+          - *17
+          - *13
+          :GPUs: []
+          :InstalledVirtualSwitchExtensions:
+          - :ToString: Microsoft Virtual Ethernet Switch Native Extension
+            :Props:
+              :Name: Microsoft Virtual Ethernet Switch Native Extension
+              :HostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :Description: Provides built-in features that may be configured on a
+                switch or port
+              :VirtualSwitchExtensionType: Native
+              :DriverId: 11ec6134-128a-4a23-b12f-164184b48348
+              :Version: 6.3.9600.18005
+              :Vendor: Microsoft
+              :ServerConnection: *9
+              :ID: ec13d78b-3ccd-4ef4-9756-4b369a5b2d52
+              :IsViewOnly: false
+              :ObjectType: InstalledVirtualSwitchExtension
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Microsoft NDIS Capture
+            :Props:
+              :Name: Microsoft NDIS Capture
+              :HostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :Description: Microsoft NDIS Packet Capture Filter Driver
+              :VirtualSwitchExtensionType: Monitoring
+              :DriverId: ea24cd6c-d17a-4348-9190-09f0d5be83dd
+              :Version: 6.3.9600.16384
+              :Vendor: Microsoft
+              :ServerConnection: *9
+              :ID: 32bcb176-a61f-4580-9f9c-5e5bb83da970
+              :IsViewOnly: false
+              :ObjectType: InstalledVirtualSwitchExtension
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Microsoft Windows Filtering Platform
+            :Props:
+              :Name: Microsoft Windows Filtering Platform
+              :HostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :Description: WFP vSwitch Extension LightWeight Filter for Hyper-V Virtual
+                Switch Filtering
+              :VirtualSwitchExtensionType: Filter
+              :DriverId: e7c3b2f0-f3c5-48df-af2b-10fed6d72e7a
+              :Version: 6.3.9600.18086
+              :Vendor: Microsoft
+              :ServerConnection: *9
+              :ID: 43c5e153-7dcd-4cbc-85d9-c8c506a39145
+              :IsViewOnly: false
+              :ObjectType: InstalledVirtualSwitchExtension
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Microsoft VMM DHCPv4 Server Switch Extension
+            :Props:
+              :Name: Microsoft VMM DHCPv4 Server Switch Extension
+              :HostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :Description: Microsoft System Center Virtual Machine Manager DHCP Server
+              :VirtualSwitchExtensionType: Filter
+              :DriverId: 0d37c9f0-ea6c-47a0-9c42-4baeba3768d1
+              :Version: 24.0.1.0
+              :Vendor: Microsoft
+              :ServerConnection: *9
+              :ID: 3209cd0c-2ebc-4513-96f2-dd903fcdfa5b
+              :IsViewOnly: false
+              :ObjectType: InstalledVirtualSwitchExtension
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :DiskVolumes:
+          - :ToString: "\\\\?\\Volume{1889d147-fcb9-11e3-80b5-806e6f6e6963}\\"
+            :Props:
+              :Name: "\\\\?\\Volume{1889d147-fcb9-11e3-80b5-806e6f6e6963}\\"
+              :StorageVolumeID: 1889d147-fcb9-11e3-80b5-806e6f6e6963
+              :ObjectID: "\\\\?\\Volume{1889d147-fcb9-11e3-80b5-806e6f6e6963}\\"
+              :HostVolumeID: 1889d147-fcb9-11e3-80b5-806e6f6e6963
+              :MountPoints:
+              - "\\\\?\\Volume{1889d147-fcb9-11e3-80b5-806e6f6e6963}\\"
+              :Capacity: 366997504
+              :FreeSpace: 77840384
+              :VolumeLabel: System Reserved
+              :FileSystem: NTFS
+              :IsSANMigrationPossible: false
+              :IsClustered: false
+              :IsClusterSharedVolume: false
+              :InUse: false
+              :VMHost: *12
+              :IsAvailableForPlacement: true
+              :HostDiskID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+              :StorageDiskID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+              :HostDisk: *13
+              :StorageDisk: *13
+              :Classification: *14
+              :StoragePool: 
+              :ServerConnection: *9
+              :ID: b06226b3-018d-4da2-9d37-2c39ce43692f
+              :IsViewOnly: false
+              :ObjectType: VMHostVolume
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - *40
+          - :ToString: C:\
+            :Props:
+              :Name: C:\
+              :StorageVolumeID: 1889d148-fcb9-11e3-80b5-806e6f6e6963
+              :ObjectID: "\\\\?\\Volume{1889d148-fcb9-11e3-80b5-806e6f6e6963}\\"
+              :HostVolumeID: 1889d148-fcb9-11e3-80b5-806e6f6e6963
+              :MountPoints:
+              - C:\
+              :Capacity: 997629882368
+              :FreeSpace: 85444444160
+              :VolumeLabel: 
+              :FileSystem: NTFS
+              :IsSANMigrationPossible: false
+              :IsClustered: false
+              :IsClusterSharedVolume: false
+              :InUse: false
+              :VMHost: *12
+              :IsAvailableForPlacement: true
+              :HostDiskID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+              :StorageDiskID: 032040df-cbd9-4cf7-9b4b-ee88671bca1c
+              :HostDisk: *13
+              :StorageDisk: *13
+              :Classification: *14
+              :StoragePool: 
+              :ServerConnection: *9
+              :ID: c7ec11d5-65da-412c-ae30-b946f343daad
+              :IsViewOnly: false
+              :ObjectType: VMHostVolume
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - *41
+          :RegisteredStorageFileShares:
+          - *29
+          :FibreChannelHbas: []
+          :FibreChannelVirtualSANs: []
+          :SASHbas:
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :Props:
+              :PortNumber: 1
+              :LocalSASAddress: 5005076B08B0A04D
+              :AttachedSASAddress: 5000C50034A73B61
+              :PortType: SASDevice
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Manufacturer: LSI Corporation
+              :DriverName: lsi_sas
+              :SerialNumber: 
+              :VMHost: *12
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:28.383000000 -04:00
+              :ServerConnection: *9
+              :ID: 94c98f72-a6ee-4b11-88cb-52856e2b0cb1
+              :IsViewOnly: false
+              :ObjectType: HostSASHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :Props:
+              :PortNumber: 0
+              :LocalSASAddress: 5005076B08B0A04C
+              :AttachedSASAddress: 5000C50034A75779
+              :PortType: SASDevice
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Manufacturer: LSI Corporation
+              :DriverName: lsi_sas
+              :SerialNumber: 
+              :VMHost: *12
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:28.367000000 -04:00
+              :ServerConnection: *9
+              :ID: 7bed9ae7-a0f6-4208-9129-a3898d19e1ff
+              :IsViewOnly: false
+              :ObjectType: HostSASHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :Props:
+              :PortNumber: 2
+              :LocalSASAddress: 5005076B08B0A04E
+              :AttachedSASAddress: '0000000000000000'
+              :PortType: SASDevice
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Manufacturer: LSI Corporation
+              :DriverName: lsi_sas
+              :SerialNumber: 
+              :VMHost: *12
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:28.393000000 -04:00
+              :ServerConnection: *9
+              :ID: 9de8b06f-c328-408b-b77d-d060a1badcb2
+              :IsViewOnly: false
+              :ObjectType: HostSASHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+            :Props:
+              :PortNumber: 3
+              :LocalSASAddress: 5005076B08B0A04F
+              :AttachedSASAddress: '0000000000000000'
+              :PortType: SASDevice
+              :Name: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Model: SAS1064
+              :InstanceName: PCI\VEN_1000&DEV_0056&SUBSYS_03A71014&REV_10\4&27b65736&0&0008_0
+              :Manufacturer: LSI Corporation
+              :DriverName: lsi_sas
+              :SerialNumber: 
+              :VMHost: *12
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:28.403000000 -04:00
+              :ServerConnection: *9
+              :ID: eafe44a0-b201-4629-b2b2-e28ee795a8ae
+              :IsViewOnly: false
+              :ObjectType: HostSASHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :InternetSCSIHbas:
+          - :ToString: ROOT\ISCSIPRT\0000_0
+            :Props:
+              :ISCSINodeName: iqn.1991-05.com.microsoft:qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :IsSoftwareBased: true
+              :Targets:
+              - iqn.1992-08.com.netapp:sn.6ff1d45251c111e59bb500a098861bb2:vs.7
+              :Portals:
+              - 10.16.4.8
+              - 10.16.4.20
+              - 10.16.4.4
+              :Name: ROOT\ISCSIPRT\0000_0
+              :Model: iSCSI Initiator
+              :InstanceName: ROOT\ISCSIPRT\0000_0
+              :Manufacturer: Microsoft Corporation
+              :DriverName: msiscsi.sys
+              :SerialNumber: MSFT-05-1991
+              :VMHost: *12
+              :LibraryServer: 
+              :ModifiedTime: 2016-07-11 15:41:28.460000000 -04:00
+              :ServerConnection: *9
+              :ID: ae1fdfc9-ce3c-4b59-a703-3a0584d5e9d3
+              :IsViewOnly: false
+              :ObjectType: HostInternetSCSIHba
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VMwareResourcePool: 
+          :IsConfiguredForOutOfBandManagement: false
+          :PhysicalMachine:
+            :ToString: 88f93543-9f60-e011-9109-5cf3fc1c861c
+            :Props:
+              :Name: 88f93543-9f60-e011-9109-5cf3fc1c861c
+              :BMCType: None
+              :BMCCustomConfigurationProvider: 
+              :BMCAddress: 
+              :BMCPort: 
+              :RunAsAccount: 
+              :SMBiosGUID: 88f93543-9f60-e011-9109-5cf3fc1c861c
+              :ComputerPowerState: Unknown
+              :SystemEventLog: []
+              :ServerConnection: *9
+              :ID: e0fc4777-9491-44e7-81a7-034a21a41213
+              :IsViewOnly: false
+              :ObjectType: PhysicalMachine
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :HealthMonitors:
+          - :ToString: Host Agent Version
+            :Props:
+              :ParentID: 047ca75b-3754-487c-98c3-149c096c8a5e
+              :Name: Host Agent Version
+              :IsRemediationAvailable: true
+              :RemediationDescription: We would try to upgrade VMM agent from 3.2.8117.0
+                to latest version.
+              :State: Warning
+              :StateString: Warning
+              :LastKnownError: HMAgentVersionUpgradeAvailable (20510)
+              :UpdatedDate: 2016-07-11 15:41:42.593000000 -04:00
+              :ServerConnection: *9
+              :ID: d639566c-4131-4ce9-abff-0d8fe0811139
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Host Agent Overall
+            :Props:
+              :ParentID: 37b66f40-f83f-42b6-8dca-ce2a1b4bb765
+              :Name: Host Agent Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Warning
+              :StateString: Warning
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:41:42.587000000 -04:00
+              :ServerConnection: *9
+              :ID: 047ca75b-3754-487c-98c3-149c096c8a5e
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Network
+            :Props:
+              :ParentID: 37b66f40-f83f-42b6-8dca-ce2a1b4bb765
+              :Name: Network
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.577000000 -04:00
+              :ServerConnection: *9
+              :ID: 39760da1-0c84-400c-8c18-1709db01f49d
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Host Agent Service
+            :Props:
+              :ParentID: 047ca75b-3754-487c-98c3-149c096c8a5e
+              :Name: Host Agent Service
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.593000000 -04:00
+              :ServerConnection: *9
+              :ID: 96140158-7d4a-4893-82db-2aa4575bc17e
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: WinRM
+            :Props:
+              :ParentID: 37b66f40-f83f-42b6-8dca-ce2a1b4bb765
+              :Name: WinRM
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.577000000 -04:00
+              :ServerConnection: *9
+              :ID: 4c037fa6-b4f3-46a5-86a2-2d706136f1b9
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Role Overall
+            :Props:
+              :ParentID: 37b66f40-f83f-42b6-8dca-ce2a1b4bb765
+              :Name: Hyper-V Role Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:41:42.597000000 -04:00
+              :ServerConnection: *9
+              :ID: b40b2edf-32c9-46a5-826b-888c0c450749
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Role Version
+            :Props:
+              :ParentID: b40b2edf-32c9-46a5-826b-888c0c450749
+              :Name: Hyper-V Role Version
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.603000000 -04:00
+              :ServerConnection: *9
+              :ID: 4f0e56fe-4ac5-4937-81fc-ce16e22d5782
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Overall
+            :Props:
+              :ParentID: 
+              :Name: Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Warning
+              :StateString: Warning
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:41:42.577000000 -04:00
+              :ServerConnection: *9
+              :ID: 37b66f40-f83f-42b6-8dca-ce2a1b4bb765
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: WMI Performance Counter
+            :Props:
+              :ParentID: 047ca75b-3754-487c-98c3-149c096c8a5e
+              :Name: WMI Performance Counter
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.593000000 -04:00
+              :ServerConnection: *9
+              :ID: 9f199f80-f8af-40b2-855e-e03874310525
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Virtual Machine Management Service
+            :Props:
+              :ParentID: b40b2edf-32c9-46a5-826b-888c0c450749
+              :Name: Hyper-V Virtual Machine Management Service
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Healthy
+              :StateString: OK
+              :LastKnownError: Success (0)
+              :UpdatedDate: 2016-07-11 15:41:42.600000000 -04:00
+              :ServerConnection: *9
+              :ID: 7b4562c6-efd9-4b35-8b0b-fccc42435e3c
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :RemoteStorageTotalCapacity: 832233830400
+          :RemoteStorageAvailableCapacity: 528009306112
+          :LocalStorageTotalCapacity: 997998985216
+          :LocalStorageAvailableCapacity: 85522284544
+          :TotalStorageCapacity: 1830232815616
+          :AvailableStorageCapacity: 613531590656
+          :UsedStorageCapacity: 1216701224960
+          :IsDedicatedToNetworkVirtualizationGateway: false
+          :FibreChannelWorldWidePortNameMinimum: C003FFE46FE20000
+          :FibreChannelWorldWidePortNameMaximum: C003FFE46FE2FFFF
+          :FibreChannelWorldWideNodeName: C003FF0000FFFF00
+          :VMConnectCertificateThumbprint: 
+          :Custom1: 
+          :Custom2: 
+          :Custom3: 
+          :Custom4: 
+          :Custom5: 
+          :Custom6: 
+          :Custom7: 
+          :Custom8: 
+          :Custom9: 
+          :Custom10: 
+          :CustomProperty: {}
+          :FibreChannelSANStatus:
+            :ToString: DeployTargetDoesNotHaveHBA (1204)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1204
+              :ErrorCodeString: '1204'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : DeployTargetDoesNotHaveHBA ; Message
+                : The server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com does
+                not contain any host bus adapter (HBA) ports. Fibre Channel SAN transfer
+                cannot be used. ; Recommended Action : Transfer the virtual machine
+                over the LAN.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: The server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not contain any host bus adapter (HBA) ports. Fibre Channel SAN
+                transfer cannot be used.
+              :CloudProblem: The server does not contain any host bus adapter (HBA)
+                ports. Fibre Channel SAN transfer cannot be used.
+              :RecommendedAction: Transfer the virtual machine over the LAN.
+              :RecommendedActionCLI: Transfer the virtual machine over the LAN.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :VMHostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :Code: DeployTargetDoesNotHaveHBA
+              :GetMessageFormatterHandler: 
+          :ISCSISANStatus:
+            :ToString: DeployHostDoesNotHaveMPIO (1253)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1253
+              :ErrorCodeString: '1253'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : DeployHostDoesNotHaveMPIO ; Message
+                : SAN operations cannot be performed because the server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not have a Microsoft MPIO feature installed. ; Recommended Action
+                : Install MPIO feature on the server and claim all MPIO capable paths.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: SAN operations cannot be performed because the server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not have a Microsoft MPIO feature installed.
+              :CloudProblem: SAN operations cannot be performed because the server
+                does not have a Microsoft MPIO feature installed.
+              :RecommendedAction: Install MPIO feature on the server and claim all
+                MPIO capable paths.
+              :RecommendedActionCLI: Install MPIO feature on the server and claim
+                all MPIO capable paths.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :VMHostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :Code: DeployHostDoesNotHaveMPIO
+              :GetMessageFormatterHandler: 
+          :NPIVFibreChannelSANStatus:
+            :ToString: DeployHostIsNotNPIVCapable (1252)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 1252
+              :ErrorCodeString: '1252'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : DeployHostIsNotNPIVCapable ; Message
+                : The server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com does
+                not have an HBA which supports NPIV. ; Recommended Action : If server
+                qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com contains an HBA
+                that supports NPIV, ensure that the right version of firmware and
+                driver are installed, or transfer the virtual machine over the LAN.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: The server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                does not have an HBA which supports NPIV.
+              :CloudProblem: The server does not have an HBA which supports NPIV.
+              :RecommendedAction: If server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                contains an HBA that supports NPIV, ensure that the right version
+                of firmware and driver are installed, or transfer the virtual machine
+                over the LAN.
+              :RecommendedActionCLI: If server qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+                contains an HBA that supports NPIV, ensure that the right version
+                of firmware and driver are installed, or transfer the virtual machine
+                over the LAN.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :VMHostName: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+              :Code: DeployHostIsNotNPIVCapable
+              :GetMessageFormatterHandler: 
+          :CertificateRequest: 
+          :ComputerState:
+            :ToString: Responding
+            :By: 2
+          :VirtualizationManager: 
+          :ServerConnection: *9
+          :ID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHost
+            :I32: 9
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+          :MostRecentTaskIfLocal: *89
+        :MS:
+          :FQDN: qeblade26.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com
+          :LogicalCPUCount: 8
+          :CPUSpeed: 2133
+          :CPUModel: Xeon
+          :CPUManufacturer: Intel
+          :CPUArchitecture: 9
+          :CPUFamily: '179'
+          :VMRCEnabled: true
+          :VMRCPort: 2179
+          :SecureVMRCEnabled: false
+          :VirtualServerState:
+            :ToString: Running
+            :By: 3
+          :VirtualServerStateString: Running
+          :VirtualServerVersion: 6.3.9600.17787
+          :VirtualServerVersionState:
+            :ToString: UpToDate
+            :By: 0
+          :ServicingWindows: *11
+      :NetworkAdapters:
+      - :ToString: 'Ethernet - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+          #52'
+        :Props:
+          :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #52'
+          :IPAddresses:
+          - :ToString: 169.254.89.78
+            :Props:
+              :Address: 1314520745
+              :AddressFamily: InterNetwork
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: false
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: 169.254.89.78
+          - :ToString: fe80::b1b6:dd38:ad16:594e
+            :Props:
+              :AddressFamily: InterNetworkV6
+              :ScopeId: 0
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: true
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: fe80::b1b6:dd38:ad16:594e
           :DHCPEnabled: true
-          :IPSubnets: []
+          :IPSubnets:
+          - :ToString: 169.254.0.0/16
+            :Props:
+              :NetworkAddress: 169.254.0.0
+              :AddressRangeEnd: 169.254.255.255
+              :AddressFamily: IPv4
+              :PrefixLength: 16
+              :SubnetMask: 255.255.0.0
+              :FirstAddressInSubnet: 169.254.0.1
+              :LastAddressInSubnet: 169.254.255.254
+          - :ToString: fe80::/64
+            :Props:
+              :NetworkAddress: 'fe80::'
+              :AddressRangeEnd: fe80::ffff:ffff:ffff:ffff
+              :AddressFamily: IPv6
+              :PrefixLength: 64
+              :SubnetMask: 'ffff:ffff:ffff:ffff::'
+              :FirstAddressInSubnet: fe80::1
+              :LastAddressInSubnet: fe80::ffff:ffff:ffff:fffe
           :DefaultIPGateways: []
-          :MacAddress: 00:10:18:CD:8D:56
-          :PhysicalAddress: 00:10:18:CD:8D:56
-          :NetworkLocation: VM_Network
-          :VirtualNetwork: 
+          :MacAddress: 5C:F3:FC:1C:86:1E
+          :PhysicalAddress: 5C:F3:FC:1C:86:1E
+          :NetworkLocation: hyperv_clus_netwk
+          :VirtualNetwork: &90
+            :ToString: hyperv_clus_netwk
+            :Props:
+              :Name: hyperv_clus_netwk
+              :HighlyAvailable: true
+              :HostBoundVlanId: 0
+              :NetworkOptimizationCapable: false
+              :NetworkOptimizationAvailable: false
+              :BoundToVMHost: true
+              :Description: 
+              :LogicalNetworks:
+              - 
+              :VMHostNetworkAdapters:
+              - 'Ethernet - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+                #52'
+              :VMHost: *12
+              :LogicalSwitch: 
+              :LogicalSwitchComplianceStatus: NotAnInstanceOfLogicalSwitch
+              :LogicalSwitchComplianceErrors: []
+              :VMwarePortGroups: []
+              :VMHostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :ServerConnection: *9
+              :ID: cea5e7b1-228c-4726-bf31-34d8ea0f59fd
+              :IsViewOnly: false
+              :ObjectType: VirtualNetwork
+              :MarkedForDeletion: false
+              :IsFullyCached: true
           :NetworkSwitchPort: 
           :UplinkPortProfileSet: 
           :VLanTags: []
@@ -8561,53 +16631,23 @@
             :I32: 1
           :VLanEnabled: true
           :ConnectionState:
-            :ToString: MediaDisconnected
-            :I32: 4
-          :ConnectionName: Ethernet 3
+            :ToString: Connected
+            :I32: 0
+          :ConnectionName: Ethernet
           :Description: 
           :PrimaryDNSSuffix: 
-          :MaxBandwidth: 0
-          :VMHost: *1
+          :MaxBandwidth: 1000
+          :VMHost: *12
           :LogicalNetworkMap:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
+            ! '': []
           :UsableVlanMode:
             :ToString: Trunk
             :I32: 1
           :ModelAccessibleSubnetVLans:
-            ! '':
-            - :ToString: '0'
-              :Props:
-                :Subnet: 
-                :VLanID: 0
-                :SecondaryVLanID: 0
-                :IsVLanEnabled: false
-                :IsSecondaryVLanEnabled: false
-                :SupportsDHCP: true
-                :ID: 
-                :IsAssignedToVMSubnet: false
+            ! '': []
           :LogicalNetworks:
-          - *21
-          :SubnetVLans:
-          - :ToString: '0'
-            :Props:
-              :Subnet: 
-              :VLanID: 0
-              :SecondaryVLanID: 0
-              :IsVLanEnabled: false
-              :IsSecondaryVLanEnabled: false
-              :SupportsDHCP: true
-              :ID: 
-              :IsAssignedToVMSubnet: false
+          - 
+          :SubnetVLans: []
           :UnassignedVLans: []
           :AvailableForPlacement: true
           :IsAvailableForHA: true
@@ -8616,10 +16656,257 @@
             :ToString: Compliant
             :I32: 1
           :LogicalNetworkComplianceErrors: []
-          :BDFLocationInformation: PCI bus 3, device 0, function 1
+          :BDFLocationInformation: PCI bus 16, device 0, function 1
           :NetworkVirtualizationEnabled: true
-          :ServerConnection: *8
-          :ID: b8106b2c-ed0e-4e17-a722-cc1bd25dd1a8
+          :ServerConnection: *9
+          :ID: 761bf1e5-2399-4800-aad8-ca908a304e85
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHostNetworkAdapter
+            :I32: 12
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+      - :ToString: 'Ethernet 2 - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+          #51'
+        :Props:
+          :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #51'
+          :IPAddresses:
+          - :ToString: 10.16.4.47
+            :Props:
+              :Address: 788795402
+              :AddressFamily: InterNetwork
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: false
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: 10.16.4.47
+          :DHCPEnabled: true
+          :IPSubnets:
+          - :ToString: 10.16.4.0/22
+            :Props:
+              :NetworkAddress: 10.16.4.0
+              :AddressRangeEnd: 10.16.7.255
+              :AddressFamily: IPv4
+              :PrefixLength: 22
+              :SubnetMask: 255.255.252.0
+              :FirstAddressInSubnet: 10.16.4.1
+              :LastAddressInSubnet: 10.16.7.254
+          :DefaultIPGateways:
+          - :ToString: 10.16.7.254
+            :Props:
+              :Address: 4261875722
+              :AddressFamily: InterNetwork
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: false
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: 10.16.7.254
+          :MacAddress: 5C:F3:FC:1C:86:1C
+          :PhysicalAddress: 5C:F3:FC:1C:86:1C
+          :NetworkLocation: rhq
+          :VirtualNetwork: &91
+            :ToString: vswitch
+            :Props:
+              :Name: vswitch
+              :HighlyAvailable: true
+              :HostBoundVlanId: 0
+              :NetworkOptimizationCapable: false
+              :NetworkOptimizationAvailable: false
+              :BoundToVMHost: true
+              :Description: 
+              :LogicalNetworks:
+              - *22
+              :VMHostNetworkAdapters:
+              - 'Ethernet 2 - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+                #51'
+              :VMHost: *12
+              :LogicalSwitch: 
+              :LogicalSwitchComplianceStatus: NotAnInstanceOfLogicalSwitch
+              :LogicalSwitchComplianceErrors: []
+              :VMwarePortGroups: []
+              :VMHostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+              :ServerConnection: *9
+              :ID: c408d625-bb22-4ba9-ae9a-35ae25b3d550
+              :IsViewOnly: false
+              :ObjectType: VirtualNetwork
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :NetworkSwitchPort: 
+          :UplinkPortProfileSet: 
+          :VLanTags: []
+          :UsableVLanTags:
+          - 0
+          :VLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :DesiredVLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :VLanEnabled: true
+          :ConnectionState:
+            :ToString: Connected
+            :I32: 0
+          :ConnectionName: Ethernet 2
+          :Description: 
+          :PrimaryDNSSuffix: rhq.lab.eng.bos.redhat.com
+          :MaxBandwidth: 1000
+          :VMHost: *12
+          :LogicalNetworkMap:
+            ! '': []
+          :UsableVlanMode:
+            :ToString: Trunk
+            :I32: 1
+          :ModelAccessibleSubnetVLans:
+            ! '': []
+          :LogicalNetworks:
+          - *22
+          :SubnetVLans: []
+          :UnassignedVLans: []
+          :AvailableForPlacement: true
+          :IsAvailableForHA: true
+          :UsedForManagement: true
+          :LogicalNetworkCompliance:
+            :ToString: Compliant
+            :I32: 1
+          :LogicalNetworkComplianceErrors: []
+          :BDFLocationInformation: PCI bus 16, device 0, function 0
+          :NetworkVirtualizationEnabled: true
+          :ServerConnection: *9
+          :ID: 60ecc9c7-444b-44e8-820a-cab5fe8c5250
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VMHostNetworkAdapter
+            :I32: 12
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+      - :ToString: Local Area Connection - IBM USB Remote NDIS Network Device
+        :Props:
+          :Name: IBM USB Remote NDIS Network Device
+          :IPAddresses:
+          - :ToString: 10.1.1.1
+            :Props:
+              :Address: 16843018
+              :AddressFamily: InterNetwork
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: false
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: 10.1.1.1
+          - :ToString: fe80::c9ec:bcd1:f517:eac9
+            :Props:
+              :AddressFamily: InterNetworkV6
+              :ScopeId: 0
+              :IsIPv6Multicast: false
+              :IsIPv6LinkLocal: true
+              :IsIPv6SiteLocal: false
+              :IsIPv6Teredo: false
+              :IsIPv4MappedToIPv6: false
+            :MS:
+              :IPAddressToString: fe80::c9ec:bcd1:f517:eac9
+          :DHCPEnabled: false
+          :IPSubnets:
+          - :ToString: 10.1.1.0/24
+            :Props:
+              :NetworkAddress: 10.1.1.0
+              :AddressRangeEnd: 10.1.1.255
+              :AddressFamily: IPv4
+              :PrefixLength: 24
+              :SubnetMask: 255.255.255.0
+              :FirstAddressInSubnet: 10.1.1.1
+              :LastAddressInSubnet: 10.1.1.254
+          - :ToString: fe80::/64
+            :Props:
+              :NetworkAddress: 'fe80::'
+              :AddressRangeEnd: fe80::ffff:ffff:ffff:ffff
+              :AddressFamily: IPv6
+              :PrefixLength: 64
+              :SubnetMask: 'ffff:ffff:ffff:ffff::'
+              :FirstAddressInSubnet: fe80::1
+              :LastAddressInSubnet: fe80::ffff:ffff:ffff:fffe
+          :DefaultIPGateways: []
+          :MacAddress: 5E:F3:FC:1E:E6:DF
+          :PhysicalAddress: 5E:F3:FC:1E:E6:DF
+          :NetworkLocation: 
+          :VirtualNetwork: 
+          :NetworkSwitchPort: 
+          :UplinkPortProfileSet: 
+          :VLanTags: []
+          :UsableVLanTags: []
+          :VLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :DesiredVLanMode:
+            :ToString: Trunk
+            :I32: 1
+          :VLanEnabled: true
+          :ConnectionState:
+            :ToString: Connected
+            :I32: 0
+          :ConnectionName: Local Area Connection
+          :Description: 
+          :PrimaryDNSSuffix: 
+          :MaxBandwidth: 9
+          :VMHost: *12
+          :LogicalNetworkMap: {}
+          :UsableVlanMode:
+            :ToString: Trunk
+            :I32: 1
+          :ModelAccessibleSubnetVLans: {}
+          :LogicalNetworks: []
+          :SubnetVLans: []
+          :UnassignedVLans: []
+          :AvailableForPlacement: true
+          :IsAvailableForHA: true
+          :UsedForManagement: true
+          :LogicalNetworkCompliance:
+            :ToString: NonCompliant
+            :I32: 3
+          :LogicalNetworkComplianceErrors:
+          - :ToString: HostNetworkAdapterNoLogicalNetwork (13706)
+            :Props:
+              :Exception: 
+              :Formatter: Microsoft.VirtualManager.Utils.MessageFormatter
+              :DisplayableErrorCode: 13706
+              :ErrorCodeString: '13706'
+              :ErrorType: Error
+              :CSMMessageString: 'Error Code : HostNetworkAdapterNoLogicalNetwork
+                ; Message : The host network adapter (IBM USB Remote NDIS Network
+                Device) is not associated with any logical networks. ; Recommended
+                Action : Specify the logical networks to which the host network adapter
+                has access.'
+              :IsSuccess: false
+              :IsTerminating: false
+              :IsConditionallyTerminating: false
+              :IsDeploymentBlocker: false
+              :ShowDetailedError: false
+              :DetailedErrorCode: 
+              :IsMomAlert: false
+              :MomAlertSeverity: Error
+              :Problem: The host network adapter (IBM USB Remote NDIS Network Device)
+                is not associated with any logical networks.
+              :CloudProblem: The host network adapter (*) is not associated with any
+                logical networks.
+              :RecommendedAction: Specify the logical networks to which the host network
+                adapter has access.
+              :RecommendedActionCLI: Specify the logical networks to which the host
+                network adapter has access.
+              :DetailedCode: 0
+              :DetailedSource: None
+              :ExceptionDetails: 
+              :MessageParameters:
+                :Name: IBM USB Remote NDIS Network Device
+              :Code: HostNetworkAdapterNoLogicalNetwork
+              :GetMessageFormatterHandler: 
+          :BDFLocationInformation: Port_#0002.Hub_#0001
+          :NetworkVirtualizationEnabled: true
+          :ServerConnection: *9
+          :ID: c1782c44-3a55-4999-944b-e75e94834166
           :IsViewOnly: false
           :ObjectType:
             :ToString: VMHostNetworkAdapter
@@ -8627,26 +16914,26 @@
           :MarkedForDeletion: false
           :IsFullyCached: true
       :VirtualSwitch:
-      - :ToString: New Virtual Switch0
+      - :ToString: hyperv_clus_netwk
         :Props:
-          :Name: New Virtual Switch0
-          :HighlyAvailable: false
+          :Name: hyperv_clus_netwk
+          :HighlyAvailable: true
           :HostBoundVlanId: 0
           :NetworkOptimizationCapable: false
           :NetworkOptimizationAvailable: false
           :BoundToVMHost: true
           :Description: 
           :LogicalNetworks:
-          - *21
+          - 
           :VMHostNetworkAdapters:
-          - :ToString: 'Ethernet 2 - Broadcom BCM5716C NetXtreme II GigE (NDIS VBD
-              Client) #33'
+          - :ToString: 'Ethernet - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client)
+              #52'
             :Props:
-              :Name: 'Broadcom BCM5716C NetXtreme II GigE (NDIS VBD Client) #33'
+              :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #52'
               :IPAddresses:
-              - :ToString: 10.8.96.25
+              - :ToString: 169.254.89.78
                 :Props:
-                  :Address: 425723914
+                  :Address: 1314520745
                   :AddressFamily: InterNetwork
                   :IsIPv6Multicast: false
                   :IsIPv6LinkLocal: false
@@ -8654,8 +16941,8 @@
                   :IsIPv6Teredo: false
                   :IsIPv4MappedToIPv6: false
                 :MS:
-                  :IPAddressToString: 10.8.96.25
-              - :ToString: fe80::7102:f721:e03b:7e51
+                  :IPAddressToString: 169.254.89.78
+              - :ToString: fe80::b1b6:dd38:ad16:594e
                 :Props:
                   :AddressFamily: InterNetworkV6
                   :ScopeId: 0
@@ -8665,15 +16952,88 @@
                   :IsIPv6Teredo: false
                   :IsIPv4MappedToIPv6: false
                 :MS:
-                  :IPAddressToString: fe80::7102:f721:e03b:7e51
+                  :IPAddressToString: fe80::b1b6:dd38:ad16:594e
               :DHCPEnabled: true
               :IPSubnets:
-              - 10.8.96.0/22
+              - 169.254.0.0/16
               - fe80::/64
-              :DefaultIPGateways:
-              - :ToString: 10.8.99.254
+              :DefaultIPGateways: []
+              :MacAddress: 5C:F3:FC:1C:86:1E
+              :PhysicalAddress: 5C:F3:FC:1C:86:1E
+              :NetworkLocation: hyperv_clus_netwk
+              :VirtualNetwork: *90
+              :NetworkSwitchPort: 
+              :UplinkPortProfileSet: 
+              :VLanTags: []
+              :UsableVLanTags:
+              - 0
+              :VLanMode: Trunk
+              :DesiredVLanMode: Trunk
+              :VLanEnabled: true
+              :ConnectionState: Connected
+              :ConnectionName: Ethernet
+              :Description: 
+              :PrimaryDNSSuffix: 
+              :MaxBandwidth: 1000
+              :VMHost: *12
+              :LogicalNetworkMap:
+                ! '': []
+              :UsableVlanMode: Trunk
+              :ModelAccessibleSubnetVLans:
+                ! '': []
+              :LogicalNetworks:
+              - 
+              :SubnetVLans: []
+              :UnassignedVLans: []
+              :AvailableForPlacement: true
+              :IsAvailableForHA: true
+              :UsedForManagement: false
+              :LogicalNetworkCompliance: Compliant
+              :LogicalNetworkComplianceErrors: []
+              :BDFLocationInformation: PCI bus 16, device 0, function 1
+              :NetworkVirtualizationEnabled: true
+              :ServerConnection: *9
+              :ID: 761bf1e5-2399-4800-aad8-ca908a304e85
+              :IsViewOnly: false
+              :ObjectType: VMHostNetworkAdapter
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          :VMHost: *12
+          :LogicalSwitch: 
+          :LogicalSwitchComplianceStatus:
+            :ToString: NotAnInstanceOfLogicalSwitch
+            :I32: 0
+          :LogicalSwitchComplianceErrors: []
+          :VMwarePortGroups: []
+          :VMHostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+          :ServerConnection: *9
+          :ID: cea5e7b1-228c-4726-bf31-34d8ea0f59fd
+          :IsViewOnly: false
+          :ObjectType:
+            :ToString: VirtualNetwork
+            :I32: 15
+          :MarkedForDeletion: false
+          :IsFullyCached: true
+      - :ToString: vswitch
+        :Props:
+          :Name: vswitch
+          :HighlyAvailable: true
+          :HostBoundVlanId: 0
+          :NetworkOptimizationCapable: false
+          :NetworkOptimizationAvailable: false
+          :BoundToVMHost: true
+          :Description: 
+          :LogicalNetworks:
+          - *22
+          :VMHostNetworkAdapters:
+          - :ToString: 'Ethernet 2 - Broadcom BCM5709S NetXtreme II GigE (NDIS VBD
+              Client) #51'
+            :Props:
+              :Name: 'Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #51'
+              :IPAddresses:
+              - :ToString: 10.16.4.47
                 :Props:
-                  :Address: 4267902986
+                  :Address: 788795402
                   :AddressFamily: InterNetwork
                   :IsIPv6Multicast: false
                   :IsIPv6LinkLocal: false
@@ -8681,11 +17041,26 @@
                   :IsIPv6Teredo: false
                   :IsIPv4MappedToIPv6: false
                 :MS:
-                  :IPAddressToString: 10.8.99.254
-              :MacAddress: 78:2B:CB:40:7B:A4
-              :PhysicalAddress: 78:2B:CB:40:7B:A4
-              :NetworkLocation: VM_Network
-              :VirtualNetwork: *100
+                  :IPAddressToString: 10.16.4.47
+              :DHCPEnabled: true
+              :IPSubnets:
+              - 10.16.4.0/22
+              :DefaultIPGateways:
+              - :ToString: 10.16.7.254
+                :Props:
+                  :Address: 4261875722
+                  :AddressFamily: InterNetwork
+                  :IsIPv6Multicast: false
+                  :IsIPv6LinkLocal: false
+                  :IsIPv6SiteLocal: false
+                  :IsIPv6Teredo: false
+                  :IsIPv4MappedToIPv6: false
+                :MS:
+                  :IPAddressToString: 10.16.7.254
+              :MacAddress: 5C:F3:FC:1C:86:1C
+              :PhysicalAddress: 5C:F3:FC:1C:86:1C
+              :NetworkLocation: rhq
+              :VirtualNetwork: *91
               :NetworkSwitchPort: 
               :UplinkPortProfileSet: 
               :VLanTags: []
@@ -8697,130 +17072,106 @@
               :ConnectionState: Connected
               :ConnectionName: Ethernet 2
               :Description: 
-              :PrimaryDNSSuffix: cloudforms.lab.eng.rdu2.redhat.com
+              :PrimaryDNSSuffix: rhq.lab.eng.bos.redhat.com
               :MaxBandwidth: 1000
-              :VMHost: *1
+              :VMHost: *12
               :LogicalNetworkMap:
-                ! '':
-                - '0'
+                ! '': []
               :UsableVlanMode: Trunk
               :ModelAccessibleSubnetVLans:
-                ! '':
-                - '0'
+                ! '': []
               :LogicalNetworks:
-              - *21
-              :SubnetVLans:
-              - '0'
+              - *22
+              :SubnetVLans: []
               :UnassignedVLans: []
               :AvailableForPlacement: true
               :IsAvailableForHA: true
               :UsedForManagement: true
               :LogicalNetworkCompliance: Compliant
               :LogicalNetworkComplianceErrors: []
-              :BDFLocationInformation: PCI bus 1, device 0, function 0
+              :BDFLocationInformation: PCI bus 16, device 0, function 0
               :NetworkVirtualizationEnabled: true
-              :ServerConnection: *8
-              :ID: dbc6b0bf-7aa9-411e-8a80-8628dda8d7fe
+              :ServerConnection: *9
+              :ID: 60ecc9c7-444b-44e8-820a-cab5fe8c5250
               :IsViewOnly: false
               :ObjectType: VMHostNetworkAdapter
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :VMHost: *1
+          :VMHost: *12
           :LogicalSwitch: 
           :LogicalSwitchComplianceStatus:
             :ToString: NotAnInstanceOfLogicalSwitch
             :I32: 0
           :LogicalSwitchComplianceErrors: []
           :VMwarePortGroups: []
-          :VMHostID: 6a2c5120-2931-4cc2-a445-8d28dfc73e03
-          :ServerConnection: *8
-          :ID: 545b4e5d-c756-4046-8aab-84c8650398a8
+          :VMHostID: 64e80126-006c-4efd-a00c-c1c4e9ee9d17
+          :ServerConnection: *9
+          :ID: c408d625-bb22-4ba9-ae9a-35ae25b3d550
           :IsViewOnly: false
           :ObjectType:
             :ToString: VirtualNetwork
             :I32: 15
           :MarkedForDeletion: false
           :IsFullyCached: true
-    :529da423-9493-4a00-9634-37c83dc1fe0e:
+    :9144beef-94c7-4d99-b3b4-1f7caae8ecde:
       :Properties:
-        :ToString: cfme-esx-55-01
+        :ToString: dhcp129-212.brq.redhat.com
         :Props:
-          :RunAsAccount: *28
-          :MostRecentTaskID: 3180e43e-d149-41d9-a868-4fcafe80b680
+          :RunAsAccount:
+            :ToString: administrator
+            :Props:
+              :Name: administrator
+              :UserName: administrator
+              :Domain: 
+              :Enabled: true
+              :IsBuiltIn: false
+              :GrantedToList: []
+              :UserRoleID: 75700cd5-893e-4f68-ada7-50ef4668acc6
+              :UserRole: *3
+              :Owner: CFME-QE-VMM-AD\Administrator
+              :ObjectType: RunAsAccount
+              :Accessibility: Public
+              :IsViewOnly: false
+              :Description: administrator R3dhat!
+              :AddedTime: 2016-07-11 15:47:30.082818000 -04:00
+              :ModifiedTime: 2016-07-11 15:47:30.082818000 -04:00
+              :MostRecentTask: 
+              :ServerConnection: *9
+              :ID: 49fca9c1-f2df-4e34-8ded-7e40a06aeaaf
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+              :MostRecentTaskIfLocal: 
+          :MostRecentTaskID: 3b9ab258-8f96-4688-b006-13f59fbeec59
           :MostRecentTaskUIState:
             :ToString: Failed
             :I32: 3
-          :MostRecentTask: &106
-            :ToString: Add virtual machine host
-            :Props:
-              :StepsLoaded: true
-              :RootStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :Description: Add virtual machine host
-              :IsVisible: true
-              :Status: Failed
-              :StatusString: Failed
-              :ErrorInfo: FailedWithCriticalException (20413)
-              :StartTime: 2016-02-24 11:48:21.327000000 -05:00
-              :EndTime: 2016-02-24 11:48:27.723000000 -05:00
-              :Owner: CLOUDFORMSWIN\scvmm
-              :OwnerIdentifier: S-1-5-21-2769651096-229053749-1596235872-1108
-              :SessionOwner: CLOUDFORMSWIN\scvmm
-              :Name: Add virtual machine host
-              :Steps:
-              - Microsoft.SystemCenter.VirtualMachineManager.Step
-              :CurrentStep: Microsoft.SystemCenter.VirtualMachineManager.Step
-              :ProgressValue: 66
-              :Progress: 66 %
-              :WasNotifiedOfCancel: false
-              :CmdletName: Add-SCVMHostCluster
-              :PROTipID: 
-              :ResultObjectID: 529da423-9493-4a00-9634-37c83dc1fe0e
-              :TargetObjectID: 529da423-9493-4a00-9634-37c83dc1fe0e
-              :TargetObjectType: VMHost
-              :IsCompleted: true
-              :AreAuditRecordsAvailable: false
-              :AuditRecords: []
-              :AdditionalMessages: []
-              :Source: 
-              :Target: 
-              :ResultObjectType: VMHost
-              :ResultObjectTypeName: Host
-              :ResultName: cfme-esx-55-01
-              :IsRestartable: true
-              :IsStoppable: false
-              :ServerConnection: *8
-              :ID: 3180e43e-d149-41d9-a868-4fcafe80b680
-              :IsViewOnly: false
-              :ObjectType: Job
-              :MarkedForDeletion: false
-              :IsFullyCached: true
-          :OverallStateString: Adding...
+          :OverallStateString: Needs Attention
           :OverallState:
-            :ToString: Adding
-            :By: 3
-          :CommunicationStateString: Connecting...
+            :ToString: NeedsAttention
+            :By: 2
+          :CommunicationStateString: Not Responding
           :CommunicationState:
-            :ToString: Connecting
-            :By: 3
-          :Name: cfme-esx-55-01
-          :FullyQualifiedDomainName: cfme-esx-55-01
-          :ComputerName: cfme-esx-55-01
-          :DomainName: cfme-esx-55-01
+            :ToString: NotResponding
+            :By: 1
+          :Name: dhcp129-212.brq.redhat.com
+          :FullyQualifiedDomainName: dhcp129-212.brq.redhat.com
+          :ComputerName: dhcp129-212
+          :DomainName: brq.redhat.com
           :Description: 
-          :RemoteUserName: localhost\root
+          :RemoteUserName: localhost\administrator
           :OverrideHostGroupReserves: false
           :CPUPercentageReserve: 10
           :NetworkPercentageReserve: 0
           :DiskSpaceReserveMB: 10240
           :MaxDiskIOReservation: 10000
           :MemoryReserveMB: 2048
-          :VMPaths: *101
-          :BaseDiskPaths: *102
+          :VMPaths: []
+          :BaseDiskPaths: []
           :PROEnabled: false
           :MaintenanceHost: false
           :AvailableForPlacement: true
           :IsEmbedded: false
-          :CredentialsNeeded: true
+          :CredentialsNeeded: false
           :PausedForNetworkIncompatibility: false
           :LogicalProcessorCount: 0
           :PhysicalCPUCount: 0
@@ -8836,41 +17187,41 @@
           :CpuUtilization: 0
           :TotalMemory: 0
           :AvailableMemory: 0
-          :OperatingSystem: *16
-          :OperatingSystemVersion: '0.0'
+          :OperatingSystem: *20
+          :OperatingSystemVersion: 6.2.9200
           :DVDDrives: 
           :DVDDriveList: []
-          :VirtualizationPlatformString: VMware ESX Server
+          :VirtualizationPlatformString: Microsoft Hyper-V
           :VirtualizationPlatform:
-            :ToString: VMWareESX
-            :I32: 4
-          :VirtualizationPlatformDetail: VMware ESX Server
+            :ToString: HyperV
+            :I32: 2
+          :VirtualizationPlatformDetail: Microsoft Hyper-V
           :IsVirtualizationSoftwareDetailUnknown: false
-          :IsViridianHost: false
+          :IsViridianHost: true
           :SupportsLiveMigration: false
           :FloppyDrives: 
           :FloppyDriveList: []
-          :VMHostGroup: *13
-          :HostCluster: *43
+          :VMHostGroup: *39
+          :HostCluster: 
           :RemoteConnectEnabled: true
-          :RemoteConnectPort: 5900
+          :RemoteConnectPort: 2179
           :SecureRemoteConnectEnabled: false
           :VMRCCertificateAvailable: false
           :EnableLiveMigration: false
           :LiveMigrationMaximum: 0
           :LiveStorageMigrationMaximum: 0
           :UseAnyMigrationSubnet: false
-          :MigrationSubnet: *103
-          :MigrationSubnetUserManaged: *104
+          :MigrationSubnet: []
+          :MigrationSubnetUserManaged: []
           :MigrationAuthProtocol:
             :ToString: CredSSP
             :By: 0
           :MigrationPerformanceOption:
             :ToString: Standard
             :By: 0
-          :SslTcpPort: 443
+          :SslTcpPort: 5986
           :SslCertificateHash: 
-          :SshTcpPort: 22
+          :SshTcpPort: 0
           :SshPublicKeyHash: 
           :SshPublicKey: 
           :IsRemoteFXRoleInstalled: false
@@ -8891,39 +17242,39 @@
             :ToString: UpToDate
             :By: 0
           :PerimeterNetworkHost: false
-          :NonTrustedDomainHost: false
+          :NonTrustedDomainHost: true
           :MaximumMemoryPerVM: 0
           :MinimumMemoryPerVM: 0
           :SuggestedMaximumMemoryPerVM: 0
-          :ModifiedTime: 2016-02-24 11:48:23.407000000 -05:00
-          :Agent: &105
-            :ToString: cfme-esx-55-01
+          :ModifiedTime: 2016-03-30 11:57:21.603000000 -04:00
+          :Agent: &92
+            :ToString: dhcp129-212.brq.redhat.com
             :Props:
-              :StateString: Responding
+              :StateString: Not Responding
               :RoleString: Host
-              :State: Responding
-              :VersionState: NotApplicable
-              :VersionStateString: Not Applicable
+              :State: NotResponding
+              :VersionState: UpToDate
+              :VersionStateString: Up-to-date
               :MarkedForDeletion: false
-              :Name: cfme-esx-55-01
+              :Name: dhcp129-212.brq.redhat.com
               :MostRecentTaskID: 
               :MostRecentTaskUIState: 
               :MostRecentTask: 
-              :FullyQualifiedDomainName: cfme-esx-55-01
-              :FQDN: cfme-esx-55-01
-              :ComputerName: cfme-esx-55-01
+              :FullyQualifiedDomainName: dhcp129-212.brq.redhat.com
+              :FQDN: dhcp129-212.brq.redhat.com
+              :ComputerName: dhcp129-212
               :Description: 
-              :AgentVersion: '0.0'
+              :AgentVersion: 3.2.7510.0
               :Role: Host
-              :UpdatedDate: 2016-02-24 11:48:21.473000000 -05:00
+              :UpdatedDate: 2015-10-19 05:07:41.370000000 -04:00
               :ComplianceStatus: 
-              :ServerConnection: *8
-              :ID: 55f6ca46-6e71-4ff1-8da9-5e6c14e4fe47
+              :ServerConnection: *9
+              :ID: 961e6aa1-88e4-4542-8fad-f6d871ac8401
               :IsViewOnly: false
               :ObjectType: AgentServer
               :IsFullyCached: true
               :MostRecentTaskIfLocal: 
-          :ManagedComputer: *105
+          :ManagedComputer: *92
           :VMs: []
           :Disks: []
           :GPUs: []
@@ -8948,13 +17299,173 @@
               :SMBiosGUID: 
               :ComputerPowerState: Unknown
               :SystemEventLog: []
-              :ServerConnection: *8
-              :ID: 10b85f63-dbb8-498a-8a0d-c31f048c4382
+              :ServerConnection: *9
+              :ID: f2f71d33-554e-4f47-97aa-f0f40949d5a5
               :IsViewOnly: false
               :ObjectType: PhysicalMachine
               :MarkedForDeletion: false
               :IsFullyCached: true
-          :HealthMonitors: []
+          :HealthMonitors:
+          - :ToString: WMI Performance Counter
+            :Props:
+              :ParentID: c08e5fe5-0ae1-4184-a20c-e6e6df246e1a
+              :Name: WMI Performance Counter
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.667000000 -04:00
+              :ServerConnection: *9
+              :ID: 90da8691-0ab2-4243-811d-0e0f49c14af0
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Network
+            :Props:
+              :ParentID: 6ba3733b-d7b8-4aae-a18e-d64485efe95c
+              :Name: Network
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Critical
+              :StateString: Critical
+              :LastKnownError: HMComputerUnreachableByPing (20503); 0
+              :UpdatedDate: 2016-07-11 15:24:31.663000000 -04:00
+              :ServerConnection: *9
+              :ID: 3dc951fd-1b8c-40bc-9a58-1e03523fe77e
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Virtual Machine Management Service
+            :Props:
+              :ParentID: 805d330d-5cd4-4fd1-a82b-f37056f36231
+              :Name: Hyper-V Virtual Machine Management Service
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.670000000 -04:00
+              :ServerConnection: *9
+              :ID: 7b8746cc-c492-4487-b46b-22621cbe13d5
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Host Agent Service
+            :Props:
+              :ParentID: c08e5fe5-0ae1-4184-a20c-e6e6df246e1a
+              :Name: Host Agent Service
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.667000000 -04:00
+              :ServerConnection: *9
+              :ID: 1ae1f736-1cc7-45dd-89a5-2790807db566
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Host Agent Version
+            :Props:
+              :ParentID: c08e5fe5-0ae1-4184-a20c-e6e6df246e1a
+              :Name: Host Agent Version
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.667000000 -04:00
+              :ServerConnection: *9
+              :ID: 5464c726-f8a7-4e72-b30c-6091c30e7bfc
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Overall
+            :Props:
+              :ParentID: 
+              :Name: Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Critical
+              :StateString: Critical
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.663000000 -04:00
+              :ServerConnection: *9
+              :ID: 6ba3733b-d7b8-4aae-a18e-d64485efe95c
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: WinRM
+            :Props:
+              :ParentID: 6ba3733b-d7b8-4aae-a18e-d64485efe95c
+              :Name: WinRM
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.663000000 -04:00
+              :ServerConnection: *9
+              :ID: 96445c4b-8742-4c50-b5e6-d7bdb5b02e70
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Host Agent Overall
+            :Props:
+              :ParentID: 6ba3733b-d7b8-4aae-a18e-d64485efe95c
+              :Name: Host Agent Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.663000000 -04:00
+              :ServerConnection: *9
+              :ID: c08e5fe5-0ae1-4184-a20c-e6e6df246e1a
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Role Overall
+            :Props:
+              :ParentID: 6ba3733b-d7b8-4aae-a18e-d64485efe95c
+              :Name: Hyper-V Role Overall
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.667000000 -04:00
+              :ServerConnection: *9
+              :ID: 805d330d-5cd4-4fd1-a82b-f37056f36231
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
+          - :ToString: Hyper-V Role Version
+            :Props:
+              :ParentID: 805d330d-5cd4-4fd1-a82b-f37056f36231
+              :Name: Hyper-V Role Version
+              :IsRemediationAvailable: false
+              :RemediationDescription: 
+              :State: Unknown
+              :StateString: Unknown
+              :LastKnownError: 
+              :UpdatedDate: 2016-07-11 15:24:31.673000000 -04:00
+              :ServerConnection: *9
+              :ID: 8f6070cc-6b94-4ad2-8af5-f7abee3af28b
+              :IsViewOnly: false
+              :ObjectType: HealthMonitor
+              :MarkedForDeletion: false
+              :IsFullyCached: true
           :RemoteStorageTotalCapacity: 0
           :RemoteStorageAvailableCapacity: 0
           :LocalStorageTotalCapacity: 0
@@ -9064,20 +17575,20 @@
               :GetMessageFormatterHandler: 
           :CertificateRequest: 
           :ComputerState:
-            :ToString: Adding
-            :By: 0
+            :ToString: NotResponding
+            :By: 3
           :VirtualizationManager: 
-          :ServerConnection: *8
-          :ID: 529da423-9493-4a00-9634-37c83dc1fe0e
+          :ServerConnection: *9
+          :ID: 9144beef-94c7-4d99-b3b4-1f7caae8ecde
           :IsViewOnly: false
           :ObjectType:
             :ToString: VMHost
             :I32: 9
           :MarkedForDeletion: false
           :IsFullyCached: true
-          :MostRecentTaskIfLocal: *106
+          :MostRecentTaskIfLocal: 
         :MS:
-          :FQDN: cfme-esx-55-01
+          :FQDN: dhcp129-212.brq.redhat.com
           :LogicalCPUCount: 0
           :CPUSpeed: 0
           :CPUModel: 
@@ -9085,7 +17596,7 @@
           :CPUArchitecture: 0
           :CPUFamily: 
           :VMRCEnabled: true
-          :VMRCPort: 5900
+          :VMRCPort: 2179
           :SecureVMRCEnabled: false
           :VirtualServerState:
             :ToString: Unknown
@@ -9095,6 +17606,6 @@
           :VirtualServerVersionState:
             :ToString: UpToDate
             :By: 0
-          :ServicingWindows: *9
+          :ServicingWindows: *11
       :NetworkAdapters: []
       :VirtualSwitch: []


### PR DESCRIPTION
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1284084

This treats DVD info as an array instead of a single object. It also reduces the data being sent over the wire a bit by selecting only those fields that we actually use, so there will be a slight performance improvement overall.

Steps for Testing/QA
--------------------

Add a new SCVMM infrastructure provider, or refresh an existing one using this code. Then check the device list for a VM that has one or more DVD's attached.

~~Why it's a WIP~~
~~--------------------~~

~~While this eliminates the bug, and inspection of the underlying array of hashes looks good, it doesn't actually appear to get saved to the guest_devices table and I'm not sure why yet.~~

~~On a side note, is there any reason we can't set :device_type to "DVD"? In the schema, it looks like a simple string field.~~


~~@bronaghs @jteehan Need some help please.~~
