### PR TITLE
Refactor api_request_handler

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -165,23 +165,17 @@ class ApiController < ApplicationController
 
   def redirect_api_request(method)
     target_method = "#{method}_#{@req.collection || "entrypoint"}"
-    if respond_to?(target_method)
-      send(target_method)
-      return true
-    end
+    return send(target_method) if respond_to?(target_method)
     target_method = "#{method}_generic"
-    if respond_to?(target_method)
-      send(target_method)
-      return true
-    end
-    false
+    return send(target_method) if respond_to?(target_method)
+    api_error_type(:not_found, "Unknown resource specified")
   end
 
   #
   # REST APIs Handler and API Entrypoints
   #
   def api_request_handler(expected_method)
-    api_error_type(:not_found, "Unknown resource specified") unless redirect_api_request(expected_method)
+    redirect_api_request(expected_method)
   end
 
   def show    # GET

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -156,6 +156,8 @@ class ApiController < ApplicationController
   #
   include_concern 'Initializer'
 
+  before_action :parse_api_request, :log_api_request, :validate_api_request
+
   def self.attr_type_hash(type)
     instance_variable_get("@attr_#{type}") || {}
   end
@@ -178,9 +180,6 @@ class ApiController < ApplicationController
   # REST APIs Handler and API Entrypoints
   #
   def api_request_handler(expected_method)
-    parse_api_request
-    log_api_request
-    validate_api_request
     api_error_type(:not_found, "Unknown resource specified") unless redirect_api_request(expected_method)
     log_api_response
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -171,22 +171,15 @@ class ApiController < ApplicationController
     api_error_type(:not_found, "Unknown resource specified")
   end
 
-  #
-  # REST APIs Handler and API Entrypoints
-  #
-  def api_request_handler(expected_method)
-    redirect_api_request(expected_method)
-  end
-
   def show    # GET
-    api_request_handler(:show)
+    redirect_api_request(:show)
   end
 
   def update  # POST, PUT, PATCH
-    api_request_handler(:update)
+    redirect_api_request(:update)
   end
 
   def destroy # DELETE
-    api_request_handler(:destroy)
+    redirect_api_request(:destroy)
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -157,6 +157,7 @@ class ApiController < ApplicationController
   include_concern 'Initializer'
 
   before_action :parse_api_request, :log_api_request, :validate_api_request
+  after_action :log_api_response
 
   def self.attr_type_hash(type)
     instance_variable_get("@attr_#{type}") || {}
@@ -181,7 +182,6 @@ class ApiController < ApplicationController
   #
   def api_request_handler(expected_method)
     api_error_type(:not_found, "Unknown resource specified") unless redirect_api_request(expected_method)
-    log_api_response
   end
 
   def show    # GET


### PR DESCRIPTION
Refactors in a few small steps to:

* move before/after logic into Rails' before/after_action
* simplifies `redirect_api_request` by removing the query aspect of it (i.e. return true/false depending on what happens) and making it responsible for handling the unhappy path itself
* after these steps the `api_request_handler` becomes redundant, so was removed

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 