### PR TITLE
Remove generic method type argument

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -161,15 +161,14 @@ class ApiController < ApplicationController
   end
 
   def redirect_api_request(method)
-    collection    = @req.collection || "entrypoint"
-    target_method = "#{method}_#{collection}"
+    target_method = "#{method}_#{@req.collection || "entrypoint"}"
     if respond_to?(target_method)
       send(target_method)
       return true
     end
     target_method = "#{method}_generic"
     if respond_to?(target_method)
-      send(target_method, collection.to_sym)
+      send(target_method)
       return true
     end
     false

--- a/app/controllers/api_controller/categories.rb
+++ b/app/controllers/api_controller/categories.rb
@@ -6,7 +6,7 @@ class ApiController
     #
     def show_categories
       request_additional_attributes
-      show_generic(:categories)
+      show_generic
     end
 
     def edit_resource_categories(type, id, data = {})

--- a/app/controllers/api_controller/container_deployments.rb
+++ b/app/controllers/api_controller/container_deployments.rb
@@ -5,7 +5,7 @@ class ApiController
       if @req.c_id == "container_deployment_data"
         render_resource :container_deployments, :data => ContainerDeploymentService.new.all_data
       else
-        show_generic(:container_deployments)
+        show_generic
       end
     end
 

--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -4,30 +4,30 @@ class ApiController
     # Primary Methods
     #
 
-    def show_generic(type)
+    def show_generic
       validate_api_action
       if @req.subcollection
         render_collection_type @req.subcollection.to_sym, @req.s_id, true
       else
-        render_collection_type type, @req.c_id
+        render_collection_type @req.collection.to_sym, @req.c_id
       end
     end
 
-    def update_generic(type)
+    def update_generic
       validate_api_action
       if @req.subcollection
-        render_normal_update type, update_collection(@req.subcollection.to_sym, @req.s_id, true)
+        render_normal_update @req.collection.to_sym, update_collection(@req.subcollection.to_sym, @req.s_id, true)
       else
-        render_normal_update type, update_collection(type, @req.c_id)
+        render_normal_update @req.collection.to_sym, update_collection(@req.collection.to_sym, @req.c_id)
       end
     end
 
-    def destroy_generic(type)
+    def destroy_generic
       validate_api_action
       if @req.subcollection
         delete_subcollection_resource @req.subcollection.to_sym, @req.s_id
       else
-        send(target_resource_method(false, type, :delete), type, @req.c_id)
+        send(target_resource_method(false, @req.collection.to_sym, :delete), @req.collection.to_sym, @req.c_id)
       end
       render_normal_destroy
     end

--- a/app/controllers/api_controller/reports.rb
+++ b/app/controllers/api_controller/reports.rb
@@ -11,12 +11,12 @@ class ApiController
       if @req.subcollection == "results" && (@req.s_id || expand?(:resources)) && attribute_selection == "all"
         @additional_attributes = %w(result_set)
       end
-      show_generic(:reports)
+      show_generic
     end
 
     def show_results
       @additional_attributes = %w(result_set)
-      show_generic(:results)
+      show_generic
     end
 
     def run_resource_reports(_type, id, _data)

--- a/app/controllers/api_controller/service_dialogs.rb
+++ b/app/controllers/api_controller/service_dialogs.rb
@@ -10,7 +10,7 @@ class ApiController
 
     def show_service_dialogs
       @additional_attributes = %w(content) if attribute_selection == "all"
-      show_generic(:service_dialogs)
+      show_generic
     end
 
     def refresh_dialog_fields_resource_service_dialogs(type, id = nil, data = nil)

--- a/app/controllers/api_controller/users.rb
+++ b/app/controllers/api_controller/users.rb
@@ -10,7 +10,7 @@ class ApiController
         end
         render_normal_update :users, update_collection(:users, @req.c_id)
       else
-        update_generic(:users)
+        update_generic
       end
     end
 


### PR DESCRIPTION
A small refactoring to remove the argument of
show/update/destroy_generic. The type that is passed in is always
`@req.collection.to_sym`.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 