### PR TITLE
Define the dynamic url spec helper methods once

### DIFF
--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -88,32 +88,23 @@ module ApiSpecHelper
     Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
     @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
-    define_entrypoint_url_methods
-    define_url_methods(Api::Settings.collections.keys)
     define_user
 
     ApplicationController.handle_exceptions = true
   end
 
-  def define_entrypoint_url_methods
-    self.class.class_eval do
-      define_method(:entrypoint_url) do
-        api_config(:entrypoint)
-      end
-      define_method(:auth_url) do
-        "#{api_config(:entrypoint)}/auth"
-      end
-    end
+  def entrypoint_url
+    api_config(:entrypoint)
   end
 
-  def define_url_methods(collections)
-    collections.each do |collection|
-      self.class.class_eval do
-        define_method("#{collection}_url".to_sym) do |id = nil|
-          path = "#{api_config(:entrypoint)}/#{collection}"
-          id.nil? ? path : "#{path}/#{id}"
-        end
-      end
+  def auth_url
+    "#{api_config(:entrypoint)}/auth"
+  end
+
+  (Api::Settings.collections.keys - [:auth]).each do |collection|
+    define_method("#{collection}_url".to_sym) do |id = nil|
+      path = "#{api_config(:entrypoint)}/#{collection}"
+      id.nil? ? path : "#{path}/#{id}"
     end
   end
 


### PR DESCRIPTION
The ApiSpecHelper module gets included into every API example group,
making its methods available to every example. However, as it stands the
dynamically defined <collection>_url methods get defined in the context
of each example group, and they get defined (and redefined) on every
single test.

This updates entrypoint_url and auth_url to be statically defined
methods in ApiSpecHelper, and the other collections have their methods
defined dynamically in the context of the module too, so they will get
included once in each example group.

This change also excludes :auth from being dynamically defined, which
was erroneously let in by #9522. This was not a breaking change as it
stands, it just allowed auth_url to be called with an optional id
argument.

Even though there is now less work being done I did not notice a
measurable difference in runtime for the API specs.

@miq-bot add-label api, test, refactoring, darga/no
@miq-bot assign @abellotti 