### PR TITLE
Translatable policy folder names under Control -> Explorer -> Policies

### DIFF
--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -41,7 +41,7 @@ class TreeBuilderPolicy < TreeBuilder
 
   # level 0 - root
   def root_options
-    [t = N_("All Policies"), t]
+    [t = _("All Policies"), t]
   end
 
   # level 1 - compliance & control

--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -1,4 +1,12 @@
 - if @folders
+  - folders_i18n = { "Compliance"                 => _("Compliance Policies"),
+                     "Control"                    => _("Control Policies"),
+                     "Host Compliance"            => _("Host Compliance Policies"),
+                     "Vm Compliance"              => _("Vm Compliance Policies"),
+                     "Container Image Compliance" => _("Container Image Compliance Policies"),
+                     "Host Control"               => _("Host Control Policies"),
+                     "Vm Control"                 => _("Vm Control Policies"),
+                     "Container Image Control"    => _("Container Image Control Policies")}
   = render :partial => "layouts/flash_msg"
   %table.table.table-striped.table-bordered.table-hover
     %tbody
@@ -14,4 +22,4 @@
           %td.narrow
             %img{:src => image_path("100/#{model_name.underscore}.png")}
           %td
-            = _("%s Policies") % h(f == "Vm" ? ui_lookup(:model => f) : f)
+            = folders_i18n[f]


### PR DESCRIPTION
This is to make sure the folder names are consistent with what is rendered on the left
in the explorer tree.

Before
![policies-before](https://cloud.githubusercontent.com/assets/6648365/16489785/4e76e76e-3ed7-11e6-9bed-89f7aae043a8.jpg)

After
![policies-after](https://cloud.githubusercontent.com/assets/6648365/16489793/5488363a-3ed7-11e6-878d-b28f3cb1c5a1.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1340808