### PR TITLE
conditionally require manageiq-providers-amazon in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,11 @@ gem "deep_merge",                      "~>1.0.1", :git => "git://github.com/Mana
 path "gems/" do
   gem "manageiq_foreman", :require => false
 end
-gem "manageiq-providers-amazon", :git => "git://github.com/ManageIQ/manageiq-providers-amazon", :branch => "master"
+
+# when using this Gemfile inside a providers Gemfile, the dependency for the provider is already declared
+unless dependencies.detect { |d| d.name == 'manageiq-providers-amazon' }
+  gem "manageiq-providers-amazon", :git => "git://github.com/ManageIQ/manageiq-providers-amazon", :branch => "master"
+end
 
 # Client-side dependencies
 gem "angular-ui-bootstrap-rails",     "~>0.13.0"


### PR DESCRIPTION
when using the Gemfile inside the provider repo the dependency on manageiq-providers-amazon is already defined

using this in favor of https://github.com/ManageIQ/manageiq/pull/9507

@miq-bot refactoring

@Fryguy I think this is better?!
