### PR TITLE
Fixing sorting in Ansible Tower Configuration Manager

### DIFF
--- a/app/models/manageiq/providers/configuration_manager/inventory_group.rb
+++ b/app/models/manageiq/providers/configuration_manager/inventory_group.rb
@@ -1,3 +1,9 @@
 class ManageIQ::Providers::ConfigurationManager::InventoryGroup < EmsFolder
   belongs_to :manager, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::ConfigurationManager"
+
+  virtual_column :total_configured_systems, :type => :integer
+
+  def total_configured_systems
+    Rbac.filtered(configured_systems).count
+  end
 end

--- a/product/views/ManageIQ_Providers_ConfigurationManager_InventoryGroup.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager_InventoryGroup.yaml
@@ -15,7 +15,7 @@ title: InventoryGroup
 name: InventoryGroup
 
 # Main DB table report is based on
-db: EmsFolder
+db: ManageIQ::Providers::ConfigurationManager::InventoryGroup
 
 # Columns to fetch from the main table
 cols:


### PR DESCRIPTION
Purpose or Intent
-----------------
Sorting broken by Total Configured Systems. There was missing virtual
column total_configured_systems. Solved by adding virtual column and
taking total_configured_systems from related ext_management_system.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1350308

cc @gmcculloug 
Thanks @lpichler 