### PR TITLE
Updates rspec to use non pre-release 3.5.0 gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,7 @@ unless ENV['APPLIANCE']
   end
 
   group :development, :test do
-    gem "rspec-rails",      "~>3.5.x"
+    gem "rspec-rails",      "~>3.5.0"
     gem "parallel_tests"
     gem "good_migrations"
   end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -89,7 +89,7 @@ unless ENV['APPLIANCE']
     gem "camcorder",                    :require => false
     gem "jasmine",       "~>2.4.0",     :require => false
     gem "phantomjs",     "=1.9.8.0",    :require => false
-    gem "rspec",         "~>3.5.x",     :require => false
+    gem "rspec",         "~>3.5.0",     :require => false
     gem "timecop",       "~>0.7.3",     :require => false
     gem "vcr",           "~>2.6",       :require => false
     gem "webmock",       "~>1.12",      :require => false


### PR DESCRIPTION
Purpose or Intent
-----------------
Make sure we are using the official rspec 3.5.0 release of rspec and not the pre-releases.  Related, but independent of the rails upgrade in https://github.com/ManageIQ/manageiq/issues/9577