### PR TITLE
Fix /miq_policy/explorer alert profile assignments

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -200,7 +200,7 @@ module MiqPolicyController::AlertProfiles
           :hideCheckbox => true
         )
         root_node[:children] = []
-        @objects.sort_by { |o| (o[:name] || o[:description]).downcase }.each do |o|
+        @objects.sort_by { |o| (o.name.presence || o.description).downcase }.each do |o|
           if @assign[:new][:assign_to].ends_with?("-tags")
             icon = "tag.png"
           else
@@ -214,7 +214,7 @@ module MiqPolicyController::AlertProfiles
           end
           node = TreeNodeBuilder.generic_tree_node(
             o.id,
-            o[:name] || o[:description],
+            (o.name.presence || o.description),
             icon,
             "",
             :select => @assign[:new][:objects].include?(o.id) # Check if tag is assigned

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -14,7 +14,7 @@
         = _('Assign To')
       .col-md-8
         = select_tag('chosen_assign_to',
-          options_for_select([["<#{_('Nothing')}>", nil]] + ASSIGN_TOS[@alert_profile.mode].map { |k, v| [v.kind_of?(PostponedTranslation) ? v.translate : _(v), k] }.sort, @assign[:new][:assign_to]),
+          options_for_select([["<#{_('Nothing')}>", nil]] + ASSIGN_TOS[@alert_profile.mode].map { |k, v| [v.kind_of?(PostponedTranslation) ? v.translate.to_s : _(v).to_s, k.to_s] }.sort, @assign[:new][:assign_to]),
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
The pages uses to assign an `alert_profile` to a resource are throwing exceptions.
So the page returns a 500, but since it is ajax, it just eats it.

Part of this looks like it was introduced in 91be50d5 but I'm unsure when this actually broke.

error reproduction:

1. Go to alert profiles
2. add an alert
3. attempt to assign to a resource (add tags)
4. nothing happens. rails console displays a bug