### PR TITLE
Add standby database configuration to the appliance_console

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -71,7 +71,8 @@ require 'appliance_console/scap'
 require 'appliance_console/certificate_authority'
 require 'appliance_console/timezone_configuration'
 require 'appliance_console/date_time_configuration'
-
+require 'appliance_console/database_replication_primary'
+require 'appliance_console/database_replication_standby'
 require 'appliance_console/prompts'
 include ApplianceConsole::Prompts
 
@@ -460,6 +461,36 @@ Static Network Configuration
         end
         dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region
         press_any_key
+
+      when I18n.t("advanced_settings.db_replication")
+        say("#{selection}\n\n")
+
+        options = {
+          "Configure Server as Primary" => "primary",
+          "Configure Server as Standby" => "standby"
+        }
+
+        action = ask_with_menu("Database replication Operation", options)
+
+        case action
+        when "primary"
+          db_replication = ApplianceConsole::DatabaseReplicationPrimary.new
+          Logging.logger.info("Configuring Server as Primary")
+        when "standby"
+          db_replication = ApplianceConsole::DatabaseReplicationStandby.new
+          Logging.logger.info("Configuring Server as Standby")
+        end
+
+        if db_replication.ask_questions && db_replication.activate
+          say("Database Replication configured")
+          Logging.logger.info("Database Replication configured")
+          press_any_key
+        else
+          say("Database Replication not configured")
+          Logging.logger.info("Database Replication not configured")
+          press_any_key
+          raise MiqSignalError
+        end
 
       when I18n.t("advanced_settings.tmp_config")
         say("#{selection}\n\n")

--- a/gems/pending/appliance_console/database_replication.rb
+++ b/gems/pending/appliance_console/database_replication.rb
@@ -1,0 +1,123 @@
+require 'appliance_console/logging'
+require 'appliance_console/prompts'
+require 'pg'
+require 'English'
+
+module ApplianceConsole
+  class DatabaseReplication
+    include ApplianceConsole::Logging
+
+    REPMGR_CONFIG = '/etc/repmgr.conf'.freeze
+
+    attr_accessor :cluster_name, :node_number,
+                  :database_name, :database_user, :database_password,
+                  :primary_host, :standby_host
+
+    def ask_for_unique_cluster_node_number
+      self.node_number = ask_for_integer("number uniquely identifying this node in the replication cluster")
+    end
+
+    def ask_for_database_credentials
+      ask_for_cluster_database_credentials
+      self.primary_host = ask_for_ip_or_hostname("primary database hostname or IP address", primary_host)
+    end
+
+    def confirm(including_standby_host = nil)
+      clear_screen
+      say(<<-EOL)
+Replication Server Configuration
+
+        Cluster Node Number:        #{node_number}
+        Cluster Database Name:      #{database_name}
+        Cluster Database User:      #{database_user}
+        Cluster Database Password:  "********"
+        Cluster Primary Host:       #{primary_host}
+        EOL
+      say("        Standby Host:               #{standby_host}") unless including_standby_host.nil?
+
+      agree("Apply this Replication Server Configuration? (Y/N): ")
+    end
+
+    def repmgr_configured?
+      File.exist?(REPMGR_CONFIG)
+    end
+
+    def confirm_reconfiguration
+      say("Warning: File #{REPMGR_CONFIG} exists. Replication is already configured")
+      Logging.logger.warn("Warning: File #{REPMGR_CONFIG} exists. Replication is already configured")
+      agree("Continue with configuration? (Y/N): ")
+    end
+
+    def create_config_file(host)
+      File.open(REPMGR_CONFIG, "w") do |f|
+        f.puts("cluster=#{cluster_name}")
+        f.puts("node=#{node_number}")
+        f.puts("node_name=#{host}")
+        f.puts("conninfo='host=#{host} user=#{database_user} dbname=#{database_name}'")
+        f.puts("use_replication_slots=1")
+        f.puts("pg_basebackup_options='--xlog-method=stream'")
+      end
+      true
+    end
+
+    def generate_cluster_name
+      begin
+        pg_conn = PG::Connection.new(:dbname   => database_name,
+                                     :host     => primary_host,
+                                     :user     => database_user,
+                                     :password => database_password)
+        primary_region_number =
+          pg_conn.exec("SELECT last_value FROM miq_databases_id_seq").first["last_value"].to_i / 1_000_000_000_000
+        self.cluster_name = "miq_region_#{primary_region_number}_cluster"
+      rescue PG::ConnectionBad => e
+        say("Failed to get primary region number #{e.message}")
+        Logging.logger.error("Failed to get primary region number #{e.message}")
+        return false
+      end
+      true
+    end
+
+    private
+
+    def ask_for_cluster_database_credentials
+      self.database_name = just_ask("cluster database name", database_name)
+      self.database_user = just_ask("cluster database username", database_user)
+
+      count = 0
+      loop do
+        count += 1
+        password1 = ask_for_password_or_none("cluster database password", database_password)
+        # if they took the default, just bail
+        break if password1 == database_password
+        password2 = ask_for_password("cluster database password")
+        if password1 == password2
+          self.database_password = password1
+          break
+        elsif count > 1 # only reprompt password once
+          raise ArgumentError, "passwords did not match"
+        else
+          say("\nThe passwords did not match, please try again")
+        end
+      end
+    end
+
+    def run_repmgr_command(cmd, params = {})
+      pid = fork do
+        Process::UID.change_privilege(Process::UID.from_name("postgres"))
+        begin
+          res = AwesomeSpawn.run!(cmd, :params => params, :env => {"PGPASSWORD" => database_password})
+          say(res.output)
+        rescue AwesomeSpawn::CommandResultError => e
+          say(e.result.output)
+          say(e.result.error)
+          say("")
+          say("Failed to configure replication server")
+          raise
+        end
+      end
+
+      Process.wait(pid)
+      $CHILD_STATUS.success?
+    end
+  end # class DatabaseReplication < DatabaseConfiguration
+end # module ApplianceConsole

--- a/gems/pending/appliance_console/database_replication_primary.rb
+++ b/gems/pending/appliance_console/database_replication_primary.rb
@@ -1,0 +1,41 @@
+require 'appliance_console/logging'
+require 'appliance_console/prompts'
+require 'appliance_console/database_configuration'
+require 'appliance_console/database_replication'
+
+module ApplianceConsole
+  class DatabaseReplicationPrimary < DatabaseReplication
+    include ApplianceConsole::Logging
+
+    REGISTER_CMD = 'repmgr master register'.freeze
+
+    def initialize
+      self.cluster_name      = nil
+      self.node_number       = nil
+      self.database_name     = "vmdb_production"
+      self.database_user     = "root"
+      self.database_password = nil
+      self.primary_host      = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE).address
+    end
+
+    def ask_questions
+      clear_screen
+      say("Establish Primary Replication Server\n")
+      ask_for_unique_cluster_node_number
+      ask_for_database_credentials
+      return false if repmgr_configured? && !confirm_reconfiguration
+      confirm
+    end
+
+    def activate
+      say("Configuring Primary Replication Server...")
+      generate_cluster_name &&
+        create_config_file(primary_host) &&
+        initialize_primary_server
+    end
+
+    def initialize_primary_server
+      run_repmgr_command(REGISTER_CMD)
+    end
+  end # class DatabaseReplicationPrimary < DatabaseReplication
+end # module ApplianceConsole

--- a/gems/pending/appliance_console/database_replication_standby.rb
+++ b/gems/pending/appliance_console/database_replication_standby.rb
@@ -1,0 +1,76 @@
+require 'appliance_console/logging'
+require 'appliance_console/prompts'
+require 'appliance_console/database_replication'
+require 'util/postgres_admin'
+
+module ApplianceConsole
+  class DatabaseReplicationStandby < DatabaseReplication
+    include ApplianceConsole::Logging
+
+    REGISTER_CMD = 'repmgr standby register'.freeze
+
+    def initialize
+      self.cluster_name      = nil
+      self.node_number       = nil
+      self.database_name     = "vmdb_production"
+      self.database_user     = "root"
+      self.database_password = nil
+      self.primary_host      = nil
+      self.standby_host      = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE).address
+    end
+
+    def ask_questions
+      clear_screen
+      say("Establish Replication Standby Server\n")
+      ask_for_unique_cluster_node_number
+      ask_for_database_credentials
+      ask_for_standby_host
+      return false if repmgr_configured? && !confirm_reconfiguration
+      confirm(:including_standby_host)
+    end
+
+    def ask_for_standby_host
+      self.standby_host = ask_for_ip_or_hostname("Standby Server hostname or IP address", standby_host)
+    end
+
+    def activate
+      say("Configuring Replication Standby Server...")
+      data_dir_empty? &&
+        generate_cluster_name &&
+        create_config_file(standby_host) &&
+        clone_standby_server &&
+        start_postgres &&
+        register_standby_server
+    end
+
+    def data_dir_empty?
+      return true if Dir[PostgresAdmin.data_directory.join("*")].empty?
+      Logging.logger.info("Appliance database found under: #{PostgresAdmin.data_directory}")
+      say("")
+      say("Appliance database found under: #{PostgresAdmin.data_directory}")
+      say("Replication standby server can not be configured if the database already exists")
+      say("Remove the existing database before configuring as a standby server")
+      say("")
+      false
+    end
+
+    def clone_standby_server
+      params = { :h  => primary_host,
+                 :U  => database_user,
+                 :d  => database_name,
+                 :D  => PostgresAdmin.data_directory,
+                 nil => %w(standby clone)
+               }
+      run_repmgr_command("repmgr", params)
+    end
+
+    def start_postgres
+      LinuxAdmin::Service.new(PostgresAdmin.service_name).enable.start
+      true
+    end
+
+    def register_standby_server
+      run_repmgr_command(REGISTER_CMD)
+    end
+  end # class DatabaseReplicationStandby < DatabaseReplication
+end # module ApplianceConsole

--- a/gems/pending/appliance_console/locales/appliance/en.yml
+++ b/gems/pending/appliance_console/locales/appliance/en.yml
@@ -12,6 +12,7 @@ en:
     - datetime
     - dbrestore
     - db_config
+    - db_replication
     - httpdauth
     - extauth_opts
     - key_gen
@@ -29,6 +30,7 @@ en:
     datetime: Set Date and Time
     dbrestore: Restore Database From Backup
     db_config: Configure Database
+    db_replication: Configure Database Replication
     httpdauth: Configure External Authentication (httpd)
     extauth_opts: Update External Authentication Options
     evmstop: Stop EVM Server Processes

--- a/gems/pending/appliance_console/locales/container/en.yml
+++ b/gems/pending/appliance_console/locales/container/en.yml
@@ -7,6 +7,7 @@ en:
     - timezone
     - dbrestore
     - db_config
+    - db_replication
     - key_gen
     - evmstop
     - evmstart
@@ -16,6 +17,7 @@ en:
     timezone: Set Timezone
     dbrestore: Restore Database From Backup
     db_config: Configure Database
+    db_replication: Configure Database Replication
     evmstop: Stop EVM Server Processes
     key_gen: Generate Custom Encryption Key
     evmstart: Start EVM Server Processes

--- a/gems/pending/spec/appliance_console/database_replication_primary_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_primary_spec.rb
@@ -1,0 +1,117 @@
+require 'appliance_console/prompts'
+require 'appliance_console/database_configuration'
+require 'appliance_console/database_replication'
+require 'appliance_console/database_replication_primary'
+require 'linux_admin'
+require 'pg'
+
+describe ApplianceConsole::DatabaseReplicationPrimary do
+  SPEC_NAME = File.basename(__FILE__).split(".rb").first.freeze
+
+  before do
+    stub_const("ApplianceConsole::NETWORK_INTERFACE", "either_net")
+    expect(LinuxAdmin::NetworkInterface).to receive(:new).and_return(double(SPEC_NAME, :address => "192.0.2.1"))
+    allow(subject).to receive(:say)
+    allow(subject).to receive(:clear_screen)
+    allow(subject).to receive(:agree)
+    allow(subject).to receive(:just_ask)
+    allow(subject).to receive(:ask_for_ip_or_hostname)
+    allow(subject).to receive(:ask_for_password_or_none)
+  end
+
+  context "#ask_questions" do
+    before do
+      allow(PG::Connection).to receive(:new).and_return(double(SPEC_NAME, :exec => double(SPEC_NAME, :first => "1")))
+    end
+
+    it "returns true when input is confirmed" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:repmgr_configured?).and_return(false)
+      expect(subject).to_not receive(:confirm_reconfiguration)
+      expect(subject).to receive(:confirm).and_return(true)
+      expect(subject.ask_questions).to be true
+    end
+
+    it "returns true when confirm_reconfigure and input is confirmed" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:repmgr_configured?).and_return(true)
+      expect(subject).to receive(:confirm_reconfiguration).and_return(true)
+      expect(subject).to receive(:confirm).and_return(true)
+      expect(subject.ask_questions).to be true
+    end
+
+    it "returns false when confirm_reconfigure is canceled" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:repmgr_configured?).and_return(true)
+      expect(subject).to receive(:confirm_reconfiguration).and_return(false)
+      expect(subject).to_not receive(:confirm)
+      expect(subject.ask_questions).to be false
+    end
+
+    it "returns false when input is not confirmed" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:repmgr_configured?).and_return(false)
+      expect(subject).to_not receive(:confirm_reconfiguration)
+      expect(subject).to receive(:confirm).and_return(false)
+      expect(subject.ask_questions).to be false
+    end
+  end
+
+  context "#activate" do
+    it "returns true when configure succeed" do
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(true)
+      expect(subject).to receive(:initialize_primary_server).and_return(true)
+      expect(subject.activate).to be true
+    end
+
+    it "returns false when create_config_file fails" do
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(false)
+      expect(subject).to_not receive(:initialize_primary_server)
+      expect(subject.activate).to be false
+    end
+
+    it "returns false when generate_cluster_name fails" do
+      expect(subject).to receive(:generate_cluster_name).and_return(false)
+      expect(subject).to_not receive(:create_config_file)
+      expect(subject).to_not receive(:initialize_primary_server)
+      expect(subject.activate).to be false
+    end
+
+    it "returns false when initialize_primary_server fails" do
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(true)
+      expect(subject).to receive(:initialize_primary_server).and_return(false)
+      expect(subject.activate).to be false
+    end
+  end
+
+  context "#initialize_primary_server" do
+    before do
+      allow(Process::UID).to receive(:change_privilege)
+      allow(Process::UID).to receive(:from_name)
+
+      expect(subject).to receive(:fork) do |&block|
+        block.call
+        1234 # return a test pid
+      end
+    end
+
+    it "raises an error when REGISTER_CMD fails" do
+      result = double(SPEC_NAME, :output => '', :error => '')
+      allow(AwesomeSpawn).to receive(:run!).and_raise(AwesomeSpawn::CommandResultError.new('', result))
+      expect { subject.initialize_primary_server }.to raise_error(AwesomeSpawn::CommandResultError)
+    end
+
+    it "Succeed when REGISTER_CMD succeeds" do
+      expect(Process).to receive(:wait).with(1234)
+      stub_const("ApplianceConsole::DatabaseReplicationPrimary::REGISTER_CMD", "pwd")
+      expect(subject.initialize_primary_server).to be true
+    end
+  end
+end

--- a/gems/pending/spec/appliance_console/database_replication_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_spec.rb
@@ -1,0 +1,134 @@
+require "appliance_console/prompts"
+require "appliance_console/database_replication"
+require "tempfile"
+
+describe ApplianceConsole::DatabaseReplication do
+  SPEC_NAME = File.basename(__FILE__).split(".rb").first.freeze
+
+  before do
+    allow(subject).to receive(:say)
+    allow(subject).to receive(:clear_screen)
+    allow(subject).to receive(:agree)
+    allow(subject).to receive(:ask_for_ip_or_hostname)
+    allow(subject).to receive(:ask_for_password_or_none)
+    allow(subject).to receive(:ask_for_password)
+  end
+
+  context "#ask_for_unique_cluster_node_number" do
+    it "should ask for a unique number" do
+      expect(subject).to receive(:ask_for_integer).with(/uniquely identifying this node/i).and_return(1)
+      subject.ask_for_unique_cluster_node_number
+      expect(subject.node_number).to eq(1)
+    end
+  end
+
+  context "#ask_for_database_credentials" do
+    before do
+      subject.database_name     = "defaultdatabasename"
+      subject.database_user     = "defaultuser"
+      subject.database_password = nil
+      subject.primary_host      = "defaultprimary"
+    end
+
+    it "should store the newly supplied values" do
+      expect(subject).to receive(:just_ask).with(/ name/i, "defaultdatabasename").and_return("newdatabasename")
+      expect(subject).to receive(:just_ask).with(/ user/i, "defaultuser").and_return("newuser")
+      expect(subject).to receive(:ask_for_password_or_none).with(/password/i, nil).and_return("newpassword")
+      expect(subject).to receive(:ask_for_password).with(/password/i).and_return("newpassword")
+      expect(subject)
+        .to receive(:ask_for_ip_or_hostname).with(/primary.*hostname/i, "defaultprimary").and_return("newprimary")
+
+      subject.ask_for_database_credentials
+
+      expect(subject.database_name).to eq("newdatabasename")
+      expect(subject.database_user).to eq("newuser")
+      expect(subject.database_password).to eq("newpassword")
+      expect(subject.primary_host).to eq("newprimary")
+    end
+  end
+
+  context "#confirm" do
+    before do
+      subject.standby_host = "defaultstandby"
+    end
+
+    it "should ask for standby host when requested" do
+      expect(subject).to receive(:say).with(/standby\shost.*defaultstandby/i)
+      subject.confirm(:including_standby_host)
+    end
+
+    it "should not ask for standby host if not requested" do
+      expect(subject).to_not receive(:say).with(/standby\shost.*defaultstandby/i)
+      subject.confirm
+    end
+  end
+
+  context "#confirm_reconfiguration" do
+    it "should log a warning and ask to continue anyway" do
+      expect(subject).to receive(:say).with(/^warning/i)
+      expect(subject).to receive(:agree).with(/^continue/i)
+
+      subject.confirm_reconfiguration
+    end
+  end
+
+  context "#create_config_file" do
+    before do
+      subject.cluster_name      = "clustername"
+      subject.node_number       = "nodenumber"
+      subject.database_name     = "databasename"
+      subject.database_user     = "user"
+
+      @temp_file = Tempfile.new(subject.class.name.split("::").last.downcase)
+      stub_const("ApplianceConsole::DatabaseReplication::REPMGR_CONFIG", @temp_file.path)
+    end
+
+    after do
+      @temp_file.close
+      @temp_file.unlink
+    end
+
+    it "should correctly populate the config file" do
+      expected_config_file = "cluster=clustername\n"
+      expected_config_file << "node=nodenumber\n"
+      expected_config_file << "node_name=host\n"
+      expected_config_file << "conninfo='host=host user=user dbname=databasename'\n"
+      expected_config_file << "use_replication_slots=1\n"
+      expected_config_file << "pg_basebackup_options='--xlog-method=stream'\n"
+
+      subject.create_config_file("host")
+
+      expect(File.read(@temp_file.path)).to eq(expected_config_file)
+    end
+
+    it "should overwrite an existing config file" do
+      expected_config_file = "cluster=clustername\n"
+      expected_config_file << "node=nodenumber\n"
+      expected_config_file << "node_name=differenthostname\n"
+      expected_config_file << "conninfo='host=differenthostname user=user dbname=databasename'\n"
+      expected_config_file << "use_replication_slots=1\n"
+      expected_config_file << "pg_basebackup_options='--xlog-method=stream'\n"
+
+      subject.create_config_file("host")
+      subject.create_config_file("differenthostname")
+
+      expect(File.read(@temp_file.path)).to eq(expected_config_file)
+    end
+  end
+
+  context "#generate_cluster_name" do
+    it "should generate a cluster name and return true" do
+      expect(PG::Connection)
+        .to receive(:new)
+        .and_return(double(SPEC_NAME, :exec => double(SPEC_NAME, :first => { "last_value" => "1_000_000_000_001" })))
+      expect(subject.generate_cluster_name).to be_truthy
+      expect(subject.cluster_name).to eq("miq_region_1_cluster")
+    end
+
+    it "should log an error on connection failures and return false" do
+      expect(PG::Connection).to receive(:new).and_raise(PG::ConnectionBad)
+      expect(subject).to receive(:say).with(/^failed/i)
+      expect(subject.generate_cluster_name).to be_falsey
+    end
+  end
+end

--- a/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
@@ -1,0 +1,211 @@
+require "appliance_console/prompts"
+require "appliance_console/database_replication"
+require "appliance_console/database_replication_standby"
+require "linux_admin"
+require "pathname"
+
+describe ApplianceConsole::DatabaseReplicationStandby do
+  SPEC_NAME = File.basename(__FILE__).split(".rb").first.freeze
+
+  before do
+    allow(ENV).to receive(:fetch).and_return("/test/postgres/directory")
+    stub_const("ApplianceConsole::NETWORK_INTERFACE", "either_net")
+    expect(LinuxAdmin::NetworkInterface).to receive(:new).and_return(double(SPEC_NAME, :address => "192.0.2.1"))
+    allow(subject).to receive(:say)
+    allow(subject).to receive(:clear_screen)
+    allow(subject).to receive(:agree)
+    allow(subject).to receive(:just_ask)
+    allow(subject).to receive(:ask_for_ip_or_hostname)
+    allow(subject).to receive(:ask_for_password_or_none)
+  end
+
+  context "#ask_questions" do
+    before do
+      allow(PG::Connection).to receive(:new).and_return(double(SPEC_NAME, :exec => double(SPEC_NAME, :first => "1")))
+    end
+
+    it "returns true when input is confirmed" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:ask_for_standby_host)
+      expect(subject).to receive(:repmgr_configured?).and_return(false)
+      expect(subject).to_not receive(:confirm_reconfiguration)
+      expect(subject).to receive(:confirm).and_return(true)
+      expect(subject.ask_questions).to be true
+    end
+
+    it "returns true when confirm_reconfigure and input is confirmed" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:ask_for_standby_host)
+      expect(subject).to receive(:repmgr_configured?).and_return(true)
+      expect(subject).to receive(:confirm_reconfiguration).and_return(true)
+      expect(subject).to receive(:confirm).and_return(true)
+      expect(subject.ask_questions).to be true
+    end
+
+    it "returns false when confirm_reconfigure is canceled" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:ask_for_standby_host)
+      expect(subject).to receive(:repmgr_configured?).and_return(true)
+      expect(subject).to receive(:confirm_reconfiguration).and_return(false)
+      expect(subject).to_not receive(:confirm)
+      expect(subject.ask_questions).to be false
+    end
+
+    it "returns false when input is not confirmed" do
+      expect(subject).to receive(:ask_for_unique_cluster_node_number)
+      expect(subject).to receive(:ask_for_database_credentials)
+      expect(subject).to receive(:ask_for_standby_host)
+      expect(subject).to receive(:repmgr_configured?).and_return(false)
+      expect(subject).to_not receive(:confirm_reconfiguration)
+      expect(subject).to receive(:confirm).and_return(false)
+      expect(subject.ask_questions).to be false
+    end
+  end
+
+  context "#activate" do
+    it "returns true when configure succeed" do
+      expect(subject).to receive(:data_dir_empty?).and_return(true)
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(true)
+      expect(subject).to receive(:clone_standby_server).and_return(true)
+      expect(subject).to receive(:start_postgres).and_return(true)
+      expect(subject).to receive(:register_standby_server).and_return(true)
+      expect(subject.activate).to be true
+    end
+
+    it "returns false when data_dir_empty? fails" do
+      expect(subject).to receive(:data_dir_empty?).and_return(false)
+      expect(subject).to_not receive(:generate_cluster_name)
+      expect(subject).to_not receive(:create_config_file)
+      expect(subject).to_not receive(:clone_standby_server)
+      expect(subject).to_not receive(:start_postgres)
+      expect(subject).to_not receive(:register_standby_server)
+      expect(subject.activate).to be false
+    end
+
+    it "returns false when generate_cluster_name fails" do
+      expect(subject).to receive(:data_dir_empty?).and_return(true)
+      expect(subject).to receive(:generate_cluster_name).and_return(false)
+      expect(subject).to_not receive(:create_config_file)
+      expect(subject).to_not receive(:clone_standby_server)
+      expect(subject).to_not receive(:start_postgres)
+      expect(subject).to_not receive(:register_standby_server)
+      expect(subject.activate).to be false
+    end
+
+    it "returns false when create_config_file fails" do
+      expect(subject).to receive(:data_dir_empty?).and_return(true)
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(false)
+      expect(subject).to_not receive(:clone_standby_server)
+      expect(subject).to_not receive(:start_postgres)
+      expect(subject).to_not receive(:register_standby_server)
+      expect(subject.activate).to be false
+    end
+
+    it "returns false when clone_standby_server fails" do
+      expect(subject).to receive(:data_dir_empty?).and_return(true)
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(true)
+      expect(subject).to receive(:clone_standby_server).and_return(false)
+      expect(subject).to_not receive(:start_postgres)
+      expect(subject).to_not receive(:register_standby_server)
+      expect(subject.activate).to be false
+    end
+
+    it "returns false when start_postgres fails" do
+      expect(subject).to receive(:data_dir_empty?).and_return(true)
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(true)
+      expect(subject).to receive(:clone_standby_server).and_return(true)
+      expect(subject).to receive(:start_postgres).and_return(false)
+      expect(subject).to_not receive(:register_standby_server)
+      expect(subject.activate).to be false
+    end
+
+    it "returns false when register_standby_server fails" do
+      expect(subject).to receive(:data_dir_empty?).and_return(true)
+      expect(subject).to receive(:generate_cluster_name).and_return(true)
+      expect(subject).to receive(:create_config_file).and_return(true)
+      expect(subject).to receive(:clone_standby_server).and_return(true)
+      expect(subject).to receive(:start_postgres).and_return(true)
+      expect(subject).to receive(:register_standby_server).and_return(false)
+      expect(subject.activate).to be false
+    end
+  end
+
+  context "create standby server" do
+    before do
+      allow(Process::UID).to receive(:change_privilege)
+      allow(Process::UID).to receive(:from_name)
+
+      expect(subject).to receive(:fork) do |&block|
+        block.call
+        1234 # return a test pid
+      end
+    end
+
+    context "#clone_standby_server" do
+      it "raises an error when REGISTER_CMD fails" do
+        result = double(SPEC_NAME, :output => "", :error => "")
+        allow(AwesomeSpawn).to receive(:run!).and_raise(AwesomeSpawn::CommandResultError.new("", result))
+        expect { subject.clone_standby_server }.to raise_error(AwesomeSpawn::CommandResultError)
+      end
+    end
+
+    context "#register_standby_server" do
+      it "raises an error when REGISTER_CMD fails" do
+        result = double(SPEC_NAME, :output => "", :error => "")
+        allow(AwesomeSpawn).to receive(:run!).and_raise(AwesomeSpawn::CommandResultError.new("", result))
+        expect { subject.register_standby_server }.to raise_error(AwesomeSpawn::CommandResultError)
+      end
+
+      it "Succeed when REGISTER_CMD succeeds" do
+        expect(Process).to receive(:wait).with(1234)
+        stub_const("ApplianceConsole::DatabaseReplicationStandby::REGISTER_CMD", "pwd")
+        expect(subject.register_standby_server).to be true
+      end
+    end
+  end
+
+  context "#ask_for_standby_host" do
+    it "should use default prompts" do
+      subject.standby_host = "defaultstandby"
+      expect(subject)
+        .to receive(:ask_for_ip_or_hostname).with(/^standby.*hostname/i, "defaultstandby").and_return("newstandby")
+      expect(subject.ask_for_standby_host).to eq("newstandby")
+    end
+  end
+
+  context "#data_dir_empty?" do
+    it "should log a message and return false when not empty" do
+      Dir.mktmpdir do |dir|
+        open("#{dir}/this_directory_is_not_empty", "w")
+        expect(subject).to receive(:say).with(/^Appliance/i)
+        expect(PostgresAdmin).to receive(:data_directory).exactly(3).times.and_return(Pathname.new(dir))
+        expect(subject.data_dir_empty?).to be_falsey
+      end
+    end
+
+    it "should quietly return true when empty" do
+      Dir.mktmpdir do |dir|
+        expect(subject).to_not receive(:say)
+        expect(PostgresAdmin).to receive(:data_directory).once.and_return(Pathname.new(dir))
+        expect(subject.data_dir_empty?).to be_truthy
+      end
+    end
+  end
+
+  context "#start_postgres" do
+    it "should start postgres and return true" do
+      service = double(SPEC_NAME, :service => nil)
+      expect(LinuxAdmin::Service).to receive(:new).and_return(service)
+      expect(service).to receive(:enable).and_return(service)
+      expect(service).to receive(:start).and_return(service)
+      expect(subject.start_postgres).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
The purpose of this PR is to add support to the appliance_console to automate the configuration
of the Standby Server Database.

Links
-----
https://www.pivotaltracker.com/projects/1608513

Steps for Testing/QA
--------------------
TODO