### PR TITLE
Ensure GitRepository.verify_ssl is either 0 or 1

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -4,6 +4,7 @@ class GitRepository < ApplicationRecord
   validates :url, :format => URI::regexp(%w(http https)), :allow_nil => false
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
+  validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
 
   has_many :git_branches, :dependent => :destroy
   has_many :git_tags, :dependent => :destroy


### PR DESCRIPTION
At this point, we don't have any code in the application that
instantiates `GitRepository`, so we perhaps don't need migration for this.
It is safe to add the validation now, before we have api end-point for
git repositories.

The semantics of this attribute is that we skip verification when `:verify_ssl == 0`. The use of SSL constants was advised in https://github.com/ManageIQ/manageiq/pull/7240#discussion_r58731437 

@miq-bot add_label automate, darga/no