### PR TITLE
Hard lock rails 5.0.0.rc2 for gems to stablize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # VMDB specific gems
 #
 
-gem "rails",                           "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
+gem "rails",                           "=5.0.0.rc2"
 gem "rails-controller-testing",        :require => false
 gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",      "~>0.1.2", :require => false

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -6,11 +6,11 @@ source 'https://rubygems.org'
 gem "bundler",       ">= 1.8.4"
 gem "rake",          "~>10.1"
 
-gem "activesupport",           "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
-gem "actionpack",              "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
+gem "activesupport",           "~> 5.0.0.rc2"
+gem "actionpack",              "~> 5.0.0.rc2"
 
 # ActiveRecord is used by appliance_console
-gem "activerecord",            "~> 5.0.x", :git => "git://github.com/rails/rails.git", :branch => "5-0-stable"
+gem "activerecord",            "~> 5.0.0.rc2"
 
 # Not locally modified and not required
 gem "addressable",             "~> 2.4",            :require => false


### PR DESCRIPTION
Purpose or Intent
-----------------
Revert to Rails `5.0.0.rc2` to allow bundle to continue to... well... `bundle`

The Rails 5.0 release broke a bunch of dependencies, and as an alternative to https://github.com/ManageIQ/manageiq/pull/9562, this is a way for devs to continue working while we wait for our dependent gems to get up to speed.