### PR TITLE
[WIP] Return task status for reports as joined column

### DIFF
--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -36,7 +36,10 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    scope = MiqReportResult.with_current_user_groups_and_report(from_cid(object[:id].split('-').last))
+    report_id = from_cid(object[:id].split('-').last)
+    scope = MiqReportResult.with_current_user_groups_and_report(report_id)
+                           .select('miq_report_results.*', 'miq_tasks.status AS task_status')
+                           .joins(:miq_task)
     count_only ? scope.size : scope.order("last_run_on DESC").to_a
   end
 end

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -38,8 +38,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   def x_get_tree_custom_kids(object, count_only, _options)
     report_id = from_cid(object[:id].split('-').last)
     scope = MiqReportResult.with_current_user_groups_and_report(report_id)
-                           .select('miq_report_results.*', 'miq_tasks.status AS task_status')
-                           .joins(:miq_task)
+                           .with_task_status
     count_only ? scope.size : scope.order("last_run_on DESC").to_a
   end
 end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -114,7 +114,7 @@ class TreeNodeBuilder
     when MiqReportResult      then miq_report_node(format_timezone(object.last_run_on, Time.zone, 'gtl'),
                                                    get_rr_status_image(object),
                                                    object.name,
-                                                   (object.try(:task_status) || object.status).downcase)
+                                                   object.get_status.downcase)
     when MiqSchedule          then generic_node(object.name, "miq_schedule.png")
     when MiqScsiLun           then generic_node(object.canonical_name,
                                                 "lun.png",
@@ -167,7 +167,7 @@ class TreeNodeBuilder
   private
 
   def get_rr_status_image(rec)
-    case (rec.try(:task_status) || rec.status).downcase
+    case rec.get_status.downcase
     when 'error'    then 'report_result_error.png'
     when 'finished' then 'report_result_completed.png'
     when 'running'  then 'report_result_running.png'

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -112,7 +112,9 @@ class TreeNodeBuilder
     when MiqAlertSet          then generic_node(object.description, "miq_alert_profile.png")
     when MiqReport            then generic_node(object.name, "report.png")
     when MiqReportResult      then miq_report_node(format_timezone(object.last_run_on, Time.zone, 'gtl'),
-                                                   get_rr_status_image(object), object.name, object.status.downcase)
+                                                   get_rr_status_image(object),
+                                                   object.name,
+                                                   (object.try(:task_status) || object.status).downcase)
     when MiqSchedule          then generic_node(object.name, "miq_schedule.png")
     when MiqScsiLun           then generic_node(object.canonical_name,
                                                 "lun.png",
@@ -165,7 +167,7 @@ class TreeNodeBuilder
   private
 
   def get_rr_status_image(rec)
-    case rec.status.downcase
+    case (rec.try(:task_status) || rec.status).downcase
     when 'error'    then 'report_result_error.png'
     when 'finished' then 'report_result_completed.png'
     when 'running'  then 'report_result_running.png'


### PR DESCRIPTION
Purpose or Intent
-----------------
Decreases the load time on the `Cloud Intel --> Reports` page for individual subtrees being loaded and full page node with subtrees expended.


Implementation
--------------
There are three major changes that were made:

**`TreeBuilderReportSavedReports#x_get_tree_custom_kids`**

This update pulls in the status information for the associated miq_task as an aliased column using a join.  This prevents an N+1 that is caused when building the tree which will iterate over each returned record and query for each associated `miq_task` individually.  It is then possible to access the column (aliased as `task_status` so it doesn't collide with the `virtual_column :status`) as if it were normal column on the model.

**Update**:  This is now using `MiqReportResult::with_task_status` instead of doing the arel inline.  See below.


**`TreeNodeBuilder#get_rr_status_image` and `TreeNodeBuilder#build`**

~~The changes to `TreeNodeBuilder` basically the following change:~~

```diff
- object.status
+ (object.try(:task_status) || object.status)
```

~~So, try to use `.task_status` if it exists, otherwise use `.status`.~~

~~This is a bit of a hack and shouldn't be necessary, since this is only used by the `TreeBuilderReportSavedReports`, but in case `get_rr_status_image` or `TreeNodeBuilder.build` was called through some metaprogramming I might have missed, it was left in place.~~

This is now just using the `.get_status` method in the `MiqReportResult` model, which does similar logic.


**`MiqReportResult#get_status` and `MiqReportResult::with_task_status`**

This are two related methods to handle getting the `task_status` alias column:

* `self.with_task_status` builds an arel query that does a left outer join to get the `MiqTasks` (if available) for each `MiqReportResult`, and add the column alias to the request.
* `get_status` will try using the `task_status` method (if it exists), and then will fallback to using the `virtual_column :status` necessary.  A safe method for finding the status.


Metrics
-------
This provides a noticable reduction in both time spent in ActiveRecord
and overall request time. :

- POST "/report/tree_autoload_dynatree" with ~1000 children:

        # before

        Started POST "/report/tree_autoload_dynatree"
        Completed 200 OK in 2719ms (Views: 14.9ms | ActiveRecord: 140.9ms)

        # after

        Started POST "/report/tree_autoload_dynatree"
        Completed 200 OK in 1997ms (Views: 14.4ms | ActiveRecord: 5.9ms)

- POST "/report/tree_autoload_dynatree" with ~10000 children:

        # before

        Started POST "/report/tree_autoload_dynatree"
        Completed 200 OK in 60738ms (Views: 374.9ms | ActiveRecord: 2998.2ms)

        # after

        Started POST "/report/tree_autoload_dynatree"
        Completed 200 OK in 44681ms (Views: 385.6ms | ActiveRecord: 166.5ms)

- GET "/report/explorer" with the above two trees expanded

        # before

        Started GET "/report/explorer"
        Completed 200 OK in 69465ms (Views: 738.5ms | ActiveRecord: 3924.8ms)

        # after

        Started GET "/report/explorer"
        Completed 200 OK in 56310ms (Views: 651.4ms | ActiveRecord: 742.9ms)

In large organizations using DB on a remote machine, the network latency and data transfer this prevents will be much more noticable.