### PR TITLE
Dashboard report widget styling fix

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,4 +1,5 @@
 // Product overrides of Boostrap & Patternfly variables
+$screen-lg:                                 1400px;  // add 200px to account for vertical nav
 $navbar-pf-navbar-navbar-brand-min-width:   270px;
 $navbar-pf-navbar-navbar-brand-padding:     8px 0 2px;
 $dropdown-link-hover-bg:                    #d4edfa;  // sets dropdown link hover


### PR DESCRIPTION
The new vertical navigation compressed the Bootstrap Grid within the viewport by 200 pixels. This created a problem for certain multi-column report widgets in the 3-column dashboard layout (and most likely elsewhere). This PR adds 200 pixels to the large device breakpoint, alleviating the problem.

https://bugzilla.redhat.com/show_bug.cgi?id=1347653

Old
<img width="1157" alt="screen shot 2016-06-29 at 5 01 30 pm" src="https://cloud.githubusercontent.com/assets/1287144/16468855/ed957cc8-3e1b-11e6-8975-02d4eb176ad2.png">

New
<img width="1268" alt="screen shot 2016-06-29 at 5 00 48 pm" src="https://cloud.githubusercontent.com/assets/1287144/16468856/ed99bc34-3e1b-11e6-94b9-8069bf947871.png">