### PR TITLE
Adding a box to endpoint authentication for RHEVM Metrics Database

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -30,6 +30,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       amqp_verify: '',
       metrics_userid: '',
       metrics_password: '',
+      metrics_database_name: '',
       metrics_verify: '',
       ssh_keypair_userid: '',
       ssh_keypair_password: '',
@@ -111,6 +112,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.amqp_api_port                   = angular.isDefined(data.amqp_api_port) && data.amqp_api_port != '' ? data.amqp_api_port.toString() : '5672';
         $scope.emsCommonModel.hawkular_api_port               = angular.isDefined(data.hawkular_api_port) && data.hawkular_api_port != '' ? data.hawkular_api_port.toString() : '443';
         $scope.emsCommonModel.metrics_api_port                = angular.isDefined(data.metrics_api_port) && data.metrics_api_port != '' ? data.metrics_api_port.toString() : '';
+        $scope.emsCommonModel.metrics_database_name           = angular.isDefined(data.metrics_database_name) && data.metrics_database_name != '' ? data.metrics_database_name : data.metrics_default_database_name;
         $scope.emsCommonModel.api_version                     = data.api_version;
         $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
         $scope.emsCommonModel.realm                           = data.realm;
@@ -305,6 +307,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.note = $scope.realmNote;
     } else if ($scope.emsCommonModel.emstype === 'rhevm') {
       $scope.emsCommonModel.metrics_api_port = "5432";
+      $scope.emsCommonModel.metrics_database_name = "ovirt_engine_history";
     } else if ($scope.emsCommonModel.ems_controller === 'ems_container') {
       $scope.emsCommonModel.default_api_port = "8443";
     }

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -188,8 +188,18 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
   def history_database_name
     @history_database_name ||= begin
-      require 'ovirt_metrics'
-      version_3_0? ? OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME_3_0 : OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME
+      version = version_3_0? ? '3_0' : '>3_0'
+      self.class.history_database_name_for(version)
+    end
+  end
+
+  def self.history_database_name_for(api_version)
+    require 'ovirt_metrics'
+    case api_version
+    when '3_0'
+      OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME_3_0
+    else
+      OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME
     end
   end
 

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -50,6 +50,26 @@
       %span.help-block{"ng-show" => "angularForm.#{prefix}_api_port.$error.detectedSpaces"}
         = _("Spaces are prohibited")
 
+%div{"ng-if" => defined?(database_name_show) ? true : false}
+  .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_database_name.$invalid}",
+    "ng-if" => "emsCommonModel.emstype == 'rhevm'"} |
+    %label.col-md-2.control-label{"for" => "#{prefix}_database_name"}
+      = _('Database Name')
+    .col-md-8
+      %input.form-control{"type"          => "text",
+                          "id"            => "#{prefix}_database_name",
+                          "name"          => "#{prefix}_database_name",
+                          "ng-model"      => "#{ng_model}.#{prefix}_database_name",
+                          "maxlength"     => 40,
+                          "required"      => defined?(database_name_required) ? true : false,
+                          "checkchange"   => "",
+                          "ng-trim"       => false,
+                          "detect-spaces" => ""}
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_database_name.$error.required"}
+        = _("Required")
+      %span.help-block{"ng-show" => "angularForm.#{prefix}_database_name.$error.detectedSpaces"}
+        = _("Spaces are prohibited")
+
 %div{"ng-if" => defined?(security_protocol_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
               "ng-if"    => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'scvmm'"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -129,6 +129,8 @@
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",
                                               :id                     => record.id,
+                                              :database_name_required => true,
+                                              :database_name_show     => true,
                                               :prefix                 => "metrics",
                                               :ng_reqd_hostname       => "#{ng_model}.metrics_userid != '' && #{ng_model}.metrics_userid != undefined",
                                               :ng_reqd_api_port       => "false"}

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -265,7 +265,7 @@ describe EmsCloudController do
                                        :button    => "validate",
                                        :id        => mocked_ems.id,
                                        :cred_type => "default")
-      expect(mocked_ems).to receive(:authentication_check).with("default", :save => false)
+      expect(mocked_ems).to receive(:authentication_check).with("default", hash_including(:save => false))
       controller.send(:update_ems_button_validate, mocked_ems)
     end
 
@@ -276,7 +276,7 @@ describe EmsCloudController do
                                        :button           => "validate",
                                        :default_password => "[FILTERED]",
                                        :cred_type        => "default")
-      expect(mocked_ems).to receive(:authentication_check).with("default", :save => false)
+      expect(mocked_ems).to receive(:authentication_check).with("default", hash_including(:save => false))
       controller.send(:update_ems_button_validate, mocked_ems)
     end
   end


### PR DESCRIPTION
The RHEVM data warehouse database name might change from the default in
some cases. So a place to input a custom database name was added to the
"C & U Database" tab in the interface to edit the RHEVM provider.

@miq-bot remove-label wip
![1184113](https://cloud.githubusercontent.com/assets/3274731/16729154/52926f86-4773-11e6-9f1c-f4c81ffa828b.png)
