### PR TITLE
Refresh service dialogs tree after importing a service dialog

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -80,7 +80,7 @@ class MiqAeCustomizationController < ApplicationController
       add_flash(_("Service dialog import cancelled"), :success)
     end
     get_node_info
-    replace_right_cell(x_node)
+    replace_right_cell(x_node, [:dialogs])
   end
 
   def export_service_dialogs

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -411,6 +411,11 @@ describe MiqAeCustomizationController do
         expect(controller.instance_variable_get(:@flash_array))
           .to include(:message => "Service dialogs imported successfully", :level => :success)
       end
+
+      it "updates the dialogs tree" do
+        expect(controller).to receive(:replace_right_cell).with(nil, [:dialogs])
+        post :import_service_dialogs, :params => params, :xhr => true
+      end
     end
 
     context "when the import file upload does not exist" do


### PR DESCRIPTION
After importing a Service Dialog and returning to the Service Dialog accordion the newly imported Dialog was not listed in the tree while being in the table in the right cell.  This PR forces the Dialog tree to refresh upon import of a new Dialog.

https://bugzilla.redhat.com/show_bug.cgi?id=1346007