### PR TITLE
[api] Refactor represent task spec helper

### DIFF
--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -262,8 +262,7 @@ module ApiSpecHelper
   end
 
   def expect_result_to_represent_task(result)
-    expect(result).to have_key("task_id")
-    expect(result).to have_key("task_href")
+    expect(result).to include("task_id", "task_href")
   end
 
   # Primary result construct methods

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -282,10 +282,15 @@ module ApiSpecHelper
 
   def expect_single_action_result(options = {})
     expect(response).to have_http_status(:ok)
-    expect(response_hash).to include("success" => options[:success]) if options.key?(:success)
-    expect(response_hash).to include("message" => a_string_matching(options[:message])) if options[:message]
-    expect(response_hash).to include("href" => a_string_matching(fetch_value(options[:href]))) if options[:href]
-    expect(response_hash).to include("task_id", "task_href") if options[:task]
+    expected = {}
+    expected["success"] = options[:success] if options.key?(:success)
+    expected["message"] = a_string_matching(options[:message]) if options[:message]
+    expected["href"] = a_string_matching(fetch_value(options[:href])) if options[:href]
+    if options[:task]
+      expected["task_id"] = anything
+      expected["task_href"] = anything
+    end
+    expect(response_hash).to include(expected)
   end
 
   def expect_multiple_action_result(count, options = {})

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -261,10 +261,6 @@ module ApiSpecHelper
     expect(response_hash[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
   end
 
-  def expect_result_to_represent_task(result)
-    expect(result).to include("task_id", "task_href")
-  end
-
   # Primary result construct methods
 
   def expect_empty_query_result(collection)
@@ -289,7 +285,7 @@ module ApiSpecHelper
     expect(response_hash).to include("success" => options[:success]) if options.key?(:success)
     expect(response_hash).to include("message" => a_string_matching(options[:message])) if options[:message]
     expect(response_hash).to include("href" => a_string_matching(fetch_value(options[:href]))) if options[:href]
-    expect_result_to_represent_task(response_hash) if options[:task]
+    expect(response_hash).to include("task_id", "task_href") if options[:task]
   end
 
   def expect_multiple_action_result(count, options = {})
@@ -299,7 +295,7 @@ module ApiSpecHelper
     expect(results.size).to eq(count)
     expect(results.all? { |r| r["success"] }).to be_truthy
 
-    results.each { |r| expect_result_to_represent_task(r) } if options[:task]
+    results.each { |r| expect(r).to include("task_id", "task_href") } if options[:task]
   end
 
   def expect_tagging_result(tagging_results)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -286,22 +286,20 @@ module ApiSpecHelper
     expected["success"] = options[:success] if options.key?(:success)
     expected["message"] = a_string_matching(options[:message]) if options[:message]
     expected["href"] = a_string_matching(fetch_value(options[:href])) if options[:href]
-    if options[:task]
-      expected["task_id"] = anything
-      expected["task_href"] = anything
-    end
+    expected.merge!(expected_task_response) if options[:task]
     expect(response_hash).to include(expected)
   end
 
   def expect_multiple_action_result(count, options = {})
     expect(response).to have_http_status(:ok)
     expected_result = {"success" => true}
-    if options[:task]
-      expected_result["task_id"] = anything
-      expected_result["task_href"] = anything
-    end
+    expected_result.merge!(expected_task_response) if options[:task]
     expected = {"results" => Array.new(count) { a_hash_including(expected_result) }}
     expect(response_hash).to include(expected)
+  end
+
+  def expected_task_response
+    {"task_id" => anything, "task_href" => anything}
   end
 
   def expect_tagging_result(tagging_results)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -295,12 +295,13 @@ module ApiSpecHelper
 
   def expect_multiple_action_result(count, options = {})
     expect(response).to have_http_status(:ok)
-    expect(response_hash).to have_key("results")
-    results = response_hash["results"]
-    expect(results.size).to eq(count)
-    expect(results.all? { |r| r["success"] }).to be_truthy
-
-    results.each { |r| expect(r).to include("task_id", "task_href") } if options[:task]
+    expected_result = {"success" => true}
+    if options[:task]
+      expected_result["task_id"] = anything
+      expected_result["task_href"] = anything
+    end
+    expected = {"results" => Array.new(count) { a_hash_including(expected_result) }}
+    expect(response_hash).to include(expected)
   end
 
   def expect_tagging_result(tagging_results)


### PR DESCRIPTION
Another small refactoring which inlines `expect_result_to_represent_task` and consolidates expectations for better error feedback.

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 
