### PR TITLE
read fixtures file relative to Rails.root

### DIFF
--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -30,7 +30,7 @@ FactoryGirl.define do
   factory :orchestration_template_vnfd_with_content,
           :parent => :orchestration_template,
           :class  => "OrchestrationTemplateVnfd" do
-    content File.read('spec/fixtures/orchestration_templates/vnfd_parameters.yml')
+    content File.read(Rails.root.join('spec/fixtures/orchestration_templates/vnfd_parameters.yml'))
   end
 
   factory :orchestration_template_azure_with_content,


### PR DESCRIPTION
otherwise this breaks when running in an engine

this fixes the build in [manageiq-providers-amazon](https://travis-ci.org/ManageIQ/manageiq-providers-amazon/builds/141628936)

@miq-bot add_label bug