### PR TITLE
Move amazon cloudmanager factory to amazon gem

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -146,13 +146,6 @@ FactoryGirl.define do
     end
   end
 
-  factory :ems_amazon_with_authentication_on_other_account,
-          :parent => :ems_amazon do
-    after(:create) do |x|
-      x.authentications << FactoryGirl.create(:authentication)
-    end
-  end
-
   factory :ems_openstack,
           :aliases => ["manageiq/providers/openstack/cloud_manager"],
           :class   => "ManageIQ::Providers::Openstack::CloudManager",


### PR DESCRIPTION
into spec file in https://github.com/ManageIQ/manageiq-providers-amazon
and remove the factory altogether

related PR https://github.com/ManageIQ/manageiq-providers-amazon/pull/14
this was introduced by https://github.com/ManageIQ/manageiq/pull/7050

@miq-bot add_labels test

@blomquisg review and merge? 