### PR TITLE
Link MiQ Alerts with Hawkular Events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -227,6 +227,7 @@ class EmsEvent < EventStream
 
     target_type = "src_vm_or_template"  if target_type == "src_vm"
     target_type = "dest_vm_or_template" if target_type == "dest_vm"
+    target_type = "middleware_server"   if event.event_type == "hawkular_event"
 
     event.send(target_type)
   end

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -22,4 +22,6 @@ class EventStream < ApplicationRecord
   belongs_to :container_replicator
   belongs_to :container_group
   belongs_to :container_node
+
+  belongs_to :middleware_server, :foreign_key => :middleware_server_id
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -291,7 +291,8 @@ module ManageIQ::Providers
         :id          => alert[:id],
         :enabled     => alert[:enabled],
         :description => alert[:description],
-        :conditions  => alert[:expression]
+        :conditions  => alert[:expression],
+        :based_on    => alert[:db]
       }
       MiddlewareManager.find_each { |m| m.alert_manager.process_alert(operation, miq_alert) }
     end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
@@ -31,7 +31,11 @@ module ManageIQ::Providers
                                       'description' => miq_alert[:description],
                                       'enabled'     => miq_alert[:enabled],
                                       'type'        => :GROUP,
-                                      'eventType'   => :EVENT)
+                                      'eventType'   => :EVENT,
+                                      'tags'        => {
+                                        'miq.event_type'    => 'hawkular_event',
+                                        'miq.resource_type' => miq_alert[:based_on]
+                                      })
     end
 
     def convert_to_group_conditions(miq_alert)

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
@@ -92,6 +92,7 @@ module ManageIQ::Providers
       new_member.group_id = group_trigger.id
       new_member.member_id = "#{group_trigger.id}-#{member_id}"
       new_member.member_name = "#{group_trigger.name} for #{server.name}"
+      new_member.member_context = {'resource_path' => server.ems_ref.to_s}
       new_member.data_id_map = calculate_member_data_id_map(server, group_trigger)
       @alerts_client.create_member_trigger(new_member)
     end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -424,17 +424,17 @@ class MiqAlert < ApplicationRecord
           }},
           {:name => :operator, :description => _("Operator"), :values => ["Changed"]}
         ]},
-      {:name => "mw_heap_used", :description => _("JVM Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "mw_event",
+      {:name => "mw_heap_used", :description => _("JVM Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
         :options => [
           {:name => :value_mw_greater_than, :description => _("> Heap Max (%)"), :numeric => true},
           {:name => :value_mw_less_than, :description => _("< Heap Max (%)"), :numeric => true}
         ]},
-      {:name => "mw_non_heap_used", :description => _("JVM Non Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "mw_event",
+      {:name => "mw_non_heap_used", :description => _("JVM Non Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
         :options => [
           {:name => :value_mw_greater_than, :description => _("> Non Heap Max (%)"), :numeric => true},
           {:name => :value_mw_less_than, :description => _("< Non Heap Max (%)"), :numeric => true}
         ]},
-      {:name => "mw_accumulated_gc_duration", :description => _("JVM Accumulated GC Duration"), :db => ["MiddlewareServer"], :responds_to_events => "mw_event",
+      {:name => "mw_accumulated_gc_duration", :description => _("JVM Accumulated GC Duration"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
         :options => [
           {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<=", "="]},
           {:name => :value_mw_garbage_collector, :description => _("Duration Per Minute (ms)"), :numeric => true}
@@ -499,7 +499,8 @@ class MiqAlert < ApplicationRecord
   end
 
   def self.raw_events
-    @raw_events ||= expression_by_name("event_threshold")[:options].find { |h| h[:name] == :event_types }[:values]
+    @raw_events ||= expression_by_name("event_threshold")[:options].find { |h| h[:name] == :event_types }[:values] +
+                    ['hawkular_event']
   end
 
   def self.event_alertable?(event)
@@ -545,15 +546,25 @@ class MiqAlert < ApplicationRecord
   end
 
   def evaluate_internal(target, _inputs = {})
-    method = "evaluate_method_#{expression[:eval_method]}"
+    if target.class.name == 'MiddlewareServer'
+      method = "evaluate_middleware"
+      options = _inputs[:ems_event]
+    else
+      method = "evaluate_method_#{expression[:eval_method]}"
+      options = expression[:options] || {}
+    end
     raise "Evaluation method '#{expression[:eval_method]}' does not exist" unless self.respond_to?(method)
 
-    send(method, target, expression[:options] || {})
+    send(method, target, options)
   end
 
   def evaluate_script
     # TODO
     true
+  end
+
+  def evaluate_middleware(target, options)
+    target.evaluate_alert(id, options)
   end
 
   # Evaluation methods

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -16,7 +16,8 @@ class MiqEvent < EventStream
 
   SUPPORTED_POLICY_AND_ALERT_CLASSES = [Host, VmOrTemplate, Storage, EmsCluster, ResourcePool,
                                         MiqServer, ExtManagementSystem,
-                                        ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage].freeze
+                                        ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage,
+                                        MiddlewareServer].freeze
 
   def self.raise_evm_event(target, raw_event, inputs = {}, options = {})
     # Target may have been deleted if it's a worker


### PR DESCRIPTION
This PR depends on #9441, #9460 and #9511.
This work completes an end-to-end flow to add alerting support into Middleware provider.
Once that the MiQ Alers are synced on the Middleware provider side, the provider starts to evaluate the conditions and emit specific provider events.
The last part is to link these provider events into MiQ Alerts subsystem as a way to evaluate the defined MiQ Alert.
This approach is different to other code inside MiQ as we are introducing a new use case:
- A scenario to detect a bad conditions is defined on MiQ side in the way of an alert (MiQ Alert).
- This scenario is synced on the provider, as the provider is responsible to compute and detect these conditions (so, in the opposite of other MiQ alerting over metrics, MiQ here is not computing when a situation is happening, it delegates into the provider).
- The Middleware events provided are implicit, so from an user perspective he is declaring just a MiQ Alert, these specific Middleware Events are part of the internal implementation.