### PR TITLE
Fixed case-typo in expression editor when operating with date-fields

### DIFF
--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -83,7 +83,7 @@
           - opts = (@edit[@expkey][:val1][:type] == :datetime ? FROM_HOURS : [])
           - opts += FROM_DAYS + FROM_WEEKS + FROM_MONTHS + FROM_QUARTERS + FROM_YEARS
           = select_tag('chosen_from_1',
-            options_for_select(HASH[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
+            options_for_select(Hash[opts.map {|x| [_(x), x]}], @edit[@expkey][:exp_value][0]),
             :multiple              => false,
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,


### PR DESCRIPTION
The fields selected on the screenshot cause an exception in the current master. The issue was introduced by b5eb253.

![screenshot from 2016-07-04 15-14-01](https://cloud.githubusercontent.com/assets/649130/16561553/15164192-41fa-11e6-8bde-7a1710e4d2cd.png)
