### PR TITLE
Models for supporting VMware Storage Profile

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -46,6 +46,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :resource_pools, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   has_many :customization_specs, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :storage_profiles,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -4,6 +4,8 @@ class Storage < ApplicationRecord
   has_many :vms,               :foreign_key => :storage_id
   has_many :host_storages
   has_many :hosts,             :through => :host_storages
+  has_many :storage_profile_storages,   :dependent  => :destroy
+  has_many :storage_profiles,           :through    => :storage_profile_storages
   has_and_belongs_to_many :all_vms_and_templates, :class_name => "VmOrTemplate", :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_miq_templates,     :class_name => "MiqTemplate",  :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_vms,               :class_name => "Vm",           :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id

--- a/app/models/storage_profile.rb
+++ b/app/models/storage_profile.rb
@@ -1,4 +1,5 @@
 class StorageProfile < ApplicationRecord
+  belongs_to :ext_management_system
   has_many :storage_profile_storages, :dependent  => :destroy
   has_many :storages,                 :through    => :storage_profile_storages
 end

--- a/app/models/storage_profile.rb
+++ b/app/models/storage_profile.rb
@@ -1,0 +1,4 @@
+class StorageProfile < ApplicationRecord
+  has_many :storage_profile_storages, :dependent  => :destroy
+  has_many :storages,                 :through    => :storage_profile_storages
+end

--- a/app/models/storage_profile_storage.rb
+++ b/app/models/storage_profile_storage.rb
@@ -1,0 +1,4 @@
+class StorageProfileStorage < ApplicationRecord
+  belongs_to :storage_profile
+  belongs_to :storage
+end

--- a/db/migrate/20160712043931_create_storage_profiles.rb
+++ b/db/migrate/20160712043931_create_storage_profiles.rb
@@ -2,7 +2,7 @@ class CreateStorageProfiles < ActiveRecord::Migration[5.0]
   def change
     create_table :storage_profiles do |t|
       t.string :name
-      t.string :uuid
+      t.string :ems_ref
       t.string :profile_type
 
       t.timestamps

--- a/db/migrate/20160712043931_create_storage_profiles.rb
+++ b/db/migrate/20160712043931_create_storage_profiles.rb
@@ -1,0 +1,11 @@
+class CreateStorageProfiles < ActiveRecord::Migration[5.0]
+  def change
+    create_table :storage_profiles do |t|
+      t.string :name
+      t.string :uuid
+      t.string :profile_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160712043931_create_storage_profiles.rb
+++ b/db/migrate/20160712043931_create_storage_profiles.rb
@@ -1,6 +1,7 @@
 class CreateStorageProfiles < ActiveRecord::Migration[5.0]
   def change
     create_table :storage_profiles do |t|
+      t.bigint :ems_id
       t.string :name
       t.string :ems_ref
       t.string :profile_type

--- a/db/migrate/20160712044409_create_join_table_storage_profile_storage.rb
+++ b/db/migrate/20160712044409_create_join_table_storage_profile_storage.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableStorageProfileStorage < ActiveRecord::Migration[5.0]
+  def change
+    create_table :storage_profile_storages do |t|
+      t.bigint  :storage_profile_id
+      t.bigint  :storage_id
+    end
+  end
+end

--- a/db/migrate/20160712044409_create_join_table_storage_profile_storage.rb
+++ b/db/migrate/20160712044409_create_join_table_storage_profile_storage.rb
@@ -3,6 +3,8 @@ class CreateJoinTableStorageProfileStorage < ActiveRecord::Migration[5.0]
     create_table :storage_profile_storages do |t|
       t.bigint  :storage_profile_id
       t.bigint  :storage_id
+      t.index   :storage_id
+      t.index   :storage_profile_id
     end
   end
 end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6131,6 +6131,17 @@ storage_metrics_metadata:
 - counter_info
 - created_at
 - updated_at
+storage_profile_storages:
+- id
+- storage_profile_id
+- storage_id
+storage_profiles:
+- id
+- name
+- ems_ref
+- profile_type
+- created_at
+- updated_at
 storages:
 - id
 - name

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6137,6 +6137,7 @@ storage_profile_storages:
 - storage_id
 storage_profiles:
 - id
+- ems_id
 - name
 - ems_ref
 - profile_type


### PR DESCRIPTION
Models for inventory of storage profiles to support VMware Storage Profile.

* Storage Profile vs Datastore
A Storage Profile is related many datastores that satisfy its requirements. A datastore can have satisfy multiple Storage Profile.

* Storage Profile vs VM/VMDK
A VM/VMDK can be associated with one Storage Profile while one Storage Profile can be applied to multiple VM/VMDK.
 
At this stage of implementation (and this PR), we only support this.
