### PR TITLE
API: Allow security_protocol specified during provider creation

### DIFF
--- a/app/controllers/api_controller/providers.rb
+++ b/app/controllers/api_controller/providers.rb
@@ -5,7 +5,7 @@ class ApiController
     CREDENTIALS_ATTR  = "credentials"
     AUTH_TYPE_ATTR    = "auth_type"
     DEFAULT_AUTH_TYPE = "default"
-    ENDPOINT_ATTRS    = %w(hostname ipaddress port)
+    ENDPOINT_ATTRS    = %w(hostname ipaddress port security_protocol).freeze
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"]
 
     def create_resource_providers(type, _id, data = {})

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -35,20 +35,22 @@ describe ApiController do
   end
   let(:sample_rhevm) do
     {
-      "type"      => "ManageIQ::Providers::Redhat::InfraManager",
-      "name"      => "sample rhevm",
-      "port"      => 5000,
-      "hostname"  => "sample_rhevm.provider.com",
-      "ipaddress" => "100.200.300.2"
+      "type"              => "ManageIQ::Providers::Redhat::InfraManager",
+      "name"              => "sample rhevm",
+      "port"              => 5000,
+      "hostname"          => "sample_rhevm.provider.com",
+      "ipaddress"         => "100.200.300.2",
+      'security_protocol' => 'kerberos',
     }
   end
   let(:sample_openshift) do
     {
-      "type"      => "ManageIQ::Providers::Openshift::ContainerManager",
-      "name"      => "sample openshift",
-      "port"      => "8443",
-      "hostname"  => "sample_openshift.provider.com",
-      "ipaddress" => "100.200.300.3",
+      "type"              => "ManageIQ::Providers::Openshift::ContainerManager",
+      "name"              => "sample openshift",
+      "port"              => 8443,
+      "hostname"          => "sample_openshift.provider.com",
+      "ipaddress"         => "100.200.300.3",
+      'security_protocol' => 'kerberos',
     }
   end
 
@@ -124,7 +126,11 @@ describe ApiController do
 
       provider_id = response_hash["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
-      expect(ExtManagementSystem.find(provider_id).authentications.size).to eq(1)
+      ems = ExtManagementSystem.find(provider_id)
+      expect(ems.authentications.size).to eq(1)
+      ENDPOINT_ATTRS.each do |attr|
+        expect(ems.send(attr)).to eq(sample_openshift[attr])
+      end
     end
 
     it "supports single provider creation via action" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix minor api regression. And write relevant spec.

Links
-----
 * Fixing https://bugzilla.redhat.com/show_bug.cgi?id=1351253
 * Caused by migrated `security_protocol` field from `ExtManagementSystem` to `Endpoint` (#7157)

@miq-bot add_label api, bug, providers, darga/yes
@miq-bot assign @abellotti 
