### PR TITLE
Patch Config::Options with fetch_path

### DIFF
--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -457,7 +457,7 @@ class ApiController
       return unless is_subcollection
       ctype = @req.collection.to_sym
       sakey = "#{@req.subcollection}_subcollection_actions".to_sym
-      collection_config[ctype][sakey] && collection_config[ctype][sakey][method.to_sym]
+      collection_config.fetch_path(ctype, sakey, method.to_sym)
     end
 
     def api_user_role_allows?(action_identifier)

--- a/lib/api/settings.rb
+++ b/lib/api/settings.rb
@@ -1,3 +1,5 @@
+require "config"
+
 module Api
   Settings = ::Config::Options.new.tap do |o|
     o.add_source!(Rails.root.join("config/api.yml").to_s)

--- a/lib/patches/config_patch.rb
+++ b/lib/patches/config_patch.rb
@@ -11,3 +11,4 @@ module ConfigDecryptPasswords
 end
 
 Config::Options.prepend(ConfigDecryptPasswords)
+Config::Options.include(MoreCoreExtensions::Shared::Nested)

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -9,8 +9,7 @@ describe ApiController do
   end
 
   def test_collection_query(collection, collection_url, klass, attr = :id)
-    collection_actions = Api::Settings.collections[collection][:collection_actions]
-    if collection_actions && collection_actions[:get]
+    if Api::Settings.fetch_path(:collections, collection, :collection_actions, :get)
       api_basic_authorize collection_action_identifier(collection, :read, :get)
     else
       api_basic_authorize


### PR DESCRIPTION
Purpose or Intent
-----------------
Includes `MoreCoreExtensions::Shared::Nested` in `Config::Options` so that some of the API code can be simplified with `#fetch_path`

@miq-bot add-label api, core, darga/no
@miq-bot assign @abellotti 