### PR TITLE
Bump hawkular-gem to v2.2.0 

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -27,7 +27,7 @@ gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.2",           :require => false
 gem "iniparse",                                     :require => false
 gem "kubeclient",              "=1.1.3",            :require => false
-gem "hawkular-client",         "=2.1.0",            :require => false
+gem "hawkular-client",         "=2.2.0",            :require => false
 gem "linux_admin",             "~>0.16.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner_spec.rb
@@ -1,8 +1,8 @@
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner do
   subject do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    auth                 = AuthToken.new(:name     => "test",
-                                         :auth_key => "valid-token",
+    auth                 = AuthToken.new(:name     => "jdoe",
+                                         :auth_key => "password",
                                          :userid   => "jdoe",
                                          :password => "password")
     ems                  = FactoryGirl.create(:ems_hawkular,

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream_spec.rb
@@ -1,8 +1,8 @@
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream do
   subject do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    auth                 = AuthToken.new(:name     => "test",
-                                         :auth_key => "valid-token",
+    auth                 = AuthToken.new(:name     => "jdoe",
+                                         :auth_key => "password",
                                          :userid   => "jdoe",
                                          :password => "password")
     ems                  = FactoryGirl.create(:ems_hawkular,
@@ -25,7 +25,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream 
 
     it "yields a valid event" do
       # if generating a cassette the polling window is the previous 1 minute
-      VCR.use_cassette(described_class.name.underscore.to_s) do # , :record => :new_episodes) do
+      VCR.use_cassette(described_class.name.underscore.to_s,
+                       :decode_compressed_response     => true) do # , :record => :new_episodes) do
         result = []
         subject.start
         subject.each_batch do |events|

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
@@ -1,4 +1,6 @@
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource do
+  THE_FEED_ID = '70c798a0-6985-4f8a-a525-012d8d28e8a3'.freeze
+
   let(:ems_hawkular) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     auth = AuthToken.new(:name => "test", :auth_key => "valid-token", :userid => "jdoe", :password => "password")
@@ -13,9 +15,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
     FactoryGirl.create(:hawkular_middleware_server,
                        :id                    => 1,
                        :name                  => 'Local',
-                       :feed                  => '27e06e8f-6e5d-45cd-8353-c1f9d4dfe991',
+                       :feed                  => THE_FEED_ID,
                        :ems_ref               => '/t;hawkular'\
-                                                 '/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~',
+                                                 "/f;#{THE_FEED_ID}/r;Local~~",
                        :nativeid              => 'Local~~',
                        :ext_management_system => ems_hawkular)
   end
@@ -24,7 +26,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
     FactoryGirl.create(:hawkular_middleware_datasource,
                        :name                  => 'KeycloakDS',
                        :ems_ref               => '/t;hawkular'\
-                                                 '/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~'\
+                                                 "/f;#{THE_FEED_ID}/r;Local~~"\
                                                  '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS',
                        :ext_management_system => ems_hawkular,
                        :middleware_server     => eap,

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -1,4 +1,6 @@
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
+  THE_FEED_ID = '70c798a0-6985-4f8a-a525-012d8d28e8a3'.freeze
+
   let(:ems_hawkular) do
     # allow(MiqServer).to receive(:my_zone).and_return("default")
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
@@ -13,9 +15,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   let(:eap) do
     FactoryGirl.create(:hawkular_middleware_server,
                        :name                  => 'Local',
-                       :feed                  => '27e06e8f-6e5d-45cd-8353-c1f9d4dfe991',
+                       :feed                  => THE_FEED_ID,
                        :ems_ref               => '/t;hawkular'\
-                                                 '/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~',
+                                                 "/f;#{THE_FEED_ID}/r;Local~~",
                        :nativeid              => 'Local~~',
                        :ext_management_system => ems_hawkular)
   end
@@ -49,8 +51,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for all metrics available" do
-    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")
-    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")
+    start_time = Time.new(2016, 7, 05, 17, 0, 0, "+02:00")
+    end_time = Time.new(2016, 7, 05, 18, 0, 0, "+02:00")
     interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
@@ -63,8 +65,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for three metrics" do
-    start_time = Time.new(2016, 6, 23, 9, 0, 0, "+02:00")
-    end_time = Time.new(2016, 6, 23, 10, 0, 0, "+02:00")
+    start_time = Time.new(2016, 7, 05, 17, 0, 0, "+02:00")
+    end_time = Time.new(2016, 7, 05, 18, 0, 0, "+02:00")
     interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'recursive-open-struct'
 
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
+  THE_FEED_ID = '70c798a0-6985-4f8a-a525-012d8d28e8a3'.freeze
+
   let(:ems_hawkular) do
     # allow(MiqServer).to receive(:my_zone).and_return("default")
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
@@ -16,9 +18,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
   let(:server) do
     FactoryGirl.create(:hawkular_middleware_server,
                        :name                  => 'Local',
-                       :feed                  => 'cda13e2a-e206-4e87-8bca-8cfdd5aea484',
-                       :ems_ref               => '/t;28026b36-8fe4-4332-84c8-524e173a68bf'\
-                                                 '/f;cda13e2a-e206-4e87-8bca-8cfdd5aea484/r;Local~~',
+                       :feed                  => THE_FEED_ID,
+                       :ems_ref               => '/t;Hawkular'\
+                                                 "/f;#{THE_FEED_ID}/r;Local~~",
                        :nativeid              => 'Local~~',
                        :ext_management_system => ems_hawkular)
   end
@@ -28,8 +30,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
       # parse_datasource(server, datasource, config)
       datasource = RecursiveOpenStruct.new(:name => 'ruby-sample-build',
                                            :id   => 'Local~/subsystem=datasources/data-source=ExampleDS',
-                                           :path => '/t;28026b36-8fe4-4332-84c8-524e173a68bf'\
-                                                    '/f;cda13e2a-e206-4e87-8bca-8cfdd5aea484/r;Local~~'\
+                                           :path => '/t;Hawkular'\
+                                                    "/f;#{THE_FEED_ID}/r;Local~~"\
                                                     '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS'
                                           )
       config = {
@@ -44,8 +46,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
         :name              => 'ruby-sample-build',
         :middleware_server => server,
         :nativeid          => 'Local~/subsystem=datasources/data-source=ExampleDS',
-        :ems_ref           => '/t;28026b36-8fe4-4332-84c8-524e173a68bf'\
-                                                 '/f;cda13e2a-e206-4e87-8bca-8cfdd5aea484/r;Local~~'\
+        :ems_ref           => '/t;Hawkular'\
+                                                 "/f;#{THE_FEED_ID}/r;Local~~"\
                                                  '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS',
         :properties        => {
           'Driver Name'    => 'h2',

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -3,8 +3,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
     allow(MiqServer).to receive(:my_zone).and_return("default")
     auth = AuthToken.new(:name => "test", :auth_key => "valid-token", :userid => "jdoe", :password => "password")
     @ems_hawkular = FactoryGirl.create(:ems_hawkular,
-                                       :hostname        => 'hservices.torii.gva.redhat.com',
-                                       :port            => 80,
+                                       :hostname        => 'localhost',
+                                       :port            => 8080,
                                        :authentications => [auth])
   end
 
@@ -24,9 +24,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
   end
 
   def assert_specific_datasource
-    datasource = @ems_hawkular.middleware_datasources.find_by_name('ExampleDS')
+    datasource = @ems_hawkular.middleware_datasources.find_by_name('Datasource [ExampleDS]')
     expect(datasource).to have_attributes(
-      :name     => 'ExampleDS',
+      :name     => 'Datasource [ExampleDS]',
       :nativeid => 'Local~/subsystem=datasources/data-source=ExampleDS'
     )
     expect(datasource.properties).not_to be_nil

--- a/spec/services/middleware_topology_service_spec.rb
+++ b/spec/services/middleware_topology_service_spec.rb
@@ -19,7 +19,7 @@ describe MiddlewareTopologyService do
     let(:middleware_server) do
       FactoryGirl.create(:hawkular_middleware_server,
                          :name                  => 'Local',
-                         :feed                  => 'cda13e2a-e206-4e87-8bca-8cfdd5aea484',
+                         :feed                  => '70c798a0-6985-4f8a-a525-012d8d28e8a3',
                          :ems_ref               => long_id_0,
                          :nativeid              => 'Local~~',
                          :ext_management_system => ems_hawkular)

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?startTime=1462564369000&tags=miq.event_type%7C*&thin=true
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/status
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.4p230
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
       Content-Type:
       - application/json
   response:
@@ -20,8 +22,51 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Content-Encoding:
-      - gzip
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '234'
+      Date:
+      - Tue, 05 Jul 2016 15:40:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "Implementation-Version" : "0.17.2.Final",
+          "Built-From-Git-SHA1" : "3c8ac6648aa0ec33643ae1b98faadc475d2c6f02",
+          "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
+          "Initialized" : "true"
+        }
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:40:04 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?startTime=1467733144000&tags=miq.event_type%7C*&thin=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
       Expires:
       - '0'
       Cache-Control:
@@ -33,7 +78,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Fri, 06 May 2016 19:53:49 GMT
+      - Tue, 05 Jul 2016 15:40:04 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -41,22 +86,16 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '339'
+      - '273'
       Link:
-      - <http://localhost:8080/hawkular/alerts/events?startTime=1462564369000&tags=miq.event_type%7c*&thin=true>;
-        rel="current", <http://localhost:8080/hawkular/alerts/events?startTime=1462564369000&tags=miq.event_type%7c*&thin=true&page=0>;
+      - <http://localhost:8080/hawkular/alerts/events?startTime=1467733144000&tags=miq.event_type%7c*&thin=true>;
+        rel="current", <http://localhost:8080/hawkular/alerts/events?startTime=1467733144000&tags=miq.event_type%7c*&thin=true&page=0>;
         rel="last"
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAAI1RXU/CMBT9K7MJbxRG99Ehr0Bior5IfDFmuWsvo7p12BVh
-        IfjbbYcuPvrQpDk9595zTl/OBD9R2023R3JLVs+rxw0ZE4satL2TDmJZyNIi
-        Smm2xZjGUcRoFouMJizGGY8gzYqtUyjPxbqlOzi+HyowtJ9Lk8Q9CqtqN34W
-        pyxJOU/TMAzHRIKFp+ZghN+c60Zj7rlgsWxM592cLBoNVW/oZB2ywdYGa1DV
-        jWc2+gqfSY1tCyX+0VRdoPQbCosyWHknQZJ4kcG2X5nvwe4cf2oX/0k43S44
-        FKzgICmbFwWN43lCIcuAcpSCFzyUgDg1i/tGQPX1NdxGbC1xXzVd7UyMouXQ
-        j2jqGrSkpQt8hI4ewUzcIReXFsq2j6U+Jn2Nub3+z68479GJMMoq0RfkqUO2
-        H/aDkrJysw0uBwfkcnn9BpoXKT31AQAA
+      encoding: UTF-8
+      string: '[{"eventType":"EVENT","tenantId":"hawkular","id":"ems-hawkular-event-4","ctime":1467733170000,"dataSource":"_none_","category":"Hawkular
+        Deployment","text":"Error","context":{"message":"This is a mock deployment
+        event"},"tags":{"miq.event_type":"hawkular_event.critical"}}]'
     http_version: 
-  recorded_at: Fri, 06 May 2016 19:53:49 GMT
+  recorded_at: Tue, 05 Jul 2016 15:40:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_datasource.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_datasource.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/metrics?sort=id
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/status
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,52 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '234'
+      Date:
+      - Tue, 05 Jul 2016 15:07:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "Implementation-Version" : "0.17.2.Final",
+          "Built-From-Git-SHA1" : "3c8ac6648aa0ec33643ae1b98faadc475d2c6f02",
+          "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
+          "Initialized" : "true"
+        }
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/metrics?sort=id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -33,7 +78,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       X-Total-Count:
       - '26'
       Connection:
@@ -41,331 +86,461 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '20378'
+      - '25961'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/metrics?sort=id>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
+          "properties" : {
+            "__identityHash" : "b3ab7316dedd2f16d7510963fe4435d9b3c9d"
+          },
           "name" : "Datasource JDBC Metrics~Prepared Statement Cache Access Count",
+          "identityHash" : "b3ab7316dedd2f16d7510963fe4435d9b3c9d",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
             "name" : "Datasource JDBC Metrics~Prepared Statement Cache Access Count",
+            "identityHash" : "23ebe568db6f52b17846c444f15932c79f78511",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Access Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Access Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Access Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
+          "properties" : {
+            "__identityHash" : "1f87c1212cce8521edc2e462f3a37cf63de209b"
+          },
           "name" : "Datasource JDBC Metrics~Prepared Statement Cache Add Count",
+          "identityHash" : "1f87c1212cce8521edc2e462f3a37cf63de209b",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
             "name" : "Datasource JDBC Metrics~Prepared Statement Cache Add Count",
+            "identityHash" : "4968d388605964fae5a92c72e4372174b51365c",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Add Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Add Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Add Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
+          "properties" : {
+            "__identityHash" : "ec791259238c4be3d425fb710d6cf60317dcb2f"
+          },
           "name" : "Datasource JDBC Metrics~Prepared Statement Cache Current Size",
+          "identityHash" : "ec791259238c4be3d425fb710d6cf60317dcb2f",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
             "name" : "Datasource JDBC Metrics~Prepared Statement Cache Current Size",
+            "identityHash" : "f74f115f7e11da9dad9987d7a616bee1339bc1f",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Current Size"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Current Size"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Current Size"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
+          "properties" : {
+            "__identityHash" : "bd69d97ed130384b8d5075f6f31abf485b5b222d"
+          },
           "name" : "Datasource JDBC Metrics~Prepared Statement Cache Delete Count",
+          "identityHash" : "bd69d97ed130384b8d5075f6f31abf485b5b222d",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
             "name" : "Datasource JDBC Metrics~Prepared Statement Cache Delete Count",
+            "identityHash" : "6cca794bea731a28ef21f4162b934f89f594a59c",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Delete Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Delete Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Delete Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
+          "properties" : {
+            "__identityHash" : "dc9810ce9d06cbeee6cb8c2a718fa168e1d9931"
+          },
           "name" : "Datasource JDBC Metrics~Prepared Statement Cache Hit Count",
+          "identityHash" : "dc9810ce9d06cbeee6cb8c2a718fa168e1d9931",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
             "name" : "Datasource JDBC Metrics~Prepared Statement Cache Hit Count",
+            "identityHash" : "bbfe3a3a6f0c857dd20105c21a3583215bb1ff6",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Hit Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Hit Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Hit Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
+          "properties" : {
+            "__identityHash" : "76bf8d5037bdc7ddb66422ef2a8173e4f3912814"
+          },
           "name" : "Datasource JDBC Metrics~Prepared Statement Cache Miss Count",
+          "identityHash" : "76bf8d5037bdc7ddb66422ef2a8173e4f3912814",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
             "name" : "Datasource JDBC Metrics~Prepared Statement Cache Miss Count",
+            "identityHash" : "b8a0f5782c83e8e4621cde1a9708b1cef9f8041",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Miss Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Miss Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Miss Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Active%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Active%20Count",
+          "properties" : {
+            "__identityHash" : "8a2ac09f2c213a2b2a36cbb8c2f2f1889fba63e1"
+          },
           "name" : "Datasource Pool Metrics~Active Count",
+          "identityHash" : "8a2ac09f2c213a2b2a36cbb8c2f2f1889fba63e1",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Active%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Active%20Count",
             "name" : "Datasource Pool Metrics~Active Count",
+            "identityHash" : "618466f7c5ba51b3a4cfbebd181983739b287b",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Active Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Active Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Active Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count",
+          "properties" : {
+            "__identityHash" : "b47a8f129f388016d49b577e5a66ba1aefbd2d"
+          },
           "name" : "Datasource Pool Metrics~Available Count",
+          "identityHash" : "b47a8f129f388016d49b577e5a66ba1aefbd2d",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Available%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Available%20Count",
             "name" : "Datasource Pool Metrics~Available Count",
+            "identityHash" : "8cde6c3fac5b49da59c13b1f75fdc64488f90f7",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Available Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Available Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Available Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
+          "properties" : {
+            "__identityHash" : "9e9ff2832f30981a5b6d67319bf31c0c3abf637"
+          },
           "name" : "Datasource Pool Metrics~Average Blocking Time",
+          "identityHash" : "9e9ff2832f30981a5b6d67319bf31c0c3abf637",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
             "name" : "Datasource Pool Metrics~Average Blocking Time",
+            "identityHash" : "1cf4767a72f5a12d3726ed37d8a3b3a5028d70",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Average Blocking Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Blocking Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Blocking Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time",
+          "properties" : {
+            "__identityHash" : "f83ad98f747c2989c68c66aa8cfcc0a1d11d85df"
+          },
           "name" : "Datasource Pool Metrics~Average Creation Time",
+          "identityHash" : "f83ad98f747c2989c68c66aa8cfcc0a1d11d85df",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Average%20Creation%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Average%20Creation%20Time",
             "name" : "Datasource Pool Metrics~Average Creation Time",
+            "identityHash" : "d37beaba7174897dcf392ee284567fcd21b092",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Average Creation Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Creation Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Creation Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time",
+          "properties" : {
+            "__identityHash" : "447d63e4f8d35261b8a03f235da5768cb15c950"
+          },
           "name" : "Datasource Pool Metrics~Average Get Time",
+          "identityHash" : "447d63e4f8d35261b8a03f235da5768cb15c950",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Average%20Get%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Average%20Get%20Time",
             "name" : "Datasource Pool Metrics~Average Get Time",
+            "identityHash" : "20c7902c49b19bc97162e8ca17ebe62dad4d1ff",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Average Get Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Get Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Get Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
+          "properties" : {
+            "__identityHash" : "961d28995a0ef23157bd8e6ff4913ed4ede23e2"
+          },
           "name" : "Datasource Pool Metrics~Blocking Failure Count",
+          "identityHash" : "961d28995a0ef23157bd8e6ff4913ed4ede23e2",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
             "name" : "Datasource Pool Metrics~Blocking Failure Count",
+            "identityHash" : "74be1a84128a299d7a09b938287d51c75ec12",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Blocking Failure Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Blocking Failure Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Blocking Failure Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Created%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Created%20Count",
+          "properties" : {
+            "__identityHash" : "3346694a52ad1b84efbf368c8c7e49f923ac1828"
+          },
           "name" : "Datasource Pool Metrics~Created Count",
+          "identityHash" : "3346694a52ad1b84efbf368c8c7e49f923ac1828",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Created%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Created%20Count",
             "name" : "Datasource Pool Metrics~Created Count",
+            "identityHash" : "324f82c7bede83c8f9ac5e0c4db1637259ff73",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Created Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Created Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Created Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Destroyed%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Destroyed%20Count",
+          "properties" : {
+            "__identityHash" : "6e7ef0fc7e965b2f011ea8326733b134d95bd3b"
+          },
           "name" : "Datasource Pool Metrics~Destroyed Count",
+          "identityHash" : "6e7ef0fc7e965b2f011ea8326733b134d95bd3b",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Destroyed%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Destroyed%20Count",
             "name" : "Datasource Pool Metrics~Destroyed Count",
+            "identityHash" : "87f3c2434743e715935d382af6266e5e6d66d469",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Destroyed Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Destroyed Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Destroyed Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Idle%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Idle%20Count",
+          "properties" : {
+            "__identityHash" : "d0e658f742f8c663613452db14cf7c53291df1"
+          },
           "name" : "Datasource Pool Metrics~Idle Count",
+          "identityHash" : "d0e658f742f8c663613452db14cf7c53291df1",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Idle%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Idle%20Count",
             "name" : "Datasource Pool Metrics~Idle Count",
+            "identityHash" : "6ba232119aae831f0fc9559fd753ce7fce69f21",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Idle Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Idle Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Idle Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count",
+          "properties" : {
+            "__identityHash" : "432ab2b226b6314829d2c7b41d13c3aa697236"
+          },
           "name" : "Datasource Pool Metrics~In Use Count",
+          "identityHash" : "432ab2b226b6314829d2c7b41d13c3aa697236",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~In%20Use%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~In%20Use%20Count",
             "name" : "Datasource Pool Metrics~In Use Count",
+            "identityHash" : "8314efb84866539834be4fdedd8cba86dffcdf",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~In Use Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~In Use Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~In Use Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Creation%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Creation%20Time",
+          "properties" : {
+            "__identityHash" : "1726f7c8ddfa4447353d9770894e1bf763ae19ce"
+          },
           "name" : "Datasource Pool Metrics~Max Creation Time",
+          "identityHash" : "1726f7c8ddfa4447353d9770894e1bf763ae19ce",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Max%20Creation%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Max%20Creation%20Time",
             "name" : "Datasource Pool Metrics~Max Creation Time",
+            "identityHash" : "d64864108b263182f32a5f64cda7637ae288b24",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Creation Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Creation Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Creation Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Get%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Get%20Time",
+          "properties" : {
+            "__identityHash" : "5bf0f984f4d03519d5b212d18a3dfc6b23869e46"
+          },
           "name" : "Datasource Pool Metrics~Max Get Time",
+          "identityHash" : "5bf0f984f4d03519d5b212d18a3dfc6b23869e46",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Max%20Get%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Max%20Get%20Time",
             "name" : "Datasource Pool Metrics~Max Get Time",
+            "identityHash" : "ac18a27bd1f463fce93157b990169aa0f896366",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Get Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Get Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Get Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Used%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Used%20Count",
+          "properties" : {
+            "__identityHash" : "9727aaff42edfd539a5915fa771d36c56863f3"
+          },
           "name" : "Datasource Pool Metrics~Max Used Count",
+          "identityHash" : "9727aaff42edfd539a5915fa771d36c56863f3",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Max%20Used%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Max%20Used%20Count",
             "name" : "Datasource Pool Metrics~Max Used Count",
+            "identityHash" : "48b4fd8514a162ee442d04faa1329794cfa14d",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Used Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Used Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Used Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Count",
+          "properties" : {
+            "__identityHash" : "377e8927db26197aa10ebb2a87ca4542e73b27c"
+          },
           "name" : "Datasource Pool Metrics~Max Wait Count",
+          "identityHash" : "377e8927db26197aa10ebb2a87ca4542e73b27c",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Count",
             "name" : "Datasource Pool Metrics~Max Wait Count",
+            "identityHash" : "95f46d183b573db9571950bb1a5fd7427615a",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Wait Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time",
+          "properties" : {
+            "__identityHash" : "91a3f8c14f626ff0c9fa5c19f23c1fc5ad60e045"
+          },
           "name" : "Datasource Pool Metrics~Max Wait Time",
+          "identityHash" : "91a3f8c14f626ff0c9fa5c19f23c1fc5ad60e045",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Time",
             "name" : "Datasource Pool Metrics~Max Wait Time",
+            "identityHash" : "f36e0dffc4255a7863606fe88907d839d9edc",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Wait Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out",
+          "properties" : {
+            "__identityHash" : "9df89e1af4a14c76f29eedc99a1a96f32cde664"
+          },
           "name" : "Datasource Pool Metrics~Timed Out",
+          "identityHash" : "9df89e1af4a14c76f29eedc99a1a96f32cde664",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Timed%20Out",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Timed%20Out",
             "name" : "Datasource Pool Metrics~Timed Out",
+            "identityHash" : "ad28789d5c06a73cd50455f1c20aaaa7a82259",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Timed Out"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Timed Out"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Timed Out"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
+          "properties" : {
+            "__identityHash" : "ff5097d2507c608d8f62c4539b0361e6a4bc196"
+          },
           "name" : "Datasource Pool Metrics~Total Blocking Time",
+          "identityHash" : "ff5097d2507c608d8f62c4539b0361e6a4bc196",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
             "name" : "Datasource Pool Metrics~Total Blocking Time",
+            "identityHash" : "a817d8533639bd1f71a70c9aefad040aacdd7cb",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Total Blocking Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Blocking Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Blocking Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Creation%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Creation%20Time",
+          "properties" : {
+            "__identityHash" : "1c842c749a8de4b9dacf35e43de8aaf9971c958"
+          },
           "name" : "Datasource Pool Metrics~Total Creation Time",
+          "identityHash" : "1c842c749a8de4b9dacf35e43de8aaf9971c958",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Total%20Creation%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Total%20Creation%20Time",
             "name" : "Datasource Pool Metrics~Total Creation Time",
+            "identityHash" : "47a62ab81c57f6b0b3cb81813acafba042615570",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Total Creation Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Creation Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Creation Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Get%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Get%20Time",
+          "properties" : {
+            "__identityHash" : "14dc2adc8cd45b67645ac517211787cf7a338b"
+          },
           "name" : "Datasource Pool Metrics~Total Get Time",
+          "identityHash" : "14dc2adc8cd45b67645ac517211787cf7a338b",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Total%20Get%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Total%20Get%20Time",
             "name" : "Datasource Pool Metrics~Total Get Time",
+            "identityHash" : "cb116e6bfac01b7c478b9cb5729b63c052bdf498",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Total Get Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Get Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Get Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Wait%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Wait%20Count",
+          "properties" : {
+            "__identityHash" : "f479dc8d605f3d3e684ce8fb416e52bcedf1de5"
+          },
           "name" : "Datasource Pool Metrics~Wait Count",
+          "identityHash" : "f479dc8d605f3d3e684ce8fb416e52bcedf1de5",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Datasource%20Pool%20Metrics~Wait%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Datasource%20Pool%20Metrics~Wait%20Count",
             "name" : "Datasource Pool Metrics~Wait Count",
+            "identityHash" : "9cd2d0e9e1657b87fcc5fb85481a93f8ebbd63c",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Wait Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Wait Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Wait Count"
         } ]
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -375,7 +550,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -396,7 +571,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -405,12 +580,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043022,"value":0.0}]'
+      string: '[{"timestamp":1467725939011,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -420,7 +595,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -441,7 +616,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -450,12 +625,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466589813000,"value":0.0}]'
+      string: '[{"timestamp":1467731239003,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -465,7 +640,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -486,7 +661,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -495,12 +670,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043020,"value":0.0}]'
+      string: '[{"timestamp":1467725939003,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -510,7 +685,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -531,7 +706,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -540,12 +715,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466589813001,"value":0.0}]'
+      string: '[{"timestamp":1467731239002,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -555,7 +730,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -576,7 +751,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -585,12 +760,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043008,"value":0.0}]'
+      string: '[{"timestamp":1467725939012,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -600,7 +775,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -621,7 +796,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -630,12 +805,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466589813001,"value":0.0}]'
+      string: '[{"timestamp":1467731239003,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -645,7 +820,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -666,7 +841,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -675,12 +850,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043014,"value":0.0}]'
+      string: '[{"timestamp":1467725939004,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -690,7 +865,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -711,7 +886,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -720,12 +895,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466589813001,"value":0.0}]'
+      string: '[{"timestamp":1467731239002,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -735,7 +910,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -756,7 +931,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -765,12 +940,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043023,"value":0.0}]'
+      string: '[{"timestamp":1467725939003,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -780,7 +955,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -801,7 +976,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:19 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -810,12 +985,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466589813000,"value":0.0}]'
+      string: '[{"timestamp":1467731239002,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:19 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
     body:
       encoding: US-ASCII
       string: ''
@@ -825,7 +1000,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -846,7 +1021,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:20 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -857,10 +1032,10 @@ http_interactions:
       encoding: UTF-8
       string: '[{"start":1466578800000,"end":1466582400000,"empty":true},{"start":1466582400000,"end":1466586000000,"empty":true},{"start":1466586000000,"end":1466589600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:20 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
     body:
       encoding: US-ASCII
       string: ''
@@ -870,7 +1045,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -891,7 +1066,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:20 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -902,10 +1077,10 @@ http_interactions:
       encoding: UTF-8
       string: '[{"start":1466578800000,"end":1466582400000,"empty":true},{"start":1466582400000,"end":1466586000000,"empty":true},{"start":1466586000000,"end":1466589600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:20 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
     body:
       encoding: US-ASCII
       string: ''
@@ -915,7 +1090,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -936,7 +1111,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:55 GMT
+      - Tue, 05 Jul 2016 15:07:20 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -947,10 +1122,10 @@ http_interactions:
       encoding: UTF-8
       string: '[{"start":1466578800000,"end":1466582400000,"empty":true},{"start":1466582400000,"end":1466586000000,"empty":true},{"start":1466586000000,"end":1466589600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:55 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:20 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
     body:
       encoding: US-ASCII
       string: ''
@@ -960,7 +1135,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -981,7 +1156,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:56 GMT
+      - Tue, 05 Jul 2016 15:07:20 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -992,10 +1167,10 @@ http_interactions:
       encoding: UTF-8
       string: '[{"start":1466578800000,"end":1466582400000,"empty":true},{"start":1466582400000,"end":1466586000000,"empty":true},{"start":1466586000000,"end":1466589600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:56 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:20 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/data/?bucketDuration=3600s&end=1466586000001&start=1466578800000
     body:
       encoding: US-ASCII
       string: ''
@@ -1005,7 +1180,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1026,7 +1201,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 22 Jun 2016 10:03:56 GMT
+      - Tue, 05 Jul 2016 15:07:20 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1037,5 +1212,5 @@ http_interactions:
       encoding: UTF-8
       string: '[{"start":1466578800000,"end":1466582400000,"empty":true},{"start":1466582400000,"end":1466586000000,"empty":true},{"start":1466586000000,"end":1466589600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 10:03:56 GMT
+  recorded_at: Tue, 05 Jul 2016 15:07:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_server.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/metrics?sort=id
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/status
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,52 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '234'
+      Date:
+      - Tue, 05 Jul 2016 15:05:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "Implementation-Version" : "0.17.2.Final",
+          "Built-From-Git-SHA1" : "3c8ac6648aa0ec33643ae1b98faadc475d2c6f02",
+          "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
+          "Initialized" : "true"
+        }
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/metrics?sort=id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -33,7 +78,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
       X-Total-Count:
       - '14'
       Connection:
@@ -41,187 +86,257 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '10061'
+      - '13054'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/metrics?sort=id>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;AI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;AI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability",
+          "properties" : {
+            "__identityHash" : "7025758379b59564746ba46c9635a845eb0c989"
+          },
           "name" : "Server Availability~Server Availability",
+          "identityHash" : "7025758379b59564746ba46c9635a845eb0c989",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Server%20Availability~Server%20Availability",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Server%20Availability~Server%20Availability",
             "name" : "Server Availability~Server Availability",
+            "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
             "type" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
-          "id" : "AI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~AT~Server Availability~Server Availability"
+          "id" : "AI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~AT~Server Availability~Server Availability"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
+          "properties" : {
+            "__identityHash" : "d31ea16143b37d9637ab90c5ae287b34991d6d"
+          },
           "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
+          "identityHash" : "d31ea16143b37d9637ab90c5ae287b34991d6d",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
+            "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+          "properties" : {
+            "__identityHash" : "8d93457bc1244b93a19b71d920136e775caab8"
+          },
           "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+          "identityHash" : "8d93457bc1244b93a19b71d920136e775caab8",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+            "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "properties" : {
+            "__identityHash" : "4ec3b5136677bdd8efaf89a61b9bfbc46982f26"
+          },
           "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+          "identityHash" : "4ec3b5136677bdd8efaf89a61b9bfbc46982f26",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+            "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "properties" : {
+            "__identityHash" : "e1c88ee17162116d4222a10c4a486b9c6c127a"
+          },
           "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+          "identityHash" : "e1c88ee17162116d4222a10c4a486b9c6c127a",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+            "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "properties" : {
+            "__identityHash" : "e6b948271cbf27f658a26d1772dbfd59574e9c"
+          },
           "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+          "identityHash" : "e6b948271cbf27f658a26d1772dbfd59574e9c",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+            "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "properties" : {
+            "__identityHash" : "b9bb7ac9ba7ea0bdd4f19bc1fa8ec2e699f188"
+          },
           "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+          "identityHash" : "b9bb7ac9ba7ea0bdd4f19bc1fa8ec2e699f188",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
             "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+            "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "properties" : {
+            "__identityHash" : "6fbaa9e9d331f97d4427043b882e1c67d246526"
+          },
           "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+          "identityHash" : "6fbaa9e9d331f97d4427043b882e1c67d246526",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
             "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+            "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
+          "properties" : {
+            "__identityHash" : "6172237d03bb7f73c7e1847f528ca2efdfaf8d6"
+          },
           "name" : "WildFly Memory Metrics~Heap Committed",
+          "identityHash" : "6172237d03bb7f73c7e1847f528ca2efdfaf8d6",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Heap%20Committed",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Memory%20Metrics~Heap%20Committed",
             "name" : "WildFly Memory Metrics~Heap Committed",
+            "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Heap Committed"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Memory Metrics~Heap Committed"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max",
+          "properties" : {
+            "__identityHash" : "d9ee316166a326ed8d60c12494c98fcf7bd0d798"
+          },
           "name" : "WildFly Memory Metrics~Heap Max",
+          "identityHash" : "d9ee316166a326ed8d60c12494c98fcf7bd0d798",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Heap%20Max",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Memory%20Metrics~Heap%20Max",
             "name" : "WildFly Memory Metrics~Heap Max",
+            "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Heap Max"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
+          "properties" : {
+            "__identityHash" : "147d79aa3ff35bbd19ceaa79c24c4c0e4af7fa4"
+          },
           "name" : "WildFly Memory Metrics~Heap Used",
+          "identityHash" : "147d79aa3ff35bbd19ceaa79c24c4c0e4af7fa4",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~Heap%20Used",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Memory%20Metrics~Heap%20Used",
             "name" : "WildFly Memory Metrics~Heap Used",
+            "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~Heap Used"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "properties" : {
+            "__identityHash" : "492b29c357d1522a0a83a6c85481f66aadc4b"
+          },
           "name" : "WildFly Memory Metrics~NonHeap Committed",
+          "identityHash" : "492b29c357d1522a0a83a6c85481f66aadc4b",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
             "name" : "WildFly Memory Metrics~NonHeap Committed",
+            "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "properties" : {
+            "__identityHash" : "c1d0f2edab6fdacdf33928bd88c7356acd2037b6"
+          },
           "name" : "WildFly Memory Metrics~NonHeap Used",
+          "identityHash" : "c1d0f2edab6fdacdf33928bd88c7356acd2037b6",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
             "name" : "WildFly Memory Metrics~NonHeap Used",
+            "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "properties" : {
+            "__identityHash" : "9f2d4d473215684d697c5e7dace78c163586c96f"
+          },
           "name" : "WildFly Threading Metrics~Thread Count",
+          "identityHash" : "9f2d4d473215684d697c5e7dace78c163586c96f",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;WildFly%20Threading%20Metrics~Thread%20Count",
             "name" : "WildFly Threading Metrics~Thread Count",
+            "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~~]~MT~WildFly Threading Metrics~Thread Count"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/children
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/children
     body:
       encoding: US-ASCII
       string: ''
@@ -231,7 +346,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -252,144 +367,111 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
       X-Total-Count:
-      - '13'
+      - '6'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '5059'
+      - '3578'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/children>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/children>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
-          "name" : "ExampleDS",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "properties" : {
+            "__identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4"
+          },
+          "name" : "Datasource [ExampleDS]",
+          "identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Datasource",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Datasource",
             "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
             "id" : "Datasource"
           },
           "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
-          "name" : "h2",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "properties" : {
+            "__identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d"
+          },
+          "name" : "JDBC Driver [h2]",
+          "identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;JDBC%20Driver",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;JDBC%20Driver",
             "name" : "JDBC Driver",
+            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
             "id" : "JDBC Driver"
           },
           "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
-          "name" : "hawkular-command-gateway-war.war",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "properties" : {
+            "__identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622"
           },
-          "id" : "Local~/deployment=hawkular-command-gateway-war.war"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
-          "name" : "hawkular-metrics-component.war",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-metrics-component.war"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
-          "name" : "hawkular-alerts-actions-email.war",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-actions-email.war"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
-          "name" : "hawkular-wildfly-agent-download.war",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
-          "name" : "hawkular-inventory-dist.war",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
-          "name" : "hawkular-alerts-rest.war",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
-          "name" : "hawkular-rest-api.war",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
           "name" : "Transaction Manager",
+          "identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Transaction%20Manager",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Transaction%20Manager",
             "name" : "Transaction Manager",
+            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
             "id" : "Transaction Manager"
           },
           "id" : "Local~/subsystem=transactions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
-          "name" : "Messaging Server [default]",
-          "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Messaging%20Server",
-            "name" : "Messaging Server",
-            "id" : "Messaging Server"
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "properties" : {
+            "__identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac"
           },
-          "id" : "Local~/subsystem=messaging-activemq/server=default"
-        }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
           "name" : "Hawkular WildFly Agent",
+          "identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Hawkular%20WildFly%20Agent",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Hawkular%20WildFly%20Agent",
             "name" : "Hawkular WildFly Agent",
+            "identityHash" : "1d7fbc312f708afc4643812f2772e7aabf283328",
             "id" : "Hawkular WildFly Agent"
           },
           "id" : "Local~/subsystem=hawkular-wildfly-agent"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "properties" : {
+            "__identityHash" : "8fbb7cddec55ee31209f8e892739da39b29cc"
+          },
           "name" : "Socket Binding Group [standard-sockets]",
+          "identityHash" : "8fbb7cddec55ee31209f8e892739da39b29cc",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/rt;Socket%20Binding%20Group",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Socket%20Binding%20Group",
             "name" : "Socket Binding Group",
+            "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
             "id" : "Socket Binding Group"
           },
           "id" : "Local~/socket-binding-group=standard-sockets"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
+          "properties" : {
+            "__identityHash" : "df72fd6d4a11a45a4a1eef5ea9ead53e9e3eb95"
+          },
+          "name" : "Infinispan",
+          "identityHash" : "df72fd6d4a11a45a4a1eef5ea9ead53e9e3eb95",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Infinispan",
+            "name" : "Infinispan",
+            "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+            "id" : "Infinispan"
+          },
+          "id" : "Local~/subsystem=infinispan"
         } ]
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/Local~%2Fsubsystem=transactions/metrics?sort=id
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/Local~%2Fsubsystem=transactions/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -399,7 +481,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -420,7 +502,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
       X-Total-Count:
       - '9'
       Connection:
@@ -428,127 +510,172 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '6950'
+      - '8881'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/resources/Local~~/Local~%2Fsubsystem%3Dtransactions/metrics?sort=id>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/Local~%2Fsubsystem%3Dtransactions/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
+          "properties" : {
+            "__identityHash" : "1ef26b92d482345f15496b9a591f3b9458d60a8"
+          },
           "name" : "Transactions Metrics~Number of Aborted Transactions",
+          "identityHash" : "1ef26b92d482345f15496b9a591f3b9458d60a8",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
             "name" : "Transactions Metrics~Number of Aborted Transactions",
+            "identityHash" : "25b4b8fa5058306e80e0295168425d6fb75f6a3",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Aborted Transactions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Aborted Transactions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Aborted Transactions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
+          "properties" : {
+            "__identityHash" : "4589a5113dbe1e9bff5eb79e2d48a6bd1b048"
+          },
           "name" : "Transactions Metrics~Number of Application Rollbacks",
+          "identityHash" : "4589a5113dbe1e9bff5eb79e2d48a6bd1b048",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
             "name" : "Transactions Metrics~Number of Application Rollbacks",
+            "identityHash" : "fc99f879312f15bc555d30d12ddd4cf3b81b2285",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Application Rollbacks"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Application Rollbacks"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Application Rollbacks"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions",
+          "properties" : {
+            "__identityHash" : "6414b7911aabcca7103a3b73838b7f69b71546"
+          },
           "name" : "Transactions Metrics~Number of Committed Transactions",
+          "identityHash" : "6414b7911aabcca7103a3b73838b7f69b71546",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Committed%20Transactions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Committed%20Transactions",
             "name" : "Transactions Metrics~Number of Committed Transactions",
+            "identityHash" : "fe60974feaf3aa227d639192b114f116274ae4b2",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Committed Transactions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Committed Transactions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Committed Transactions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics",
+          "properties" : {
+            "__identityHash" : "f5efe14139366c4528a4a982223bfdb6e3609276"
+          },
           "name" : "Transactions Metrics~Number of Heuristics",
+          "identityHash" : "f5efe14139366c4528a4a982223bfdb6e3609276",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Heuristics",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Heuristics",
             "name" : "Transactions Metrics~Number of Heuristics",
+            "identityHash" : "e9dc6c8454d533e67b609a8a411ce24c7a4a2b69",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Heuristics"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Heuristics"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Heuristics"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
+          "properties" : {
+            "__identityHash" : "b528ae57cadf61ac5de4952f626ebadb5c33a89"
+          },
           "name" : "Transactions Metrics~Number of In-Flight Transactions",
+          "identityHash" : "b528ae57cadf61ac5de4952f626ebadb5c33a89",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
             "name" : "Transactions Metrics~Number of In-Flight Transactions",
+            "identityHash" : "deb940deaf6f7c6db1bd23c1673ca4f19394b4d",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of In-Flight Transactions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of In-Flight Transactions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of In-Flight Transactions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions",
+          "properties" : {
+            "__identityHash" : "38c1b74994a64501e312535bec8643127c0484f"
+          },
           "name" : "Transactions Metrics~Number of Nested Transactions",
+          "identityHash" : "38c1b74994a64501e312535bec8643127c0484f",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Nested%20Transactions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Nested%20Transactions",
             "name" : "Transactions Metrics~Number of Nested Transactions",
+            "identityHash" : "6a43c18b6984c4a5b6642f6e38d25d9ce66e2",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Nested Transactions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Nested Transactions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Nested Transactions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
+          "properties" : {
+            "__identityHash" : "91e59cb696550604ece282483fa1b1942f5f9a5"
+          },
           "name" : "Transactions Metrics~Number of Resource Rollbacks",
+          "identityHash" : "91e59cb696550604ece282483fa1b1942f5f9a5",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
             "name" : "Transactions Metrics~Number of Resource Rollbacks",
+            "identityHash" : "2a1e4fb6d47babebfd5e92b377d5b15e8bcce54",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Resource Rollbacks"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Resource Rollbacks"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Resource Rollbacks"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
+          "properties" : {
+            "__identityHash" : "10f71d3ff21f5bb8eef944e51be7aeadb247e76d"
+          },
           "name" : "Transactions Metrics~Number of Timed Out Transactions",
+          "identityHash" : "10f71d3ff21f5bb8eef944e51be7aeadb247e76d",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
             "name" : "Transactions Metrics~Number of Timed Out Transactions",
+            "identityHash" : "489a7f12f69723b83099d4111f8fea767a0",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Timed Out Transactions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Timed Out Transactions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Timed Out Transactions"
         }, {
-          "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/m;MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/m;MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions",
+          "properties" : {
+            "__identityHash" : "2594c9f1fa9d6dbb781442314291a4c38884371"
+          },
           "name" : "Transactions Metrics~Number of Transactions",
+          "identityHash" : "2594c9f1fa9d6dbb781442314291a4c38884371",
           "type" : {
-            "path" : "/t;hawkular/f;27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/mt;Transactions%20Metrics~Number%20of%20Transactions",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/mt;Transactions%20Metrics~Number%20of%20Transactions",
             "name" : "Transactions Metrics~Number of Transactions",
+            "identityHash" : "affa229994b569b825e763d3b4194a613520dbb3",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Transactions"
           },
-          "id" : "MI~R~[27e06e8f-6e5d-45cd-8353-c1f9d4dfe991/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Transactions"
+          "id" : "MI~R~[70c798a0-6985-4f8a-a525-012d8d28e8a3/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Transactions"
         } ]
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -558,7 +685,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -579,7 +706,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -588,12 +715,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587073008,"value":0.0}]'
+      string: '[{"timestamp":1467725969002,"value":0.0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -603,7 +730,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -624,7 +751,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -633,12 +760,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675971001,"value":0.0}]'
+      string: '[{"timestamp":1467731123002,"value":0.0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -648,7 +775,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -669,7 +796,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -678,12 +805,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587073034,"value":0}]'
+      string: '[{"timestamp":1467725969006,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -693,7 +820,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -714,7 +841,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -723,12 +850,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675971006,"value":0}]'
+      string: '[{"timestamp":1467731123002,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -738,7 +865,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -759,7 +886,367 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:39 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467725969005,"value":0.0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:39 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731123002,"value":0.0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:39 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467725969004,"value":0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731123002,"value":0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467725969007,"value":0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731123002,"value":0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467725969035,"value":0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731123002,"value":0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -768,12 +1255,12 @@ http_interactions:
       - '42'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587073002,"value":-7.0}]'
+      string: '[{"timestamp":1467725969004,"value":1533}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -783,7 +1270,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -804,7 +1291,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -813,12 +1300,12 @@ http_interactions:
       - '42'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675971003,"value":-7.0}]'
+      string: '[{"timestamp":1467731123002,"value":1637}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -828,7 +1315,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -849,682 +1336,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587073007,"value":0}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466675971002,"value":0}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587073014,"value":0}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466675971007,"value":0}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587073030,"value":0}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466675971005,"value":0}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587073017,"value":2877}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466675971003,"value":8320}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587073008,"value":4.51411968E8}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466675971001,"value":3.47078656E8}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587073018,"value":4.77626368E8}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466675971002,"value":4.77626368E8}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587043010,"value":2.91170712E8}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466675967012,"value":2.77421952E8}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1466587073013,"value":2.78986752E8}]'
-    http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1533,12 +1345,12 @@ http_interactions:
       - '49'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675974000,"value":2.9229056E8}]'
+      string: '[{"timestamp":1467725969030,"value":2.3330816E8}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1548,7 +1360,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1569,7 +1381,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1578,12 +1390,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043023,"value":2.60806648E8}]'
+      string: '[{"timestamp":1467731123001,"value":2.21249536E8}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1593,7 +1405,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1614,7 +1426,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1623,12 +1435,12 @@ http_interactions:
       - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967015,"value":2.74720936E8}]'
+      string: '[{"timestamp":1467725969002,"value":4.77626368E8}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1638,7 +1450,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1659,21 +1471,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:35 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '43'
+      - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587133016,"value":854.0}]'
+      string: '[{"timestamp":1467731123002,"value":4.77626368E8}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:35 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1683,7 +1495,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1704,21 +1516,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '43'
+      - '50'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675965004,"value":849.0}]'
+      string: '[{"timestamp":1467725939013,"value":1.05089848E8}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1728,7 +1540,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1749,7 +1561,322 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '47'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731115002,"value":8.23386E7}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '49'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467725969004,"value":8.1788928E7}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '49'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731123002,"value":9.0308608E7}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '48'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467725939002,"value":7.307408E7}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '49'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731115001,"value":8.2019928E7}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467726029003,"value":52.0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467731096001,"value":52.0}]'
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/data/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1758,12 +1885,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043017,"value":0}]'
+      string: '[{"timestamp":1467725939010,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1773,7 +1900,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1794,7 +1921,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1803,12 +1930,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967001,"value":0}]'
+      string: '[{"timestamp":1467731115002,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1818,7 +1945,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1839,7 +1966,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:40 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1848,12 +1975,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043017,"value":0}]'
+      string: '[{"timestamp":1467725939011,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1863,7 +1990,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1884,7 +2011,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1893,12 +2020,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967001,"value":0}]'
+      string: '[{"timestamp":1467731115002,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1908,7 +2035,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1929,7 +2056,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1938,12 +2065,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043011,"value":0}]'
+      string: '[{"timestamp":1467725939010,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1953,7 +2080,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1974,7 +2101,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1983,12 +2110,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967012,"value":0}]'
+      string: '[{"timestamp":1467731115002,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1998,7 +2125,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2019,7 +2146,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2028,12 +2155,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043014,"value":0}]'
+      string: '[{"timestamp":1467725939009,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2043,7 +2170,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2064,7 +2191,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2073,12 +2200,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967014,"value":0}]'
+      string: '[{"timestamp":1467731115002,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2088,7 +2215,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2109,7 +2236,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2118,12 +2245,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043022,"value":0.0}]'
+      string: '[{"timestamp":1467725939004,"value":0.0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2133,7 +2260,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2154,7 +2281,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2163,12 +2290,12 @@ http_interactions:
       - '41'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967014,"value":0.0}]'
+      string: '[{"timestamp":1467731115001,"value":0.0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2178,7 +2305,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2199,7 +2326,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2208,12 +2335,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043015,"value":0}]'
+      string: '[{"timestamp":1467725939008,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2223,7 +2350,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2244,7 +2371,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2253,12 +2380,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967014,"value":0}]'
+      string: '[{"timestamp":1467731115001,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2268,7 +2395,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2289,7 +2416,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2298,12 +2425,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043009,"value":0}]'
+      string: '[{"timestamp":1467725939013,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2313,7 +2440,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2334,7 +2461,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2343,12 +2470,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967012,"value":0}]'
+      string: '[{"timestamp":1467731115002,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2358,7 +2485,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2379,7 +2506,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2388,12 +2515,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043026,"value":0}]'
+      string: '[{"timestamp":1467725939004,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2403,7 +2530,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2424,7 +2551,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2433,12 +2560,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967015,"value":0}]'
+      string: '[{"timestamp":1467731115001,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/data/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/data/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2448,7 +2575,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2469,7 +2596,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2478,12 +2605,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466587043007,"value":0}]'
+      string: '[{"timestamp":1467725939012,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/data/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/data/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2493,7 +2620,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2514,7 +2641,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2523,12 +2650,12 @@ http_interactions:
       - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1466675967011,"value":0}]'
+      string: '[{"timestamp":1467731115002,"value":0}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2538,7 +2665,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2559,21 +2686,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '305'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":59,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2583,7 +2710,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2604,21 +2731,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:41 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '305'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":58,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2628,7 +2755,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2649,21 +2776,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '246'
+      - '305'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":-7.0,"avg":-7.0,"median":-7.0,"max":-7.0,"sum":-224.0,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":59,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2673,7 +2800,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2694,21 +2821,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '305'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":58,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2718,7 +2845,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2739,21 +2866,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '305'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":58,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2763,7 +2890,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2784,21 +2911,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '305'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":58,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2808,7 +2935,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2829,21 +2956,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '285'
+      - '365'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":15.0,"avg":30.621003804460255,"median":26.770489404701543,"max":80.0,"sum":949.2511179382681,"samples":31,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":1.2300860010554708,"median":0.012022398512408772,"max":25.57377049180328,"sum":71.34498806121726,"samples":58,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2853,7 +2980,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2874,21 +3001,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '302'
+      - '413'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":3.38690048E8,"avg":3.6197171200000006E8,"median":3.578944918551577E8,"max":4.12614656E8,"sum":1.1583094784E10,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":2.2020096E8,"avg":2.3379690305084753E8,"median":2.3516978792404816E8,"max":2.39075328E8,"sum":1.379401728E10,"samples":59,"empty":false},{"start":1467730800000,"end":1467734400000,"min":2.21249536E8,"avg":2.21249536E8,"median":2.21249536E8,"max":2.21249536E8,"sum":1.327497216E9,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2898,7 +3025,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2919,21 +3046,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '287'
+      - '399'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":4.77626368E8,"avg":4.77626368E8,"median":4.77626368E8,"max":4.77626368E8,"sum":1.5284043776E10,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":4.77626368E8,"avg":4.77626368E8,"median":4.77626368E8,"max":4.77626368E8,"sum":2.8179955712E10,"samples":59,"empty":false},{"start":1467730800000,"end":1467734400000,"min":4.77626368E8,"avg":4.77626368E8,"median":4.77626368E8,"max":4.77626368E8,"sum":2.865758208E9,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2943,7 +3070,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2964,21 +3091,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '294'
+      - '417'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":2.17532352E8,"avg":2.48390008E8,"median":2.4639471284073105E8,"max":2.82220992E8,"sum":1.614535052E10,"samples":65,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":5.3694048E7,"avg":1.2296928923076926E8,"median":1.17327631422772E8,"max":1.84128E8,"sum":1.438740684E10,"samples":117,"empty":false},{"start":1467730800000,"end":1467734400000,"min":6.340384E7,"avg":7.294701163636364E7,"median":7.34352648785185E7,"max":8.23386E7,"sum":8.02417128E8,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -2988,7 +3115,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3009,21 +3136,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '292'
+      - '404'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":2.6017792E8,"avg":2.81786368E8,"median":2.8377350722703856E8,"max":2.86588928E8,"sum":9.017163776E9,"samples":32,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":8.7752704E7,"avg":8.934111891525425E7,"median":8.963851660629241E7,"max":9.0308608E7,"sum":5.271126016E9,"samples":59,"empty":false},{"start":1467730800000,"end":1467734400000,"min":9.0308608E7,"avg":9.0308608E7,"median":9.0308608E7,"max":9.0308608E7,"sum":5.41851648E8,"samples":6,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3033,7 +3160,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3054,21 +3181,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '303'
+      - '413'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":2.42853744E8,"avg":2.6605683778461537E8,"median":2.6748501020246232E8,"max":2.70352656E8,"sum":1.7293694456E10,"samples":65,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":7.9358968E7,"avg":8.1065226940171E7,"median":8.130356051672074E7,"max":8.2027768E7,"sum":9.484631552E9,"samples":117,"empty":false},{"start":1467730800000,"end":1467734400000,"min":8.194296E7,"avg":8.198579563636364E7,"median":8.198103425E7,"max":8.2019928E7,"sum":9.01843752E8,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3078,7 +3205,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3099,21 +3226,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '275'
+      - '345'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":847.0,"avg":850.4374999999999,"median":850.8492063492064,"max":855.0,"sum":13607.0,"samples":16,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":48.0,"avg":51.400000000000006,"median":51.98685706962966,"max":53.0,"sum":1542.0,"samples":30,"empty":false},{"start":1467730800000,"end":1467734400000,"min":50.0,"avg":51.0,"median":51.0,"max":52.0,"sum":153.0,"samples":3,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3123,7 +3250,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3144,21 +3271,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3168,7 +3295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3189,21 +3316,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3213,7 +3340,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3234,21 +3361,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3258,7 +3385,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3279,21 +3406,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/data/?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3303,7 +3430,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3324,21 +3451,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:36 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":65,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":117,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:36 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3348,7 +3475,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3369,21 +3496,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:37 GMT
+      - Tue, 05 Jul 2016 15:05:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3393,7 +3520,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3414,21 +3541,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:37 GMT
+      - Tue, 05 Jul 2016 15:05:43 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:43 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3438,7 +3565,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3459,21 +3586,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:37 GMT
+      - Tue, 05 Jul 2016 15:05:43 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:43 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B27e06e8f-6e5d-45cd-8353-c1f9d4dfe991%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/rate?bucketDuration=3600s&end=1466668800001&start=1466661600000
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B70c798a0-6985-4f8a-a525-012d8d28e8a3%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/rate?bucketDuration=3600s&end=1467734400001&start=1467727200000
     body:
       encoding: US-ASCII
       string: ''
@@ -3483,7 +3610,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3504,16 +3631,16 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 23 Jun 2016 09:59:37 GMT
+      - Tue, 05 Jul 2016 15:05:43 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '239'
+      - '307'
     body:
       encoding: UTF-8
-      string: '[{"start":1466661600000,"end":1466665200000,"empty":true},{"start":1466665200000,"end":1466668800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":64,"empty":false},{"start":1466668800000,"end":1466672400000,"empty":true}]'
+      string: '[{"start":1467727200000,"end":1467730800000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":116,"empty":false},{"start":1467730800000,"end":1467734400000,"min":0.0,"avg":0.0,"median":0.0,"max":0.0,"sum":0.0,"samples":11,"empty":false},{"start":1467734400000,"end":1467738000000,"empty":true}]'
     http_version: 
-  recorded_at: Thu, 23 Jun 2016 09:59:37 GMT
+  recorded_at: Tue, 05 Jul 2016 15:05:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/status
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -22,44 +22,96 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
       Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:50 GMT
+      - WildFly/10
       Content-Type:
       - application/json
       Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
+      - '234'
+      Date:
+      - Tue, 05 Jul 2016 14:00:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "Implementation-Version" : "0.17.2.Final",
+          "Built-From-Git-SHA1" : "3c8ac6648aa0ec33643ae1b98faadc475d2c6f02",
+          "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
+          "Initialized" : "true"
+        }
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:31 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:31 GMT
       X-Total-Count:
-      - '1'
+      - '2'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '542'
       Link:
-      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/feeds>; rel="current"
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds>; rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e",
           "properties" : {
-            "__identityHash" : "62858e30771ee535cedb9779ea1fdd199197eec"
+            "__identityHash" : "5c76e6f66a08176a1e413e9acb433f534c3e31a"
           },
-          "identityHash" : "62858e30771ee535cedb9779ea1fdd199197eec",
-          "id" : "71daaa4b-da76-4373-8753-68279f33a884"
+          "identityHash" : "5c76e6f66a08176a1e413e9acb433f534c3e31a",
+          "id" : "5f040b77-8929-46f4-ace2-4da64c370a0e"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3",
+          "properties" : {
+            "__identityHash" : "fe2613e3b6df7c9dadc6f314e1902b1395445ceb"
+          },
+          "identityHash" : "fe2613e3b6df7c9dadc6f314e1902b1395445ceb",
+          "id" : "70c798a0-6985-4f8a-a525-012d8d28e8a3"
         } ]
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:50 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:31 GMT
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resourceTypes/WildFly%20Server/resources
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resourceTypes/WildFly%20Server/resources
     body:
       encoding: US-ASCII
       string: ''
@@ -69,7 +121,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -79,47 +131,52 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:51 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '302'
-      Connection:
-      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:31 GMT
       X-Total-Count:
       - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '517'
       Link:
-      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resourceTypes/WildFly%20Server/resources>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resourceTypes/WildFly%20Server/resources>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~",
+          "properties" : {
+            "__identityHash" : "31cce2701f6a8d28e2e166ff3e7becbcf339e74"
+          },
           "name" : "WildFly Server [Local]",
+          "identityHash" : "31cce2701f6a8d28e2e166ff3e7becbcf339e74",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;WildFly%20Server",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;WildFly%20Server",
             "name" : "WildFly Server",
+            "identityHash" : "617542c89b86e3ce52b819c1deae7ca37cf7851",
             "id" : "WildFly Server"
           },
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:51 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:31 GMT
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resources/Local~~/data?dataType=configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resources/Local~~/data?dataType=configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -129,7 +186,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -139,44 +196,52 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:51 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '363'
-      Connection:
-      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:31 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '637'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/d;configuration",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/d;configuration",
+          "properties" : {
+            "__identityHash" : "6ef1256dc92e639571b12241d6374122d4f20b2"
+          },
           "name" : "configuration",
+          "identityHash" : "6ef1256dc92e639571b12241d6374122d4f20b2",
           "value" : {
             "Suspend State" : "RUNNING",
             "Bound Address" : "0.0.0.0",
             "Running Mode" : "NORMAL",
+            "Version" : "10.0.0.Final",
+            "Node Name" : "f8a01ad2ff6f",
             "Server State" : "running",
-            "Qualified Host Name" : "hawkular02",
-            "UUID" : "71daaa4b-da76-4373-8753-68279f33a884"
+            "Product Name" : "WildFly Full",
+            "Hostname" : "f8a01ad2ff6f",
+            "UUID" : "5f040b77-8929-46f4-ace2-4da64c370a0e",
+            "Name" : "f8a01ad2ff6f"
           }
         }
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:51 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:31 GMT
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resourceTypes
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resourceTypes
     body:
       encoding: US-ASCII
       string: ''
@@ -186,7 +251,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -196,118 +261,148 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:51 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2954'
-      Connection:
-      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:31 GMT
       X-Total-Count:
-      - '20'
+      - '22'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4632'
       Link:
-      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resourceTypes>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resourceTypes>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Operating%20System",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Operating%20System",
           "name" : "Operating System",
+          "identityHash" : "12ec4befc53b1ed52f39fb292ed1eea8213323",
           "id" : "Operating System"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;File%20Store",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;File%20Store",
           "name" : "File Store",
+          "identityHash" : "1c35dc8269c6fd21df472c92f3d7aaee59fde",
           "id" : "File Store"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Memory",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Memory",
           "name" : "Memory",
+          "identityHash" : "3ed4d86c86c18faa2676e56879af947d776efba",
           "id" : "Memory"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Processor",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Processor",
           "name" : "Processor",
+          "identityHash" : "81d477a597103350cafceab3588c61e5f4895e34",
           "id" : "Processor"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;WildFly%20Server",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;WildFly%20Server",
           "name" : "WildFly Server",
+          "identityHash" : "617542c89b86e3ce52b819c1deae7ca37cf7851",
           "id" : "WildFly Server"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Datasource",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Datasource",
           "name" : "Datasource",
+          "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
           "id" : "Datasource"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;JDBC%20Driver",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;JDBC%20Driver",
           "name" : "JDBC Driver",
+          "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
           "id" : "JDBC Driver"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
           "name" : "Deployment",
+          "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
           "id" : "Deployment"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Servlet",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Servlet",
           "name" : "Servlet",
+          "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
           "id" : "Servlet"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Singleton%20EJB",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Singleton%20EJB",
           "name" : "Singleton EJB",
+          "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
           "id" : "Singleton EJB"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Message%20Driven%20EJB",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Message%20Driven%20EJB",
           "name" : "Message Driven EJB",
+          "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
           "id" : "Message Driven EJB"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Stateless%20Session%20EJB",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Stateless%20Session%20EJB",
           "name" : "Stateless Session EJB",
+          "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
           "id" : "Stateless Session EJB"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Transaction%20Manager",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Transaction%20Manager",
           "name" : "Transaction Manager",
+          "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
           "id" : "Transaction Manager"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Messaging%20Server",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Messaging%20Server",
           "name" : "Messaging Server",
+          "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
           "id" : "Messaging Server"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;JMS%20Topic",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;JMS%20Topic",
           "name" : "JMS Topic",
+          "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
           "id" : "JMS Topic"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;JMS%20Queue",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;JMS%20Queue",
           "name" : "JMS Queue",
+          "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
           "id" : "JMS Queue"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Hawkular%20WildFly%20Agent",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Hawkular%20WildFly%20Agent",
           "name" : "Hawkular WildFly Agent",
+          "identityHash" : "1d7fbc312f708afc4643812f2772e7aabf283328",
           "id" : "Hawkular WildFly Agent"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Socket%20Binding%20Group",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Socket%20Binding%20Group",
           "name" : "Socket Binding Group",
+          "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
           "id" : "Socket Binding Group"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Socket%20Binding",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Socket%20Binding",
           "name" : "Socket Binding",
+          "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
           "id" : "Socket Binding"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
           "name" : "Remote Destination Outbound Socket Binding",
+          "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
           "id" : "Remote Destination Outbound Socket Binding"
+        }, {
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Infinispan",
+          "name" : "Infinispan",
+          "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+          "id" : "Infinispan"
+        }, {
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Infinispan%20Cache%20Container",
+          "name" : "Infinispan Cache Container",
+          "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+          "id" : "Infinispan Cache Container"
         } ]
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:51 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:31 GMT
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resourceTypes/Operating%20System/resources
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resourceTypes/Operating%20System/resources
     body:
       encoding: US-ASCII
       string: ''
@@ -317,7 +412,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -327,47 +422,52 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:51 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '486'
-      Connection:
-      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:31 GMT
       X-Total-Count:
       - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '698'
       Link:
-      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resourceTypes/Operating%20System/resources>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resourceTypes/Operating%20System/resources>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;platform~%2FOPERATING_SYSTEM%3D71daaa4b-da76-4373-8753-68279f33a884_OperatingSystem",
-          "name" : "71daaa4b-da76-4373-8753-68279f33a884_OperatingSystem",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;platform~%2FOPERATING_SYSTEM%3D5f040b77-8929-46f4-ace2-4da64c370a0e_OperatingSystem",
+          "properties" : {
+            "__identityHash" : "9d0a47566b0dcbd90ecec8f1b05e296053842c"
+          },
+          "name" : "5f040b77-8929-46f4-ace2-4da64c370a0e_OperatingSystem",
+          "identityHash" : "9d0a47566b0dcbd90ecec8f1b05e296053842c",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Operating%20System",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Operating%20System",
             "name" : "Operating System",
+            "identityHash" : "12ec4befc53b1ed52f39fb292ed1eea8213323",
             "id" : "Operating System"
           },
-          "id" : "platform~/OPERATING_SYSTEM=71daaa4b-da76-4373-8753-68279f33a884_OperatingSystem"
+          "id" : "platform~/OPERATING_SYSTEM=5f040b77-8929-46f4-ace2-4da64c370a0e_OperatingSystem"
         } ]
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:51 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:31 GMT
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resources/platform~%2FOPERATING_SYSTEM=71daaa4b-da76-4373-8753-68279f33a884_OperatingSystem/data?dataType=configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resources/platform~%2FOPERATING_SYSTEM=5f040b77-8929-46f4-ace2-4da64c370a0e_OperatingSystem/data?dataType=configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -377,7 +477,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -387,39 +487,43 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:52 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '270'
-      Connection:
-      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '403'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;platform~%2FOPERATING_SYSTEM%3D71daaa4b-da76-4373-8753-68279f33a884_OperatingSystem/d;configuration",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;platform~%2FOPERATING_SYSTEM%3D5f040b77-8929-46f4-ace2-4da64c370a0e_OperatingSystem/d;configuration",
+          "properties" : {
+            "__identityHash" : "6a69be4a8e7994d94a9f42718eb5b8fe9748b65c"
+          },
           "name" : "configuration",
+          "identityHash" : "6a69be4a8e7994d94a9f42718eb5b8fe9748b65c",
           "value" : {
-            "Machine Id" : "2f68d133a4bc4c4bb19ecb47d344746c"
+            "Machine Id" : "f8a01ad2ff6f"
           }
         }
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:52 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resources/Local~~/children
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resourceTypes/WildFly%20Server/resources
     body:
       encoding: US-ASCII
       string: ''
@@ -429,7 +533,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -439,155 +543,604 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:52 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '5059'
-      Connection:
-      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
       X-Total-Count:
-      - '13'
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '519'
       Link:
-      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resources/Local~~/children>;
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resourceTypes/WildFly%20Server/resources>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
-          "name" : "ExampleDS",
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~",
+          "properties" : {
+            "__identityHash" : "4368e334f46a462720cb6910226c5d9b1bd957b8"
+          },
+          "name" : "WildFly Server [Local]",
+          "identityHash" : "4368e334f46a462720cb6910226c5d9b1bd957b8",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Datasource",
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;WildFly%20Server",
+            "name" : "WildFly Server",
+            "identityHash" : "617542c89b86e3ce52b819c1deae7ca37cf7851",
+            "id" : "WildFly Server"
+          },
+          "id" : "Local~~"
+        } ]
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/data?dataType=configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '633'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/d;configuration",
+          "properties" : {
+            "__identityHash" : "36e37d9296510a7a52df7234d721a6f0103b"
+          },
+          "name" : "configuration",
+          "identityHash" : "36e37d9296510a7a52df7234d721a6f0103b",
+          "value" : {
+            "Suspend State" : "RUNNING",
+            "Bound Address" : "127.0.0.1",
+            "Running Mode" : "NORMAL",
+            "Version" : "10.0.0.Final",
+            "Node Name" : "e0dd3f4d2d30",
+            "Server State" : "running",
+            "Product Name" : "WildFly Full",
+            "Hostname" : "e0dd3f4d2d30",
+            "UUID" : "70c798a0-6985-4f8a-a525-012d8d28e8a3",
+            "Name" : "e0dd3f4d2d30"
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resourceTypes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      X-Total-Count:
+      - '14'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3000'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resourceTypes>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Operating%20System",
+          "name" : "Operating System",
+          "identityHash" : "12ec4befc53b1ed52f39fb292ed1eea8213323",
+          "id" : "Operating System"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;File%20Store",
+          "name" : "File Store",
+          "identityHash" : "1c35dc8269c6fd21df472c92f3d7aaee59fde",
+          "id" : "File Store"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Memory",
+          "name" : "Memory",
+          "identityHash" : "3ed4d86c86c18faa2676e56879af947d776efba",
+          "id" : "Memory"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Processor",
+          "name" : "Processor",
+          "identityHash" : "81d477a597103350cafceab3588c61e5f4895e34",
+          "id" : "Processor"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;WildFly%20Server",
+          "name" : "WildFly Server",
+          "identityHash" : "617542c89b86e3ce52b819c1deae7ca37cf7851",
+          "id" : "WildFly Server"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Datasource",
+          "name" : "Datasource",
+          "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+          "id" : "Datasource"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;JDBC%20Driver",
+          "name" : "JDBC Driver",
+          "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
+          "id" : "JDBC Driver"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Transaction%20Manager",
+          "name" : "Transaction Manager",
+          "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
+          "id" : "Transaction Manager"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Hawkular%20WildFly%20Agent",
+          "name" : "Hawkular WildFly Agent",
+          "identityHash" : "1d7fbc312f708afc4643812f2772e7aabf283328",
+          "id" : "Hawkular WildFly Agent"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Socket%20Binding%20Group",
+          "name" : "Socket Binding Group",
+          "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
+          "id" : "Socket Binding Group"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Socket%20Binding",
+          "name" : "Socket Binding",
+          "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+          "id" : "Socket Binding"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
+          "name" : "Remote Destination Outbound Socket Binding",
+          "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
+          "id" : "Remote Destination Outbound Socket Binding"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Infinispan",
+          "name" : "Infinispan",
+          "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+          "id" : "Infinispan"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Infinispan%20Cache%20Container",
+          "name" : "Infinispan Cache Container",
+          "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+          "id" : "Infinispan Cache Container"
+        } ]
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resourceTypes/Operating%20System/resources
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '700'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resourceTypes/Operating%20System/resources>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;platform~%2FOPERATING_SYSTEM%3D70c798a0-6985-4f8a-a525-012d8d28e8a3_OperatingSystem",
+          "properties" : {
+            "__identityHash" : "32b6f29715a5791d682466f6d4a1290a67214cd"
+          },
+          "name" : "70c798a0-6985-4f8a-a525-012d8d28e8a3_OperatingSystem",
+          "identityHash" : "32b6f29715a5791d682466f6d4a1290a67214cd",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Operating%20System",
+            "name" : "Operating System",
+            "identityHash" : "12ec4befc53b1ed52f39fb292ed1eea8213323",
+            "id" : "Operating System"
+          },
+          "id" : "platform~/OPERATING_SYSTEM=70c798a0-6985-4f8a-a525-012d8d28e8a3_OperatingSystem"
+        } ]
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/platform~%2FOPERATING_SYSTEM=70c798a0-6985-4f8a-a525-012d8d28e8a3_OperatingSystem/data?dataType=configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '367'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;platform~%2FOPERATING_SYSTEM%3D70c798a0-6985-4f8a-a525-012d8d28e8a3_OperatingSystem/d;configuration",
+          "properties" : {
+            "__identityHash" : "5f7812fb77ebdf9f5c6228edde5fdc134dd3bfc2"
+          },
+          "name" : "configuration",
+          "identityHash" : "5f7812fb77ebdf9f5c6228edde5fdc134dd3bfc2",
+          "value" : { }
+        }
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resources/Local~~/children
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      X-Total-Count:
+      - '14'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '8503'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resources/Local~~/children>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "properties" : {
+            "__identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4"
+          },
+          "name" : "Datasource [ExampleDS]",
+          "identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4",
+          "type" : {
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Datasource",
             "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
             "id" : "Datasource"
           },
           "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
-          "name" : "h2",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "properties" : {
+            "__identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d"
+          },
+          "name" : "JDBC Driver [h2]",
+          "identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;JDBC%20Driver",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;JDBC%20Driver",
             "name" : "JDBC Driver",
+            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
             "id" : "JDBC Driver"
           },
           "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
-          "name" : "hawkular-command-gateway-war.war",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
+          "properties" : {
+            "__identityHash" : "145efc8c7d6ce8c93167dd4956a3c1cbc6d0d1a"
+          },
+          "name" : "Deployment [hawkular-command-gateway-war.war]",
+          "identityHash" : "145efc8c7d6ce8c93167dd4956a3c1cbc6d0d1a",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
             "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-command-gateway-war.war"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
-          "name" : "hawkular-metrics-component.war",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
+          "properties" : {
+            "__identityHash" : "eff2441b1d32b22a2428bec8fe59452ef5711e"
+          },
+          "name" : "Deployment [hawkular-metrics-component.war]",
+          "identityHash" : "eff2441b1d32b22a2428bec8fe59452ef5711e",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
             "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-metrics-component.war"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
-          "name" : "hawkular-alerts-actions-email.war",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
+          "properties" : {
+            "__identityHash" : "f07118ef62f45788dba5d01a38b13fe33115785e"
+          },
+          "name" : "Deployment [hawkular-alerts-actions-email.war]",
+          "identityHash" : "f07118ef62f45788dba5d01a38b13fe33115785e",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
             "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-alerts-actions-email.war"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
-          "name" : "hawkular-wildfly-agent-download.war",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
+          "properties" : {
+            "__identityHash" : "10181e9ef78b953ed93eb67f0d270de8dd5cce4"
+          },
+          "name" : "Deployment [hawkular-wildfly-agent-download.war]",
+          "identityHash" : "10181e9ef78b953ed93eb67f0d270de8dd5cce4",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
             "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
-          "name" : "hawkular-alerts-rest.war",
-          "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
-            "name" : "Deployment",
-            "id" : "Deployment"
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
+          "properties" : {
+            "__identityHash" : "fe13b87cf8edfcd191a6d5169c3f376ac6b5d6"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war"
-        }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
-          "name" : "hawkular-inventory-dist.war",
+          "name" : "Deployment [hawkular-inventory-dist.war]",
+          "identityHash" : "fe13b87cf8edfcd191a6d5169c3f376ac6b5d6",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
             "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-inventory-dist.war"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
-          "name" : "hawkular-rest-api.war",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
+          "properties" : {
+            "__identityHash" : "3fbe2fcdf21d9886257438b2aeb957825d6ffe"
+          },
+          "name" : "Deployment [hawkular-alerts-rest.war]",
+          "identityHash" : "3fbe2fcdf21d9886257438b2aeb957825d6ffe",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
             "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-alerts-rest.war"
+        }, {
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
+          "properties" : {
+            "__identityHash" : "d99ddc62fe9a955b3bc7a309f761f763f527516"
+          },
+          "name" : "Deployment [hawkular-rest-api.war]",
+          "identityHash" : "d99ddc62fe9a955b3bc7a309f761f763f527516",
+          "type" : {
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Deployment",
+            "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-rest-api.war"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "properties" : {
+            "__identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622"
+          },
           "name" : "Transaction Manager",
+          "identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Transaction%20Manager",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Transaction%20Manager",
             "name" : "Transaction Manager",
+            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
             "id" : "Transaction Manager"
           },
           "id" : "Local~/subsystem=transactions"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
+          "properties" : {
+            "__identityHash" : "974ff756ed785e2264577211c2bb843e27c991f"
+          },
           "name" : "Messaging Server [default]",
+          "identityHash" : "974ff756ed785e2264577211c2bb843e27c991f",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Messaging%20Server",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Messaging%20Server",
             "name" : "Messaging Server",
+            "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
             "id" : "Messaging Server"
           },
           "id" : "Local~/subsystem=messaging-activemq/server=default"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "properties" : {
+            "__identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac"
+          },
           "name" : "Hawkular WildFly Agent",
+          "identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Hawkular%20WildFly%20Agent",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Hawkular%20WildFly%20Agent",
             "name" : "Hawkular WildFly Agent",
+            "identityHash" : "1d7fbc312f708afc4643812f2772e7aabf283328",
             "id" : "Hawkular WildFly Agent"
           },
           "id" : "Local~/subsystem=hawkular-wildfly-agent"
         }, {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "properties" : {
+            "__identityHash" : "46dd1eae29f56639b947a9a85ef7c5833ec324"
+          },
           "name" : "Socket Binding Group [standard-sockets]",
+          "identityHash" : "46dd1eae29f56639b947a9a85ef7c5833ec324",
           "type" : {
-            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Socket%20Binding%20Group",
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Socket%20Binding%20Group",
             "name" : "Socket Binding Group",
+            "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
             "id" : "Socket Binding Group"
           },
           "id" : "Local~/socket-binding-group=standard-sockets"
+        }, {
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
+          "properties" : {
+            "__identityHash" : "693fc87bc7a8fba877b299f333f86b67ff644a3c"
+          },
+          "name" : "Infinispan",
+          "identityHash" : "693fc87bc7a8fba877b299f333f86b67ff644a3c",
+          "type" : {
+            "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/rt;Infinispan",
+            "name" : "Infinispan",
+            "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+            "id" : "Infinispan"
+          },
+          "id" : "Local~/subsystem=infinispan"
         } ]
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:52 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
 - request:
     method: get
-    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/feeds/71daaa4b-da76-4373-8753-68279f33a884/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/data?dataType=configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/5f040b77-8929-46f4-ace2-4da64c370a0e/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/data?dataType=configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -597,7 +1150,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -607,30 +1160,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.6.3
-      Date:
-      - Wed, 22 Jun 2016 08:45:52 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '434'
-      Connection:
-      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
+      Server:
+      - WildFly/10
       Pragma:
       - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "properties" : {
+            "__identityHash" : "db85f6b08996789d6b315151197ef115897dc12"
+          },
           "name" : "configuration",
+          "identityHash" : "db85f6b08996789d6b315151197ef115897dc12",
           "value" : {
             "Username" : "sa",
             "Driver Name" : "h2",
@@ -641,5 +1198,201 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 22 Jun 2016 08:45:52 GMT
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/children
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      X-Total-Count:
+      - '6'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3578'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/children>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "properties" : {
+            "__identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4"
+          },
+          "name" : "Datasource [ExampleDS]",
+          "identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "id" : "Datasource"
+          },
+          "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "properties" : {
+            "__identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d"
+          },
+          "name" : "JDBC Driver [h2]",
+          "identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;JDBC%20Driver",
+            "name" : "JDBC Driver",
+            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
+            "id" : "JDBC Driver"
+          },
+          "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "properties" : {
+            "__identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622"
+          },
+          "name" : "Transaction Manager",
+          "identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Transaction%20Manager",
+            "name" : "Transaction Manager",
+            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
+            "id" : "Transaction Manager"
+          },
+          "id" : "Local~/subsystem=transactions"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "properties" : {
+            "__identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac"
+          },
+          "name" : "Hawkular WildFly Agent",
+          "identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Hawkular%20WildFly%20Agent",
+            "name" : "Hawkular WildFly Agent",
+            "identityHash" : "1d7fbc312f708afc4643812f2772e7aabf283328",
+            "id" : "Hawkular WildFly Agent"
+          },
+          "id" : "Local~/subsystem=hawkular-wildfly-agent"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "properties" : {
+            "__identityHash" : "8fbb7cddec55ee31209f8e892739da39b29cc"
+          },
+          "name" : "Socket Binding Group [standard-sockets]",
+          "identityHash" : "8fbb7cddec55ee31209f8e892739da39b29cc",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Socket%20Binding%20Group",
+            "name" : "Socket Binding Group",
+            "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
+            "id" : "Socket Binding Group"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
+          "properties" : {
+            "__identityHash" : "df72fd6d4a11a45a4a1eef5ea9ead53e9e3eb95"
+          },
+          "name" : "Infinispan",
+          "identityHash" : "df72fd6d4a11a45a4a1eef5ea9ead53e9e3eb95",
+          "type" : {
+            "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/rt;Infinispan",
+            "name" : "Infinispan",
+            "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+            "id" : "Infinispan"
+          },
+          "id" : "Local~/subsystem=infinispan"
+        } ]
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds/70c798a0-6985-4f8a-a525-012d8d28e8a3/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/data?dataType=configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.3.0 x86_64) ruby/2.2.4p230
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 05 Jul 2016 14:00:32 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "properties" : {
+            "__identityHash" : "db85f6b08996789d6b315151197ef115897dc12"
+          },
+          "name" : "configuration",
+          "identityHash" : "db85f6b08996789d6b315151197ef115897dc12",
+          "value" : {
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:jboss/datasources/ExampleDS",
+            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "Enabled" : "true",
+            "Password" : "sa"
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 05 Jul 2016 14:00:32 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Purpose or Intent
-----------------

This PR bumps the hawkular-client gem to v 2.2.0, which is required in further development of the Middleware provider.

As some Hawkular components have changed their rest-apis, a re-recording of some cassettes was required.

Links
-----

Hawkular-ruby-gem changelog https://github.com/hawkular/hawkular-client-ruby/blob/master/CHANGES.rdoc#v-220
and https://github.com/hawkular/hawkular-client-ruby/issues?q=milestone%3A2.2.0+is%3Aclosed

@yaacov Please verify from CM side.
@miq-bot add_label providers/hawkular, darga/no, enhancement
@miq-bot assign abonas

Travis build at https://travis-ci.org/pilhuhn/manageiq/builds/142495569 was happy.