### PR TITLE
Chart interactivity

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -641,7 +641,6 @@ function miqChartLinkData(col, row, value, category, series, id, message) {
 }
 
 function miqBuildChartMenu(col, row, _value, category, series, id, _message) {
-  console.log('miqBuildChartMenuEx');
   var set = id.split('_')[1]; // Get the chart set
   var idx = id.split('_')[2]; // Get the chart index
   var chart_data = ManageIQ.charts.chartData[set];
@@ -662,7 +661,6 @@ function miqBuildChartMenu(col, row, _value, category, series, id, _message) {
       }
 
       var menu_title = chart_data[idx].menu[i].split(":")[1];
-      console.log(menu_title);
       menu_title = menu_title.replace("<series>", series);
       menu_title = menu_title.replace("<category>", category);
       $("#" + pid).append("<li><a id='" + menu_id +

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -641,6 +641,7 @@ function miqChartLinkData(col, row, value, category, series, id, message) {
 }
 
 function miqBuildChartMenu(col, row, _value, category, series, id, _message) {
+  console.log('miqBuildChartMenuEx');
   var set = id.split('_')[1]; // Get the chart set
   var idx = id.split('_')[2]; // Get the chart index
   var chart_data = ManageIQ.charts.chartData[set];
@@ -661,6 +662,7 @@ function miqBuildChartMenu(col, row, _value, category, series, id, _message) {
       }
 
       var menu_title = chart_data[idx].menu[i].split(":")[1];
+      console.log(menu_title);
       menu_title = menu_title.replace("<series>", series);
       menu_title = menu_title.replace("<category>", category);
       $("#" + pid).append("<li><a id='" + menu_id +

--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -25,15 +25,15 @@ function load_c3_chart(data, chart_id, height) {
   var generate_args = chartData(data.miqChart, data, { bindto: "#" + chart_id, size: {height: height}})
 
   generate_args.data.onclick = function (data, _i) {
-    var seriesIndex = data.id - 1;
-    var pointIndex = data.x;
+    var seriesIndex = _.isObject(data.id) ? data.id - 1 : _.findIndex(generate_args.data.columns, {0 : data.name})
+    var pointIndex = _.isObject(data.x) ? data.x.getHours() : _.findIndex(generate_args.data.columns, {0 : data.name})
+    var value = data.value;
 
     var parts = chart_id.split('_'); //miq_chart_candu_2
     var chart_set   = parts[2];
     var chart_index = parts[3];
-    console.log('before miqBuildChartMenuEx');
-    miqBuildChartMenuEx(pointIndex, seriesIndex, null, 'CAT', data.name, chart_set, chart_index);
-    console.log('after miqBuildChartMenuEx');
+
+    miqBuildChartMenuEx(pointIndex, seriesIndex, value, data.id, data.name, chart_set, chart_index);
 
     // This is to allow the bootstrap pop-up to be manually fired from the chart's click event
     // and have it closed by clicking outside of the pop-up menu.

--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -31,8 +31,9 @@ function load_c3_chart(data, chart_id, height) {
     var parts = chart_id.split('_'); //miq_chart_candu_2
     var chart_set   = parts[2];
     var chart_index = parts[3];
-
+    console.log('before miqBuildChartMenuEx');
     miqBuildChartMenuEx(pointIndex, seriesIndex, null, 'CAT', data.name, chart_set, chart_index);
+    console.log('after miqBuildChartMenuEx');
 
     // This is to allow the bootstrap pop-up to be manually fired from the chart's click event
     // and have it closed by clicking outside of the pop-up menu.

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -156,6 +156,8 @@ module ReportFormatter
       return no_records_found_chart if series.empty?
 
       add_axis_category_text(categories)
+
+      series.zip(categories) { |ser, category| ser[:tooltip] = category }
       add_series('', series)
     end
 


### PR DESCRIPTION
Add some missing pieces for chart interactivity. Mostly just modify parameters we pass to functions..
In UI you can get there by clicking on: Compute -> Infrastructure -> Host / Nodes OR Virtual Machines OR Clusters -> select something with C&U enabled -> Monitoring -> Utilitization -> then just left click on charts and interactivity menu will appear. For each entity menu has different items.

![screenshot from 2016-07-19 13-16-55](https://cloud.githubusercontent.com/assets/9535558/16948127/2d36950a-4db3-11e6-9c19-7f3ac1c4fb87.png)

Display top VMs:
![screenshot from 2016-07-19 13-17-53](https://cloud.githubusercontent.com/assets/9535558/16948142/4766083e-4db3-11e6-823c-972aa19e82d1.png)



@martinpovolny review please