### PR TITLE
Convert ExplorerPresenter to JSON

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,3 +74,4 @@
 //= require resizable_sidebar
 //= require xml_display
 //= require miq_c3
+//= require miq_explorer

--- a/app/assets/javascripts/jquery_overrides.js
+++ b/app/assets/javascripts/jquery_overrides.js
@@ -13,10 +13,19 @@ jQuery.evalLog = function (text) {
 };
 
 $.ajaxSetup({
-  converters: { // Log exceptions when evaling javascripts
-    "text script": function( text ) {
-      jQuery.evalLog.call(this, text);
-      return text;
+  converters: {
+    "text script": function(text) {
+      if (text.match(/^{/)) { // JSON payload
+        var parsed_json = jQuery.parseJSON(text);
+        if (parsed_json['explorer']) {
+          return ManageIQ.explorer.process(parsed_json); // ExplorerPresenter payload
+        } else {
+          return null;
+        }
+      } else { // JavaScript payload
+        jQuery.evalLog.call(this, text);
+        return text;
+      }
     }
   }
 });

--- a/app/assets/javascripts/jquery_overrides.js
+++ b/app/assets/javascripts/jquery_overrides.js
@@ -12,12 +12,12 @@ jQuery.evalLog = function (text) {
   return text;
 };
 
-jQuery.jsonPayload = function (text) {
+jQuery.jsonPayload = function (text, fallback) {
   var parsed_json = jQuery.parseJSON(text);
   if (parsed_json['explorer']) {
     return ManageIQ.explorer.process(parsed_json); // ExplorerPresenter payload
   } else {
-    return text;
+    return fallback(text);
   }
 };
 
@@ -30,11 +30,11 @@ $.ajaxSetup({
   },
   converters: {
     "text json": function (text) {
-      return jQuery.jsonPayload(text);
+      return jQuery.jsonPayload(text, function (text) { return jQuery.parseJSON(text); });
     },
     "text script": function (text) {
       if (text.match(/^{/)) {
-        return jQuery.jsonPayload(text);
+        return jQuery.jsonPayload(text, function (text) { return text; });
       } else { // JavaScript payload
         jQuery.evalLog.call(this, text);
         return text;

--- a/app/assets/javascripts/jquery_overrides.js
+++ b/app/assets/javascripts/jquery_overrides.js
@@ -12,16 +12,29 @@ jQuery.evalLog = function (text) {
   return text;
 };
 
+jQuery.jsonPayload = function (text) {
+  var parsed_json = jQuery.parseJSON(text);
+  if (parsed_json['explorer']) {
+    return ManageIQ.explorer.process(parsed_json); // ExplorerPresenter payload
+  } else {
+    return text;
+  }
+};
+
 $.ajaxSetup({
+  accepts: {
+    json: "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"
+  },
+  contents: {
+    json: /application\/json/
+  },
   converters: {
-    "text script": function(text) {
-      if (text.match(/^{/)) { // JSON payload
-        var parsed_json = jQuery.parseJSON(text);
-        if (parsed_json['explorer']) {
-          return ManageIQ.explorer.process(parsed_json); // ExplorerPresenter payload
-        } else {
-          return null;
-        }
+    "text json": function (text) {
+      return jQuery.jsonPayload(text);
+    },
+    "text script": function (text) {
+      if (text.match(/^{/)) {
+        return jQuery.jsonPayload(text);
       } else { // JavaScript payload
         jQuery.evalLog.call(this, text);
         return text;

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -23,7 +23,7 @@ ManageIQ.explorer.lock_tree = function(tree, lock) {
   miqDimDiv('#' + tree + '_div', lock);
 }
 
-ManageIQ.explorer.clear_search_show_or_hide = function(show) {
+ManageIQ.explorer.clear_search_toggle = function(show) {
   if ( show ) {
     $('#clear_search').show();
   } else {
@@ -167,7 +167,7 @@ ManageIQ.explorer.process = function(data) {
   }
 
   if ( !_.isUndefined(data.clearSearch) ) {
-    ManageIQ.explorer.clear_search_show_or_hide('show' == data.clearSearch);
+    ManageIQ.explorer.clear_search_toggle(data.clearSearch);
   }
 
   miqInitMainContent();

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -134,7 +134,7 @@ ManageIQ.explorer.process = function(data) {
   }
 
   if ( _.isObject(data.reloadToolbars) ) {
-    _.forEach(data.replacePartials, function (content, element) {
+    _.forEach(data.reloadToolbars, function (content, element) {
       $('#' + element).html(content);
     });
     miqInitToolbars();

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -81,7 +81,7 @@ ManageIQ.explorer.process = function(data) {
     del_node.remove();
   }
 
-  if ( !_.isString(data.dashboardUrl) ) {
+  if ( _.isString(data.dashboardUrl) ) {
     ManageIQ.widget.dashboardUrl = data.dashboardUrl;
   }
 

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -9,11 +9,9 @@ ManageIQ.explorer.updateElement = function(element, options) {
 };
 
 ManageIQ.explorer.buildCalendar = function(options) {
-  var skip_days = _.isObject(options.skipDays) ? options.skipDays : undefined;
-
-  ManageIQ.calendar.calDateFrom = options.dateFrom; //# FIXME js_format_date
-  ManageIQ.calendar.calDateTo   = options.dateTo;
-  ManageIQ.calendar.calSkipDays = skip_days;
+  ManageIQ.calendar.calDateFrom = _.isString(options.dateFrom) ? new Date(options.dateFrom) : undefined;
+  ManageIQ.calendar.calDateTo = _.isString(options.dateTo) ? new Date(options.dateTo) : undefined;
+  ManageIQ.calendar.calSkipDays = _.isObject(options.skipDays) ? options.skipDays : undefined;
 
   miqBuildCalendar();
 }

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -1,7 +1,7 @@
 ManageIQ.explorer = {}
 
 ManageIQ.explorer.updateElement = function(element, options) {
-  if ( _.isString(options.legend) ) 
+  if ( _.isString(options.legend) )
     $('#' + element).html(options.legend);
   else if ( _.isString(options.title) )
     $('#' + element).attr( {'title': options.title});
@@ -20,6 +20,13 @@ ManageIQ.explorer.buildCalendar = function(options) {
 ManageIQ.explorer.lock_tree = function(tree, lock) {
   $('#' + tree + 'box').dynatree(lock ? 'disable' : 'enable');
   miqDimDiv('#' + tree + '_div', lock);
+}
+
+ManageIQ.exlorer.clear_search_show_or_hide(show) {
+  if ( show )
+    $('#clear_search').show();
+  else
+    $('#clear_search').hide();
 }
 
 ManageIQ.explorer.process = function(data) {
@@ -112,7 +119,7 @@ ManageIQ.explorer.process = function(data) {
   if ( _.isString(data.rightCellText) )
     $('h1#explorer_title > span#explorer_title_text').
       html(data.rightCellText);
-  
+
   if ( _.isObject(data.reloadToolbars) ) {
     _.forEach(data.replacePartials, function (content, element) {
       $('#' + element).html(content);
@@ -146,12 +153,8 @@ ManageIQ.explorer.process = function(data) {
     if ( element.length ) element.focus();
   }
 
-  // FIXME: change 'clear_search_show_or_hide' to bool
-  if ( _.isString(data.clearSearch) )
-    if ( 'show' == data.clearSearch )
-      $('#clear_search').show();
-    else
-      $('#clear_search').hide();
+  if ( !_.isUndefined(data.clearSearch) )
+    ManageIQ.explorer.clear_search_show_or_hide('show' == data.clearSearch);
 
   miqInitMainContent();
 

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -1,10 +1,11 @@
 ManageIQ.explorer = {}
 
 ManageIQ.explorer.updateElement = function(element, options) {
-  if ( _.isString(options.legend) )
+  if ( _.isString(options.legend) ) {
     $('#' + element).html(options.legend);
-  else if ( _.isString(options.title) )
+  } else if ( _.isString(options.title) ) {
     $('#' + element).attr( {'title': options.title});
+  }
 };
 
 ManageIQ.explorer.buildCalendar = function(options) {
@@ -22,44 +23,50 @@ ManageIQ.explorer.lock_tree = function(tree, lock) {
   miqDimDiv('#' + tree + '_div', lock);
 }
 
-ManageIQ.exlorer.clear_search_show_or_hide(show) {
-  if ( show )
+ManageIQ.explorer.clear_search_show_or_hide = function(show) {
+  if ( show ) {
     $('#clear_search').show();
-  else
+  } else {
     $('#clear_search').hide();
+  }
 }
 
 ManageIQ.explorer.process = function(data) {
   /* variables for the expression editor */
   if ( _.isObject(data.expEditor)) {
     if ( _.isObject(data.expEditor.first)) {
-      if ( !_.isUndefined(data.expEditor.first.type))
+      if ( !_.isUndefined(data.expEditor.first.type)) {
         ManageIQ.expEditor.first.type   = data.expEditor.first.type;
-      if ( !_.isUndefined(data.expEditor.first.title))
+      }
+      if ( !_.isUndefined(data.expEditor.first.title)) {
         ManageIQ.expEditor.first.title  = data.expEditor.first.title;
+      }
     }
 
     if ( _.isObject(data.expEditor.second)) {
-      if ( !_.isUndefined(data.expEditor.second.type))
+      if ( !_.isUndefined(data.expEditor.second.type)) {
         ManageIQ.expEditor.second.type   = data.expEditor.second.type;
-      if ( !_.isUndefined(data.expEditor.second.title))
+      }
+      if ( !_.isUndefined(data.expEditor.second.title)) {
         ManageIQ.expEditor.second.title  = data.expEditor.second.title;
+      }
     }
   }
 
   miqButtons( data.showMiqButtons ? 'show' : 'hide' );
 
-  if ( _.isString(data.clearTreeCookies) )
-    miqDeleteDynatreeCookies(data.clearTreeCookies);
+  if ( _.isString(data.clearTreeCookies) ) { miqDeleteDynatreeCookies(data.clearTreeCookies); }
 
-  if ( _.isString(data.accordionSwap) )
+  if ( _.isString(data.accordionSwap) ) {
     miqAccordionSwap('#accordion .panel-collapse.collapse.in', '#' + data.accordionSwap);
+  }
 
   /* dealing with tree nodes */
   if ( !_.isUndefined(data.addNodes) ) {
 
-    if (data.addNodes.remove)
+    if (data.addNodes.remove) {
       miqRemoveNodeChildren(data.addNodes.activeTree, data.addNodes.key);
+    }
 
     miqAddNodeChildren(data.addNodes.activeTree,
                        data.addNodes.key,
@@ -69,56 +76,62 @@ ManageIQ.explorer.process = function(data) {
 
 
   if ( !_.isUndefined(data.deleteNode) ) {
-    var del_node = $('#' + data.deleteNode.activeTree + 'box').
-      dynatree('getTree').
-      getNodeByKey(data.deleteNode.node);
+    var del_node = $('#' + data.deleteNode.activeTree + 'box')
+      .dynatree('getTree')
+      .getNodeByKey(data.deleteNode.node);
 
     del_node.remove();
   }
 
-  if ( !_.isString(data.dashboardUrl) )
+  if ( !_.isString(data.dashboardUrl) ) {
     ManageIQ.widget.dashboardUrl = data.dashboardUrl;
+  }
 
-  if ( $('#advsearchModal').hasClass('modal fade in') )
+  if ( $('#advsearchModal').hasClass('modal fade in') ) {
     $('#advsearchModal').modal('hide');
+  }
 
-  if ( _.isObject(data.updatePartials) )
+  if ( _.isObject(data.updatePartials) ) {
     _.forEach(data.updatePartials, function (content, element) {
       $('#' + element).html(content);
     });
+  }
 
-  if ( _.isObject(data.updateElement) )
+  if ( _.isObject(data.updateElement) ) {
     _.forEach(data.updateElement, function (options, element) {
         ManageIQ.explorer.updateElement(element, options);
     });
+  }
 
-  if ( _.isObject(data.replacePartials) )
+  if ( _.isObject(data.replacePartials) ) {
     _.forEach(data.replacePartials, function (content, element) {
       $('#' + element).replaceWith(content);
     });
+  }
 
-  if ( _.isObject(data.buildCalendar) )
-    ManageIQ.explorer.buildCalendar(data.buildCalendar);
+  if ( _.isObject(data.buildCalendar) ) { ManageIQ.explorer.buildCalendar(data.buildCalendar); }
 
-  if ( data.initDashboard ) miqInitDashboardCols();
+  if ( data.initDashboard ) { miqInitDashboardCols(); }
 
-  if ( data.clearGtlListGrid )
-    ManageIQ.grids.gtl_list_grid = undefined;
+  if ( data.clearGtlListGrid ) { ManageIQ.grids.gtl_list_grid = undefined; }
 
   if ( _.isObject(data.setVisibility) )
     _.forEach(data.setVisibility, function (visible, element) {
-      if ( miqDomElementExists(element) )
-        if ( visible )
+      if ( miqDomElementExists(element) ) {
+        if ( visible ) {
           $('#' + element).show()
-        else
+        } else {
           $('#' + element).hide()
+        }
+      }
     });
 
   $('#main_div').scrollTop(0);
 
-  if ( _.isString(data.rightCellText) )
-    $('h1#explorer_title > span#explorer_title_text').
-      html(data.rightCellText);
+  if ( _.isString(data.rightCellText) ) {
+    $('h1#explorer_title > span#explorer_title_text')
+      .html(data.rightCellText);
+  }
 
   if ( _.isObject(data.reloadToolbars) ) {
     _.forEach(data.replacePartials, function (content, element) {
@@ -144,27 +157,29 @@ ManageIQ.explorer.process = function(data) {
     // FIXME:  @out << Charting.js_load_statement(true)
   }
 
-  if ( data.resetChanges ) ManageIQ.changes = null;
-  if ( data.resetOneTrans ) ManageIQ.oneTransition.oneTrans = 0;
-  if ( data.oneTransIE ) ManageIQ.oneTransition.IEButtonPressed = true;
+  if ( data.resetChanges ) { ManageIQ.changes = null; }
+  if ( data.resetOneTrans ) { ManageIQ.oneTransition.oneTrans = 0; }
+  if ( data.oneTransIE ) { ManageIQ.oneTransition.IEButtonPressed = true; }
 
   if ( _.isString( data.focus ) ) {
     var element = $('#' + data.focus);
     if ( element.length ) element.focus();
   }
 
-  if ( !_.isUndefined(data.clearSearch) )
+  if ( !_.isUndefined(data.clearSearch) ) {
     ManageIQ.explorer.clear_search_show_or_hide('show' == data.clearSearch);
+  }
 
   miqInitMainContent();
 
-  if ( data.hideModal ) $('#quicksearchbox').modal('hide');
-  if ( data.initAccords ) miqInitAccordions();
+  if ( data.hideModal ) { $('#quicksearchbox').modal('hide'); }
+  if ( data.initAccords ) { miqInitAccordions(); }
 
-  if ( _.isString(data.ajaxUrl) )
+  if ( _.isString(data.ajaxUrl) ) {
     miqAsyncAjax(data.ajaxUrl);
-  else
+  } else {
     miqSparkleOff();
+  }
 
   return null;
 };

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -56,7 +56,7 @@ ManageIQ.explorer.process = function(data) {
   if ( _.isString(data.clearTreeCookies) ) { miqDeleteDynatreeCookies(data.clearTreeCookies); }
 
   if ( _.isString(data.accordionSwap) ) {
-    miqAccordionSwap('#accordion .panel-collapse.collapse.in', '#' + data.accordionSwap);
+    miqAccordionSwap('#accordion .panel-collapse.collapse.in', '#' + data.accordionSwap + '_accord');
   }
 
   /* dealing with tree nodes */

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -1,0 +1,167 @@
+ManageIQ.explorer = {}
+
+ManageIQ.explorer.updateElement = function(element, options) {
+  if ( _.isString(options.legend) ) 
+    $('#' + element).html(options.legend);
+  else if ( _.isString(options.title) )
+    $('#' + element).attr( {'title': options.title});
+};
+
+ManageIQ.explorer.buildCalendar = function(options) {
+  var skip_days = _.isObject(options.skipDays) ? options.skipDays : undefined;
+
+  ManageIQ.calendar.calDateFrom = options.dateFrom; //# FIXME js_format_date
+  ManageIQ.calendar.calDateTo   = options.dateTo;
+  ManageIQ.calendar.calSkipDays = skip_days;
+
+  miqBuildCalendar();
+}
+
+ManageIQ.explorer.lock_tree = function(tree, lock) {
+  $('#' + tree + 'box').dynatree(lock ? 'disable' : 'enable');
+  miqDimDiv('#' + tree + '_div', lock);
+}
+
+ManageIQ.explorer.process = function(data) {
+  /* variables for the expression editor */
+  if ( _.isObject(data.expEditor)) {
+    if ( _.isObject(data.expEditor.first)) {
+      if ( !_.isUndefined(data.expEditor.first.type))
+        ManageIQ.expEditor.first.type   = data.expEditor.first.type;
+      if ( !_.isUndefined(data.expEditor.first.title))
+        ManageIQ.expEditor.first.title  = data.expEditor.first.title;
+    }
+
+    if ( _.isObject(data.expEditor.second)) {
+      if ( !_.isUndefined(data.expEditor.second.type))
+        ManageIQ.expEditor.second.type   = data.expEditor.second.type;
+      if ( !_.isUndefined(data.expEditor.second.title))
+        ManageIQ.expEditor.second.title  = data.expEditor.second.title;
+    }
+  }
+
+  miqButtons( data.showMiqButtons ? 'show' : 'hide' );
+
+  if ( _.isString(data.clearTreeCookies) )
+    miqDeleteDynatreeCookies(data.clearTreeCookies);
+
+  if ( _.isString(data.accordionSwap) )
+    miqAccordionSwap('#accordion .panel-collapse.collapse.in', '#' + data.accordionSwap);
+
+  /* dealing with tree nodes */
+  if ( !_.isUndefined(data.addNodes) ) {
+
+    if (data.addNodes.remove)
+      miqRemoveNodeChildren(data.addNodes.activeTree, data.addNodes.key);
+
+    miqAddNodeChildren(data.addNodes.activeTree,
+                       data.addNodes.key,
+                       data.addNodes.osf,
+                       data.addNodes.children);
+  }
+
+
+  if ( !_.isUndefined(data.deleteNode) ) {
+    var del_node = $('#' + data.deleteNode.activeTree + 'box').
+      dynatree('getTree').
+      getNodeByKey(data.deleteNode.node);
+
+    del_node.remove();
+  }
+
+  if ( !_.isString(data.dashboardUrl) )
+    ManageIQ.widget.dashboardUrl = data.dashboardUrl;
+
+  if ( $('#advsearchModal').hasClass('modal fade in') )
+    $('#advsearchModal').modal('hide');
+
+  if ( _.isObject(data.updatePartials) )
+    _.forEach(data.updatePartials, function (content, element) {
+      $('#' + element).html(content);
+    });
+
+  if ( _.isObject(data.updateElement) )
+    _.forEach(data.updateElement, function (options, element) {
+        ManageIQ.explorer.updateElement(element, options);
+    });
+
+  if ( _.isObject(data.replacePartials) )
+    _.forEach(data.replacePartials, function (content, element) {
+      $('#' + element).replaceWith(content);
+    });
+
+  if ( _.isObject(data.buildCalendar) )
+    ManageIQ.explorer.buildCalendar(data.buildCalendar);
+
+  if ( data.initDashboard ) miqInitDashboardCols();
+
+  if ( data.clearGtlListGrid )
+    ManageIQ.grids.gtl_list_grid = undefined;
+
+  if ( _.isObject(data.setVisibility) )
+    _.forEach(data.setVisibility, function (visible, element) {
+      if ( miqDomElementExists(element) )
+        if ( visible )
+          $('#' + element).show()
+        else
+          $('#' + element).hide()
+    });
+
+  $('#main_div').scrollTop(0);
+
+  if ( _.isString(data.rightCellText) )
+    $('h1#explorer_title > span#explorer_title_text').
+      html(data.rightCellText);
+  
+  if ( _.isObject(data.reloadToolbars) ) {
+    _.forEach(data.replacePartials, function (content, element) {
+      $('#' + element).html(content);
+    });
+    miqInitToolbars();
+  }
+
+  ManageIQ.record = data.record;
+
+  if ( !_.isUndefined(data.activateNode) ) {
+    miqDynatreeActivateNodeSilently(data.activateNode.activeTree, data.activateNode.osf);
+  }
+
+  if ( _.isObject(data.lockTrees) ) {
+    _.forEach(data.lockTrees, function (lock, tree) {
+      ManageIQ.explorer.lock_tree(tree, lock);
+    });
+  }
+
+  if ( _.isObject(data.chartData) ) {
+    ManageIQ.charts.chartData = data.chartData;
+    // FIXME:  @out << Charting.js_load_statement(true)
+  }
+
+  if ( data.resetChanges ) ManageIQ.changes = null;
+  if ( data.resetOneTrans ) ManageIQ.oneTransition.oneTrans = 0;
+  if ( data.oneTransIE ) ManageIQ.oneTransition.IEButtonPressed = true;
+
+  if ( _.isString( data.focus ) ) {
+    var element = $('#' + data.focus);
+    if ( element.length ) element.focus();
+  }
+
+  // FIXME: change 'clear_search_show_or_hide' to bool
+  if ( _.isString(data.clearSearch) )
+    if ( 'show' == data.clearSearch )
+      $('#clear_search').show();
+    else
+      $('#clear_search').hide();
+
+  miqInitMainContent();
+
+  if ( data.hideModal ) $('#quicksearchbox').modal('hide');
+  if ( data.initAccords ) miqInitAccordions();
+
+  if ( _.isString(data.ajaxUrl) )
+    miqAsyncAjax(data.ajaxUrl);
+  else
+    miqSparkleOff();
+
+  return null;
+};

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -45,6 +45,7 @@ if (! window.ManageIQ) {
       c3: {}, // C3 charts by id
       c3config: null, // C3 chart configuration
     },
+    explorer: {}, // methods to manipulate explorer screens through ExplorerPresenter
     grids: {}, // stored grids on the screen
     i18n: {
       mark_translated_strings: false,

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -466,7 +466,7 @@ module ApplicationController::Filter
         page << javascript_hide("blocker_div")
       else
         @edit[:adv_search_open] = true
-        page << "ManageIQ.explorer.clear_search_show_or_hide(#{clear_search_show_or_hide});"
+        page << "ManageIQ.explorer.clear_search_toggle(#{clear_search_status});"
         page.replace("adv_search_body", :partial => "layouts/adv_search_body")
         page.replace("adv_search_footer", :partial => "layouts/adv_search_footer")
         page << "$('#adv_search_img').prop('src', '#{ActionController::Base.helpers.image_path('toolbars/squashed-false.png')}')"

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -466,7 +466,7 @@ module ApplicationController::Filter
         page << javascript_hide("blocker_div")
       else
         @edit[:adv_search_open] = true
-        page << "$('#clear_search').#{clear_search_show_or_hide}();"
+        page << "ManageIQ.explorer.clear_search_show_or_hide(#{clear_search_show_or_hide});"
         page.replace("adv_search_body", :partial => "layouts/adv_search_body")
         page.replace("adv_search_footer", :partial => "layouts/adv_search_footer")
         page << "$('#adv_search_img').prop('src', '#{ActionController::Base.helpers.image_path('toolbars/squashed-false.png')}')"

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1981,7 +1981,7 @@ class CatalogController < ApplicationController
     presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
 
     presenter[:record_id] = determine_record_id_for_presenter
-    presenter[:lock_unlock_trees][x_active_tree] = @edit && @edit[:current]
+    presenter.lock_tree(x_active_tree, @edit && @edit[:current])
     presenter[:osf_node] = x_node
     presenter.reset_changes
     presenter.reset_one_trans

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1986,7 +1986,7 @@ class CatalogController < ApplicationController
     presenter.reset_changes
     presenter.reset_one_trans
 
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   # Build a Catalog Items explorer tree

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -873,7 +873,7 @@ class ChargebackController < ApplicationController
 
     presenter[:right_cell_text]     = @right_cell_text
     unless x_active_tree == :cb_assignments_tree
-      presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
+      presenter.lock_tree(x_active_tree, @in_a_form && @edit)
     end
 
     render :json => presenter.to_json

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -875,7 +875,8 @@ class ChargebackController < ApplicationController
     unless x_active_tree == :cb_assignments_tree
       presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
     end
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def get_session_data

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -327,8 +327,8 @@ class ContainerController < ApplicationController
     presenter.hide(:blocker_div) unless @edit && @edit[:adv_search_open]
     presenter.hide(:quicksearchbox)
     presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   # Build a Containers explorer tree

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -326,7 +326,7 @@ class ContainerController < ApplicationController
 
     presenter.hide(:blocker_div) unless @edit && @edit[:adv_search_open]
     presenter.hide(:quicksearchbox)
-    presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
+    presenter.lock_tree(x_active_tree, @in_a_form && @edit)
 
     render :json => presenter.to_json
   end

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -320,7 +320,7 @@ class ContainerController < ApplicationController
 
     # Hide/show searchbox depending on if a list is showing
     presenter.set_visibility(!(@record || @in_a_form), :adv_searchbox_div)
-    presenter[:clear_search_show_or_hide] = clear_search_show_or_hide
+    presenter[:clear_search_toggle] = clear_search_status
 
     presenter[:osf_node] = x_node  # Open, select, and focus on this node
 

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -375,8 +375,7 @@ class MiqAeClassController < ApplicationController
     presenter[:osf_node] = x_node
     presenter.show_miq_buttons if @changed
 
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def build_type_options

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -354,7 +354,7 @@ class MiqAeClassController < ApplicationController
       presenter.hide(:paging_div, :form_buttons_div)
     end
 
-    presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
+    presenter.lock_tree(x_active_tree, @in_a_form && @edit)
 
     if @record.kind_of?(MiqAeMethod) && !@in_a_form
       presenter.set_visibility(!@record.inputs.blank?, :params_div)

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -395,7 +395,7 @@ class MiqAeCustomizationController < ApplicationController
 
     # Replace right side with based on selected tree node type
     presenter.update(:main_div, render_proc[:partial => "shared/buttons/ab_list"])
-    presenter[:lock_unlock_trees][:ab_tree] = !!@edit
+    presenter.lock_tree(:ab_tree, @edit)
   end
 
   def setup_presenter_for_dialog_edit_tree(presenter)

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -229,7 +229,7 @@ class MiqAeCustomizationController < ApplicationController
     setup_dialog_sample_buttons(nodetype, presenter)
     set_miq_record_id(presenter)
 
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def dialog_edit_tree_active?

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -509,7 +509,7 @@ class MiqCapacityController < ApplicationController
       :skip_days => @sb[:util][:options][:skip_days],
     }
 
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def planning_build_options
@@ -615,7 +615,7 @@ class MiqCapacityController < ApplicationController
                                       _("Best Fit Clusters")
                                     end
 
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def bottleneck_replace_right_cell
@@ -627,7 +627,7 @@ class MiqCapacityController < ApplicationController
     presenter[:build_calendar] = true
     presenter[:right_cell_text] = @right_cell_text
 
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def bottleneck_get_node_info(treenodeid, refresh = nil)

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -739,8 +739,7 @@ class MiqPolicyController < ApplicationController
       end
     end
 
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def send_button_changes

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -552,10 +552,6 @@ class MiqPolicyController < ApplicationController
         self.x_node = @new_action_node if @new_action_node
       when :alert_profile
         self.x_node = @new_alert_profile_node if @new_alert_profile_node
-        # Send down extra alert_profile tree if present
-        if @assign && @assign[:object_tree]
-          presenter[:object_tree_json] = @assign[:object_tree]
-        end
       when :alert
         self.x_node = @new_alert_node if @new_alert_node
       else

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -727,11 +727,11 @@ class MiqPolicyController < ApplicationController
 
     # Lock current tree if in edit or assign, else unlock all trees
     if (@edit || @assign) && params[:action] != "x_search_by_name"
-      presenter[:lock_unlock_trees][x_active_tree] = true
+      presenter.lock_tree(x_active_tree)
     else
       [:policy_profile_tree, :policy_tree, :condition_tree,
        :action_tree, :alert_profile_tree, :alert_tree].each do |tree|
-        presenter[:lock_unlock_trees][tree] = false
+        presenter.lock_tree(tree, false)
       end
     end
 

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -496,8 +496,8 @@ class OpsController < ApplicationController
     handle_bottom_cell(nodetype, presenter, r, locals)
     x_active_tree_replace_cell(nodetype, presenter, r)
     extra_js_commands(presenter)
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def x_active_tree_replace_cell(nodetype, presenter, r)

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -991,7 +991,7 @@ class ProviderForemanController < ApplicationController
     presenter.hide(:quicksearchbox)
     presenter[:hide_modal] = true
 
-    presenter[:lock_unlock_trees][x_active_tree] = @in_a_form
+    presenter.lock_tree(x_active_tree, @in_a_form)
   end
 
   def display_adv_searchbox

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -752,7 +752,8 @@ class ProviderForemanController < ApplicationController
     update_title(presenter)
     rebuild_toolbars(false, presenter)
     handle_bottom_cell(presenter, r)
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def render_tagging_form
@@ -765,7 +766,8 @@ class ProviderForemanController < ApplicationController
     update_title(presenter)
     rebuild_toolbars(false, presenter)
     handle_bottom_cell(presenter, r)
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def render_service_dialog_form
@@ -777,7 +779,8 @@ class ProviderForemanController < ApplicationController
     rebuild_toolbars(false, presenter)
     handle_bottom_cell(presenter, r)
     presenter[:right_cell_text] = @right_cell_text
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def update_tree_and_render_list(replace_trees)
@@ -789,7 +792,8 @@ class ProviderForemanController < ApplicationController
     presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     rebuild_toolbars(false, presenter)
     handle_bottom_cell(presenter, r)
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def update_title(presenter)
@@ -826,8 +830,7 @@ class ProviderForemanController < ApplicationController
     presenter[:right_cell_text] = @right_cell_text
     presenter[:osf_node] = x_node  # Open, select, and focus on this node
 
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def leaf_record

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -985,7 +985,7 @@ class ProviderForemanController < ApplicationController
 
     # Hide/show searchbox depending on if a list is showing
     presenter.set_visibility(display_adv_searchbox, :adv_searchbox_div)
-    presenter[:clear_search_show_or_hide] = clear_search_show_or_hide
+    presenter[:clear_search_toggle] = clear_search_status
 
     presenter.hide(:blocker_div) unless @edit && @edit[:adv_search_open]
     presenter.hide(:quicksearchbox)

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -258,7 +258,7 @@ class PxeController < ApplicationController
 
     # Save open nodes, if any were added
     presenter[:osf_node] = x_node
-    presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
+    presenter.lock_tree(x_active_tree, @in_a_form && @edit)
 
     render :json => presenter.to_json
   end

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -259,8 +259,8 @@ class PxeController < ApplicationController
     # Save open nodes, if any were added
     presenter[:osf_node] = x_node
     presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def get_session_data

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -883,8 +883,7 @@ class ReportController < ApplicationController
       end
     end
 
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def get_session_data

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -873,13 +873,13 @@ class ReportController < ApplicationController
 
     # Lock current tree if in edit or assign, else unlock all trees
     if @edit && @edit[:current]
-      presenter[:lock_unlock_trees][x_active_tree] = true
+      presenter.lock_tree(x_active_tree)
       # lock schedules tree when jumping from reports to add a schedule for a report
-      presenter[:lock_unlock_trees][:schedules_tree] = true if params[:pressed] == 'miq_report_schedules'
+      presenter.lock_tree(:schedules_tree) if params[:pressed] == 'miq_report_schedules'
     else
-      presenter[:lock_unlock_trees][x_active_tree] = false
+      presenter.lock_tree(x_active_tree, false)
       [:db_tree, :reports_tree, :savedreports_tree, :schedules_tree, :widgets_tree, :roles_tree].each do |tree|
-        presenter[:lock_unlock_trees][tree] = false
+        presenter.lock_tree(tree, false)
       end
     end
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -364,7 +364,7 @@ class ServiceController < ApplicationController
 
     presenter[:record_id] = determine_record_id_for_presenter
 
-    presenter[:lock_unlock_trees][x_active_tree] = @edit && @edit[:current]
+    presenter.lock_tree(x_active_tree, @edit && @edit[:current])
     presenter[:osf_node] = x_node
     # unset variable that was set in form_field_changed to prompt for changes when leaving the screen
     presenter.reset_changes

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -369,8 +369,7 @@ class ServiceController < ApplicationController
     # unset variable that was set in form_field_changed to prompt for changes when leaving the screen
     presenter.reset_changes
 
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   # Build a Services explorer tree

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -649,7 +649,7 @@ class StorageController < ApplicationController
     presenter.hide(:quicksearchbox)
     presenter[:hide_modal] = true
 
-    presenter[:lock_unlock_trees][x_active_tree] = @in_a_form
+    presenter.lock_tree(x_active_tree, @in_a_form)
   end
 
   def display_adv_searchbox

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -508,8 +508,7 @@ class StorageController < ApplicationController
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
     presenter[:osf_node] = x_node # Open, select, and focus on this node
 
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+    render :json => presenter.to_json
   end
 
   def search_text_type(node)
@@ -616,7 +615,8 @@ class StorageController < ApplicationController
     # update_title(presenter)
     rebuild_toolbars(false, presenter)
     handle_bottom_cell(presenter, r)
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def update_tree_and_render_list(replace_trees)
@@ -628,7 +628,8 @@ class StorageController < ApplicationController
     presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     rebuild_toolbars(false, presenter)
     handle_bottom_cell(presenter, r)
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   def rebuild_toolbars(record_showing, presenter)

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -643,7 +643,7 @@ class StorageController < ApplicationController
 
     # Hide/show searchbox depending on if a list is showing
     presenter.set_visibility(display_adv_searchbox, :adv_searchbox_div)
-    presenter[:clear_search_show_or_hide] = clear_search_show_or_hide
+    presenter[:clear_search_toggle] = clear_search_status
 
     presenter.hide(:blocker_div) unless @edit && @edit[:adv_search_open]
     presenter.hide(:quicksearchbox)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1491,8 +1491,8 @@ module VmCommon
     presenter.hide(:blocker_div) unless @edit && @edit[:adv_search_open]
     presenter[:hide_modal] = true
     presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
-    # Render the JS responses to update the explorer screen
-    render :js => presenter.to_html
+
+    render :json => presenter.to_json
   end
 
   # get the host that this vm belongs to

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1484,7 +1484,7 @@ module VmCommon
 
     # Hide/show searchbox depending on if a list is showing
     presenter.set_visibility(!(@record || @in_a_form), :adv_searchbox_div)
-    presenter[:clear_search_show_or_hide] = clear_search_show_or_hide
+    presenter[:clear_search_toggle] = clear_search_status
 
     presenter[:osf_node] = x_node  # Open, select, and focus on this node
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1490,7 +1490,7 @@ module VmCommon
 
     presenter.hide(:blocker_div) unless @edit && @edit[:adv_search_open]
     presenter[:hide_modal] = true
-    presenter[:lock_unlock_trees][x_active_tree] = @in_a_form && @edit
+    presenter.lock_tree(x_active_tree, @in_a_form && @edit)
 
     render :json => presenter.to_json
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -825,7 +825,7 @@ module ApplicationHelper
 
   # Do we show or hide the clear_search link in the list view title
   def clear_search_show_or_hide
-    @edit && @edit.fetch_path(:adv_search_applied, :text) ? "show" : "hide"
+    !!(@edit && @edit.fetch_path(:adv_search_applied, :text))
   end
 
   # Should we allow the user input checkbox be shown for an atom in the expression editor

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -824,7 +824,7 @@ module ApplicationHelper
   end
 
   # Do we show or hide the clear_search link in the list view title
-  def clear_search_show_or_hide
+  def clear_search_status
     !!(@edit && @edit.fetch_path(:adv_search_applied, :text))
   end
 

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -187,7 +187,6 @@ class ExplorerPresenter
     data[:oneTransIE] = !!@options[:one_trans_ie]
     data[:focus] = @options[:focus]
 
-    # FIXME: change to bool + nil
     data[:clearSearch] = @options[:clear_search_show_or_hide] if @options[:clear_search_show_or_hide]
 
     data[:hideModal] if @options[:hide_modal]

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -32,7 +32,6 @@ class ExplorerPresenter
   #   osf_node                         -- node to open, select and focus
   #   open_accord                      -- accordion to open
   #
-  #   object_tree_json            --
   #   exp                         --
   #
   #   active_tree                 -- x_active_tree view state from controller
@@ -54,7 +53,6 @@ class ExplorerPresenter
       :element_updates      => {},
       :replace_partials     => {},
       :reload_toolbars      => {},
-      :object_tree_json     => '',
       :exp                  => {},
       :osf_node             => '',
       :show_miq_buttons     => false,

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -10,31 +10,32 @@ class ExplorerPresenter
 
   attr_reader :options
 
-  # Renders JS to replace the contents of an explorer view as directed by the controller
+  # Returns hash for ManageIQ.explorer that contains data needed to replace the
+  # contents of an explorer view as directed by the (server side) controller.
 
   # This presenter supports these options:
-  #   FIXME: fill in missing doc
   #
   #   add_nodes                        -- JSON string of nodes to add to the active tree
   #   delete_node                      -- key of node to be deleted from the active tree
   #   build_calendar                   -- call miqBuildCalendar, true/false or Hash (:date_from, :date_to, :skip_days)
-  #   init_dashboard
+  #
+  #   init_dashboard                   -- call miqInitDashboardCols
+  #   miq_widget_dd_url                -- url to be used in url in miqDropComplete method
+  #                                       (ManageIQ.widget.dashboardUrl)
+  #
   #   init_accords                     -- initialize accordion autoresize
   #   ajax_action                      -- Hash of options for AJAX action to fire
   #   clear_gtl_list_grid              -- Clear ManageIQ.grids.gtl_list_grid
   #   right_cell_text
   #
   #   ManageIQ.record.recordId         -- record being displayed or edited
-  #   ManageIQ.record.parentId
-  #   ManageIQ.record.parentClass
+  #   ManageIQ.record.parentId         -- it's parent
+  #   ManageIQ.record.parentClass      -- and it's (parent's) class
   #
-  #   ManageIQ.widget.dashboardUrl     -- set dashboard widget drag drop url
   #   osf_node                         -- node to open, select and focus
   #   open_accord                      -- accordion to open
-  #
-  #   exp                         --
-  #
-  #   active_tree                 -- x_active_tree view state from controller
+  #   exp                              -- data for the expression editor
+  #   active_tree                      -- x_active_tree view state from controller
   #
   # Following options are hashes:
   #   lock_unlock_trees         -- trees to lock/unlock
@@ -42,7 +43,7 @@ class ExplorerPresenter
   #   replace_partials          -- partials to replace (also wrapping tag)
   #   element_updates           -- do we need all 3 of the above?
   #   set_visible_elements      -- elements to cal 'set_visible' on
-  #   reload_toolbars
+  #   reload_toolbars           -- toolbars to reload and their content
   #
 
   def initialize(options = {})

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -166,9 +166,9 @@ class ExplorerPresenter
     end
 
     data[:record] = {
-      :parentId    => @options[:parentId],
-      :parentClass => @options[:parentClass],
-      :recordId    => @options[:parentId],
+      :parentId    => @options[:parent_id],
+      :parentClass => @options[:parent_class],
+      :recordId    => @options[:record_id],
     }
 
     unless @options[:osf_node].blank?

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -88,6 +88,11 @@ class ExplorerPresenter
     self
   end
 
+  def lock_tree(tree, lock = true)
+    @options[:lock_unlock_trees][tree] = !!lock
+    self
+  end
+
   def hide(*elements)
     set_visibility(false, *elements)
   end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -1,5 +1,4 @@
 class ExplorerPresenter
-  # FIXME: temporary solution, until we clean up more...
   include ApplicationHelper
   include JsHelper
   include ActionView::Helpers::JavaScriptHelper
@@ -7,8 +6,6 @@ class ExplorerPresenter
   include ToolbarHelper
   include ActionView::Helpers::TagHelper
   include ActionView::Context
-
-  attr_reader :options
 
   # Returns hash for ManageIQ.explorer that contains data needed to replace the
   # contents of an explorer view as directed by the (server side) controller.

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -23,9 +23,11 @@ class ExplorerPresenter
   #   ajax_action                      -- Hash of options for AJAX action to fire
   #   clear_gtl_list_grid              -- Clear ManageIQ.grids.gtl_list_grid
   #   right_cell_text
+  #
+  #   ManageIQ.record.recordId         -- record being displayed or edited
   #   ManageIQ.record.parentId
   #   ManageIQ.record.parentClass
-  #   ManageIQ.record.recordId         -- record being displayed or edited
+  #
   #   ManageIQ.widget.dashboardUrl     -- set dashboard widget drag drop url
   #   osf_node                         -- node to open, select and focus
   #   open_accord                      -- accordion to open
@@ -122,166 +124,90 @@ class ExplorerPresenter
     @options[key]
   end
 
-  def to_html
-    @out = []
-    process
-    @out.join("\n")
+  def to_json
+    data = { :explorer => true }
+
+    # see if any miq expression vars need to be set
+    unless @options[:exp].empty?
+      data.store_path(:expEditor, :first, :type,   @options[:exp][:val1_type]) if @options[:exp][:val1_type]
+      data.store_path(:expEditor, :first, :title,  @options[:exp][:val1_title]) if @options[:exp][:val1_title]
+      data.store_path(:expEditor, :second, :type,  @options[:exp][:val2_type]) if @options[:exp][:val2_type]
+      data.store_path(:expEditor, :second, :title, @options[:exp][:val2_title]) if @options[:exp][:val2_title]
+    end
+
+    data[:showMiqButtons]   = @options[:show_miq_buttons]
+    data[:clearTreeCookies] = @options[:clear_tree_cookies]
+
+    # Open an accordion inside an other AJAX call
+    data[:accordionSwap] = @options[:open_accord] unless @options[:open_accord].to_s.empty?
+
+    data[:addNodes] = {
+      :activeTree => @options[:active_tree],
+      :key        => @options[:add_nodes][:key],
+      :osf        => @options[:osf_node],
+      :children   => @options[:add_nodes][:children],
+      :remove     => !!@options[:remove_nodes],
+    } if @options[:add_nodes]
+
+    data[:deleteNode] = {
+      :node       => @options[:delete_node],
+      :activeTree => @options[:active_tree],
+    } if @options[:delete_node]
+
+    data[:dashboardUrl] = @options[:miq_widget_dd_url] if @options[:miq_widget_dd_url]
+
+    # FIXME: remove show_clear_search
+    # # Always set 'def' view in left cell as active in case it was changed to show compare/drift sections
+    # @out << "var show_clear_search = undefined;"
+
+    data[:updatePartials] = @options[:update_partials] # Update elements in the DOM with rendered partials
+    data[:updateElements] = @options[:element_updates] # Update element in the DOM with given options
+    data[:replacePartials] = @options[:replace_partials] # Replace elements in the DOM with rendered partials
+    data[:buildCalendar] = @options[:build_calendar].kind_of?(Hash) ? @options[:build_calendar] : {}
+    data[:initDashboard] = !! @options[:init_dashboard]
+    data[:ajaxUrl] = ajax_action_url(@options[:ajax_action]) if @options[:ajax_action]
+    data[:clearGtlListGrid] = !!@options[:clear_gtl_list_grid]
+    data[:setVisibility] = @options[:set_visible_elements]
+    data[:rightCellText] = @options[:right_cell_text] if @options[:right_cell_text]
+
+    data[:reloadToolbars] = @options[:reload_toolbars].each_with_object({}) do | (div_name, toolbar), h|
+      h["#{div_name}_tb"] = buttons_to_html(Array(toolbar))
+    end
+
+    data[:record] = {
+      :parentId    => @options[:parentId],
+      :parentClass => @options[:parentClass],
+      :recordId    => @options[:parentId],
+    }
+
+    unless @options[:osf_node].blank?
+      data[:activateNode] = {
+        :activeTree => @options[:active_tree],
+        :osf        => @options[:osf_node]
+      }
+    end
+
+    data[:lockTrees] = @options[:lock_unlock_trees]
+    data[:chartData] = @options[:load_chart]
+
+    # FIXME: remove !! if all are bool
+    data[:resetChanges] = !!@options[:reset_changes]
+    data[:resetOneTrans] = !!@options[:reset_one_trans]
+    data[:oneTransIE] = !!@options[:one_trans_ie]
+    data[:focus] = @options[:focus]
+
+    # FIXME: change to bool + nil
+    data[:clearSearch] = @options[:clear_search_show_or_hide] if @options[:clear_search_show_or_hide]
+
+    data[:hideModal] if @options[:hide_modal]
+    data[:initAccords] if @options[:init_accords]
+
+    data
   end
 
   private
 
-  def process
-    @out << javascript_prologue
-
-    # see if any miq expression vars need to be set
-    unless @options[:exp].empty?
-      @out << "ManageIQ.expEditor.first.type = '#{@options[:exp][:val1_type]}';"  if @options[:exp][:val1_type]
-      @out << "ManageIQ.expEditor.first.title = '#{@options[:exp][:val1_title]}';" if @options[:exp][:val1_title]
-      @out << "ManageIQ.expEditor.second.type  = '#{@options[:exp][:val2_type]};"   if @options[:exp][:val2_type]
-      @out << "ManageIQ.expEditor.second.title = '#{@options[:exp][:val2_title]}';" if @options[:exp][:val2_title]
-    end
-
-    # Turn off form buttons when replacing explorer right cell
-    @out << javascript_for_miq_button_visibility(@options[:show_miq_buttons]).html_safe
-
-    @out << "miqDeleteDynatreeCookies('#{@options[:clear_tree_cookies]}')" if @options[:clear_tree_cookies]
-
-    # Open an accordion inside an other AJAX call
-    unless @options[:open_accord].to_s.empty?
-      @out << "miqAccordionSwap('#accordion .panel-collapse.collapse.in', '##{j(@options[:open_accord])}_accord');"
-    end
-
-    if @options[:remove_nodes]
-      @out << "miqRemoveNodeChildren('#{@options[:active_tree]}',
-                                     '#{@options[:add_nodes][:key]}'
-      );\n"
-    end
-
-    if @options[:add_nodes]
-      @out << "
-        miqAddNodeChildren('#{@options[:active_tree]}',
-                           '#{@options[:add_nodes][:key]}',
-                           '#{@options[:osf_node]}',
-                            #{@options[:add_nodes][:children].to_json.html_safe}
-        );
-      \n"
-    end
-
-    if @options[:delete_node]
-      @out << "
-        var del_node = $('##{@options[:active_tree]}box').dynatree('getTree').getNodeByKey('#{@options[:delete_node]}');
-        del_node.remove();
-        \n"
-    end
-
-    @out << "ManageIQ.widget.dashboardUrl = '#{@options[:miq_widget_dd_url]}';" if @options[:miq_widget_dd_url]
-
-    # Always set 'def' view in left cell as active in case it was changed to show compare/drift sections
-    @out << "var show_clear_search = undefined"
-    @out << "
-      if ($('#advsearchModal').hasClass('modal fade in')){
-        $('#advsearchModal').modal('hide');}"
-
-    # Update elements in the DOM with rendered partials
-    @options[:update_partials].each { |element, content| @out << update_partial(element, content) }
-
-    # Update element in the DOM with given options
-    @options[:element_updates].each { |element, options| @out << update_element(element, options) }
-
-    # Replace elements in the DOM with rendered partials
-    @options[:replace_partials].each { |element, content| @out << replace_partial(element, content) }
-
-    @out << build_calendar if @options[:build_calendar]
-
-    @out << 'miqInitDashboardCols();' if @options[:init_dashboard]
-
-    @out << ajax_action(@options[:ajax_action]) if @options[:ajax_action]
-
-    @out << "ManageIQ.grids.gtl_list_grid = undefined;" if @options[:clear_gtl_list_grid]
-
-    @options[:set_visible_elements].each do |el, visible|
-      @out << set_element_visible(el, visible)
-    end
-
-    # Scroll to top of main div
-    @out << "$('#main_div').scrollTop(0);"
-
-    @out << "$('h1#explorer_title > span#explorer_title_text').html('#{j ERB::Util.h(URI.unescape(@options[:right_cell_text]))}');" if @options[:right_cell_text]
-
-    # Reload toolbars
-    @options[:reload_toolbars].each_pair do |div_name, toolbar|
-      # we need to render even empty toolbar to actually remove the buttons
-      # that might be there
-      @out << javascript_pf_toolbar_reload("#{div_name}_tb", Array(toolbar)).html_safe
-    end
-
-    # reset miq_record_id, else it remembers prev id and sends it when add is pressed from list view
-    [:record_id, :parent_id, :parent_class].each { |variable| @out << set_or_undef(variable) }
-
-    # Open, select, and focus node in current tree
-    @out << "miqDynatreeActivateNodeSilently('#{@options[:active_tree]}', '#{@options[:osf_node]}');" unless @options[:osf_node].blank?
-
-    @options[:lock_unlock_trees].each { |tree, lock| @out << tree_lock(tree, lock) }
-
-    if @options[:load_chart]
-      @out << 'ManageIQ.charts.chartData = ' + @options[:load_chart].to_json + ';'
-      @out << Charting.js_load_statement(true)
-    end
-
-    @out << 'ManageIQ.changes = null;'                       if @options[:reset_changes]
-    @out << 'ManageIQ.oneTransition.oneTrans = 0;'           if @options[:reset_one_trans]
-    @out << 'ManageIQ.oneTransition.IEButtonPressed = true;' if @options[:one_trans_ie]
-
-    if @options[:focus]
-      @out << "if ($('##{@options[:focus]}').length) $('##{@options[:focus]}').focus();"
-    end
-
-    @out << "$('#clear_search').#{@options[:clear_search_show_or_hide]}();" if @options[:clear_search_show_or_hide]
-    # always replace content partial to adjust height of content div
-    @out << "miqInitMainContent();"
-    @out << "$('#quicksearchbox').modal('hide');" if @options[:hide_modal]
-
-    @out << "miqInitAccordions();" if @options[:init_accords]
-
-    # Don't turn off spinner for charts/timelines
-    @out << set_spinner_off unless @options[:ajax_action]
-  end
-
-  def build_calendar
-    if @options[:build_calendar].kind_of? Hash
-      calendar_options = @options[:build_calendar]
-    else
-      calendar_options = {}
-    end
-
-    js_build_calendar(calendar_options)
-  end
-
-  # Fire an AJAX action
-  def ajax_action(options)
-    url = [options[:controller], options[:action], options[:record_id]].join('/')
-    "miqAsyncAjax('/#{url}');"
-  end
-
-  # Set a JS variable to value from options or 'undefined'
-  def set_or_undef(variable)
-    if @options[variable]
-      "ManageIQ.record.#{variable.to_s.camelize(:lower)} = '#{@options[variable]}';"
-    else
-      "ManageIQ.record.#{variable.to_s.camelize(:lower)} = null;"
-    end
-  end
-
-  # Replaces an element (div) using options :partial and :locals
-  # options
-  #     :locals   --- FIXME
-  #     :partial  --- FIXME
-  def replace_partial(element, content)
-    "$('##{element}').replaceWith('#{escape_javascript(content)}');"
-  end
-
-  def update_partial(element, content)
-    # FIXME: replace with javascript_update_element
-    "$('##{element}').html('#{escape_javascript(content)}');"
+  def ajax_action_url(options)
+    ['', options[:controller], options[:action], options[:record_id]].join('/')
   end
 end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -25,9 +25,9 @@ class ExplorerPresenter
   #   clear_gtl_list_grid              -- Clear ManageIQ.grids.gtl_list_grid
   #   right_cell_text
   #
-  #   ManageIQ.record.recordId         -- record being displayed or edited
-  #   ManageIQ.record.parentId         -- it's parent
-  #   ManageIQ.record.parentClass      -- and it's (parent's) class
+  #   :record_id    sets ManageIQ.record.recordId     -- record being displayed or edited
+  #   :parent_id    sets ManageIQ.record.parentId     -- it's parent
+  #   :parent_class sets ManageIQ.record.parentClass  -- and it's (parent's) class
   #
   #   osf_node                         -- node to open, select and focus
   #   open_accord                      -- accordion to open
@@ -38,7 +38,8 @@ class ExplorerPresenter
   #   lock_unlock_trees         -- trees to lock/unlock
   #   update_partials           -- partials to update contents
   #   replace_partials          -- partials to replace (also wrapping tag)
-  #   element_updates           -- do we need all 3 of the above?
+  #   element_updates           -- update DOM element content or title FIXME: content can be
+  #                                replaced with update_partials
   #   set_visible_elements      -- elements to cal 'set_visible' on
   #   reload_toolbars           -- toolbars to reload and their content
   #

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -130,15 +130,14 @@ class ExplorerPresenter
   def to_json
     data = {:explorer => true}
 
-    # see if any miq expression vars need to be set
-    unless @options[:exp].empty?
+    if @options[:exp].present?
       data.store_path(:expEditor, :first, :type,   @options[:exp][:val1_type]) if @options[:exp][:val1_type]
       data.store_path(:expEditor, :first, :title,  @options[:exp][:val1_title]) if @options[:exp][:val1_title]
       data.store_path(:expEditor, :second, :type,  @options[:exp][:val2_type]) if @options[:exp][:val2_type]
       data.store_path(:expEditor, :second, :title, @options[:exp][:val2_title]) if @options[:exp][:val2_title]
     end
 
-    data[:showMiqButtons]   = @options[:show_miq_buttons]
+    data[:showMiqButtons] = @options[:show_miq_buttons]
     data[:clearTreeCookies] = @options[:clear_tree_cookies]
 
     # Open an accordion inside an other AJAX call
@@ -161,7 +160,7 @@ class ExplorerPresenter
     data[:updatePartials] = @options[:update_partials] # Update elements in the DOM with rendered partials
     data[:updateElements] = @options[:element_updates] # Update element in the DOM with given options
     data[:replacePartials] = @options[:replace_partials] # Replace elements in the DOM with rendered partials
-    data[:buildCalendar] = @options[:build_calendar].kind_of?(Hash) ? @options[:build_calendar] : {}
+    data[:buildCalendar] = format_calendar_dates(@options[:build_calendar])
     data[:initDashboard] = !! @options[:init_dashboard]
     data[:ajaxUrl] = ajax_action_url(@options[:ajax_action]) if @options[:ajax_action]
     data[:clearGtlListGrid] = !!@options[:clear_gtl_list_grid]
@@ -187,15 +186,11 @@ class ExplorerPresenter
 
     data[:lockTrees] = @options[:lock_unlock_trees]
     data[:chartData] = @options[:load_chart]
-
-    # FIXME: remove !! if all are bool
     data[:resetChanges] = !!@options[:reset_changes]
     data[:resetOneTrans] = !!@options[:reset_one_trans]
     data[:oneTransIE] = !!@options[:one_trans_ie]
     data[:focus] = @options[:focus]
-
     data[:clearSearch] = @options[:clear_search_toggle] if @options[:clear_search_toggle]
-
     data[:hideModal] if @options[:hide_modal]
     data[:initAccords] if @options[:init_accords]
 
@@ -203,6 +198,15 @@ class ExplorerPresenter
   end
 
   private
+
+  def format_calendar_dates(options)
+    return {} unless @options[:build_calendar].kind_of?(Hash)
+    {}.tap do |h|
+      %i(date_from date_to).each do |key|
+        h[key] = options[key].iso8601 if options[key].present?
+      end
+    end
+  end
 
   def ajax_action_url(options)
     ['', options[:controller], options[:action], options[:record_id]].join('/')

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -201,10 +201,8 @@ class ExplorerPresenter
 
   def format_calendar_dates(options)
     return {} unless @options[:build_calendar].kind_of?(Hash)
-    {}.tap do |h|
-      %i(date_from date_to).each do |key|
-        h[key] = options[key].iso8601 if options[key].present?
-      end
+    %i(date_from date_to).each_with_object({}) do |key, h|
+      h[key] = options[key].iso8601 if options[key].present?
     end
   end
 

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -151,11 +151,6 @@ class ExplorerPresenter
     } if @options[:delete_node]
 
     data[:dashboardUrl] = @options[:miq_widget_dd_url] if @options[:miq_widget_dd_url]
-
-    # FIXME: remove show_clear_search
-    # # Always set 'def' view in left cell as active in case it was changed to show compare/drift sections
-    # @out << "var show_clear_search = undefined;"
-
     data[:updatePartials] = @options[:update_partials] # Update elements in the DOM with rendered partials
     data[:updateElements] = @options[:element_updates] # Update element in the DOM with given options
     data[:replacePartials] = @options[:replace_partials] # Replace elements in the DOM with rendered partials

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -14,6 +14,7 @@ class ExplorerPresenter
   #
   #   add_nodes                        -- JSON string of nodes to add to the active tree
   #   delete_node                      -- key of node to be deleted from the active tree
+  #   clear_search_toggle              -- show or hide 'clear search' button
   #   build_calendar                   -- call miqBuildCalendar, true/false or Hash (:date_from, :date_to, :skip_days)
   #
   #   init_dashboard                   -- call miqInitDashboardCols
@@ -193,7 +194,7 @@ class ExplorerPresenter
     data[:oneTransIE] = !!@options[:one_trans_ie]
     data[:focus] = @options[:focus]
 
-    data[:clearSearch] = @options[:clear_search_show_or_hide] if @options[:clear_search_show_or_hide]
+    data[:clearSearch] = @options[:clear_search_toggle] if @options[:clear_search_toggle]
 
     data[:hideModal] if @options[:hide_modal]
     data[:initAccords] if @options[:init_accords]

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -127,7 +127,7 @@ class ExplorerPresenter
   end
 
   def to_json
-    data = { :explorer => true }
+    data = {:explorer => true}
 
     # see if any miq expression vars need to be set
     unless @options[:exp].empty?

--- a/app/views/layouts/_x_adv_searchbox.html.haml
+++ b/app/views/layouts/_x_adv_searchbox.html.haml
@@ -38,15 +38,15 @@
         %button{:type           => "button",
                 :class          => "btn btn-default",
                 "data-toggle"   => "modal",
-                "data-target"   => "#advsearchModal", 
+                "data-target"   => "#advsearchModal",
                 "data-whatever" => "@mdo",
                 :id             => "adv_search",
-                :alt            => t, 
+                :alt            => t,
                 :title          => t}
           %span.fa.fa-angle-double-down
 
     :javascript
-      $('#clear_search').#{clear_search_show_or_hide}();
+      ManageIQ.explorer.clear_search_show_or_hide(#{clear_search_show_or_hide});
       $(function() {
         $(document).ready(function() {
           miqHideSearchClearButton();

--- a/app/views/layouts/_x_adv_searchbox.html.haml
+++ b/app/views/layouts/_x_adv_searchbox.html.haml
@@ -46,7 +46,7 @@
           %span.fa.fa-angle-double-down
 
     :javascript
-      ManageIQ.explorer.clear_search_show_or_hide(#{clear_search_show_or_hide});
+      ManageIQ.explorer.clear_search_toggle(#{clear_search_status});
       $(function() {
         $(document).ready(function() {
           miqHideSearchClearButton();

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -218,17 +218,17 @@ describe ChargebackController do
 
     it "renders edit form with correct values" do
       post :x_button, :params => {:pressed => "chargeback_rates_edit", :id => chargeback_rate.id}
-      response_body = response.body.delete('\\')
       expect(response).to render_template(:partial => 'chargeback/_cb_rate_edit')
       expect(response).to render_template(:partial => 'chargeback/_cb_rate_edit_table')
 
-      expect_input(response_body, "description", "foo")
+      main_content = JSON.parse(response.body)['updatePartials']['main_div']
+      expect_input(main_content, "description", "foo")
 
-      expect_rendered_tiers(response_body, [{:start => "0.0", :finish => "20.0"},
+      expect_rendered_tiers(main_content, [{:start => "0.0", :finish => "20.0"},
                                             {:start => "20.0", :finish => "40.0"},
                                             {:start => "40.0", :finish => Float::INFINITY}])
 
-      expect_rendered_tiers(response_body, [{:start => "0.0", :finish => Float::INFINITY}], 1)
+      expect_rendered_tiers(main_content, [{:start => "0.0", :finish => Float::INFINITY}], 1)
     end
 
     it "removes requested tier line from edit from" do

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -151,8 +151,8 @@ describe ReportController do
       end
 
       def row_count_html(row_count_value)
-        "<label class=\\'control-label col-md-2\\'>Row Count<\\/label>\\n" \
-        "<div class=\\'col-md-10\\'>\\n<p class=\\'form-control-static\\'>#{row_count_value}<\\/p>\\n<\\/div>"
+        "<label class='control-label col-md-2'>Row Count</label>\n" \
+        "<div class='col-md-10'>\n<p class='form-control-static'>#{row_count_value}</p>\n</div>"
       end
 
       it "renders show of Dashboard Widget in Widgets tree with default row_count value" do
@@ -160,7 +160,9 @@ describe ReportController do
 
         expect(response).to render_template('report/_widget_show')
         expect(response.status).to eq(200)
-        expect(response.body).to include(row_count_html(default_row_count_value))
+
+        main_content = JSON.parse(response.body)['updatePartials']['main_div']
+        expect(main_content).to include(row_count_html(default_row_count_value))
       end
 
       it "renders show of Dashboard Widget in Widgets tree with row_count value from widget" do
@@ -168,7 +170,9 @@ describe ReportController do
 
         expect(response).to render_template('report/_widget_show')
         expect(response.status).to eq(200)
-        expect(response.body).to include(row_count_html(other_row_count_value))
+
+        main_content = JSON.parse(response.body)['updatePartials']['main_div']
+        expect(main_content).to include(row_count_html(other_row_count_value))
       end
     end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -49,12 +49,14 @@ describe OpsController do
 
         expect(response).to render_template('ops/_rbac_details_tab')
         expect(response.status).to eq(200)
-        expect(response.body).to include('Tenant Quota')
-        expect(response.body).to include('<th>\nName\n<\/th>\n<th>\nTotal Quota\n<\/th>\n<th>\nIn Use\n' \
-                                         '<\/th>\n<th>\nAllocated\n<\/th>\n<th>\nAvailable\n<\/th>')
-        expect(response.body).to include('4096.0 GB')
-        expect(response.body).to include('1024 Count')
-        expect(response.body).to include('27 Count')
+
+        tab_content = JSON.parse(response.body)['replacePartials']['ops_tabs']
+        expect(tab_content).to include('Tenant Quota')
+        expect(tab_content).to include("<th>\nName\n<\/th>\n<th>\nTotal Quota\n<\/th>\n<th>\nIn Use\n" \
+                                         "<\/th>\n<th>\nAllocated\n<\/th>\n<th>\nAvailable\n<\/th>")
+        expect(tab_content).to include('4096.0 GB')
+        expect(tab_content).to include('1024 Count')
+        expect(tab_content).to include('27 Count')
       end
     end
 

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -286,21 +286,21 @@ describe OpsController do
     it "does not render toolbar buttons when edit is clicked" do
       post :x_button, :params => { :id => @miq_server.id, :pressed => 'log_depot_edit', :format => :js }
       expect(response.status).to eq(200)
-      expect(response.body).to include("if (miqDomElementExists('toolbar')) $('#toolbar').hide();")
+      expect(JSON.parse(response.body)['setVisibility']['toolbar']).to be false
     end
 
     it "renders toolbar buttons when cancel is clicked" do
       allow(controller).to receive(:diagnostics_set_form_vars)
       post :x_button, :params => { :id => @miq_server.id, :pressed => 'log_depot_edit', :button => "cancel", :format => :js }
       expect(response.status).to eq(200)
-      expect(response.body).to include("if (miqDomElementExists('toolbar')) $('#toolbar').show();")
+      expect(JSON.parse(response.body)['setVisibility']['toolbar']).to be
     end
 
     it "renders toolbar buttons when save is clicked" do
       allow(controller).to receive(:diagnostics_set_form_vars)
       post :x_button, :params => { :id => @miq_server.id, :pressed => 'log_depot_edit', :button => "save", :format => :js }
       expect(response.status).to eq(200)
-      expect(response.body).to include("if (miqDomElementExists('toolbar')) $('#toolbar').show();")
+      expect(JSON.parse(response.body)['setVisibility']['toolbar']).to be
     end
   end
 

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -157,8 +157,10 @@ describe StorageController do
         allow(Classification).to receive(:find_assigned_entries).and_return([@tag1, @tag2])
         post :x_button, :params => {:miq_grid_checks => to_cid(datastore.id), :pressed => "storage_tag", :format => :js}
         expect(response.status).to eq(200)
-        expect(response.body).to include('<h3>\n1 Datastore Being Tagged\n<\/h3>')
-        expect(response.body).to include("Name: #{datastore.name} | Datastores Type: ")
+
+        main_content = JSON.parse(response.body)['updatePartials']['main_div']
+        expect(main_content).to include("<h3>\n1 Datastore Being Tagged\n<\/h3>")
+        expect(main_content).to include("Name: #{datastore.name} | Datastores Type: ")
       end
 
       it 'can Perform a datastore Smart State Analysis from the datastore summary page' do

--- a/spec/presenters/explorer_presenter_spec.rb
+++ b/spec/presenters/explorer_presenter_spec.rb
@@ -45,8 +45,8 @@ describe ExplorerPresenter do
 
     context "#build_calendar" do
       it 'passes data to :buildCalendar' do
-        @presenter[:build_calendar] = {:foo => 'bar'}
-        expect(subject[:buildCalendar]).to include(:foo => 'bar')
+        @presenter[:build_calendar] = {:date_from => t = Time.now.utc}
+        expect(subject[:buildCalendar]).to include(:date_from => t.iso8601)
       end
     end
   end

--- a/spec/presenters/explorer_presenter_spec.rb
+++ b/spec/presenters/explorer_presenter_spec.rb
@@ -6,62 +6,47 @@ describe ExplorerPresenter do
       @content   = "<div>Sample div element</div>"
     end
 
-    context "#replace_partial" do
-      it 'returns proper JS' do
-        js_str = @presenter.send(:replace_partial, @el, @content)
-        expect(js_str).to eq("$('##{@el}').replaceWith('#{escape_javascript(@content)}');")
+    subject { @presenter.to_json }
+
+    context "#replace" do
+      it 'adds content to :replacePartials' do
+
+        @presenter.replace(@el, @content)
+
+        expect(subject[:replacePartials]).to include(@el => @content)
       end
     end
 
-    context "#update_partial" do
-      it 'returns proper JS' do
-        js_str = @presenter.send(:update_partial, @el, @content)
-        expect(js_str).to eq("$('##{@el}').html('#{escape_javascript(@content)}');")
+    context "#update" do
+      it 'adds content to :updatePartials' do
+        @presenter.update(@el, @content)
+
+        expect(subject[:updatePartials]).to include(@el => @content)
       end
     end
 
-    context "#set_or_undef" do
-      it 'return proper JS for nil' do
-        js_str = @presenter.send(:set_or_undef, "var1")
-        expect(js_str).to eq('ManageIQ.record.var1 = null;')
-      end
-
-      it 'return proper JS for a random value' do
-        random_value = 'xxx' + rand(10).to_s
-        @presenter['var2'] = random_value
-        js_str = @presenter.send(:set_or_undef, "var2")
-        expect(js_str).to eq("ManageIQ.record.var2 = '#{random_value}';")
+    context "#[:record_id]" do
+      it 'sets :record object' do
+        @presenter[:record_id] = 666
+        expect(subject[:record][:recordId]).to eq(666)
       end
     end
 
     context "#ajax_action" do
-      it 'returns JS to call miqAsyncAjax with proper url' do
-        js_str = @presenter.send(:ajax_action,
+      it 'sets ajaxUrl to proper url' do
+        @presenter[:ajax_action] = {
           :controller => 'foo',
           :action     => 'bar',
           :record_id  => 42,
-        )
-        expect(js_str).to eq("miqAsyncAjax('/foo/bar/42');")
+        }
+        expect(subject[:ajaxUrl]).to eq('/foo/bar/42')
       end
     end
 
     context "#build_calendar" do
-      it 'calls js_build_calendar' do
-        @presenter[:build_calendar] = true
-        expect(@presenter).to receive(:js_build_calendar)
-        @presenter.send(:build_calendar)
-      end
-
-      it 'calls js_build_calendar with params' do
-        # with_indifferent_access because ExplorerPresenter#options is, and it's recursively infectious - ie. won't compare otherwise
-        obj = {
-          :date_from => Time.at(0).utc,
-          :date_to   => Time.at(946684800).utc,
-          :skip_days => [ 1, 2, 3 ],
-        }.with_indifferent_access
-        @presenter[:build_calendar] = obj
-        expect(@presenter).to receive(:js_build_calendar).with(obj)
-        @presenter.send(:build_calendar)
+      it 'passes data to :buildCalendar' do
+        @presenter[:build_calendar] = {:foo => 'bar'}
+        expect(subject[:buildCalendar]).to include(:foo => 'bar')
       end
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
We want to get rid of RJS (and javascript eval). This PR converts all the actions that go through ExplorerPresenter to JSON. This is surely not as good as using some nice JSON/REST API or converting the stuff in question to Angular. But it implements a more restricted interface and removes the need to call `eval` in many situations.

Steps for Testing/QA
--------------------
Every screen that uses explorer (trees on the left) is affected by this change. And some more. I expect bugs. Actually if there would be no bugs found, I would be pretty scared.

Make sure that `miqBuildCalendar` related stuff works well. Note: Seems to me that there's a lot of unused code around that. Needs a cleanup (in a separate PR).