### PR TITLE
Enable custom buttons for CloudTenant

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -248,7 +248,7 @@ module ApplicationController::Buttons
   private ###########
 
   BASE_MODEL_EXPLORER_CLASSES = [Vm, MiqTemplate, Service].freeze
-  APPLIES_TO_CLASS_BASE_MODELS = %w(EmsCluster ExtManagementSystem Host MiqTemplate Service ServiceTemplate Storage Vm).freeze
+  APPLIES_TO_CLASS_BASE_MODELS = %w(CloudTenant EmsCluster ExtManagementSystem Host MiqTemplate Service ServiceTemplate Storage Vm).freeze
   def applies_to_class_model(applies_to_class)
     # TODO: Give a better name for this concept, including ServiceTemplate using Service
     # This should probably live in the model once this concept is defined.

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -34,6 +34,10 @@ class CloudTenantController < ApplicationController
         @refresh_partial = "layouts/gtl"
         show
       end
+    elsif params[:pressed] == "custom_button"
+      custom_buttons
+      # custom button screen, so return, let custom_buttons method handle everything
+      return
     end
     render_button_partial(pfx)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -693,6 +693,7 @@ module ApplicationHelper
   end
 
   CUSTOM_TOOLBAR_CONTROLLERS = [
+    "cloud_tenant",
     "service",
     "vm_cloud",
     "vm_infra",
@@ -700,7 +701,7 @@ module ApplicationHelper
   ]
   # Return a blank tb if a placeholder is needed for AJAX explorer screens, return nil if no custom toolbar to be shown
   def custom_toolbar_filename
-    if %w(ems_cloud ems_cluster ems_infra host miq_template storage ems_network).include?(@layout) # Classic CIs
+    if %w(ems_cloud ems_cluster ems_infra host miq_template storage ems_network cloud_tenant).include?(@layout) # Classic CIs
       return "custom_buttons_tb" if @record && @lastaction == "show" && @display == "main"
     end
 

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -19,7 +19,8 @@ class CustomButton < ApplicationRecord
     Storage,
     EmsCluster,
     MiqTemplate,
-    Service
+    Service,
+    CloudTenant
   ]
 
   def self.buttons_for(other, applies_to_id = nil)


### PR DESCRIPTION
Adds Cloud Tenant option in Automate > Customization > Buttons, and activates
those custom buttons in the cloud tenant controller.