### PR TITLE
Adding the MiqAeBrowser

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_browser.rb
+++ b/lib/miq_automation_engine/models/miq_ae_browser.rb
@@ -5,7 +5,10 @@ class MiqAeBrowser
 
   # Searches directory ala LDAP style
   #   Starting point of searches using fqname  (dn)
-  #   Supporing scope base, one and sub
+  #   Supporing scopes base - return object itself
+  #                    one  - return object and its first level children
+  #                    sub  - return object and tree below it
+  #
   # Returns array of objects
   #
   # Supporting options:
@@ -56,37 +59,37 @@ class MiqAeBrowser
         raise "Invalid Automate object path #{object_ref} specified to search" if object.blank?
       end
     end
-    options[:serialize] ? _search_serialize(object, options) : _search(object, options)
+    options[:serialize] ? search_ae_model_serialize(object, options) : search_ae_model(object, options)
   end
 
   private
 
-  def _search_serialize(object = nil, options = {})
-    _search(object, options).collect { |obj| serialize(obj) }
+  def search_ae_model_serialize(object = nil, options = {})
+    search_ae_model(object, options).collect { |obj| serialize(obj) }
   end
 
-  def _search(object = nil, options = {})
+  def search_ae_model(object = nil, options = {})
     validate_options(options)
     if object
-      _search_object(object, options)
+      search_object(object, options)
     else
-      _search_domains(options)
+      search_domains(options)
     end.flatten
   end
 
-  def _search_object(object, options)
+  def search_object(object, options)
     case options[:scope]
     when SCOPE_BASE then Array(object)
     when SCOPE_ONE  then Array(object) + children(object, options)
-    else Array(object) + children(object, options).collect { |child| _search(child, options) }
+    else Array(object) + children(object, options).collect { |child| search_ae_model(child, options) }
     end
   end
 
-  def _search_domains(options)
+  def search_domains(options)
     case options[:scope]
     when SCOPE_BASE then []
     when SCOPE_ONE  then Array(domains(options))
-    else domains(options).collect { |domain| _search(domain, options) }
+    else domains(options).collect { |domain| search_ae_model(domain, options) }
     end
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_browser.rb
+++ b/lib/miq_automation_engine/models/miq_ae_browser.rb
@@ -1,0 +1,139 @@
+class MiqAeBrowser
+  attr_accessor :user
+
+  # Automate Datastore Browser starting at MiqAeDomain, down to the MiqAeInstances and MiqAeMethods.
+
+  # Searches directory ala LDAP style
+  #   Starting point of searches using fqname  (dn)
+  #   Supporing scope base, one and sub
+  # Returns array of objects
+  #
+  # Supporting options:
+  #   :serialize
+  #   :state_machines
+  #
+  # :serialize returns the Hash serialized objects including fqname, domain_fqname and klass
+  # i.e.
+  #   {
+  #     "fqname": "/ManageIQ/System/Request",
+  #     "domain_fqname": "/System/Request",       # fqname relative to /domain
+  #     "klass": "MiqAeClass",
+  #     "id": 75,
+  #     "description": "Automation Requests",
+  #     "name": "Request",
+  #     "created_on": "2015-12-09T20:56:44Z",
+  #     "updated_on": "2015-12-09T20:56:44Z",
+  #     "namespace_id": 41,
+  #     "updated_by": "system"
+  #   }
+  #
+  # with :state_machines true, only the objects belonging to a sub-tree that
+  # includes state machine entrypoints are returned.
+
+  SCOPE_BASE = "base".freeze
+  SCOPE_ONE  = "one".freeze
+  SCOPE_SUB  = "sub".freeze
+  SCOPES = [SCOPE_BASE, SCOPE_ONE, SCOPE_SUB].freeze
+
+  def initialize(user = User.current_user)
+    raise "Must be authenticated before using #{self.class.name}" unless user
+    @user = user
+    @waypoint_ids = MiqAeClass.waypoint_ids_for_state_machines
+  end
+
+  def domains(options = {})
+    filter_ae_objects(@user.current_tenant.visible_domains, options)
+  end
+
+  def search(object_ref = nil, options = {})
+    validate_options(options)
+    object = object_ref
+    if object_ref.kind_of?(String)
+      if object_ref.blank? || object_ref == "/"
+        object = nil
+      else
+        object = find_base_object(object_ref, options)
+        raise "Invalid Automate object path #{object_ref} specified to search" if object.blank?
+      end
+    end
+    options[:serialize] ? _search_serialize(object, options) : _search(object, options)
+  end
+
+  private
+
+  def _search_serialize(object = nil, options = {})
+    _search(object, options).collect { |obj| serialize(obj) }
+  end
+
+  def _search(object = nil, options = {})
+    validate_options(options)
+    if object
+      _search_object(object, options)
+    else
+      _search_domains(options)
+    end.flatten
+  end
+
+  def _search_object(object, options)
+    case options[:scope]
+    when SCOPE_BASE then Array(object)
+    when SCOPE_ONE  then Array(object) + children(object, options)
+    else Array(object) + children(object, options).collect { |child| _search(child, options) }
+    end
+  end
+
+  def _search_domains(options)
+    case options[:scope]
+    when SCOPE_BASE then []
+    when SCOPE_ONE  then Array(domains(options))
+    else domains(options).collect { |domain| _search(domain, options) }
+    end
+  end
+
+  def serialize(object)
+    fqname = object.fqname
+    domain_fqname = fqname[1..-1].sub(%r{^[^/]+}, '')
+    domain_fqname = "/" if domain_fqname.blank?
+    object.attributes.reverse_merge("fqname" => fqname, "domain_fqname" => domain_fqname, "klass" => object.class.name)
+  end
+
+  def validate_options(options)
+    if options[:scope] && !SCOPES.include?(options[:scope])
+      raise "Invalid scope #{options[:scope]} specified, valid scopes are #{SCOPES.join(', ')}"
+    end
+  end
+
+  def find_base_object(path, options)
+    parts = path.split('/').select { |p| p != "" }
+    object = find_domain(parts[0], options)
+    parts[1..-1].each { |part| object = children(object, options).find { |obj| part.casecmp(obj.name) == 0 } }
+    object
+  end
+
+  def find_domain(domain_name, options)
+    domain = domains(options).find { |d| domain_name.casecmp(d.name) == 0 }
+    raise "Invalid Automate Domain #{domain_name} specified" if domain.blank?
+    domain
+  end
+
+  def children(object, options = {})
+    return [] unless object
+    filter_ae_objects(Array(object.try(:ae_namespaces)) +
+                      Array(object.try(:ae_classes)) +
+                      Array(object.try(:ae_instances)) +
+                      Array(object.try(:ae_methods)), options)
+  end
+
+  def filter_ae_objects(objects, options)
+    return objects unless options[:state_machines]
+    objects.select do |obj|
+      klass_name = obj.class.name
+      if klass_name == "MiqAeInstance"
+        true
+      else
+        prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
+        @waypoint_ids.include?("#{prefix}::#{obj.id}")
+      end
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_browser_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_browser_spec.rb
@@ -1,0 +1,106 @@
+include AutomationSpecHelper
+module MiqAeBrowserSpec
+  include MiqAeEngine
+  describe MiqAeBrowser do
+    before(:each) do
+      MiqAeDatastore.reset
+      @composition_fields = {"title" => {:aetype => "attribute", :datatype => "string"}}
+
+      @chopin_domain = {:name => "Chopin", :ae_namespace => "SelectedWorks", :ae_class => "Piano"}
+      @chopin_piano_compositions = {"Nocturnes" => {"title"    => {:value => "18 Noctures"}},
+                                    "Ballades"  => {"title" => {:value => "4 Ballades"}},
+                                    "Scherzos"  => {"title" => {:value => "4 Scherzos"}}}
+
+      @liszt_domain = {:name => "Liszt", :ae_namespace => "SelectedWorks", :ae_class => "Piano"}
+      @liszt_piano_compositions = {"Rhapsodies" => {"title" => {:value => "19 Hungarian Rhapsodies"}},
+                                   "Etudes"     => {"title" => {:value => "12 Transcendental Etudes"}}}
+
+      create_ae_model(@chopin_domain.merge(:ae_fields    => @composition_fields,
+                                           :ae_instances => @chopin_piano_compositions))
+
+      create_ae_model(@liszt_domain.merge(:ae_fields    => @composition_fields,
+                                          :ae_instances => @liszt_piano_compositions))
+      @state_machine_fqnames = %w(
+        /Liszt
+        /Liszt/SelectedWorks
+        /Liszt/SelectedWorks/Learning
+        /Liszt/SelectedWorks/Learning/Campanella
+      )
+
+      learning_fields = {"study"   => {:aetype => "state", :datatype => "string"},
+                         "perform" => {:aetype => "state", :datatype => "string"}}
+
+      learning_instances = {"Campanella" => {"study"   => {:value => "inprogress"},
+                                             "perform" => {:value => ""}}}
+
+      FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
+                         :name => "Learning", :namespace => "/Liszt/SelectedWorks",
+                         :ae_fields => learning_fields, :ae_methods => {}, :ae_instances => learning_instances)
+
+      @user = FactoryGirl.create(:user_with_group)
+      @browser = MiqAeBrowser.new(@user)
+    end
+
+    it "can query root base object" do
+      res = @browser.search("/", :scope => "base")
+      expect(res.size).to eq(0)
+    end
+
+    it "can query root domains" do
+      res = @browser.search(nil, :scope => "one")
+      expect(res.pluck(:name)).to match_array(%w(Chopin Liszt))
+    end
+
+    it "can query a domain base object" do
+      res = @browser.search("/Chopin", :scope => "base")
+      expect(res.first).to eq(MiqAeDomain.where(:name => "Chopin").first)
+    end
+
+    it "defaults to scope sub search" do
+      res = @browser.search("/Chopin")
+      expect(res.pluck(:name)).to match_array(%w(Chopin SelectedWorks Piano Nocturnes Ballades Scherzos))
+    end
+
+    it "supports scope sub search" do
+      res = @browser.search("/Liszt", :scope => "sub")
+      expect(res.pluck(:name)).to match_array(%w(Liszt SelectedWorks Piano Rhapsodies Etudes Learning Campanella))
+    end
+
+    it "scope sub search on root gets all objects" do
+      res = @browser.search("/", :scope => "sub")
+      all_nodes = %w(Chopin SelectedWorks Piano Nocturnes Ballades Scherzos
+                     Liszt SelectedWorks Piano Rhapsodies Etudes Learning Campanella)
+      expect(res.pluck(:name)).to match_array(all_nodes)
+    end
+
+    it "supports serialized output" do
+      res = @browser.search("/Liszt/SelectedWorks/Piano/Etudes", :scope => "base", :serialize => true)
+      expect(res.size).to eq(1)
+      expect(res.first).to be_kind_of(Hash)
+      expect(res.first).to include("fqname"        => "/Liszt/SelectedWorks/Piano/Etudes",
+                                   "domain_fqname" => "/SelectedWorks/Piano/Etudes",
+                                   "klass"         => "MiqAeInstance")
+    end
+
+    it "supports serialized output with scope one" do
+      res = @browser.search("/Chopin/SelectedWorks/Piano", :scope => "one", :serialize => true)
+      expected_chopin_piano_works = %w(
+        /Chopin/SelectedWorks/Piano
+        /Chopin/SelectedWorks/Piano/Nocturnes
+        /Chopin/SelectedWorks/Piano/Ballades
+        /Chopin/SelectedWorks/Piano/Scherzos
+      )
+      expect(res.collect { |h| h["fqname"] }).to match_array(expected_chopin_piano_works)
+    end
+
+    it "support query of state_machine tree" do
+      res = @browser.search("/", :scope => "sub", :state_machines => true)
+      expect(res.collect(&:fqname)).to match_array(@state_machine_fqnames)
+    end
+
+    it "support serialized query of state_machine tree" do
+      res = @browser.search("/", :scope => "sub", :state_machines => true, :serialize => true)
+      expect(res.collect { |h| h["fqname"] }).to match_array(@state_machine_fqnames)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_browser_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_browser_spec.rb
@@ -4,16 +4,16 @@ module MiqAeBrowserSpec
   describe MiqAeBrowser do
     before(:each) do
       MiqAeDatastore.reset
-      @composition_fields = {"title" => {:aetype => "attribute", :datatype => "string"}}
+      @composition_fields = { "title" => { :aetype => "attribute", :datatype => "string" } }
 
-      @chopin_domain = {:name => "Chopin", :ae_namespace => "SelectedWorks", :ae_class => "Piano"}
-      @chopin_piano_compositions = {"Nocturnes" => {"title"    => {:value => "18 Noctures"}},
-                                    "Ballades"  => {"title" => {:value => "4 Ballades"}},
-                                    "Scherzos"  => {"title" => {:value => "4 Scherzos"}}}
+      @chopin_domain = { :name => "Chopin", :ae_namespace => "SelectedWorks", :ae_class => "Piano" }
+      @chopin_piano_compositions = { "Nocturnes" => { "title" => { :value => "18 Noctures" } },
+                                     "Ballades"  => { "title" => { :value => "4 Ballades"  } },
+                                     "Scherzos"  => { "title" => { :value => "4 Scherzos"  } } }
 
-      @liszt_domain = {:name => "Liszt", :ae_namespace => "SelectedWorks", :ae_class => "Piano"}
-      @liszt_piano_compositions = {"Rhapsodies" => {"title" => {:value => "19 Hungarian Rhapsodies"}},
-                                   "Etudes"     => {"title" => {:value => "12 Transcendental Etudes"}}}
+      @liszt_domain = { :name => "Liszt", :ae_namespace => "SelectedWorks", :ae_class => "Piano" }
+      @liszt_piano_compositions = { "Rhapsodies" => { "title" => { :value => "19 Hungarian Rhapsodies"  } },
+                                    "Etudes"     => { "title" => { :value => "12 Transcendental Etudes" } } }
 
       create_ae_model(@chopin_domain.merge(:ae_fields    => @composition_fields,
                                            :ae_instances => @chopin_piano_compositions))
@@ -27,11 +27,11 @@ module MiqAeBrowserSpec
         /Liszt/SelectedWorks/Learning/Campanella
       )
 
-      learning_fields = {"study"   => {:aetype => "state", :datatype => "string"},
-                         "perform" => {:aetype => "state", :datatype => "string"}}
+      learning_fields = { "study"   => { :aetype => "state", :datatype => "string" },
+                          "perform" => { :aetype => "state", :datatype => "string" } }
 
-      learning_instances = {"Campanella" => {"study"   => {:value => "inprogress"},
-                                             "perform" => {:value => ""}}}
+      learning_instances = { "Campanella" => { "study"   => { :value => "inprogress" },
+                                               "perform" => { :value => "" } } }
 
       FactoryGirl.create(:miq_ae_class, :with_instances_and_methods,
                          :name => "Learning", :namespace => "/Liszt/SelectedWorks",
@@ -42,39 +42,39 @@ module MiqAeBrowserSpec
     end
 
     it "can query root base object" do
-      res = @browser.search("/", :scope => "base")
+      res = @browser.search("/", :depth => 0)
       expect(res.size).to eq(0)
     end
 
     it "can query root domains" do
-      res = @browser.search(nil, :scope => "one")
+      res = @browser.search(nil, :depth => 1)
       expect(res.pluck(:name)).to match_array(%w(Chopin Liszt))
     end
 
     it "can query a domain base object" do
-      res = @browser.search("/Chopin", :scope => "base")
+      res = @browser.search("/Chopin", :depth => 0)
       expect(res.first).to eq(MiqAeDomain.where(:name => "Chopin").first)
     end
 
-    it "defaults to scope sub search" do
+    it "defaults to sub-tree search" do
       res = @browser.search("/Chopin")
       expect(res.pluck(:name)).to match_array(%w(Chopin SelectedWorks Piano Nocturnes Ballades Scherzos))
     end
 
-    it "supports scope sub search" do
-      res = @browser.search("/Liszt", :scope => "sub")
+    it "supports sub-tree search" do
+      res = @browser.search("/Liszt", :depth => nil)
       expect(res.pluck(:name)).to match_array(%w(Liszt SelectedWorks Piano Rhapsodies Etudes Learning Campanella))
     end
 
-    it "scope sub search on root gets all objects" do
-      res = @browser.search("/", :scope => "sub")
+    it "sub-tree search on root gets all objects" do
+      res = @browser.search("/", :depth => nil)
       all_nodes = %w(Chopin SelectedWorks Piano Nocturnes Ballades Scherzos
                      Liszt SelectedWorks Piano Rhapsodies Etudes Learning Campanella)
       expect(res.pluck(:name)).to match_array(all_nodes)
     end
 
     it "supports serialized output" do
-      res = @browser.search("/Liszt/SelectedWorks/Piano/Etudes", :scope => "base", :serialize => true)
+      res = @browser.search("/Liszt/SelectedWorks/Piano/Etudes", :depth => 0, :serialize => true)
       expect(res.size).to eq(1)
       expect(res.first).to be_kind_of(Hash)
       expect(res.first).to include("fqname"        => "/Liszt/SelectedWorks/Piano/Etudes",
@@ -82,8 +82,8 @@ module MiqAeBrowserSpec
                                    "klass"         => "MiqAeInstance")
     end
 
-    it "supports serialized output with scope one" do
-      res = @browser.search("/Chopin/SelectedWorks/Piano", :scope => "one", :serialize => true)
+    it "supports serialized output with first level children objects" do
+      res = @browser.search("/Chopin/SelectedWorks/Piano", :depth => 1, :serialize => true)
       expected_chopin_piano_works = %w(
         /Chopin/SelectedWorks/Piano
         /Chopin/SelectedWorks/Piano/Nocturnes
@@ -93,13 +93,24 @@ module MiqAeBrowserSpec
       expect(res.collect { |h| h["fqname"] }).to match_array(expected_chopin_piano_works)
     end
 
+    it "supports serialized output with n-level children objects" do
+      res = @browser.search("/Liszt", :depth => 2, :serialize => true)
+      expected_liszt_works = %w(
+        /Liszt
+        /Liszt/SelectedWorks
+        /Liszt/SelectedWorks/Piano
+        /Liszt/SelectedWorks/Learning
+      )
+      expect(res.collect { |h| h["fqname"] }).to match_array(expected_liszt_works)
+    end
+
     it "support query of state_machine tree" do
-      res = @browser.search("/", :scope => "sub", :state_machines => true)
+      res = @browser.search("/", :state_machines => true)
       expect(res.collect(&:fqname)).to match_array(@state_machine_fqnames)
     end
 
     it "support serialized query of state_machine tree" do
-      res = @browser.search("/", :scope => "sub", :state_machines => true, :serialize => true)
+      res = @browser.search("/", :state_machines => true, :serialize => true)
       expect(res.collect { |h| h["fqname"] }).to match_array(@state_machine_fqnames)
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------

- Support arbitrary depth tree search of the Automate model
- Supports serialized objects to include fqname, domain_fqname and klass
- Supports searching state_machines only subtree
- Added rspecs for it

PivotalTracker: https://www.pivotaltracker.com/story/show/121850007