### PR TITLE
Error message for automate names not descriptive

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_class.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class.rb
@@ -12,8 +12,8 @@ class MiqAeClass < ApplicationRecord
 
   validates_presence_of   :name, :namespace_id
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id
-  validates_format_of     :name, :with    => /\A[A-Za-z0-9_.-]+\z/i,
-                                 :message => N_("Only alpha numeric and _ . - characters are allowed")
+  validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
+                                 :message => N_("only alpha numeric and _ . - characters are allowed")
 
   def self.find_by_fqname(fqname, args = {})
     ns, name = parse_fqname(fqname)

--- a/lib/miq_automation_engine/models/miq_ae_class.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class.rb
@@ -12,8 +12,8 @@ class MiqAeClass < ApplicationRecord
 
   validates_presence_of   :name, :namespace_id
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_.-]+\z/i,
-                          :message => "Only alpha numeric and _ . - charachters are allowed"
+  validates_format_of     :name, :with    => /\A[A-Za-z0-9_.-]+\z/i,
+                                 :message => "Only alpha numeric and _ . - charachters are allowed"
 
   def self.find_by_fqname(fqname, args = {})
     ns, name = parse_fqname(fqname)

--- a/lib/miq_automation_engine/models/miq_ae_class.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class.rb
@@ -12,7 +12,8 @@ class MiqAeClass < ApplicationRecord
 
   validates_presence_of   :name, :namespace_id
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_.-]+\z/i
+  validates_format_of     :name, :with => /\A[A-Za-z0-9_.-]+\z/i,
+                          :message => "Only alpha numeric and _ . - charachters are allowed"
 
   def self.find_by_fqname(fqname, args = {})
     ns, name = parse_fqname(fqname)

--- a/lib/miq_automation_engine/models/miq_ae_class.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class.rb
@@ -13,7 +13,7 @@ class MiqAeClass < ApplicationRecord
   validates_presence_of   :name, :namespace_id
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id
   validates_format_of     :name, :with    => /\A[A-Za-z0-9_.-]+\z/i,
-                                 :message => "Only alpha numeric and _ . - charachters are allowed"
+                                 :message => N_("Only alpha numeric and _ . - characters are allowed")
 
   def self.find_by_fqname(fqname, args = {})
     ns, name = parse_fqname(fqname)

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -9,7 +9,7 @@ class MiqAeField < ApplicationRecord
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]
   validates_presence_of   :name
   validates_format_of     :name, :with    => /\A[A-Za-z0-9_]+\z/i,
-                                 :message => "Only alpha numeric and _ charachters are allowed"
+                                 :message => N_("Only alpha numeric and _ characters are allowed")
 
   validates_inclusion_of  :substitute, :in => [true, false]
   AVAILABLE_SCOPES    = ["class", "instance", "local"]

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -8,7 +8,8 @@ class MiqAeField < ApplicationRecord
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]
   validates_presence_of   :name
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_]+\z/i
+  validates_format_of     :name, :with => /\A[A-Za-z0-9_]+\z/i,
+                          :message => "Only alpha numeric and _ charachters are allowed"
 
   validates_inclusion_of  :substitute, :in => [true, false]
   AVAILABLE_SCOPES    = ["class", "instance", "local"]

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -8,8 +8,8 @@ class MiqAeField < ApplicationRecord
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]
   validates_presence_of   :name
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_]+\z/i,
-                          :message => "Only alpha numeric and _ charachters are allowed"
+  validates_format_of     :name, :with    => /\A[A-Za-z0-9_]+\z/i,
+                                 :message => "Only alpha numeric and _ charachters are allowed"
 
   validates_inclusion_of  :substitute, :in => [true, false]
   AVAILABLE_SCOPES    = ["class", "instance", "local"]

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -8,8 +8,8 @@ class MiqAeField < ApplicationRecord
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]
   validates_presence_of   :name
-  validates_format_of     :name, :with    => /\A[A-Za-z0-9_]+\z/i,
-                                 :message => N_("Only alpha numeric and _ characters are allowed")
+  validates_format_of     :name, :with    => /\A[\w]+\z/i,
+                                 :message => N_("only alpha numeric and _ characters are allowed")
 
   validates_inclusion_of  :substitute, :in => [true, false]
   AVAILABLE_SCOPES    = ["class", "instance", "local"]

--- a/lib/miq_automation_engine/models/miq_ae_instance.rb
+++ b/lib/miq_automation_engine/models/miq_ae_instance.rb
@@ -8,8 +8,8 @@ class MiqAeInstance < ApplicationRecord
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
   validates_presence_of   :name
-  validates_format_of     :name, :with    => /\A[A-Za-z0-9_.-]+\z/i,
-                                 :message => N_("Only alpha numeric and _ . - characters are allowed")
+  validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
+                                 :message => N_("only alpha numeric and _ . - characters are allowed")
 
   def self.find_by_name(name)
     where("lower(name) = ?", name.downcase).first

--- a/lib/miq_automation_engine/models/miq_ae_instance.rb
+++ b/lib/miq_automation_engine/models/miq_ae_instance.rb
@@ -9,7 +9,7 @@ class MiqAeInstance < ApplicationRecord
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
   validates_presence_of   :name
   validates_format_of     :name, :with    => /\A[A-Za-z0-9_.-]+\z/i,
-                                 :message => "Only alpha numeric and _ . - charachters are allowed"
+                                 :message => N_("Only alpha numeric and _ . - characters are allowed")
 
   def self.find_by_name(name)
     where("lower(name) = ?", name.downcase).first

--- a/lib/miq_automation_engine/models/miq_ae_instance.rb
+++ b/lib/miq_automation_engine/models/miq_ae_instance.rb
@@ -8,8 +8,8 @@ class MiqAeInstance < ApplicationRecord
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
   validates_presence_of   :name
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_.-]+\z/i,
-                          :message => "Only alpha numeric and _ . - charachters are allowed"
+  validates_format_of     :name, :with    => /\A[A-Za-z0-9_.-]+\z/i,
+                                 :message => "Only alpha numeric and _ . - charachters are allowed"
 
   def self.find_by_name(name)
     where("lower(name) = ?", name.downcase).first

--- a/lib/miq_automation_engine/models/miq_ae_instance.rb
+++ b/lib/miq_automation_engine/models/miq_ae_instance.rb
@@ -8,7 +8,8 @@ class MiqAeInstance < ApplicationRecord
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
   validates_presence_of   :name
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_.-]+\z/i
+  validates_format_of     :name, :with => /\A[A-Za-z0-9_.-]+\z/i,
+                          :message => "Only alpha numeric and _ . - charachters are allowed"
 
   def self.find_by_name(name)
     where("lower(name) = ?", name.downcase).first

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -10,7 +10,8 @@ class MiqAeMethod < ApplicationRecord
 
   validates_presence_of   :name, :scope
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_]+\z/i
+  validates_format_of     :name, :with => /\A[A-Za-z0-9_]+\z/i,
+                          :message => "Only alpha numeric and _ charachters are allowed"
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -10,8 +10,8 @@ class MiqAeMethod < ApplicationRecord
 
   validates_presence_of   :name, :scope
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]
-  validates_format_of     :name, :with    => /\A[A-Za-z0-9_]+\z/i,
-                                 :message => N_("Only alpha numeric and _ characters are allowed")
+  validates_format_of     :name, :with    => /\A[\w]+\z/i,
+                                 :message => N_("only alpha numeric and _ characters are allowed")
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -10,8 +10,8 @@ class MiqAeMethod < ApplicationRecord
 
   validates_presence_of   :name, :scope
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_]+\z/i,
-                          :message => "Only alpha numeric and _ charachters are allowed"
+  validates_format_of     :name, :with    => /\A[A-Za-z0-9_]+\z/i,
+                                 :message => "Only alpha numeric and _ charachters are allowed"
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -11,7 +11,7 @@ class MiqAeMethod < ApplicationRecord
   validates_presence_of   :name, :scope
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]
   validates_format_of     :name, :with    => /\A[A-Za-z0-9_]+\z/i,
-                                 :message => "Only alpha numeric and _ charachters are allowed"
+                                 :message => N_("Only alpha numeric and _ characters are allowed")
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -13,8 +13,8 @@ class MiqAeNamespace < ApplicationRecord
   has_many   :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) },    :class_name => "MiqAeClass",      :foreign_key => :namespace_id, :dependent => :destroy
 
   validates_presence_of   :name
-  validates_format_of     :name, :with    => /\A[A-Za-z0-9_\.\-\$]+\z/i,
-                                 :message => N_("Only alpha numeric and _ . - $ characters are allowed")
+  validates_format_of     :name, :with    => /\A[\w\.\-\$]+\z/i,
+                                 :message => N_("only alpha numeric and _ . - $ characters are allowed")
   validates_uniqueness_of :name, :scope => :parent_id
 
   def self.find_by_fqname(fqname, include_classes = true)

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -13,7 +13,8 @@ class MiqAeNamespace < ApplicationRecord
   has_many   :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) },    :class_name => "MiqAeClass",      :foreign_key => :namespace_id, :dependent => :destroy
 
   validates_presence_of   :name
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_\.\-\$]+\z/i
+  validates_format_of     :name, :with => /\A[A-Za-z0-9_\.\-\$]+\z/i,
+                          :message => "Only alpha numeric and _ . - $ charachters are allowed"
   validates_uniqueness_of :name, :scope => :parent_id
 
   def self.find_by_fqname(fqname, include_classes = true)

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -13,8 +13,8 @@ class MiqAeNamespace < ApplicationRecord
   has_many   :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) },    :class_name => "MiqAeClass",      :foreign_key => :namespace_id, :dependent => :destroy
 
   validates_presence_of   :name
-  validates_format_of     :name, :with => /\A[A-Za-z0-9_\.\-\$]+\z/i,
-                          :message => "Only alpha numeric and _ . - $ charachters are allowed"
+  validates_format_of     :name, :with    => /\A[A-Za-z0-9_\.\-\$]+\z/i,
+                                 :message => "Only alpha numeric and _ . - $ charachters are allowed"
   validates_uniqueness_of :name, :scope => :parent_id
 
   def self.find_by_fqname(fqname, include_classes = true)

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -14,7 +14,7 @@ class MiqAeNamespace < ApplicationRecord
 
   validates_presence_of   :name
   validates_format_of     :name, :with    => /\A[A-Za-z0-9_\.\-\$]+\z/i,
-                                 :message => "Only alpha numeric and _ . - $ charachters are allowed"
+                                 :message => N_("Only alpha numeric and _ . - $ characters are allowed")
   validates_uniqueness_of :name, :scope => :parent_id
 
   def self.find_by_fqname(fqname, include_classes = true)


### PR DESCRIPTION
Purpose or Intent
-----------------
> When we create a new domain, namespace, class, instance, method or field in Automate, the name goes thru a validation process. If the name contains invalid characters we display the default message "Name is Invalid". The user doesn't know which are  the valid characters. This PR adds the valid characters to the message
> 
Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1347158

New Message
![newerrormessage](https://cloud.githubusercontent.com/assets/6452699/16467568/ede419c4-3e15-11e6-983e-9c4b0fef4741.png)

Old Message
![olderrormessage](https://cloud.githubusercontent.com/assets/6452699/16467589/027f19a6-3e16-11e6-8df3-c6968c607f96.png)


