### PR TITLE
[api] Prefer have_http_status(<status>)

### DIFF
--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -10,7 +10,7 @@ describe ApiController do
 
       run_get entrypoint_url
 
-      expect_user_unauthorized
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it "test basic authentication with correct credentials" do
@@ -30,7 +30,7 @@ describe ApiController do
 
       run_get entrypoint_url
 
-      expect_user_unauthorized
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it "test basic authentication with a user without a group" do
@@ -41,7 +41,7 @@ describe ApiController do
 
       run_get entrypoint_url
 
-      expect_user_unauthorized
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
@@ -59,7 +59,7 @@ describe ApiController do
 
       run_get entrypoint_url, :headers => {"miq_group" => "bogus_group"}
 
-      expect_user_unauthorized
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it "test basic authentication with a primary group" do
@@ -133,7 +133,7 @@ describe ApiController do
     it "authentication using a bad token" do
       run_get entrypoint_url, :headers => {"auth_token" => "badtoken"}
 
-      expect_user_unauthorized
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it "authentication using a valid token" do

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -31,7 +31,7 @@ describe ApiController do
 
       run_post(automation_requests_url, single_automation_request)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
@@ -44,7 +44,7 @@ describe ApiController do
 
       run_post(automation_requests_url, gen_request(:create, single_automation_request))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
@@ -57,7 +57,7 @@ describe ApiController do
 
       run_post(automation_requests_url, gen_request(:create, [single_automation_request, single_automation_request]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "categories API" do
       "resources",
       categories.map { |category| categories_url(category.id) }
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can filter the list of categories by name" do
@@ -43,7 +43,7 @@ RSpec.describe "categories API" do
       "href"        => categories_url(category.id),
       "id"          => category.id
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can list all the tags under a category" do
@@ -59,7 +59,7 @@ RSpec.describe "categories API" do
       "resources",
       ["#{categories_url(category.id)}/tags/#{tag.id}"]
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   context "with an appropriate role" do
@@ -70,7 +70,7 @@ RSpec.describe "categories API" do
         run_post categories_url, :name => "test", :description => "Test"
       end.to change(Category, :count).by(1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can set read_only/show/single_value when creating a category" do
@@ -110,7 +110,7 @@ RSpec.describe "categories API" do
         run_post categories_url(category.id), gen_request(:edit, :description => "New description")
       end.to change { category.reload.description }.to("New description")
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id description name))
     end
 
@@ -122,7 +122,7 @@ RSpec.describe "categories API" do
         run_post categories_url(category.id), gen_request(:delete)
       end.to change(Category, :count).by(-1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can delete a category through DELETE" do
@@ -133,7 +133,7 @@ RSpec.describe "categories API" do
         run_delete categories_url(category.id)
       end.to change(Category, :count).by(-1)
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     context "read-only categories" do
@@ -145,7 +145,7 @@ RSpec.describe "categories API" do
           run_post categories_url(category.id), gen_request(:delete)
         end.not_to change(Category, :count)
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "can't update a read-only category" do
@@ -156,7 +156,7 @@ RSpec.describe "categories API" do
           run_post categories_url(category.id), gen_request(:edit, :description => "new description")
         end.not_to change { category.reload.description }
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -168,7 +168,7 @@ RSpec.describe "categories API" do
           run_post categories_url, :name => "test", :description => "Test"
         end.not_to change(Category, :count)
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "cannot update a category" do
@@ -179,7 +179,7 @@ RSpec.describe "categories API" do
           run_post categories_url(category.id), gen_request(:edit, :description => "New description")
         end.not_to change { category.reload.description }
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "cannot delete a category through POST" do
@@ -190,7 +190,7 @@ RSpec.describe "categories API" do
           run_post categories_url(category.id), gen_request(:delete)
         end.not_to change(Category, :count)
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "cannot delete a category through DELETE" do
@@ -201,7 +201,7 @@ RSpec.describe "categories API" do
           run_delete categories_url(category.id)
         end.not_to change(Category, :count)
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "chargebacks API" do
       "resources", [chargebacks_url(chargeback_rate.id)]
     )
     expect_result_to_match_hash(response_hash, "count" => 1)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can show an individual chargeback rate" do
@@ -25,7 +25,7 @@ RSpec.describe "chargebacks API" do
       "id"          => chargeback_rate.id,
       "href"        => chargebacks_url(chargeback_rate.id)
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can fetch chargeback rate details" do
@@ -66,7 +66,7 @@ RSpec.describe "chargebacks API" do
       "id"                 => chargeback_rate_detail.id,
       "description"        => "rate_1"
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can list of all currencies" do
@@ -79,7 +79,7 @@ RSpec.describe "chargebacks API" do
       "resources", ["/api/currencies/#{currency.id}"]
     )
     expect_result_to_match_hash(response_hash, "count" => 1)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can show an individual currency" do
@@ -94,7 +94,7 @@ RSpec.describe "chargebacks API" do
       "id"   => currency.id,
       "href" => "/api/currencies/#{currency.id}"
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can list of all measures" do
@@ -107,7 +107,7 @@ RSpec.describe "chargebacks API" do
       "resources", ["/api/measures/#{measure.id}"]
     )
     expect_result_to_match_hash(response_hash, "count" => 1)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can show an individual measure" do
@@ -122,7 +122,7 @@ RSpec.describe "chargebacks API" do
       "id"   => measure.id,
       "href" => "/api/measures/#{measure.id}",
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   context "with an appropriate role" do
@@ -137,7 +137,7 @@ RSpec.describe "chargebacks API" do
       expect_result_to_match_hash(response_hash["results"].first, "description" => "chargeback_0",
                                                                   "rate_type"   => "Storage",
                                                                   "default"     => false)
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns bad request for incomplete chargeback rate" do
@@ -157,7 +157,7 @@ RSpec.describe "chargebacks API" do
       run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
 
       expect(response_hash["description"]).to eq("chargeback_1")
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(chargeback_rate.reload.description).to eq("chargeback_1")
     end
 
@@ -170,7 +170,7 @@ RSpec.describe "chargebacks API" do
                                                        :value  => "chargeback_1"}]
 
       expect(response_hash["description"]).to eq("chargeback_1")
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(chargeback_rate.reload.description).to eq("chargeback_1")
     end
 
@@ -182,7 +182,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_delete chargebacks_url(chargeback_rate.id)
       end.to change(ChargebackRate, :count).by(-1)
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     it "can delete a chargeback rate through POST" do
@@ -193,7 +193,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_post chargebacks_url(chargeback_rate.id), :action => "delete"
       end.to change(ChargebackRate, :count).by(-1)
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can create a new chargeback rate detail" do
@@ -209,7 +209,7 @@ RSpec.describe "chargebacks API" do
                  :enabled            => true
       end.to change(ChargebackRateDetail, :count).by(1)
       expect_result_to_match_hash(response_hash["results"].first, "description" => "rate_0", "enabled" => true)
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns bad request for incomplete chargeback rate detail" do
@@ -236,7 +236,7 @@ RSpec.describe "chargebacks API" do
       run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_1")
 
       expect(response_hash["description"]).to eq("rate_1")
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(chargeback_rate_detail.reload.description).to eq("rate_1")
     end
 
@@ -252,7 +252,7 @@ RSpec.describe "chargebacks API" do
       run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "description", :value => "rate_1"}]
 
       expect(response_hash["description"]).to eq("rate_1")
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(chargeback_rate_detail.reload.description).to eq("rate_1")
     end
 
@@ -269,7 +269,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_delete rates_url(chargeback_rate_detail.id)
       end.to change(ChargebackRateDetail, :count).by(-1)
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     it "can delete a chargeback rate detail through POST" do
@@ -285,7 +285,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_post rates_url(chargeback_rate_detail.id), :action => "delete"
       end.to change(ChargebackRateDetail, :count).by(-1)
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -295,7 +295,7 @@ RSpec.describe "chargebacks API" do
 
       expect { run_post chargebacks_url, :description => "chargeback_0" }.not_to change(ChargebackRate,
                                                                                         :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "cannot edit a chargeback rate" do
@@ -306,7 +306,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
       end.not_to change { chargeback_rate.reload.description }
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "cannot delete a chargeback rate" do
@@ -317,7 +317,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_delete chargebacks_url(chargeback_rate.id)
       end.not_to change(ChargebackRate, :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "cannot create a chargeback rate detail" do
@@ -325,7 +325,7 @@ RSpec.describe "chargebacks API" do
 
       expect { run_post rates_url, :description => "rate_0", :enabled => true }.not_to change(ChargebackRateDetail,
                                                                                               :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "cannot edit a chargeback rate detail" do
@@ -341,7 +341,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_2")
       end.not_to change { chargeback_rate_detail.reload.description }
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "cannot delete a chargeback rate detail" do
@@ -357,7 +357,7 @@ RSpec.describe "chargebacks API" do
       expect do
         run_delete rates_url(chargeback_rate_detail.id)
       end.not_to change(ChargebackRateDetail, :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -24,7 +24,7 @@ describe ApiController do
 
       run_get conditions_url(999_999)
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query conditions with no conditions defined" do

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -3,7 +3,7 @@ describe ApiController do
     allow_any_instance_of(ContainerDeploymentService).to receive(:cloud_init_template_id).and_return(1)
     api_basic_authorize collection_action_identifier(:container_deployments, :read, :get)
     run_get container_deployments_url + "/container_deployment_data"
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect_hash_to_have_only_keys(response_hash["data"], %w(providers provision))
   end
 
@@ -11,6 +11,6 @@ describe ApiController do
     allow_any_instance_of(ContainerDeployment).to receive(:create_deployment).and_return(true)
     api_basic_authorize collection_action_identifier(:container_deployments, :create)
     run_post(container_deployments_url, gen_request(:create, :example_data => true))
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 end

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -20,7 +20,7 @@ describe ApiController do
 
       run_get events_url(999_999)
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query events with no events defined" do

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -27,7 +27,7 @@ describe ApiController do
 
       run_post(groups_url, sample_group1)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects group creation with id specified" do
@@ -43,7 +43,7 @@ describe ApiController do
 
       run_post(groups_url, "description" => "sample group", "role" => {"id" => 999_999})
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "rejects group creation with invalid tenant specified" do
@@ -51,7 +51,7 @@ describe ApiController do
 
       run_post(groups_url, "description" => "sample group", "tenant" => {"id" => 999_999})
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "rejects group creation with invalid filters specified" do
@@ -67,7 +67,7 @@ describe ApiController do
 
       run_post(groups_url, sample_group1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       group_id = response_hash["results"].first["id"]
@@ -79,7 +79,7 @@ describe ApiController do
 
       run_post(groups_url, gen_request(:create, sample_group1))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       group_id = response_hash["results"].first["id"]
@@ -94,7 +94,7 @@ describe ApiController do
                                        "role"        => {"name" => role3.name},
                                        "tenant"      => {"href" => tenants_url(tenant3.id)}))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       result = response_hash["results"].first
@@ -119,7 +119,7 @@ describe ApiController do
       }
       run_post(groups_url, gen_request(:create, sample_group))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       group_id = response_hash["results"][0]["id"]
@@ -135,7 +135,7 @@ describe ApiController do
 
       run_post(groups_url, gen_request(:create, [sample_group1, sample_group2]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = response_hash["results"]
@@ -153,7 +153,7 @@ describe ApiController do
                                        "description" => "updated_group",
                                        "href"        => groups_url(group1.id)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects group edits for invalid resources" do
@@ -161,7 +161,7 @@ describe ApiController do
 
       run_post(groups_url(999_999), gen_request(:edit, "description" => "updated_group"))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single group edit" do
@@ -196,7 +196,7 @@ describe ApiController do
 
       run_post(groups_url, gen_request(:delete, "description" => "group_description", "href" => groups_url(100)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects group deletion without appropriate role" do
@@ -204,7 +204,7 @@ describe ApiController do
 
       run_delete(groups_url(100))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects group deletes for invalid groups" do
@@ -212,7 +212,7 @@ describe ApiController do
 
       run_delete(groups_url(999_999))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single group delete" do
@@ -221,7 +221,7 @@ describe ApiController do
       g1_id = group1.id
       run_delete(groups_url(g1_id))
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
       expect(MiqGroup.exists?(g1_id)).to be_falsey
     end
 

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "hosts API" do
         expect do
           run_post hosts_url(host.id), gen_request(:edit, options)
         end.to change { host.reload.authentication_password(:default) }.to("abc123")
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "will update the default authentication if no type is given" do
@@ -20,7 +20,7 @@ RSpec.describe "hosts API" do
         expect do
           run_post hosts_url(host.id), gen_request(:edit, options)
         end.to change { host.reload.authentication_password(:default) }.to("abc123")
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "sending non-credentials attributes will result in a bad request error" do
@@ -31,7 +31,7 @@ RSpec.describe "hosts API" do
         expect do
           run_post hosts_url(host.id), gen_request(:edit, options)
         end.not_to change { host.reload.name }
-        expect_bad_request
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "can update passwords on multiple hosts by href" do
@@ -44,7 +44,7 @@ RSpec.describe "hosts API" do
         ]
 
         run_post hosts_url, gen_request(:edit, options)
-        expect_request_success
+        expect(response).to have_http_status(:ok)
         expect(host1.reload.authentication_password(:default)).to eq("abc123")
         expect(host2.reload.authentication_password(:default)).to eq("def456")
       end
@@ -59,7 +59,7 @@ RSpec.describe "hosts API" do
         ]
 
         run_post hosts_url, gen_request(:edit, options)
-        expect_request_success
+        expect(response).to have_http_status(:ok)
         expect(host1.reload.authentication_password(:default)).to eq("abc123")
         expect(host2.reload.authentication_password(:default)).to eq("def456")
       end
@@ -74,7 +74,7 @@ RSpec.describe "hosts API" do
         expect do
           run_post hosts_url(host.id), gen_request(:edit, options)
         end.not_to change { host.reload.authentication_password(:default) }
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:terminate))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "responds forbidden for an invalid instance without appropriate role" do
@@ -42,7 +42,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:terminate))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "terminates a single valid Instance" do
@@ -78,7 +78,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:stop))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "stopping an invalid instance without appropriate role is forbidden" do
@@ -86,7 +86,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:stop))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "fails to stop a powered off instance" do
@@ -122,7 +122,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:start))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "starting an invalid instance without appropriate role is forbidden" do
@@ -130,7 +130,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:start))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "fails to start a powered on instance" do
@@ -167,7 +167,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:pause))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "pausing an invalid instance without appropriate role is forbidden" do
@@ -175,7 +175,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:pause))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "fails to pause a powered off instance" do
@@ -220,7 +220,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:suspend))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "responds forbidden for an invalid instance without appropriate role" do
@@ -228,7 +228,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:suspend))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "cannot suspend a powered off instance" do
@@ -273,7 +273,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:shelve))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "responds forbidden for an invalid instance without appropriate role" do
@@ -281,7 +281,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:shelve))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "shelves a powered off instance" do
@@ -351,7 +351,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:reboot_guest))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "responds forbidden for an invalid instance without appropriate role" do
@@ -359,7 +359,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:reboot_guest))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "fails to reboot a powered off instance" do
@@ -395,7 +395,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:reset))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "responds forbidden for an invalid instance without appropriate role" do
@@ -403,7 +403,7 @@ RSpec.describe "Instances API" do
 
       run_post(invalid_instance_url, gen_request(:reset))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "fails to reset a powered off instance" do

--- a/spec/requests/api/policies_assignment_spec.rb
+++ b/spec/requests/api/policies_assignment_spec.rb
@@ -50,7 +50,7 @@ describe ApiController do
 
     run_post(object_policies_url, gen_request(:assign))
 
-    expect_request_forbidden
+    expect(response).to have_http_status(:forbidden)
   end
 
   def test_policy_assign_invalid_policy(object_policies_url, collection, subcollection)
@@ -58,7 +58,7 @@ describe ApiController do
 
     run_post(object_policies_url, gen_request(:assign, :href => "/api/#{subcollection}/999999"))
 
-    expect_resource_not_found
+    expect(response).to have_http_status(:not_found)
   end
 
   def test_policy_assign_invalid_policy_guid(object_url, object_policies_url, collection, subcollection)
@@ -66,7 +66,7 @@ describe ApiController do
 
     run_post(object_policies_url, gen_request(:assign, :guid => "xyzzy"))
 
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     results_hash = [{"success" => false, "href" => object_url, "message" => /must specify a valid/i}]
     expect_results_to_match_hash("results", results_hash)
   end
@@ -94,7 +94,7 @@ describe ApiController do
 
     run_post(object_policies_url, gen_request(:unassign))
 
-    expect_request_forbidden
+    expect(response).to have_http_status(:forbidden)
   end
 
   def test_policy_unassign_invalid_policy(object_policies_url, collection, subcollection)
@@ -102,7 +102,7 @@ describe ApiController do
 
     run_post(object_policies_url, gen_request(:unassign, :href => "/api/#{subcollection}/999999"))
 
-    expect_resource_not_found
+    expect(response).to have_http_status(:not_found)
   end
 
   def test_policy_unassign_invalid_policy_guid(object_url, object_policies_url, collection, subcollection)
@@ -110,7 +110,7 @@ describe ApiController do
 
     run_post(object_policies_url, gen_request(:unassign, :guid => "xyzzy"))
 
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     results_hash = [{"success" => false, "href" => object_url, "message" => /must specify a valid/i}]
     expect_results_to_match_hash("results", results_hash)
   end

--- a/spec/requests/api/policies_spec.rb
+++ b/spec/requests/api/policies_spec.rb
@@ -105,7 +105,7 @@ describe ApiController do
 
       run_get policies_url(999_999)
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query policies" do
@@ -137,7 +137,7 @@ describe ApiController do
 
       run_get policy_profiles_url(999_999)
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query Policy Profiles" do

--- a/spec/requests/api/policy_actions_spec.rb
+++ b/spec/requests/api/policy_actions_spec.rb
@@ -22,7 +22,7 @@ describe ApiController do
 
       run_get policy_actions_url(999_999)
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query policy actions with no actions defined" do

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -79,7 +79,7 @@ describe ApiController do
 
       run_post(providers_url, sample_rhevm)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects provider creation with id specified" do
@@ -103,7 +103,7 @@ describe ApiController do
 
       run_post(providers_url, sample_rhevm)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
@@ -118,7 +118,7 @@ describe ApiController do
 
       run_post(providers_url, sample_openshift.merge("credentials" => [openshift_credentials]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_openshift.except(*ENDPOINT_ATTRS)])
 
@@ -132,7 +132,7 @@ describe ApiController do
 
       run_post(providers_url, gen_request(:create, sample_rhevm))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
@@ -145,7 +145,7 @@ describe ApiController do
 
       run_post(providers_url, sample_vmware.merge("credentials" => default_credentials))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_vmware.except(*ENDPOINT_ATTRS)])
 
@@ -161,7 +161,7 @@ describe ApiController do
 
       run_post(providers_url, sample_rhevm.merge("credentials" => compound_credentials))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
@@ -179,7 +179,7 @@ describe ApiController do
 
       run_post(providers_url, gen_request(:create, [sample_vmware, sample_rhevm]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results",
                                    [sample_vmware.except(*ENDPOINT_ATTRS), sample_rhevm.except(*ENDPOINT_ATTRS)])
@@ -197,7 +197,7 @@ describe ApiController do
 
       run_post(providers_url, gen_request(:edit, "name" => "provider name", "href" => providers_url(999_999)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects edits for invalid resources" do
@@ -205,7 +205,7 @@ describe ApiController do
 
       run_post(providers_url(999_999), gen_request(:edit, "name" => "updated provider name"))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single resource edit" do
@@ -276,7 +276,7 @@ describe ApiController do
 
       run_post(providers_url, gen_request(:delete, "name" => "provider name", "href" => providers_url(100)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects deletion without appropriate role" do
@@ -284,7 +284,7 @@ describe ApiController do
 
       run_delete(providers_url(100))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects deletes for invalid providers" do
@@ -292,7 +292,7 @@ describe ApiController do
 
       run_delete(providers_url(999_999))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single provider delete" do
@@ -302,7 +302,7 @@ describe ApiController do
 
       run_delete(providers_url(provider.id))
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     it "supports single provider delete action" do
@@ -343,7 +343,7 @@ describe ApiController do
 
       run_post(providers_url(100), gen_request(:refresh))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "supports single provider refresh" do
@@ -368,7 +368,7 @@ describe ApiController do
 
       run_post(providers_url, gen_request(:refresh, [{"href" => providers_url(p1.id)},
                                                      {"href" => providers_url(p2.id)}]))
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [failed_auth_action(p1.id), failed_auth_action(p2.id)])
     end
   end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -48,7 +48,7 @@ describe ApiController do
 
       run_post(provision_requests_url, single_provision_request)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "supports single request with normal post" do
@@ -57,7 +57,7 @@ describe ApiController do
       dialog  # Create the Provisioning dialog
       run_post(provision_requests_url, single_provision_request)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
@@ -71,7 +71,7 @@ describe ApiController do
       dialog  # Create the Provisioning dialog
       run_post(provision_requests_url, gen_request(:create, single_provision_request))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
@@ -85,7 +85,7 @@ describe ApiController do
       dialog  # Create the Provisioning dialog
       run_post(provision_requests_url, gen_request(:create, [single_provision_request, single_provision_request]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
@@ -167,7 +167,7 @@ describe ApiController do
 
       run_post(provision_requests_url, body)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
@@ -199,7 +199,7 @@ describe ApiController do
 
       run_post(provision_requests_url, body)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
@@ -228,7 +228,7 @@ describe ApiController do
 
       run_post(provision_requests_url, body)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -116,7 +116,7 @@ describe ApiController do
 
       run_get(providers_url(provider.id), :attributes => "authentications")
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_match_hash(response_hash, "name" => "sample")
       expect_result_to_have_keys(%w(authentications))
       authentication = response_hash["authentications"].first
@@ -139,7 +139,7 @@ describe ApiController do
 
       run_get provision_requests_url(request.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_match_hash(response_hash, "description" => "sample provision")
       provision_attrs = response_hash.fetch_path("options", "attrs")
       expect(provision_attrs).to_not be_nil

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -333,7 +333,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id), :attributes => "bogus"
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor))
     end
   end
@@ -405,7 +405,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(response_hash).to_not have_key("actions")
     end
 
@@ -414,7 +414,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
     end
 
@@ -423,7 +423,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
       actions = response_hash["actions"]
       expect(actions.size).to eq(1)
@@ -437,7 +437,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
       expect(response_hash["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
     end
@@ -447,7 +447,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id), :attributes => "name,vendor,actions"
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_only_keys(%w(id href name vendor actions))
     end
 
@@ -456,7 +456,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id), :attributes => "name"
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_only_keys(%w(id href name))
     end
 
@@ -465,7 +465,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id), :attributes => "disconnected"
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor disconnected actions))
     end
 
@@ -474,7 +474,7 @@ describe ApiController do
 
       run_get vms_url(vm1.id), :attributes => "name,disconnected"
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_only_keys(%w(id href name disconnected))
     end
   end

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "reports API" do
       ]
     )
     expect_result_to_match_hash(response_hash, "count" => 2, "name" => "reports")
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can fetch a report" do
@@ -30,7 +30,7 @@ RSpec.describe "reports API" do
       "name"  => report.name,
       "title" => report.title
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can fetch a report's results" do
@@ -47,7 +47,7 @@ RSpec.describe "reports API" do
       ]
     )
     expect(response_hash["resources"]).not_to be_any { |resource| resource.key?("result_set") }
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can fetch a report's result" do
@@ -64,7 +64,7 @@ RSpec.describe "reports API" do
     run_get "#{reports_url(report.id)}/results/#{report_result.to_param}"
 
     expect_result_to_match_hash(response_hash, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can fetch all the results" do
@@ -80,7 +80,7 @@ RSpec.describe "reports API" do
         "#{results_url(result.id)}"
       ]
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can fetch a specific result as a primary collection" do
@@ -97,7 +97,7 @@ RSpec.describe "reports API" do
     run_get results_url(report_result.id)
 
     expect_result_to_match_hash(response_hash, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "returns an empty result set if none has been run" do
@@ -108,7 +108,7 @@ RSpec.describe "reports API" do
     run_get "#{reports_url(report.id)}/results/#{report_result.id}"
 
     expect_result_to_match_hash(response_hash, "result_set" => [])
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   context "with an appropriate role" do
@@ -158,7 +158,7 @@ RSpec.describe "reports API" do
         "message" => "Imported Report: [Test Report]",
         "success" => true
       )
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can import multiple reports in a single call" do
@@ -205,7 +205,7 @@ RSpec.describe "reports API" do
         api_basic_authorize
         run_post "#{reports_url(report.id)}", :action => "run"
       end.not_to change(MiqReportResult, :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "cannot import a report" do
@@ -225,7 +225,7 @@ RSpec.describe "reports API" do
       expect do
         run_post reports_url, gen_request(:import, :report => serialized_report, :options => options)
       end.not_to change(MiqReport, :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -63,7 +63,7 @@ describe ApiController do
     api_basic_authorize action_identifier(:roles, :read, :resource_actions, :get)
 
     run_get role_url, :expand => "features"
-    expect_request_success
+    expect(response).to have_http_status(:ok)
 
     expect(response_hash).to have_key("name")
     expect(response_hash["name"]).to eq(role.name)
@@ -88,7 +88,7 @@ describe ApiController do
 
       run_post(roles_url, sample_role1)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects role creation with id specified" do
@@ -104,7 +104,7 @@ describe ApiController do
 
       run_post(roles_url, sample_role1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       role_id = response_hash["results"].first["id"]
@@ -124,7 +124,7 @@ describe ApiController do
 
       run_post(roles_url, gen_request(:create, sample_role1))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       role_id = response_hash["results"].first["id"]
@@ -140,7 +140,7 @@ describe ApiController do
 
       run_post(roles_url, gen_request(:create, [sample_role1, sample_role2]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = response_hash["results"]
@@ -167,7 +167,7 @@ describe ApiController do
       api_basic_authorize
       run_post(roles_url, gen_request(:edit, "name" => "role name", "href" => roles_url(role.id)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects role edits for invalid resources" do
@@ -175,7 +175,7 @@ describe ApiController do
 
       run_post(roles_url(999_999), gen_request(:edit, "name" => "updated role name"))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single role edit" do
@@ -221,7 +221,7 @@ describe ApiController do
       url = "#{roles_url}/#{role.id}/features"
       run_post(url, gen_request(:assign, new_feature))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", %w(id name read_only))
 
       # Refresh the role object
@@ -241,7 +241,7 @@ describe ApiController do
       url = "#{roles_url}/#{role.id}/features"
       run_post(url, gen_request(:assign, features_list))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", %w(id name read_only))
 
       # Refresh the role object
@@ -264,7 +264,7 @@ describe ApiController do
       url = "#{roles_url}/#{role.id}/features"
       run_post(url, gen_request(:unassign, removed_feature))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       # Confirm that we've only removed ems_infra_tag
       expect_result_resources_to_include_keys("results", %w(id name read_only))
 
@@ -284,7 +284,7 @@ describe ApiController do
       url = "#{roles_url}/#{role.id}/features"
       run_post(url, gen_request(:unassign, features_list))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", %w(id name read_only))
 
       # Refresh the role object
@@ -308,7 +308,7 @@ describe ApiController do
 
       run_post(roles_url, gen_request(:delete, "name" => "role name", "href" => roles_url(100)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects role deletion without appropriate role" do
@@ -316,7 +316,7 @@ describe ApiController do
 
       run_delete(roles_url(100))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects role deletes for invalid roles" do
@@ -324,7 +324,7 @@ describe ApiController do
 
       run_delete(roles_url(999_999))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single role delete" do
@@ -334,7 +334,7 @@ describe ApiController do
 
       run_delete(roles_url(role.id))
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
       expect(MiqUserRole.exists?(role.id)).to be_falsey
     end
 
@@ -345,7 +345,7 @@ describe ApiController do
 
       run_post(roles_url(role.id), gen_request(:delete))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(MiqUserRole.exists?(role.id)).to be_falsey
     end
 
@@ -359,7 +359,7 @@ describe ApiController do
                                       [{"href" => roles_url(r1.id)},
                                        {"href" => roles_url(r2.id)}]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(MiqUserRole.exists?(r1.id)).to be_falsey
       expect(MiqUserRole.exists?(r2.id)).to be_falsey
     end

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -30,7 +30,7 @@ describe ApiController do
 
       run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects resource creation via create action without appropriate role" do
@@ -38,7 +38,7 @@ describe ApiController do
 
       run_post(service_catalogs_url, "name" => "sample service catalog")
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects resource creation with id specified" do
@@ -54,7 +54,7 @@ describe ApiController do
 
       run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
@@ -68,7 +68,7 @@ describe ApiController do
 
       run_post(service_catalogs_url, "name" => "sample service catalog")
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
@@ -82,7 +82,7 @@ describe ApiController do
 
       run_post(service_catalogs_url, gen_request(:add, [{"name" => "sc1"}, {"name" => "sc2"}]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sc1"}, {"name" => "sc2"}])
 
@@ -106,7 +106,7 @@ describe ApiController do
                                                    {"href" => service_templates_url(st2.id)}
                                                  ]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"name" => "sc", "description" => "sc description"}])
 
       sc_id = response_hash["results"].first["id"]
@@ -122,7 +122,7 @@ describe ApiController do
 
       run_post(service_catalogs_url, gen_request(:edit, "name" => "sc1", "href" => service_catalogs_url(999_999)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects edits for invalid resources" do
@@ -130,7 +130,7 @@ describe ApiController do
 
       run_post(service_catalogs_url(999_999), gen_request(:edit, "description" => "updated sc description"))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single resource edit" do
@@ -169,7 +169,7 @@ describe ApiController do
 
       run_post(service_catalogs_url, gen_request(:delete, "name" => "sc1", "href" => service_catalogs_url(100)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects resource deletion without appropriate role" do
@@ -177,7 +177,7 @@ describe ApiController do
 
       run_delete(service_catalogs_url(100))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects resource deletes for invalid resources" do
@@ -185,7 +185,7 @@ describe ApiController do
 
       run_delete(service_catalogs_url(999_999))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single resource deletes" do
@@ -195,7 +195,7 @@ describe ApiController do
 
       run_delete(service_catalogs_url(sc.id))
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
       expect { sc.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -233,7 +233,7 @@ describe ApiController do
 
       run_post(sc_templates_url(100), gen_request(:assign, "href" => service_templates_url(1)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects unassign requests without appropriate role" do
@@ -241,7 +241,7 @@ describe ApiController do
 
       run_post(sc_templates_url(100), gen_request(:unassign, "href" => service_templates_url(1)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects assign requests with invalid service template" do
@@ -251,7 +251,7 @@ describe ApiController do
 
       run_post(sc_templates_url(sc.id), gen_request(:assign, "href" => service_templates_url(999_999)))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"success" => false, "href" => service_catalogs_url(sc.id)}])
     end
 
@@ -263,7 +263,7 @@ describe ApiController do
 
       run_post(sc_templates_url(sc.id), gen_request(:assign, "href" => service_templates_url(st.id)))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"success"               => true,
                                                 "href"                  => service_catalogs_url(sc.id),
                                                 "service_template_id"   => st.id,
@@ -282,7 +282,7 @@ describe ApiController do
 
       run_post(sc_templates_url(sc.id), gen_request(:unassign, "href" => service_templates_url(st1.id)))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"success"               => true,
                                                 "href"                  => service_catalogs_url(sc.id),
                                                 "service_template_id"   => st1.id,
@@ -329,7 +329,7 @@ describe ApiController do
 
       run_get sc_templates_url(sc.id, st1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(response_hash).to_not include_actions("order")
     end
 
@@ -342,7 +342,7 @@ describe ApiController do
 
       run_get sc_templates_url(sc.id, st1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(response_hash).to include_actions("order")
     end
 
@@ -351,7 +351,7 @@ describe ApiController do
 
       run_post(sc_templates_url(100), gen_request(:order, "href" => service_templates_url(1)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "supports single order request" do
@@ -398,7 +398,7 @@ describe ApiController do
 
       run_post(sc_templates_url(sc.id), gen_request(:order, [{"href" => service_templates_url(st1.id)},
                                                              {"href" => service_templates_url(st2.id)}]))
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [order_request, order_request])
     end
   end
@@ -429,7 +429,7 @@ describe ApiController do
 
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(test1)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects refresh dialog fields with unspecified fields" do

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -100,7 +100,7 @@ describe ApiController do
 
       run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(test1)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects refresh dialog fields with unspecified fields" do

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "service orders API" do
 
     run_get service_orders_url
 
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect_result_resources_to_include_hrefs("resources", [service_orders_url(service_order.id)])
   end
 
@@ -32,7 +32,7 @@ RSpec.describe "service orders API" do
       run_post service_orders_url, :name => "service order", :state => "wish"
     end.to change(ServiceOrder, :count).by(1)
 
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can create multiple service orders" do
@@ -43,7 +43,7 @@ RSpec.describe "service orders API" do
                :action => "create", :resources => [{:name => "service order 1", :state => "wish"},
                                                    {:name => "service order 2", :state => "wish"}])
     end.to change(ServiceOrder, :count).by(2)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   specify "the default state for a service order is 'cart'" do
@@ -72,7 +72,7 @@ RSpec.describe "service orders API" do
     run_get service_orders_url(service_order.id)
 
     expect_result_to_match_hash(response_hash, "name" => service_order.name, "state" => service_order.state)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can show the shopping cart" do
@@ -103,7 +103,7 @@ RSpec.describe "service orders API" do
     run_post service_orders_url(service_order.id), :action => "edit", :resource => {:name => "new name"}
 
     expect_result_to_match_hash(response_hash, "name" => "new name")
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can update multiple service orders" do
@@ -116,7 +116,7 @@ RSpec.describe "service orders API" do
                                                {:id => service_order_2.id, :name => "new name 2"}])
 
     expect_results_to_match_hash("results", [{"name" => "new name 1"}, {"name" => "new name 2"}])
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can delete a service order" do
@@ -126,7 +126,7 @@ RSpec.describe "service orders API" do
     expect do
       run_delete service_orders_url(service_order.id)
     end.to change(ServiceOrder, :count).by(-1)
-    expect_request_success_with_no_content
+    expect(response).to have_http_status(:no_content)
   end
 
   it "can delete a service order through POST" do
@@ -136,7 +136,7 @@ RSpec.describe "service orders API" do
     expect do
       run_post service_orders_url(service_order.id), :action => "delete"
     end.to change(ServiceOrder, :count).by(-1)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can delete multiple service orders" do
@@ -149,7 +149,7 @@ RSpec.describe "service orders API" do
                :action => "delete", :resources => [{:id => service_order_1.id},
                                                    {:id => service_order_2.id}])
     end.to change(ServiceOrder, :count).by(-2)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   context "service requests subcollection" do

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -35,7 +35,7 @@ describe ApiController do
   end
 
   def expect_result_to_have_user_email(email)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect_result_to_have_keys(%w(id href user))
     expect(response_hash["user"]["email"]).to eq(email)
   end

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -72,7 +72,7 @@ describe ApiController do
       st = FactoryGirl.create(:service_template, :name => "st")
       run_post(service_templates_url(st.id), gen_request(:edit, "name" => "sample service template"))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "supports edits of single resource" do
@@ -95,7 +95,7 @@ describe ApiController do
                                                   [{"href" => service_templates_url(st1.id), "name" => "updated st1"},
                                                    {"href" => service_templates_url(st2.id), "name" => "updated st2"}]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
                                    [{"id" => st1.id, "name" => "updated st1"},
                                     {"id" => st2.id, "name" => "updated st2"}])
@@ -111,7 +111,7 @@ describe ApiController do
 
       run_post(service_templates_url, gen_request(:delete, "href" => service_templates_url(100)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects resource deletion without appropriate role" do
@@ -119,7 +119,7 @@ describe ApiController do
 
       run_delete(service_templates_url(100))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects resource deletes for invalid resources" do
@@ -127,7 +127,7 @@ describe ApiController do
 
       run_delete(service_templates_url(999_999))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single resource deletes" do
@@ -137,7 +137,7 @@ describe ApiController do
 
       run_delete(service_templates_url(st.id))
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
       expect { st.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -31,7 +31,7 @@ describe ApiController do
 
       run_post(services_url(svc.id), gen_request(:edit, "name" => "sample service"))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "supports edits of single resource" do
@@ -72,7 +72,7 @@ describe ApiController do
                                          [{"href" => services_url(svc1.id), "name" => "updated svc1"},
                                           {"href" => services_url(svc2.id), "name" => "updated svc2"}]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
                                    [{"id" => svc1.id, "name" => "updated svc1"},
                                     {"id" => svc2.id, "name" => "updated svc2"}])
@@ -87,7 +87,7 @@ describe ApiController do
 
       run_post(services_url, gen_request(:delete, "href" => services_url(100)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects DELETE requests without appropriate role" do
@@ -95,7 +95,7 @@ describe ApiController do
 
       run_delete(services_url(100))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects requests for invalid resources" do
@@ -103,7 +103,7 @@ describe ApiController do
 
       run_delete(services_url(999_999))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single resource deletes" do
@@ -111,7 +111,7 @@ describe ApiController do
 
       run_delete(services_url(svc.id))
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
       expect { svc.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -139,7 +139,7 @@ describe ApiController do
 
       run_post(services_url(100), gen_request(:retire))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects multiple requests without appropriate role" do
@@ -147,7 +147,7 @@ describe ApiController do
 
       run_post(services_url, gen_request(:retire, [{"href" => services_url(1)}, {"href" => services_url(2)}]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "supports single service retirement now" do
@@ -219,7 +219,7 @@ describe ApiController do
 
       run_post(services_url(100), gen_request(:reconfigure))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "does not return reconfigure action for non-reconfigurable services" do
@@ -229,7 +229,7 @@ describe ApiController do
 
       run_get services_url(svc1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(response_hash).to declare_actions("retire")
     end
 
@@ -244,7 +244,7 @@ describe ApiController do
 
       run_get services_url(svc1.id)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(response_hash).to declare_actions("retire", "reconfigure")
     end
 

--- a/spec/requests/api/set_ownership_spec.rb
+++ b/spec/requests/api/set_ownership_spec.rb
@@ -21,7 +21,7 @@ describe ApiController do
 
       run_post(services_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "without appropriate action role" do
@@ -29,7 +29,7 @@ describe ApiController do
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "with missing owner or group" do
@@ -128,7 +128,7 @@ describe ApiController do
 
       run_post(vms_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "without appropriate action role" do
@@ -136,7 +136,7 @@ describe ApiController do
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "with missing owner or group" do
@@ -235,7 +235,7 @@ describe ApiController do
 
       run_post(templates_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "without appropriate action role" do
@@ -243,7 +243,7 @@ describe ApiController do
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "with missing owner or group" do

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -36,7 +36,7 @@ describe ApiController do
 
       run_get settings_url("invalid_setting")
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -52,7 +52,7 @@ describe ApiController do
 
       run_post(provider_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Provider" do
@@ -68,7 +68,7 @@ describe ApiController do
 
       run_post(provider_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Provider" do
@@ -101,7 +101,7 @@ describe ApiController do
 
       run_post(host_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Host" do
@@ -117,7 +117,7 @@ describe ApiController do
 
       run_post(host_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Host" do
@@ -151,7 +151,7 @@ describe ApiController do
 
       run_post(ds_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Data Store" do
@@ -167,7 +167,7 @@ describe ApiController do
 
       run_post(ds_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Data Store" do
@@ -201,7 +201,7 @@ describe ApiController do
 
       run_post(rp_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Resource Pool" do
@@ -217,7 +217,7 @@ describe ApiController do
 
       run_post(rp_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Resource Pool" do
@@ -258,7 +258,7 @@ describe ApiController do
 
       run_post(cluster_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Cluster" do
@@ -274,7 +274,7 @@ describe ApiController do
 
       run_post(cluster_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Cluster" do
@@ -308,7 +308,7 @@ describe ApiController do
 
       run_post(service_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Service" do
@@ -324,7 +324,7 @@ describe ApiController do
 
       run_post(service_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Service" do
@@ -358,7 +358,7 @@ describe ApiController do
 
       run_post(service_template_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Service Template" do
@@ -374,7 +374,7 @@ describe ApiController do
 
       run_post(service_template_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Service Template" do
@@ -408,7 +408,7 @@ describe ApiController do
 
       run_post(tenant_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Tenant" do
@@ -424,7 +424,7 @@ describe ApiController do
 
       run_post(tenant_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Tenant" do

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -51,7 +51,7 @@ describe ApiController do
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "can create a tag with a category by id" do
@@ -66,7 +66,7 @@ describe ApiController do
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "can create a tag with a category by name" do
@@ -81,7 +81,7 @@ describe ApiController do
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "can create a tag as a subresource of a category" do
@@ -95,7 +95,7 @@ describe ApiController do
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "returns bad request when the category doesn't exist" do
@@ -103,7 +103,7 @@ describe ApiController do
 
         run_post tags_url, :name => "test_tag", :description => "Test Tag"
 
-        expect_bad_request
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "can update a tag's name" do
@@ -116,7 +116,7 @@ describe ApiController do
           run_post tags_url(tag.id), gen_request(:edit, :name => "new_name")
         end.to change { classification.reload.tag.name }.to("#{category.tag.name}/new_name")
         expect(response_hash["name"]).to eq("#{category.tag.name}/new_name")
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "can update a tag's description" do
@@ -129,7 +129,7 @@ describe ApiController do
           run_post tags_url(tag.id), gen_request(:edit, :description => "New Description")
         end.to change { tag.reload.classification.description }.to("New Description")
 
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "can delete a tag through POST" do
@@ -139,7 +139,7 @@ describe ApiController do
 
         expect { run_post tags_url(tag.id), :action => :delete }.to change(Tag, :count).by(-1)
         expect { classification.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "can delete a tag through DELETE" do
@@ -149,7 +149,7 @@ describe ApiController do
 
         expect { run_delete tags_url(tag.id) }.to change(Tag, :count).by(-1)
         expect { classification.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect_request_success_with_no_content
+        expect(response).to have_http_status(:no_content)
       end
 
       it "will respond with 404 not found when deleting a non-existent tag through DELETE" do
@@ -160,7 +160,7 @@ describe ApiController do
 
         run_delete tags_url(tag_id)
 
-        expect_resource_not_found
+        expect(response).to have_http_status(:not_found)
       end
 
       it "will respond with 404 not found when deleting a non-existent tag through POST" do
@@ -171,7 +171,7 @@ describe ApiController do
 
         run_post tags_url(tag_id), :action => :delete
 
-        expect_resource_not_found
+        expect(response).to have_http_status(:not_found)
       end
 
       it "can delete multiple tags within a category by id" do
@@ -194,7 +194,7 @@ describe ApiController do
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}
           ]
         )
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
 
       it "can delete multiple tags within a category by name" do
@@ -218,7 +218,7 @@ describe ApiController do
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}
           ]
         )
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -230,7 +230,7 @@ describe ApiController do
           run_post tags_url, :name => "test_tag", :description => "Test Tag"
         end.not_to change(Tag, :count)
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "cannot update a tag" do
@@ -241,7 +241,7 @@ describe ApiController do
           run_post tags_url(tag.id), gen_request(:edit, :name => "New name")
         end.not_to change { tag.reload.name }
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "cannot delete a tag through POST" do
@@ -250,7 +250,7 @@ describe ApiController do
 
         expect { run_post tags_url(tag.id), :action => :delete }.not_to change(Tag, :count)
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "cannot delete a tag through DELETE" do
@@ -259,7 +259,7 @@ describe ApiController do
 
         expect { run_delete tags_url(tag.id) }.not_to change(Tag, :count)
 
-        expect_request_forbidden
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -268,7 +268,7 @@ describe ApiController do
 
       run_get invalid_tag_url
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query tags with expanded resources" do
@@ -356,7 +356,7 @@ describe ApiController do
 
       run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "assigns a tag to a Vm" do
@@ -394,7 +394,7 @@ describe ApiController do
 
       run_post(vm1_tags_url, gen_request(:assign, :href => invalid_tag_url))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "assigns an invalid tag to a Vm" do
@@ -435,7 +435,7 @@ describe ApiController do
 
       run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "unassigns a tag from a Vm" do

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -18,7 +18,7 @@ describe "tenant quotas API" do
         ]
       )
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can show a single quota from a tenant" do
@@ -37,7 +37,7 @@ describe "tenant quotas API" do
         "unit"      => "fixnum",
         "value"     => 1.0
       )
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can create a quota from a tenant" do
@@ -47,7 +47,7 @@ describe "tenant quotas API" do
         run_post "/api/tenants/#{tenant.id}/quotas/", :name => :cpu_allocated, :value => 1
       end.to change(TenantQuota, :count).by(1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can update a quota from a tenant with POST" do
@@ -59,7 +59,7 @@ describe "tenant quotas API" do
 
       run_post "/api/tenants/#{tenant.id}/quotas/#{quota.id}", gen_request(:edit, options)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       quota.reload
       expect(quota.value).to eq(5)
     end
@@ -73,7 +73,7 @@ describe "tenant quotas API" do
 
       run_put "/api/tenants/#{tenant.id}/quotas/#{quota.id}", options
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       quota.reload
       expect(quota.value).to eq(5)
     end
@@ -91,7 +91,7 @@ describe "tenant quotas API" do
 
       run_post "/api/tenants/#{tenant.id}/quotas/", gen_request(:edit, options)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash(
         "results",
         [{"id" => quota_1.id, "value" => 3},
@@ -110,7 +110,7 @@ describe "tenant quotas API" do
         run_post "/api/tenants/#{tenant.id}/quotas/#{quota.id}", gen_request(:delete)
       end.to change(TenantQuota, :count).by(-1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can delete a quota from a tenant with DELETE" do
@@ -122,7 +122,7 @@ describe "tenant quotas API" do
         run_delete "/api/tenants/#{tenant.id}/quotas/#{quota.id}"
       end.to change(TenantQuota, :count).by(-1)
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     it "can delete multiple quotas from a tenant with POST" do
@@ -140,7 +140,7 @@ describe "tenant quotas API" do
         run_post "/api/tenants/#{tenant.id}/quotas/", gen_request(:delete, options)
       end.to change(TenantQuota, :count).by(-2)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -152,7 +152,7 @@ describe "tenant quotas API" do
         run_post "/api/tenants/#{tenant.id}/quotas/", :name => :cpu_allocated, :value => 1
       end.not_to change(TenantQuota, :count)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "will not update a tenant quota with POST" do
@@ -164,7 +164,7 @@ describe "tenant quotas API" do
 
       run_post "/api/tenants/#{tenant.id}/quotas/#{quota.id}", gen_request(:edit, options)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
       quota.reload
       expect(quota.value).to eq(1)
     end
@@ -178,7 +178,7 @@ describe "tenant quotas API" do
 
       run_put "/api/tenants/#{tenant.id}/quotas/#{quota.id}", options
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
       quota.reload
       expect(quota.value).to eq(1)
     end
@@ -196,7 +196,7 @@ describe "tenant quotas API" do
 
       run_post "/api/tenants/#{tenant.id}/quotas/", gen_request(:edit, options)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
       expect(quota_1.reload.value).to eq(1)
       expect(quota_2.reload.value).to eq(2)
     end
@@ -210,7 +210,7 @@ describe "tenant quotas API" do
         run_post "/api/tenants/#{tenant.id}/quotas/#{quota.id}", gen_request(:delete)
       end.not_to change(TenantQuota, :count)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "will not delete a tenant quota with DELETE" do
@@ -222,7 +222,7 @@ describe "tenant quotas API" do
         run_delete "/api/tenants/#{tenant.id}/quotas/#{quota.id}"
       end.not_to change(TenantQuota, :count)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "will not update multiple tenants with POST" do
@@ -240,7 +240,7 @@ describe "tenant quotas API" do
         run_post "/api/tenants/#{tenant.id}/quotas/", gen_request(:delete, options)
       end.not_to change(TenantQuota, :count)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "tenants API" do
       ]
     )
 
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   it "can show a single tenant" do
@@ -38,7 +38,7 @@ RSpec.describe "tenants API" do
       "name"        => "Test Tenant",
       "description" => "Tenant for this test"
     )
-    expect_request_success
+    expect(response).to have_http_status(:ok)
   end
 
   context "with an appropriate role" do
@@ -49,7 +49,7 @@ RSpec.describe "tenants API" do
         run_post tenants_url, :parent => {:id => root_tenant.id}
       end.to change(Tenant, :count).by(1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "will not create a tenant with an invalid parent" do
@@ -60,7 +60,7 @@ RSpec.describe "tenants API" do
         run_post tenants_url, :parent => {:id => invalid_tenant.id}
       end.not_to change(Tenant, :count)
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "can update a tenant with POST" do
@@ -75,7 +75,7 @@ RSpec.describe "tenants API" do
 
       run_post tenants_url(tenant.id), gen_request(:edit, options)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       tenant.reload
       expect(tenant.name).to eq("New Tenant name")
       expect(tenant.description).to eq("New Tenant description")
@@ -93,7 +93,7 @@ RSpec.describe "tenants API" do
 
       run_put tenants_url(tenant.id), options
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       tenant.reload
       expect(tenant.name).to eq("New Tenant name")
       expect(tenant.description).to eq("New Tenant description")
@@ -117,7 +117,7 @@ RSpec.describe "tenants API" do
                                     "id"   => root_tenant.id,
                                     "name" => config_attributes[:company],
                                    )
-        expect_request_success
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe "tenants API" do
 
       run_post tenants_url, gen_request(:edit, options)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_results_to_match_hash(
         "results",
         [{"id" => tenant_1.id, "name" => "Updated Test Tenant 1"},
@@ -155,7 +155,7 @@ RSpec.describe "tenants API" do
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
       expect { run_post tenants_url(tenant.id), gen_request(:delete) }.to change(Tenant, :count).by(-1)
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can delete a tenant with DELETE" do
@@ -163,7 +163,7 @@ RSpec.describe "tenants API" do
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
       expect { run_delete tenants_url(tenant.id) }.to change(Tenant, :count).by(-1)
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     it "can delete multiple tenants with POST" do
@@ -178,7 +178,7 @@ RSpec.describe "tenants API" do
       expect do
         run_post tenants_url, gen_request(:delete, options)
       end.to change(Tenant, :count).by(-2)
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -190,7 +190,7 @@ RSpec.describe "tenants API" do
         run_post tenants_url, :parent => {:id => root_tenant.id}
       end.not_to change(Tenant, :count)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "will not update a tenant with POST" do
@@ -205,7 +205,7 @@ RSpec.describe "tenants API" do
 
       run_post tenants_url(tenant.id), gen_request(:edit, options)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
       tenant.reload
       expect(tenant.name).to eq("Test Tenant")
       expect(tenant.description).to eq("Tenant for this test")
@@ -223,7 +223,7 @@ RSpec.describe "tenants API" do
 
       run_put tenants_url(tenant.id), options
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
       tenant.reload
       expect(tenant.name).to eq("Test Tenant")
       expect(tenant.description).to eq("Tenant for this test")
@@ -248,7 +248,7 @@ RSpec.describe "tenants API" do
 
       run_post tenants_url, gen_request(:edit, options)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
       expect(tenant_1.reload.name).to eq("Test Tenant 1")
       expect(tenant_2.reload.name).to eq("Test Tenant 2")
     end
@@ -258,7 +258,7 @@ RSpec.describe "tenants API" do
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
       expect { run_post tenants_url(tenant.id), gen_request(:delete) }.not_to change(Tenant, :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "will not delete a tenant with DELETE" do
@@ -266,7 +266,7 @@ RSpec.describe "tenants API" do
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
       expect { run_delete tenants_url(tenant.id) }.not_to change(Tenant, :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "will not update multiple tenants with POST" do
@@ -281,7 +281,7 @@ RSpec.describe "tenants API" do
       expect do
         run_post tenants_url, gen_request(:delete, options)
       end.not_to change(Tenant, :count)
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "users API" do
         run_post users_url(@user.id), gen_request(:edit, :password => "new_password")
       end.to change { @user.reload.password_digest }
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "can change another user's password" do
@@ -44,7 +44,7 @@ RSpec.describe "users API" do
         run_post users_url(user.id), gen_request(:edit, :password => "new_password")
       end.to change { user.reload.password_digest }
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe "users API" do
         run_post users_url(@user.id), gen_request(:edit, :password => "new_password")
       end.to change { @user.reload.password_digest }
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
     end
 
     it "will not allow the changing of attributes other than the password" do
@@ -66,7 +66,7 @@ RSpec.describe "users API" do
         run_post users_url(@user.id), gen_request(:edit, :email => "new.email@example.com")
       end.not_to change { @user.reload.email }
 
-      expect_bad_request
+      expect(response).to have_http_status(:bad_request)
     end
 
     it "cannot change another user's password" do
@@ -77,7 +77,7 @@ RSpec.describe "users API" do
         run_post users_url(user.id), gen_request(:edit, :password => "new_password")
       end.not_to change { user.reload.password_digest }
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, sample_user1)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects user creation with id specified" do
@@ -103,7 +103,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, sample_user2.merge("group" => {"id" => 999_999}))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "rejects user creation with missing attribute" do
@@ -119,7 +119,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, sample_user1)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       user_id = response_hash["results"].first["id"]
@@ -131,7 +131,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, gen_request(:create, sample_user1))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       user_id = response_hash["results"].first["id"]
@@ -143,7 +143,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, gen_request(:create, [sample_user1, sample_user2]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = response_hash["results"]
@@ -161,7 +161,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, gen_request(:edit, "name" => "updated name", "href" => users_url(user1.id)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects user edits for invalid resources" do
@@ -169,7 +169,7 @@ RSpec.describe "users API" do
 
       run_post(users_url(999_999), gen_request(:edit, "name" => "updated name"))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "supports single user edit" do
@@ -215,7 +215,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, gen_request(:delete, "href" => users_url(100)))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects user deletion without appropriate role" do
@@ -223,7 +223,7 @@ RSpec.describe "users API" do
 
       run_delete(users_url(100))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "rejects user deletes for invalid users" do
@@ -231,7 +231,7 @@ RSpec.describe "users API" do
 
       run_delete(users_url(999_999))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "rejects user delete of requesting user via action" do
@@ -256,7 +256,7 @@ RSpec.describe "users API" do
       user1_id = user1.id
       run_delete(users_url(user1_id))
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
       expect(User.exists?(user1_id)).to be_falsey
     end
 

--- a/spec/requests/api/versioning_spec.rb
+++ b/spec/requests/api/versioning_spec.rb
@@ -44,7 +44,7 @@ describe ApiController do
 
       run_get "#{entrypoint_url}/v9999.9999"
 
-      expect_bad_request
+      expect(response).to have_http_status(:bad_request)
     end
   end
 end

--- a/spec/requests/api/virtual_templates_spec.rb
+++ b/spec/requests/api/virtual_templates_spec.rb
@@ -70,14 +70,14 @@ RSpec.describe 'Virtual Template API' do
 
       run_post(virtual_templates_url, template)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it 'supports single virtual_template creation' do
       api_basic_authorize collection_action_identifier(:virtual_templates, :create)
       run_post(virtual_templates_url, template)
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys('results', expected_attributes)
 
       id = response_hash['results'].first['id']
@@ -88,7 +88,7 @@ RSpec.describe 'Virtual Template API' do
       api_basic_authorize collection_action_identifier(:virtual_templates, :create)
       run_post(virtual_templates_url, gen_request(:create, template.except(:action)))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys('results', expected_attributes)
 
       id = response_hash['results'].first['id']
@@ -172,7 +172,7 @@ RSpec.describe 'Virtual Template API' do
       api_basic_authorize collection_action_identifier(:virtual_templates, :delete)
 
       run_delete(virtual_templates_url(template.id))
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     it 'supports multiple virtual_template delete' do
@@ -192,7 +192,7 @@ RSpec.describe 'Virtual Template API' do
       api_basic_authorize collection_action_identifier(:virtual_templates, :delete)
 
       run_delete(virtual_templates_url(99))
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -70,7 +70,7 @@ describe ApiController do
 
       run_get "#{vm_accounts_url}/999999"
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query VM accounts subcollection with two related accounts using expand directive" do
@@ -127,7 +127,7 @@ describe ApiController do
 
       run_get "#{vm_software_url}/999999"
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "query VM software subcollection with two related software using expand directive" do
@@ -149,7 +149,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:start))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "starts an invalid vm without appropriate role" do
@@ -157,7 +157,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:start))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "starts a powered on vm" do
@@ -207,7 +207,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:stop))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "stops an invalid vm without appropriate role" do
@@ -215,7 +215,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:stop))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "stops a powered off vm" do
@@ -251,7 +251,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:suspend))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "suspends an invalid vm without appropriate role" do
@@ -259,7 +259,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:suspend))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "suspends a powered off vm" do
@@ -304,7 +304,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:pause))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "pauses an invalid vm without appropriate role" do
@@ -312,7 +312,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:pause))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "pauses a powered off vm" do
@@ -357,7 +357,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:shelve))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "shelves an invalid vm without appropriate role" do
@@ -365,7 +365,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:shelve))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "shelves a powered off vm" do
@@ -441,7 +441,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:shelve_offload))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "shelve_offloads an invalid vm without appropriate role" do
@@ -449,7 +449,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:shelve_offload))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "shelve_offloads a active vm" do
@@ -547,7 +547,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:delete))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "deletes a vm via a resource POST without appropriate role" do
@@ -555,7 +555,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:delete))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "deletes a vm via a resource DELETE without appropriate role" do
@@ -563,7 +563,7 @@ describe ApiController do
 
       run_delete(invalid_vm_url)
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "deletes a vm via a resource POST" do
@@ -579,7 +579,7 @@ describe ApiController do
 
       run_delete(vm_url)
 
-      expect_request_success_with_no_content
+      expect(response).to have_http_status(:no_content)
     end
 
     it "deletes multiple vms" do
@@ -597,7 +597,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:set_owner, "owner" => "admin"))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "set_owner without appropriate action role" do
@@ -605,7 +605,7 @@ describe ApiController do
 
       run_post(vm_url, gen_request(:set_owner, "owner" => "admin"))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "set_owner with missing owner" do
@@ -697,7 +697,7 @@ describe ApiController do
 
       run_post(vm_ca_url, gen_request(:delete, nil, vm_url))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "delete a custom_attribute from a vm via the delete action" do
@@ -706,7 +706,7 @@ describe ApiController do
 
       run_post(vm_ca_url, gen_request(:delete, nil, ca1_url))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect(vm.reload.custom_attributes).to be_empty
     end
 
@@ -724,7 +724,7 @@ describe ApiController do
       run_post(vm_ca_url, gen_request(:add, [{"name" => "name1", "value" => "value1"},
                                              {"name" => "name2", "value" => "value2"}]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_data("results", "name" => %w(name1 name2))
       expect(vm.custom_attributes.size).to eq(2)
       expect(vm.custom_attributes.pluck(:value).sort).to eq(%w(value1 value2))
@@ -736,7 +736,7 @@ describe ApiController do
 
       run_post(vm_ca_url, gen_request(:edit, "name" => "name1", "value" => "value one"))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_data("results", "value" => ["value one"])
       expect(vm.reload.custom_attributes.first.value).to eq("value one")
     end
@@ -747,7 +747,7 @@ describe ApiController do
 
       run_post(vm_ca_url, gen_request(:edit, "href" => ca1_url, "value" => "new value1"))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_data("results", "value" => ["new value1"])
       expect(vm.reload.custom_attributes.first.value).to eq("new value1")
     end
@@ -759,7 +759,7 @@ describe ApiController do
       run_post(vm_ca_url, gen_request(:edit, [{"name" => "name1", "value" => "new value1"},
                                               {"name" => "name2", "value" => "new value2"}]))
 
-      expect_request_success
+      expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_data("results", "value" => ["new value1", "new value2"])
       expect(vm.reload.custom_attributes.pluck(:value).sort).to eq(["new value1", "new value2"])
     end
@@ -777,7 +777,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:add_lifecycle_event, :event => "event 1"))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "add_lifecycle_event without appropriate action role" do
@@ -785,7 +785,7 @@ describe ApiController do
 
       run_post(vm_url, gen_request(:add_lifecycle_event, :event => "event 1"))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "add_lifecycle_event to a vm" do
@@ -816,7 +816,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:scan))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "scans an invalid Vm without appropriate role" do
@@ -824,7 +824,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:scan))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "scan a Vm" do
@@ -851,7 +851,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:add_event))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "to an invalid vm without appropriate role" do
@@ -859,7 +859,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:add_event))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "to a single Vm" do
@@ -891,7 +891,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:retire))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "to an invalid vm without appropriate role" do
@@ -899,7 +899,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:retire))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "to a single Vm" do
@@ -939,7 +939,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:reset))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "to an invalid vm without appropriate role" do
@@ -947,7 +947,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:reset))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "to a single Vm" do
@@ -979,7 +979,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:shutdown_guest))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "to an invalid vm without appropriate role" do
@@ -987,7 +987,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:shutdown_guest))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "to a single Vm" do
@@ -1019,7 +1019,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:refresh))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "to an invalid vm without appropriate role" do
@@ -1027,7 +1027,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:refresh))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "to a single Vm" do
@@ -1059,7 +1059,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:reboot_guest))
 
-      expect_resource_not_found
+      expect(response).to have_http_status(:not_found)
     end
 
     it "to an invalid vm without appropriate role" do
@@ -1067,7 +1067,7 @@ describe ApiController do
 
       run_post(invalid_vm_url, gen_request(:reboot_guest))
 
-      expect_request_forbidden
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "to a single Vm" do

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -189,32 +189,12 @@ module ApiSpecHelper
 
   # Rest API Expects
 
-  def expect_request_success
-    expect(response).to have_http_status(:ok)
-  end
-
-  def expect_request_success_with_no_content
-    expect(response).to have_http_status(:no_content)
-  end
-
   def expect_bad_request(error_message = nil)
     expect(response).to have_http_status(:bad_request)
     return if error_message.blank?
 
     expect(response_hash).to have_key("error")
     expect(response_hash["error"]["message"]).to match(error_message)
-  end
-
-  def expect_user_unauthorized
-    expect(response).to have_http_status(:unauthorized)
-  end
-
-  def expect_request_forbidden
-    expect(response).to have_http_status(:forbidden)
-  end
-
-  def expect_resource_not_found
-    expect(response).to have_http_status(:not_found)
   end
 
   def expect_result_resources_to_include_data(collection, data)
@@ -318,24 +298,24 @@ module ApiSpecHelper
   # Primary result construct methods
 
   def expect_empty_query_result(collection)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect(response_hash).to include("name" => collection.to_s, "resources" => [])
   end
 
   def expect_query_result(collection, subcount, count = nil)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect(response_hash).to include("name" => collection.to_s, "subcount" => fetch_value(subcount))
     expect(response_hash["resources"].size).to eq(fetch_value(subcount))
     expect(response_hash["count"]).to eq(fetch_value(count)) if count.present?
   end
 
   def expect_single_resource_query(attr_hash = {})
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect_result_to_match_hash(response_hash, fetch_value(attr_hash))
   end
 
   def expect_single_action_result(options = {})
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect(response_hash).to include("success" => options[:success]) if options.key?(:success)
     expect(response_hash).to include("message" => a_string_matching(options[:message])) if options[:message]
     expect(response_hash).to include("href" => a_string_matching(fetch_value(options[:href]))) if options[:href]
@@ -343,7 +323,7 @@ module ApiSpecHelper
   end
 
   def expect_multiple_action_result(count, options = {})
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     expect(response_hash).to have_key("results")
     results = response_hash["results"]
     expect(results.size).to eq(count)
@@ -353,7 +333,7 @@ module ApiSpecHelper
   end
 
   def expect_tagging_result(tagging_results)
-    expect_request_success
+    expect(response).to have_http_status(:ok)
     tag_results = fetch_value(tagging_results)
     expect(response_hash).to have_key("results")
     results = response_hash["results"]


### PR DESCRIPTION
Replaces expect_request_response_with_no_content,
expect_request_success, expect_user_unauthorized,
expect_request_forbidden, expect_resource_not_found, and some uses of
expect_bad_request with matcher have_http_status(<status>).

These helper methods add a layer of indirection which adds to congnitive
load - I can never remember which one of them does something other than
check the response status (it is expect_bad_request, which is left
intact where we're passing the optional argument to check the response body).

@abellotti if you feel strongly the other way I won't have lost much - this was mostly a quick find and replace. I don't feel strongly, but I do prefer the clarity of seeing the matcher (have_http_status) next to the thing it is matching against (response) vs having to remember what the helper method does.

@miq-bot add-label test, refactoring, darga/no
@miq-bot assign @abellotti 