### PR TITLE
Settings on Region and Zone level – accepting from ‘settings_changes’ table

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -2,6 +2,7 @@ class MiqRegion < ApplicationRecord
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource # Destroy will be handled by purger
+  has_many :settings_changes, :as => :resource, :dependent => :destroy
 
   virtual_has_many :database_backups,       :class_name => "DatabaseBackup"
   virtual_has_many :ext_management_systems, :class_name => "ExtManagementSystem"

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -608,4 +608,8 @@ class MiqServer < ApplicationRecord
   def tenant_identity
     User.super_admin
   end
+
+  def miq_region
+    MiqRegion.my_region
+  end
 end # class MiqServer

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -14,6 +14,7 @@ class Zone < ApplicationRecord
   has_many :storage_managers
   has_many :ldap_regions
   has_many :providers
+  has_many :settings_changes, :as => :resource, :dependent => :destroy
 
   virtual_has_many :hosts,              :uses => {:ext_management_systems => :hosts}
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -52,8 +52,8 @@ module VMDB
       config.store_path(keys, value)
     end
 
-    def save
-      MiqServer.my_server.set_config(config)
+    def save(resource = MiqServer.my_server)
+      resource.set_config(config)
     end
 
     # NOTE: Used by Configuration -> Advanced
@@ -62,7 +62,7 @@ module VMDB
     end
 
     # NOTE: Used by Configuration -> Advanced
-    def self.save_file(contents)
+    def self.save_file(contents, resource = MiqServer.my_server)
       config = new("vmdb")
 
       begin
@@ -73,7 +73,7 @@ module VMDB
       end
 
       return config.errors unless config.errors.blank?
-      config.save
+      config.save(resource)
       true
     end
 

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -44,11 +44,7 @@ module Vmdb
       SETTINGS_HIERARCHY = %i(MiqRegion Zone MiqServer).freeze
 
       def settings_holder
-        direct_call = true
-        if resource
-          direct_call = resource.class.name.to_sym == settings_change_holder
-        end
-        return resource if direct_call
+        return resource.reload if resource.class.name.to_sym == settings_change_holder
         ind = SETTINGS_HIERARCHY.index(settings_change_holder)
         resource.reload.send(METHODS_FOR_SETTINGS[ind])
       end

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -3,27 +3,27 @@ module Vmdb
     class DatabaseSource
       include Vmdb::Logging
 
-      attr_reader :resource_instance, :settings_holder_class
+      attr_reader :resource_instance, :settings_holder_class_name
 
       # @param resource [MiqRegion, Zone, MiqServer] the resource
-      # @param klass [Symbol] class name of object which provides access to SettingsChange for resource
-      #   possible values of klass are {DatabaseSource::SETTINGS_HIERARCHY the setting hierarchy}
+      # @param class_name [Symbol] class name of object which provides access to SettingsChange for resource
+      #   possible values of class_name are {DatabaseSource::SETTINGS_HIERARCHY the setting hierarchy}
       #
       #   Example:
-      #   1. resource is instance of MiqServer and klass is 'Zone', than settings will be loaded
+      #   1. resource is instance of MiqServer and class_name is 'Zone', than settings will be loaded
       #      from resource.zone.settings_changes
-      #   2. resource is instance of MiqServer and klass is 'MiqRegion' than settings will be loaded
+      #   2. resource is instance of MiqServer and class_name is 'MiqRegion' than settings will be loaded
       #      from resource.miq_region.settings_changes
-      def initialize(resource, klass)
+      def initialize(resource, class_name)
         @resource_instance = resource
-        @settings_holder_class = klass
+        @settings_holder_class_name = class_name.to_sym
       end
 
       def self.sources_for(resource)
         return [] if resource.nil?
         hierarchy_index = SETTINGS_HIERARCHY.index(resource.class.name.to_sym)
-        SETTINGS_HIERARCHY[0..hierarchy_index].collect do |klass|
-          new(resource, klass)
+        SETTINGS_HIERARCHY[0..hierarchy_index].collect do |class_name|
+          new(resource, class_name)
         end
       end
 
@@ -52,9 +52,9 @@ module Vmdb
       def settings_holder
         return nil if resource_instance.nil?
         resource_instance.reload
-        return resource_instance if resource_instance.class.name.to_sym == settings_holder_class
+        return resource_instance if resource_instance.class.name.to_sym == settings_holder_class_name
 
-        index = SETTINGS_HIERARCHY.index(settings_holder_class)
+        index = SETTINGS_HIERARCHY.index(settings_holder_class_name)
         resource_instance.send(METHODS_FOR_SETTINGS[index])
       end
     end

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -51,9 +51,11 @@ module Vmdb
 
       def settings_holder
         return nil if resource_instance.nil?
-        return resource_instance.reload if resource_instance.class.name.to_sym == settings_holder_class
+        resource_instance.reload
+        return resource_instance if resource_instance.class.name.to_sym == settings_holder_class
+
         index = SETTINGS_HIERARCHY.index(settings_holder_class)
-        resource_instance.reload.send(METHODS_FOR_SETTINGS[index])
+        resource_instance.send(METHODS_FOR_SETTINGS[index])
       end
     end
   end

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -4,14 +4,15 @@ module Vmdb
       include Vmdb::Logging
 
       attr_reader :resource_instance, :settings_holder_class
-      
+
       # NOTE: resource - instance of MiqRegion, Zone or MiqServer
       #       klass    - class name of object which provides access to SettingsChange for resource
       #                  possible values of klass are in SETTINGS_HIERARCHY
-      #                  Example: 1. resource is instance of MiqServer and klass is 'Zone',
-      #                              than settings will be loaded from resource.zone.settings_changes
-      #                           2. resource is instance of MiqServer and klass is 'MiqRegion'
-      #                              than settings will be loaded from resource.miq_region.settings_changes                
+      # EXAMPLE: 1. resource is instance of MiqServer and klass is 'Zone',
+      #             than settings will be loaded from resource.zone.settings_changes
+      #          2. resource is instance of MiqServer and klass is 'MiqRegion'
+      #             than settings will be loaded from resource.miq_region.settings_changes
+      
       def initialize(resource, klass)
         @resource_instance = resource
         @settings_holder_class = klass
@@ -30,7 +31,8 @@ module Vmdb
       end
 
       def load
-        if settings_holder_ = settings_holder
+        settings_holder_ = settings_holder
+        if settings_holder_
           settings_holder_.settings_changes.reload.each_with_object({}) do |c, h|
             h.store_path(c.key_path, c.value)
           end
@@ -50,7 +52,7 @@ module Vmdb
         return nill if resource_instance.nil?
         return resource_instance.reload if resource_instance.class.name.to_sym == settings_holder_class
         index = SETTINGS_HIERARCHY.index(settings_holder_class)
-        return resource_instance.reload.send(METHODS_FOR_SETTINGS[index])
+        resource_instance.reload.send(METHODS_FOR_SETTINGS[index])
       end
     end
   end

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -3,22 +3,54 @@ module Vmdb
     class DatabaseSource
       include Vmdb::Logging
 
-      attr_reader :resource
+      attr_reader :resource, :settings_change_holder
 
-      def initialize(resource)
-        @resource = resource
+      def initialize(resource_to_get_settings_about, class_to_call_settings_changes_on)
+        @resource = resource_to_get_settings_about
+        @settings_change_holder = class_to_call_settings_changes_on
+      end
+
+      def self.sources_for(resource_to_get_settings_about)
+        return [] if resource_to_get_settings_about.nil?
+        hierarchy_index = SETTINGS_HIERARCHY.index(resource_to_get_settings_about.class.name.to_sym)
+        SETTINGS_HIERARCHY[0..hierarchy_index].collect do |class_to_call_settings_changes_on|
+          new(resource_to_get_settings_about, class_to_call_settings_changes_on)
+        end
+      end
+
+      def self.parent_sources_for(resource_to_get_settings_about)
+        return [] if resource_to_get_settings_about.nil?
+        hierarchy_index = SETTINGS_HIERARCHY.index(resource_to_get_settings_about.class.name.to_sym)
+        SETTINGS_HIERARCHY[0..hierarchy_index][0...-1].collect do |class_to_call_settings_changes_on|
+          new(resource_to_get_settings_about, class_to_call_settings_changes_on)
+        end
       end
 
       def load
         return if resource.nil?
-
-        resource.settings_changes.reload.each_with_object({}) do |c, h|
+        obj_with_settings = settings_holder
+        obj_with_settings.settings_changes.reload.each_with_object({}) do |c, h|
           h.store_path(c.key_path, c.value)
-        end
+        end unless obj_with_settings.nil?
       rescue => err
         _log.error("#{err.class}: #{err}")
         _log.error(err.backtrace.join("\n"))
         raise
+      end
+
+      private
+
+      METHODS_FOR_SETTINGS = %i(miq_region zone miq_server).freeze
+      SETTINGS_HIERARCHY = %i(MiqRegion Zone MiqServer).freeze
+
+      def settings_holder
+        direct_call = true
+        if resource
+          direct_call = resource.class.name.to_sym == settings_change_holder
+        end
+        return resource if direct_call
+        ind = SETTINGS_HIERARCHY.index(settings_change_holder)
+        resource.reload.send(METHODS_FOR_SETTINGS[ind])
       end
     end
   end

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -5,14 +5,15 @@ module Vmdb
 
       attr_reader :resource_instance, :settings_holder_class
 
-      # NOTE: resource - instance of MiqRegion, Zone or MiqServer
-      #       klass    - class name of object which provides access to SettingsChange for resource
-      #                  possible values of klass are in SETTINGS_HIERARCHY
-      # EXAMPLE: 1. resource is instance of MiqServer and klass is 'Zone',
-      #             than settings will be loaded from resource.zone.settings_changes
-      #          2. resource is instance of MiqServer and klass is 'MiqRegion'
-      #             than settings will be loaded from resource.miq_region.settings_changes
-      
+      # @param resource [MiqRegion, Zone, MiqServer] the resource
+      # @param klass [Symbol] class name of object which provides access to SettingsChange for resource
+      #   possible values of klass are {DatabaseSource::SETTINGS_HIERARCHY the setting hierarchy}
+      #
+      #   Example:
+      #   1. resource is instance of MiqServer and klass is 'Zone', than settings will be loaded
+      #      from resource.zone.settings_changes
+      #   2. resource is instance of MiqServer and klass is 'MiqRegion' than settings will be loaded
+      #      from resource.miq_region.settings_changes
       def initialize(resource, klass)
         @resource_instance = resource
         @settings_holder_class = klass
@@ -31,9 +32,9 @@ module Vmdb
       end
 
       def load
-        settings_holder_ = settings_holder
-        if settings_holder_
-          settings_holder_.settings_changes.reload.each_with_object({}) do |c, h|
+        holder = settings_holder
+        if holder
+          holder.settings_changes.reload.each_with_object({}) do |c, h|
             h.store_path(c.key_path, c.value)
           end
         end
@@ -49,7 +50,7 @@ module Vmdb
       SETTINGS_HIERARCHY = %i(MiqRegion Zone MiqServer).freeze
 
       def settings_holder
-        return nill if resource_instance.nil?
+        return nil if resource_instance.nil?
         return resource_instance.reload if resource_instance.class.name.to_sym == settings_holder_class
         index = SETTINGS_HIERARCHY.index(settings_holder_class)
         resource_instance.reload.send(METHODS_FOR_SETTINGS[index])

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -12,15 +12,12 @@ describe VMDB::Config do
 
   context ".save_file" do
     it "normal" do
-      EvmSpecHelper.local_miq_server
-      stub_my_server_settings
-
+      resource = EvmSpecHelper.local_miq_server
       data = Settings.to_hash
       data.store_path(:api, :token_ttl, "1.day")
       data = data.to_yaml
 
-      expect(VMDB::Config.save_file(data)).to be true
-
+      expect(VMDB::Config.save_file(data, resource)).to be true
       expect(SettingsChange.count).to eq(1)
       expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")
     end
@@ -34,12 +31,11 @@ describe VMDB::Config do
   end
 
   it "#save" do
-    EvmSpecHelper.local_miq_server
-    stub_my_server_settings
+    resource = EvmSpecHelper.local_miq_server
 
     config = VMDB::Config.new("vmdb")
     config.config.store_path(:api, :token_ttl, "1.day")
-    config.save
+    config.save(resource)
 
     expect(SettingsChange.count).to eq(1)
     expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")
@@ -47,7 +43,6 @@ describe VMDB::Config do
 
   it "#set_worker_setting!" do
     EvmSpecHelper.local_miq_server
-    stub_my_server_settings
 
     config = VMDB::Config.new("vmdb")
     config.set_worker_setting!(:MiqEmsMetricsCollectorWorker, :memory_threshold, "1.terabyte")
@@ -55,14 +50,5 @@ describe VMDB::Config do
     fq_keys = [:workers, :worker_base, :queue_worker_base, :ems_metrics_collector_worker, :memory_threshold]
     v = config.config.fetch_path(fq_keys).to_i_with_method
     expect(v).to eq(1.terabyte)
-  end
-
-  # HACK: Temporary fix because zone name is stored in the configuration, but
-  #   when calling EvmSpecHelper.local_miq_server, it does not update the
-  #   corresponding settings.  enqueue_for_server expects that the zone is set,
-  #   and this can get messed up during Config activation during a change.
-  def stub_my_server_settings
-    server = MiqServer.my_server
-    allow(server).to receive(:enqueue_for_server)
   end
 end

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -12,7 +12,8 @@ describe VMDB::Config do
 
   context ".save_file" do
     it "normal" do
-      resource = EvmSpecHelper.local_miq_server
+      resource = FactoryGirl.create(:miq_server)
+      MiqRegion.seed
       data = Settings.to_hash
       data.store_path(:api, :token_ttl, "1.day")
       data = data.to_yaml
@@ -31,8 +32,9 @@ describe VMDB::Config do
   end
 
   it "#save" do
-    resource = EvmSpecHelper.local_miq_server
-
+    resource = FactoryGirl.create(:miq_server)
+    MiqRegion.seed
+    
     config = VMDB::Config.new("vmdb")
     config.config.store_path(:api, :token_ttl, "1.day")
     config.save(resource)

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -32,12 +32,12 @@ describe VMDB::Config do
   end
 
   it "#save" do
-    resource = FactoryGirl.create(:miq_server)
+    server = FactoryGirl.create(:miq_server)
     MiqRegion.seed
-    
-    config = VMDB::Config.new("vmdb")
+
+    config = server.get_config
     config.config.store_path(:api, :token_ttl, "1.day")
-    config.save(resource)
+    config.save(server)
 
     expect(SettingsChange.count).to eq(1)
     expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -202,7 +202,7 @@ describe Vmdb::Settings do
 
       expect(miq_server.miq_region.settings_changes.count).to eq 1
       expect(miq_server.miq_region.settings_changes.first).to have_attributes(:key   => "/api/token_ttl",
-                                                                                   :value => "3.hour")
+                                                                              :value => "3.hour")
       miq_server.reload
       expect(miq_server.settings_changes.count).to eq 0
 

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -178,6 +178,37 @@ describe Vmdb::Settings do
       change = miq_server.settings_changes.find_by(:key => "/authentication/user_proxies")
       expect(change.value).to eq [{:bind_pwd => encrypted}]
     end
+
+    it "saving settings for Zone does not change saved Region or Server settings" do
+      MiqRegion.seed
+
+      described_class.save!(miq_server.zone, :api => {:token_ttl => "2.hour"})
+      miq_server.zone.reload
+      expect(miq_server.zone.settings_changes.count).to eq 1
+      expect(miq_server.zone.settings_changes.first).to have_attributes(:key   => "/api/token_ttl",
+                                                                        :value => "2.hour")
+      miq_server.reload
+      expect(miq_server.settings_changes.count).to eq 0
+
+      miq_server.zone.miq_region.reload
+      expect(miq_server.zone.miq_region.settings_changes.count).to eq 0
+    end
+
+    it "saving settings for Region does not change saved Zone or Server settings" do
+      MiqRegion.seed
+
+      described_class.save!(miq_server.zone.miq_region, :api => {:token_ttl => "3.hour"})
+      miq_server.zone.miq_region.reload
+
+      expect(miq_server.zone.miq_region.settings_changes.count).to eq 1
+      expect(miq_server.zone.miq_region.settings_changes.first).to have_attributes(:key   => "/api/token_ttl",
+                                                                                   :value => "3.hour")
+      miq_server.reload
+      expect(miq_server.settings_changes.count).to eq 0
+
+      miq_server.zone.reload
+      expect(miq_server.zone.settings_changes.count).to eq 0
+    end
   end
 
   shared_examples_for "password handling" do
@@ -272,6 +303,38 @@ describe Vmdb::Settings do
       server.settings_changes.create!(:key => "/log/collection/current/pattern", :value => ["*.log"])
       settings = Vmdb::Settings.for_resource(server)
       expect(settings.log.collection.current.pattern).to eq ["*.log"]
+    end
+
+    it "can load settings on each level from Region -> Zone -> Server hierarchy" do
+      MiqRegion.seed
+      described_class.save!(server.zone.miq_region, :api => {:token_ttl => "3.hour"})
+      described_class.save!(server.zone, :api => {:token_ttl => "4.hour"})
+      described_class.save!(server, :api => {:token_ttl => "5.hour"})
+
+      settings = Vmdb::Settings.for_resource(server)
+      expect(settings.api.token_ttl).to eq "5.hour"
+
+      settings = Vmdb::Settings.for_resource(server.zone)
+      expect(settings.api.token_ttl).to eq "4.hour"
+
+      settings = Vmdb::Settings.for_resource(server.zone.miq_region)
+      expect(settings.api.token_ttl).to eq "3.hour"
+    end
+
+    it "applied settings from hierarchy Region -> Zone -> Server" do
+      MiqRegion.seed
+
+      described_class.save!(server.zone.miq_region, :api => {:token_ttl => "3.hour"})
+      settings = Vmdb::Settings.for_resource(server)
+      expect(settings.api.token_ttl).to eq "3.hour"
+
+      described_class.save!(server.zone, :api => {:token_ttl => "4.hour"})
+      settings = Vmdb::Settings.for_resource(server)
+      expect(settings.api.token_ttl).to eq "4.hour"
+
+      described_class.save!(server, :api => {:token_ttl => "5.hour"})
+      settings = Vmdb::Settings.for_resource(server)
+      expect(settings.api.token_ttl).to eq "5.hour"
     end
   end
 end

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -190,8 +190,8 @@ describe Vmdb::Settings do
       miq_server.reload
       expect(miq_server.settings_changes.count).to eq 0
 
-      miq_server.zone.miq_region.reload
-      expect(miq_server.zone.miq_region.settings_changes.count).to eq 0
+      miq_server.miq_region.reload
+      expect(miq_server.miq_region.settings_changes.count).to eq 0
     end
 
     it "saving settings for Region does not change saved Zone or Server settings" do
@@ -200,8 +200,8 @@ describe Vmdb::Settings do
       described_class.save!(miq_server.zone.miq_region, :api => {:token_ttl => "3.hour"})
       miq_server.zone.miq_region.reload
 
-      expect(miq_server.zone.miq_region.settings_changes.count).to eq 1
-      expect(miq_server.zone.miq_region.settings_changes.first).to have_attributes(:key   => "/api/token_ttl",
+      expect(miq_server.miq_region.settings_changes.count).to eq 1
+      expect(miq_server.miq_region.settings_changes.first).to have_attributes(:key   => "/api/token_ttl",
                                                                                    :value => "3.hour")
       miq_server.reload
       expect(miq_server.settings_changes.count).to eq 0


### PR DESCRIPTION
Settings on Region and Zone level – accepting from ‘settings_changes’ table

In this PR:
1.  Added ```:settings_changes``` association to ```Zone``` and ```MiqRegion``` classes
2. Refactored ```Vmdb::Settings``` to support saving and loading settings for Region and Zone
3. added ```resource``` parameter to ```Config.save_file()``` and ```Config#save()``` methods 
4. rspec for saving and loading settings on different levels
5. modified config_spec.rb: ```save``` and ```save_file``` now passing instance of MiqServer as parameter.
