### PR TITLE
Do not assume location property exists for list_all results for Azure.

### DIFF
--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -24,7 +24,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   def gather_data_for_this_region(arm_service, method_name = 'list_all')
     if method_name.to_s == 'list_all'
       arm_service.send(method_name).select do |resource|
-        resource.location == @ems.provider_region
+        resource.try(:location) == @ems.provider_region
       end.flatten
     else
       resource_groups.collect do |resource_group|


### PR DESCRIPTION
It turns out that not necessarily every resource returned from a list_all method in the azure-armrest gem will necessarily have a location property. Specifically, network interface cards that are part of a scale set do not have this property set, and are effectively "private". These are not listed under the regular list of network interface cards that you can see in the azure portal, so skipping them matches the portal's current behavior.

So, this PR just checks to ensure that the resource has a location property first before attempting a comparison.



