### PR TITLE
Update cfme yum repos

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -32,7 +32,7 @@ class MiqDatabase < ApplicationRecord
   end
 
   def self.registration_default_value_for_update_repo_name
-    "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+    "cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
   end
 
   def update_repo_names

--- a/db/migrate/20160425161456_update_default_yum_repo_name_for56.rb
+++ b/db/migrate/20160425161456_update_default_yum_repo_name_for56.rb
@@ -1,0 +1,27 @@
+class UpdateDefaultYumRepoNameFor56 < ActiveRecord::Migration[5.0]
+  class MiqDatabase < ActiveRecord::Base; end
+
+  REPO_NAME_HASH = {
+    "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms" => "cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+  }.freeze
+
+  def up
+    say_with_time("Updating update_repo_name") do
+      update(REPO_NAME_HASH)
+    end
+  end
+
+  def down
+    say_with_time("Updating update_repo_name") do
+      update(REPO_NAME_HASH.invert)
+    end
+  end
+
+  def update(hash)
+    db = MiqDatabase.first
+    if db
+      new_repo = hash[db.update_repo_name]
+      db.update_attributes(:update_repo_name => new_repo) if new_repo
+    end
+  end
+end

--- a/spec/migrations/20160425161456_update_default_yum_repo_name_for56_spec.rb
+++ b/spec/migrations/20160425161456_update_default_yum_repo_name_for56_spec.rb
@@ -1,0 +1,29 @@
+require_migration
+
+describe UpdateDefaultYumRepoNameFor56 do
+  let(:db_stub) { migration_stub(:MiqDatabase) }
+
+  migration_context :up do
+    it "migrates the repo data" do
+      existing_repo = "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+      desired_repo  = "cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+      db = db_stub.create!(:update_repo_name => existing_repo)
+
+      migrate
+
+      expect(db.reload.update_repo_name).to eq(desired_repo)
+    end
+  end
+
+  migration_context :down do
+    it "migrates the data back" do
+      desired_repo  = "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+      existing_repo = "cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+      db = db_stub.create!(:update_repo_name => existing_repo)
+
+      migrate
+
+      expect(db.reload.update_repo_name).to eq(desired_repo)
+    end
+  end
+end

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -7,7 +7,7 @@ describe MiqDatabase do
         db = MiqDatabase.seed
         expect(db.csrf_secret_token_encrypted).to be_encrypted
         expect(db.session_secret_token_encrypted).to be_encrypted
-        expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
+        expect(db.update_repo_name).to eq("cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         expect(db.registration_type).to eq("sm_hosted")
         expect(db.registration_server).to eq("subscription.rhn.redhat.com")
       end
@@ -23,7 +23,7 @@ describe MiqDatabase do
           db = MiqDatabase.seed
           expect(db.csrf_secret_token_encrypted).to be_encrypted
           expect(db.session_secret_token_encrypted).to be_encrypted
-          expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
+          expect(db.update_repo_name).to eq("cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         end
 
         it "will not change existing values" do


### PR DESCRIPTION
The upgrade repos need to be changed after the new release

This PR migrates the current data in the `miq_databases` table if the existing data is the old default and also updates the new default value for the yum repos.

https://bugzilla.redhat.com/show_bug.cgi?id=1351339
