### PR TITLE
Pull out 'PxeImage'  declaration if it exists in a provision request

### DIFF
--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -266,7 +266,8 @@ class AutomateHash
 
   def provision_options
     find_request_options
-    @provision_options.options.dup.merge!(:request_type => @provision_options.request_type)
+    opts = @provision_options.options.dup.merge!(:request_type => @provision_options.request_type)
+    if_pxe_image?(opts) ? strip_out_pxe_klass(opts) : opts
   end
 
   def dialog
@@ -286,6 +287,16 @@ class AutomateHash
   end
 
   private
+
+  def if_pxe_image?(opts)
+    opts[:pxe_image_id] && opts[:pxe_image_id][0].match("::")
+  end
+
+  def strip_out_pxe_klass(opts)
+    stripped_value = opts[:pxe_image_id][0].split("::")
+    opts[:pxe_image_id][0] = stripped_value.last.to_i
+    opts
+  end
 
   def build_url
     @url ||= begin


### PR DESCRIPTION
Purpose or Intent
-----------------
Provision requests using PXE provisioning include
the PxeImage class declaration in :pxe_image_id value
when it exists in the provision options hash.

rebuild_automate_request was passing this value via the rest client post
causing the provision to fail.  Stripping out that class value and leaving only the
id allows these requests to go through.


Steps for Testing/QA
--------------------
* Build and run a provision request in the UI using PXE provisioning
* Copy the id of this provisioning request.
* run `rails r tools/rebuild_provision_request.rb --request-id=<request_id> --console`
* The `:pxe_image_id` value should only be an integer vs a string: e.g. `PxeImage::<pxe_image_id>`

