### PR TITLE
Upgrade fog-openstack to 0.1.7

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -22,7 +22,7 @@ gem "excon",                   "~>0.40",            :require => false
 gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
-gem "fog-openstack",           "~>0.1.6",           :require => false
+gem "fog-openstack",           "~>0.1.7",           :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.2",           :require => false
 gem "iniparse",                                     :require => false


### PR DESCRIPTION
This PR upgrades the fog-opentack gem to 0.1.7
This change is needed to support host aggregates,
as the 0.1.7 fog-openstack gem fixes several bugs
related to aggregates.