### PR TITLE
Remove expect_result_resource_keys_to_match_pattern

### DIFF
--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -24,8 +24,8 @@ describe ApiController do
       run_get vms_url
 
       expect_query_result(:vms, 3, 3)
-      expect_result_resources_to_have_only_keys("resources", %w(href))
-      expect(response_hash).to include("resources" => all(a_hash_including("href" => a_string_matching(fetch_value(:vm_href_pattern)))))
+      expected = {"resources" => all(match("href" => a_string_matching(fetch_value(:vm_href_pattern))))}
+      expect(response_hash).to include(expected)
     end
 
     it "returns seperate ids and href when expanded" do
@@ -35,9 +35,12 @@ describe ApiController do
       run_get vms_url, :expand => "resources"
 
       expect_query_result(:vms, 3, 3)
-      expect(response_hash).to include("resources" => all(a_hash_including("href" => a_string_matching(fetch_value(:vm_href_pattern)))))
-      expect_result_resource_keys_to_be_like_klass("resources", "id", Integer)
-      expect_result_resources_to_include_keys("resources", %w(guid))
+      expected = {
+        "resources" => all(a_hash_including("href" => a_string_matching(fetch_value(:vm_href_pattern)),
+                                            "id"   => a_kind_of(Integer),
+                                            "guid" => anything))
+      }
+      expect(response_hash).to include(expected)
     end
 
     it "always return ids and href when asking for specific attributes" do

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -24,8 +24,7 @@ describe ApiController do
       run_get vms_url
 
       expect_query_result(:vms, 3, 3)
-      expected = {"resources" => all(match("href" => a_string_matching(fetch_value(:vm_href_pattern))))}
-      expect(response_hash).to include(expected)
+      expect(response_hash).to include("resources" => all(match("href" => a_string_matching(vm_href_pattern))))
     end
 
     it "returns seperate ids and href when expanded" do
@@ -36,7 +35,7 @@ describe ApiController do
 
       expect_query_result(:vms, 3, 3)
       expected = {
-        "resources" => all(a_hash_including("href" => a_string_matching(fetch_value(:vm_href_pattern)),
+        "resources" => all(a_hash_including("href" => a_string_matching(vm_href_pattern),
                                             "id"   => a_kind_of(Integer),
                                             "guid" => anything))
       }

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -25,7 +25,7 @@ describe ApiController do
 
       expect_query_result(:vms, 3, 3)
       expect_result_resources_to_have_only_keys("resources", %w(href))
-      expect_result_resource_keys_to_match_pattern("resources", "href", :vm_href_pattern)
+      expect(response_hash).to include("resources" => all(a_hash_including("href" => a_string_matching(fetch_value(:vm_href_pattern)))))
     end
 
     it "returns seperate ids and href when expanded" do
@@ -35,7 +35,7 @@ describe ApiController do
       run_get vms_url, :expand => "resources"
 
       expect_query_result(:vms, 3, 3)
-      expect_result_resource_keys_to_match_pattern("resources", "href", :vm_href_pattern)
+      expect(response_hash).to include("resources" => all(a_hash_including("href" => a_string_matching(fetch_value(:vm_href_pattern)))))
       expect_result_resource_keys_to_be_like_klass("resources", "id", Integer)
       expect_result_resources_to_include_keys("resources", %w(guid))
     end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -209,9 +209,7 @@ module ApiSpecHelper
   end
 
   def expect_result_resource_keys_to_match_pattern(collection, key, pattern)
-    pattern = fetch_value(pattern)
-    expect(response_hash).to have_key(collection)
-    expect(response_hash[collection].all? { |result| result[key].match(pattern) }).to be_truthy
+    expect(response_hash).to include(collection => all(a_hash_including(key => a_string_matching(fetch_value(pattern)))))
   end
 
   def expect_result_to_have_keys(keys)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -208,10 +208,6 @@ module ApiSpecHelper
     end
   end
 
-  def expect_result_resource_keys_to_match_pattern(collection, key, pattern)
-    expect(response_hash).to include(collection => all(a_hash_including(key => a_string_matching(fetch_value(pattern)))))
-  end
-
   def expect_result_to_have_keys(keys)
     expect_hash_to_have_keys(response_hash, keys)
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Just a small refactoring which removes `expect_result_resource_keys_to_match_pattern` and refactors the two tests that used it to combine their other expectations for better readability and test feedback.

@miq-bot add-label refactoring, test, api
@miq-bot assign @abellotti 