### PR TITLE
Truncate request user_message and add test.

### DIFF
--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -14,6 +14,7 @@ module MiqRequestMixin
   end
 
   def user_message=(msg)
+    msg = msg.truncate(255)
     options[:user_message] = msg
     update_attribute(:options, options)
     update_attributes(:message => msg) unless msg.blank?

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
@@ -42,5 +42,12 @@ module MiqAeServiceServiceTemplateProvisionRequestSpec
       expect(@service_template_provision_request.reload.message).to eq("fred")
       expect(@service_template_provision_request.reload.options[:user_message]).to be_blank
     end
+
+    it "#truncated user_message" do
+      msg = "ReallyLongString" * 20
+      expect(msg.length).to be > 255
+      service_service_template_provision_request.user_message = msg
+      expect(@service_template_provision_request.reload.message.length).to eq(255)
+    end
   end
 end


### PR DESCRIPTION
Each automate method that sets the user_message has to truncate the message length to 255. 
Fixing it in the mixin makes more sense.  

Will make followup PR to remove the truncate from the automate methods.

https://bugzilla.redhat.com/show_bug.cgi?id=1353730

Original complaint about user message length.
https://bugzilla.redhat.com/show_bug.cgi?id=1252849
https://github.com/ManageIQ/manageiq/pull/4129

Original Error:
[----] E, [2015-08-28T11:47:10.309347 #6179:46f6220] ERROR -- : Q-task_id([service_template_provision_task_4]) <AutomationEngine> The following error occurred during instance method <user_message=> for AR object <#<ServiceTemplateProvisionRequest id: 4, description: "Provisioning Service [Wordpress] from [Wordpress]", approval_state: "approved", type: "ServiceTemplateProvisionRequest", created_on: "2015-08-28 15:46:35", updated_on: "2015-08-28 15:47:10", fulfilled_on: nil, requester_id: 1, requester_name: "Administrator", request_type: "clone_to_service", request_state: "pending", message: "Expected(201) <=> Actual(400 Bad Request)\nexcon.err...", status: "Ok", options: {:dialog=>{"dialog_stack_name"=>"wp-test", "dialog_stack_onfailure"=>"ROLLBACK", "dialog_stack_timeout"=>nil, "dialog_param_image"=>"Fedora22", "dialog_param_flavor"=>"m1.small", "dialog_param_key"=>"userkey", "dialog_param_private_network"=>"tenant-net", "dialog_param_public_network"=>"public-net", "password::dialog_param_DBRootPassword"=>"v2:{d/AiAQBRT9hsL6jtf2WIkg==}", "dialog_param_DBName"=>"wordpress", "dialog_param_DBUsername"=>"admin", "password::dialog_param_DBPassword"=>"v2:{d/AiAQBRT9hsL6jtf2WIkg==}"}, :workflow_settings=>{:resource_action_id=>101, :dialog_id=>2}, :src_id=>1, :delivered_on=>2015-08-28 15:46:50 UTC, :pass=>0, :user_message=>"Expected(201) <=> Actual(400 Bad Request)\nexcon.error.response\n  :body          => \"{\\\"explanation\\\": \\\"The server could not comply with the request since it is either malformed or otherwise incorrect.\\\", \\\"code\\\": 400, \\\"error\\\": {\\\"message\\\": \\\"Property error : my_instance: key_name Error validating value u'userkey': The Key (userkey) could not be found.\\\", \\\"traceback\\\": null, \\\"type\\\": \\\"StackValidationFailed\\\"}, \\\"title\\\": \\\"Bad Request\\\"}\"\n  :headers       => {\n    \"Content-Length\"         => \"342\"\n    \"Content-Type\"           => \"application/json; charset=UTF-8\"\n    \"Date\"                   => \"Fri, 28 Aug 2015 15:47:59 GMT\"\n    \"X-Openstack-Request-Id\" => \"req-17493d41-62de-46f8-999a-c9313a2670a5\"\n  }\n  :local_address => \"10.3.59.198\"\n  :local_port    => 49558\n  :reason_phrase => \"Bad Request\"\n  :remote_ip     => \"10.3.53.10\"\n  :status        => 400\n  :status_line   => \"HTTP/1.1 400 Bad Request\\r\\n\"\n (MiqException::MiqOrchestrationProvisionError)"}, userid: "admin", source_id: 1, source_type: "ServiceTemplate", destination_id: nil, destination_type: nil>>
[----] E, [2015-08-28T11:47:10.309645 #6179:46f6220] ERROR -- : Q-task_id([service_template_provision_task_4]) <AutomationEngine> MiqAeServiceModelBase.ar_method raised: <ActiveRecord::StatementInvalid>: <Database statement error encountered>
[----] E, [2015-08-28T11:47:10.309856 #6179:46f6220] ERROR -- : Q-task_id([service_template_provision_task_4]) <AutomationEngine> /opt/rh/cfme-gemset/bundler/gems/rails-