### PR TITLE
Use standard cache for my_enterprise

### DIFF
--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -27,13 +27,7 @@ class MiqEnterprise < ApplicationRecord
     end
   end
 
-  def self.my_enterprise
-    # Cache the enterprise instance, but clear the association
-    #   cache to support keeping the associations fresh
-    @my_enterprise ||= in_my_region.first
-    @my_enterprise.send(:clear_association_cache) unless @my_enterprise.nil?
-    @my_enterprise
-  end
+  cache_with_timeout(:my_enterprise) { in_my_region.first }
 
   def self.is_enterprise?
     # TODO: Need to implement a way to determine whether we're running on an "enterprise" server or a "regional" server.


### PR DESCRIPTION
Purpose or Intent
-----------------

When we are performing `performance_capacity_timer`, refresh, and others, the individual classes return their own parent. Many of these return `MiqEnterprise.my_enterprise` as the root node.

So in the code, many root enterprise records are looked up at the same time.
The current implementation blows away the relations for the enterprise.

`MiqServer`, `MiqRegion`, and others use a simpler cache, one that has the record valid for 10 minutes.

Can we just move `MiqEnterprise.my_enterprise` over to the same mechanism as `my_server` and `my_region`?

Performance numbers:
For 100vms this calls ~145 fewer queries to `MiqEnterprise.my_enterprise.tags` and 145 fewer queries to `MiqEnterprise.my_enterprise.taggings`.
And unfortunately, I am unable to pass this value around.

/cc @Fryguy @jrafanie @gtanzillo While this is just following the current common mechanism, this may generate a lot of chatter.