### PR TITLE
Upgrade to gem release of Rails 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "manageiq-providers-amazon", :git => "git://github.com/ManageIQ/manageiq-pro
 
 # Client-side dependencies
 gem "angular-ui-bootstrap-rails",     "~>0.13.0"
-gem "codemirror-rails",               "=4.2"
+gem "codemirror-rails",               "~>5.11.1"
 gem "jquery-hotkeys-rails"
 gem "jquery-rails",                   "~>4.1.1"
 gem "jquery-rjs",                     "=0.1.1",                       :git => "git://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"
@@ -66,7 +66,7 @@ gem "secure_headers",                 "~>3.0.0"
 gem "gettext_i18n_rails",             "~>1.4.0"
 gem "gettext_i18n_rails_js",          "~>1.0.3"
 gem "fast_gettext",                   "~>1.1.0"
-gem "jbuilder",                       "~>2.3.1"
+gem "jbuilder",                       "~>2.5.0"
 gem "paperclip",                      "~>4.3.0"
 gem "rails-i18n",                     "~>5.x"
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # VMDB specific gems
 #
 
-gem "rails",                           "=5.0.0.rc2"
+gem "rails",                           "~>5.0.0"
 gem "rails-controller-testing",        :require => false
 gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",      "~>1.0.0"

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -6,11 +6,11 @@ source 'https://rubygems.org'
 gem "bundler",       ">= 1.8.4"
 gem "rake",          "~>10.1"
 
-gem "activesupport",           "~> 5.0.0.rc2"
-gem "actionpack",              "~> 5.0.0.rc2"
+gem "activesupport",           "~> 5.0.0"
+gem "actionpack",              "~> 5.0.0"
 
 # ActiveRecord is used by appliance_console
-gem "activerecord",            "~> 5.0.0.rc2"
+gem "activerecord",            "~> 5.0.0"
 
 # Not locally modified and not required
 gem "addressable",             "~> 2.4",            :require => false


### PR DESCRIPTION
Purpose or Intent
-----------------
Update to newest version of Rails to get us to the official 5.0 release.

An extra shoutout to @hayesr and @imtayadeway for helping with some of the gem updates in this process (honestly, I probably just did the last 10% in this whole effort).


Links
-----
* https://github.com/fixlr/codemirror-rails
* https://github.com/fixlr/codemirror-rails/pull/49
* https://github.com/rails/jbuilder/blob/master/CHANGELOG.md


Steps for Testing/QA
--------------------
* This is a large jump for codemirror as far as minor releases goes, so we should make sure there are no issues with that.
* jbuilder also got an update, though the test suite should probably be covering that.