### PR TITLE
Trim down alert profile assignments call

### DIFF
--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -1,0 +1,42 @@
+describe AssignmentMixin do
+  # too ingrained in AR - has many, acts_as_miq_taggable, ...
+  let(:test_class) { MiqAlertSet }
+
+  describe '#assignments' do
+    it "finds no assignments" do
+      expect(test_class.assignments).to eq([])
+    end
+
+    it "detects tags on alert_set" do
+      ct1 = ctag("environment", "test")
+      alert_set = FactoryGirl.create(:miq_alert_set, :mode => "VmOrTemplate")
+      alert_set.assign_to_tags([ct1], "vm")
+      alert_set.reload # reload ensures the tag is set
+
+      ct2 = ctag("environment", "staging")
+      alert_set2 = FactoryGirl.create(:miq_alert_set, :mode => "VmOrTemplate")
+      alert_set2.assign_to_tags([ct2], "vm")
+      alert_set2.reload # reload ensures the tag is set
+
+      expect(test_class.assignments).to match_array(
+        [
+          {:assigned => alert_set, :assigned_to => "vm/tag/managed/environment/test"},
+          {:assigned => alert_set2, :assigned_to => "vm/tag/managed/environment/staging"},
+        ]
+      )
+    end
+  end
+
+  private
+
+  # creates a tag e.g. "/managed/environment/test"
+  #
+  # @param category [String] category name e.g.: "environment"
+  # @param value    [String] value e.g.: "test"
+  # @return [ClassificationTag] classification tag. `.tag()` is an available method
+  def ctag(category = "environment", value = "test")
+    env = Classification.find_by_name(category) ||
+          FactoryGirl.create(:classification, :name => category, :single_value => 1)
+    FactoryGirl.create(:classification_tag, :name => value, :parent => env)
+  end
+end


### PR DESCRIPTION
part of #9447 

Looking up the tags for all the alert profiles is an expensive query. It is cached for 10 seconds.

**before**
Run a query to fetch `taggings` for every `tag` in the alert profiles (`alert_sets`). There will probably always be 1 `tagging` per `tag`.

**after**

Bring back the `taggings` (that was already part of the join before). This removes the N+1 and brings back no extra data.

```
MiqAlertSet.count #=> 1
```

before
----

|     ms | bytes | objects |   queries | query (ms) |     rows |`comments`
|    ---:|   ---:|   ---:|   ---:|     ---:|      ---:| ---
|   64.4 | 1,325,032 | 15,335 |   18 |   6.4 |       33 |`no name-1`
|    0.8 |       |       |           1 |   0.6 |        1 |`.SELECT "miq_sets".* ` - 1 query
|    1.1 |       |       |           1 |   0.9 |       16 |`.SELECT "tags".* ` - 1 query
|    4.5 |       |       |          16 |   4.4 |       16 |`.SELECT "taggings".* ` - **N** queries

after
----

|     ms | bytes | objects |   queries | query (ms) |     rows |`comments`
|    ---:|   ---:|   ---:|   ---:|  ---:|         ---:| ---
|   58.8 | 701,806 | 8,482 |      2 |   2.3 |       17 |after
|    0.6 |       |       |          1 |   0.5 |        1 |`.SELECT "miq_sets".* ` - 1 query
|    1.7 |       |       |          1 |   0.9 |       16 |`.SELECT "tags", "taggings"."id" AS t0_r0, "tags"."name" AS t0_r1, "taggings"."id" AS t1_r0, "taggings"."taggable_i"` 1 query