### PR TITLE
Remove unused parameter from Rbac.find_targets_filtered_by_ids

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -208,7 +208,7 @@ module Rbac
     return targets, auth_count
   end
 
-  def self.find_targets_filtered_by_ids(scope, find_options, u_filtered_ids, filtered_ids)
+  def self.find_targets_filtered_by_ids(scope, find_options, filtered_ids)
     if filtered_ids
       ids_clause  = ["#{scope.table_name}.id IN (?)", filtered_ids]
       find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], ids_clause)
@@ -233,7 +233,7 @@ module Rbac
 
   def self.find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
     filtered_ids, u_filtered_ids = calc_filtered_ids(scope, rbac_filters, user, miq_group)
-    find_targets_filtered_by_ids(scope, find_options, u_filtered_ids, filtered_ids)
+    find_targets_filtered_by_ids(scope, find_options, filtered_ids)
   end
 
   def self.find_targets_with_user_group_rbac(scope, _rbac_filters, find_options, user, miq_group)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -136,8 +136,7 @@ module Rbac
     d_filtered_ids = pluck_ids(matches_via_descendants(rbac_class(klass), user_filters['match_via_descendants'],
                                                        :user => user, :miq_group => miq_group))
 
-    filtered_ids = combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids)
-    [filtered_ids, u_filtered_ids]
+    combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids)
   end
 
   #
@@ -178,7 +177,7 @@ module Rbac
 
   def self.find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
     parent_class = rbac_class(scope)
-    filtered_ids, _ = calc_filtered_ids(parent_class, rbac_filters, user, miq_group)
+    filtered_ids = calc_filtered_ids(parent_class, rbac_filters, user, miq_group)
 
     find_targets_filtered_by_parent_ids(parent_class, scope, find_options, filtered_ids)
   end
@@ -232,7 +231,7 @@ module Rbac
   end
 
   def self.find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
-    filtered_ids, u_filtered_ids = calc_filtered_ids(scope, rbac_filters, user, miq_group)
+    filtered_ids = calc_filtered_ids(scope, rbac_filters, user, miq_group)
     find_targets_filtered_by_ids(scope, find_options, filtered_ids)
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
- Remove unused parameter `u_filtered_ids` from from find_targets_with_direct_rbac
- Reduce returning values from calc_filtered_ids 
u_filtered_ids is not no longer needed, ids are combined in
combine_filtered_ids method

Links
-----
We got rid off dependency on `u_filtered_ids` in https://github.com/ManageIQ/manageiq/pull/7167 (https://github.com/ManageIQ/manageiq/pull/7167/files#diff-c51171acee026d8d9d3cd886ccad2954R218)

cc @kbrock @gtanzillo 
