### PR TITLE
DRY: Centralize policy & condition folder list

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -13,6 +13,14 @@ class MiqPolicyController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  # These all should typically be the same but the separation is useful when landing support in parts.
+  POLICY_FOLDERS = HashWithIndifferentAccess.new(
+    :compliance => [Host, Vm, ContainerImage],
+    :control    => [Host, Vm, ContainerImage]
+  ).freeze
+
+  CONDITION_FOLDERS = [Host, Vm, ContainerImage].freeze
+
   def index
     redirect_to :action => 'explorer'
   end
@@ -954,11 +962,14 @@ class MiqPolicyController < ApplicationController
     @sb[:folder] = nodeid.nil? ? nodetype.split("-").last : nodeid
     if x_active_tree == :policy_tree
       if nodeid.nil? && ["compliance", "control"].include?(nodetype.split('-').last)
-        @folders = MiqPolicy::UI_FOLDERS.collect do |model|
-          "#{model.name.titleize} #{nodetype.split('-').last.titleize}"
+        # level 1 - compliance & control
+        _, mode = nodetype.split('-')
+        @folders = POLICY_FOLDERS[mode].collect do |model|
+          "#{model.name.titleize} #{mode.titleize}"
         end
-        @right_cell_text = _("%{typ} %{model}") % {:typ => nodetype.split('-').last.titleize, :model => ui_lookup(:models => "MiqPolicy")}
+        @right_cell_text = _("%{typ} %{model}") % {:typ => mode.titleize, :model => ui_lookup(:models => "MiqPolicy")}
       else
+        # level 2 - host, vm, etc. under compliance/control - OR deeper levels
         @sb[:mode] = nodeid.split("-")[1]
         @sb[:nodeid] = nodeid.split("-").last
         @sb[:folder] = "#{nodeid.split("-")[1]}-#{nodeid.split("-")[2]}"

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -223,7 +223,7 @@ module MiqPolicyController::Conditions
   end
 
   def condition_get_all_folders
-    @folders = MiqPolicy::UI_FOLDERS.collect(&:name)
+    @folders = MiqPolicyController::CONDITION_FOLDERS.collect(&:name)
     @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "Condition")}
     @right_cell_div = "condition_folders"
   end

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -226,7 +226,8 @@ module MiqPolicyController::Policies
 
   def policy_get_all_folders(parent = nil)
     if !parent.nil?
-      @folders = MiqPolicy::UI_FOLDERS.collect(&:name)
+      # TODO: this is dead code, the one caller passes no arguments
+      @folders = MiqPolicyController::POLICY_FOLDERS[parent.downcase].collect(&:name)
       @right_cell_text = _("%{typ} %{model}") % {:typ => parent, :model => ui_lookup(:models => "MiqPolicy")}
       @right_cell_div = "policy_folders"
     else

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -35,8 +35,6 @@ class MiqPolicy < ApplicationRecord
 
   @@built_in_policies = nil
 
-  UI_FOLDERS = [Host, Vm, ContainerImage].freeze
-
   def self.built_in_policies
     return @@built_in_policies.dup unless @@built_in_policies.nil?
 

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -21,7 +21,7 @@ class TreeBuilderCondition < TreeBuilder
   # level 1 - host / vm
   def x_get_tree_roots(count_only, _options)
     text_i18n = {:Host           => N_("Host Conditions"),
-                 :Vm             => N_("All VM and Instance Conditions"),
+                 :Vm             => N_("VM and Instance Conditions"),
                  :ContainerImage => N_("Container Image Conditions")}
 
     objects = MiqPolicyController::CONDITION_FOLDERS.collect do |model|

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -20,21 +20,27 @@ class TreeBuilderCondition < TreeBuilder
 
   # level 1 - host / vm
   def x_get_tree_roots(count_only, _options)
-    objects = []
-    objects << {:id => "host", :text => N_("Host Conditions"), :image => "host", :tip => N_("Host Conditions")}
-    objects << {:id => "vm", :text => N_("All VM and Instance Conditions"), :image => "vm", :tip => N_("All VM and Instance Conditions")}
-    objects << {:id => "containerImage", :text => N_("Container Image Conditions"), :image => "container_image", :tip => N_("All Container Image Conditions")}
+    text_i18n = {:Host           => N_("Host Conditions"),
+                 :Vm             => N_("All VM and Instance Conditions"),
+                 :ContainerImage => N_("Container Image Conditions")}
 
+    objects = MiqPolicyController::CONDITION_FOLDERS.collect do |model|
+      text = text_i18n[model.name.to_sym]
+      {:id    => model.name.camelize(:lower),
+       :image => model.name.underscore,
+       :text  => text,
+       :tip   => text}
+    end
     count_only_or_objects(count_only, objects)
   end
 
   # level 2 - conditions
   def x_get_tree_custom_kids(parent, count_only, options)
     assert_type(options[:type], :condition)
-    return super unless %w(host vm containerImage).include?(parent[:id])
+    towhat = parent[:id].camelize
+    return super unless MiqPolicyController::CONDITION_FOLDERS.collect(&:name).include?(towhat)
 
-    objects = Condition.where(:towhat => parent[:id].camelize)
-
+    objects = Condition.where(:towhat => towhat)
     count_only_or_objects(count_only, objects, :description)
   end
 end

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -16,27 +16,21 @@ class TreeBuilderPolicy < TreeBuilder
     )
   end
 
-  def compliance_control_kids(pid)
-    text_i18n = {:compliance => {:host            => N_("Host Compliance Policies"),
-                                 :vm              => N_("Vm Compliance Policies"),
-                                 :container_image => N_("Container Image Compliance Policies")},
-                 :control    => {:host            => N_("Host Control Policies"),
-                                 :vm              => N_("Vm Control Policies"),
-                                 :container_image => N_("Container Image Control Policies")}}
+  def compliance_control_kids(mode)
+    text_i18n = {:compliance => {:Host           => N_("Host Compliance Policies"),
+                                 :Vm             => N_("Vm Compliance Policies"),
+                                 :ContainerImage => N_("Container Image Compliance Policies")},
+                 :control    => {:Host           => N_("Host Control Policies"),
+                                 :Vm             => N_("Vm Control Policies"),
+                                 :ContainerImage => N_("Container Image Control Policies")}}
 
-    [{:id    => "#{pid}-host",
-      :text  => text_i18n[pid.to_sym][:host],
-      :image => "host",
-      :tip   => N_("Host Policies")},
-     {:id    => "#{pid}-vm",
-      :text  => text_i18n[pid.to_sym][:vm],
-      :image => "vm",
-      :tip   => N_("Vm Policies")},
-     {:id    => "#{pid}-containerImage",
-      :text  => text_i18n[pid.to_sym][:container_image],
-      :image => "container_image",
-      :tip   => N_("Container Image Policies")
-     }]
+    MiqPolicyController::POLICY_FOLDERS[mode].collect do |model|
+      text = text_i18n[mode.to_sym][model.name.to_sym]
+      {:id    => "#{mode}-#{model.name.camelize(:lower)}",
+       :image => model.name.underscore,
+       :text  => text,
+       :tip   => text}
+    end
   end
 
   # level 0 - root
@@ -46,12 +40,12 @@ class TreeBuilderPolicy < TreeBuilder
 
   # level 1 - compliance & control
   def x_get_tree_roots(count_only, _options)
-    # Push folder node ids onto open_nodes array
-    %w(xx-compliance xx-control).each { |n| open_node(n) }
-
     objects = []
     objects << {:id => "compliance", :text => N_("Compliance Policies"), :image => "compliance", :tip => N_("Compliance Policies")}
     objects << {:id => "control", :text => N_("Control Policies"), :image => "control", :tip => N_("Control Policies")}
+
+    # Push folder node ids onto open_nodes array
+    objects.each { |o| open_node("xx-#{o[:id]}") }
 
     count_only_or_objects(count_only, objects)
   end
@@ -60,27 +54,28 @@ class TreeBuilderPolicy < TreeBuilder
   def x_get_tree_custom_kids(parent, count_only, options)
     assert_type(options[:type], :policy)
 
-    # level 2 - host and vm under compliance/control
+    # level 2 - host, vm, etc. under compliance/control
     if %w(compliance control).include?(parent[:id])
-      pid = parent[:id]
+      mode = parent[:id]
+      objects = compliance_control_kids(mode)
 
       # Push folder node ids onto open_nodes array
-      %W(xx-#{pid}_xx-#{pid}-host xx-#{pid}_xx-#{pid}-vm xx-#{pid}_xx-#{pid}-containerImage).each { |n| open_node(n) }
+      objects.each { |o| open_node("xx-#{mode}_xx-#{o[:id]}") }
 
-      objects = compliance_control_kids(pid)
-      count_only_or_objects(count_only, objects)
-    # level 3 - actual policies
-    elsif %w(host vm containerImage).include?(parent[:id].split('-').last)
-      mode, towhat = parent[:id].split('-')
-
-      objects = MiqPolicy.where(:mode   => mode.downcase,
-                                :towhat => towhat.camelize)
-
-      count_only_or_objects(count_only, objects, :description)
-    else
-      # error checking
-      super
+      return count_only_or_objects(count_only, objects)
     end
+
+    # level 3 - actual policies
+    mode, towhat = parent[:id].split('-')
+    towhat = towhat.camelize
+    if MiqPolicyController::POLICY_FOLDERS[mode.to_sym].collect(&:name).include?(towhat)
+      objects = MiqPolicy.where(:mode => mode, :towhat => towhat)
+
+      return count_only_or_objects(count_only, objects, :description)
+    end
+
+    # error checking
+    super
   end
 
   # level 4 - conditions & events for policy


### PR DESCRIPTION
**NOTE: Please do NOT merge into master without backporting.**  See [below](https://github.com/ManageIQ/manageiq/pull/9538#issuecomment-230142916).

This continues refactoring from #7132 which created MiqPolicy::UI_FOLDERS and:

 1. Moves it into controller (there was agreement it doesn't belong in a model; don't know if this is the Right place but at least more UI-related).
 2. Expands use instead of hardcoded lists in more places.
 3. Separates control pol. / compliance pol. / conditions consts.
    Motivation: While working on #8815, I saw that landing support for everything at once would require an impractically-huge PR.  This will allow e.g. merging control additions before compliance.

Tested manually both by subsetting each of the 3 lists, and by testing my future container additions on top of it.

@miq-bot add-labels refactoring, contorol, ui, darga/yes

Needed for
https://bugzilla.redhat.com/show_bug.cgi?id=1341253 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1346057 (darga)
I strived to keep this refactoring as minimal as possible, so it's reasonable to backport.
It makes the darga/yes #8815 much cleaner.
(compare 114bc120aa191c15282c1b244bb63b3cadef864b extending literal lists all over the place with 10bb5e759e0ea5f79888ceae9e82065b396acec1 that does it less.)

Things that are not pure refactoring:
- I dropped some text-vs-tooltip distinctions.
- There is 1 msgid change (requiring new translation).  If you don't want to backport that, let me know and I'll take the 2nd commit out of this PR.