### PR TITLE
Pass connection argument properly to storage_accounts method for Azure metrics collection

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -59,8 +59,8 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
     ]
   end
 
-  def storage_accounts
-    @storage_accounts ||= with_metrics_services do |_metrics_conn, storage_conn|
+  def storage_accounts(connection)
+    @storage_accounts ||= with_metrics_services(connection) do |_metrics_conn, storage_conn|
       storage_conn.list_all
     end
   end
@@ -125,7 +125,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
     partition_key = availability.location.partition_key
 
     storage_acct_name = URI.parse(endpoint).host.split('.').first
-    storage_account   = storage_accounts.find { |account| account.name == storage_acct_name }
+    storage_account   = storage_accounts(storage_conn).find { |account| account.name == storage_acct_name }
     storage_key       = storage_conn.list_account_keys(storage_account.name, storage_account.resource_group).fetch('key1')
 
     # TODO: The following needs to pass :all => true for proper paging in case


### PR DESCRIPTION
Addresses BZ https://bugzilla.redhat.com/show_bug.cgi?id=1349768

Accidentally introduced in https://github.com/ManageIQ/manageiq/pull/8911 while trying to address a storage account / resource group mismatch. If `@storage_accounts` wasn't already set, it would try to with_metrics_services without an argument, resulting in `wrong number of arguments (0 for 1)`.

This PR passes the argument properly.



