### PR TITLE
Perf Capture timer - don't pull back tags or taggings

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -80,7 +80,7 @@ class Chargeback < ActsAsArModel
     parents = [perf.parent_host, perf.parent_ems_cluster, perf.parent_storage, perf.parent_ems, @enterprise].compact
     parents.push(tenant_resource) unless tenant_resource.nil?
 
-    @rates[key] = ChargebackRate.get_assigned_for_target(perf.resource, :tag_list => tag_list, :parents => parents, :associations_preloaded => true)
+    @rates[key] = ChargebackRate.get_assigned_for_target(perf.resource, :tag_list => tag_list, :parents => parents)
   end
 
   def self.calculate_costs(perf, h, rates)

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -132,14 +132,7 @@ module AssignmentMixin
         tags = parents.collect { |p| p.tags.select { |t| t.name.starts_with?("/managed/") } }.flatten.uniq
       else
         # Collect tags from all parent objects in a single query if they were NOT already preloaded by the caller
-        tcond = []; targs = []
-        parents.each do |p|
-          tcond << "(taggings.taggable_type=? AND taggings.taggable_id=?)"
-          # TODO: we may need to change taggings-related code to use base_model too
-          targs << p.class.base_class.name << p.id
-        end
-        cond = ["(#{tcond.join(" OR ")}) AND (name like '/managed/%')", *targs]
-        tags = Tag.where(cond).joins(:taggings)
+        tags = Tag.joins(:taggings).where("name like '/managed/%'").where(:taggings => {:taggable => parents})
       end
       individually_assigned_alerts = alist.select { |a| tlist.include?(a[:assigned_to]) }.map { |a| a[:assigned] }
 

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -150,12 +150,10 @@ module AssignmentMixin
         tag.taggings.each do |t|
           # Only collect taggings for parent objects
           klass = t.taggable_type
+          # right now NO support for tagged templates
+          lower_klass = klass == "VmOrTemplate" ? "vm" : klass.underscore
           if parent_ids_by_type[klass] && parent_ids_by_type[klass].include?(t.taggable_id)
-            if klass == "VmOrTemplate"       # right now NO support for tagged templates
-              arr << "vm/tag#{tag.name}"
-            else
-              arr << "#{klass.underscore}/tag#{tag.name}"
-            end
+            arr << "#{lower_klass}/tag#{tag.name}"
           end
         end
         arr

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -127,7 +127,7 @@ module AssignmentMixin
       tlist =  parents.collect { |p| "#{p.class.base_model.name.underscore}/id/#{p.id}" } # Assigned directly to parents
       tlist += options[:tag_list] if options[:tag_list]                        # Assigned to target (passed in)
 
-      individually_assigned_alerts = alist.select { |a| tlist.include?(a[:assigned_to]) }.map { |a| a[:assigned] }
+      individually_assigned_resources = alist.select { |a| tlist.include?(a[:assigned_to]) }.map { |a| a[:assigned] }
 
       # look for alert_set running off of tags (not individual tags)
       # TODO: we may need to change taggings-related code to use base_model too
@@ -138,9 +138,9 @@ module AssignmentMixin
         lower_klass = klass == "VmOrTemplate" ? "vm" : klass.underscore
         "#{lower_klass}/tag#{t.tag.name}"
       end
-      tagged_alerts = alist.select { |a| tlist.include?(a[:assigned_to]) }.map { |a| a[:assigned] }
+      tagged_resources = alist.select { |a| tlist.include?(a[:assigned_to]) }.map { |a| a[:assigned] }
 
-      (individually_assigned_alerts + tagged_alerts).uniq
+      (individually_assigned_resources + tagged_resources).uniq
     end
 
     def namespace


### PR DESCRIPTION
Purpose or Intent
-----------------
Scheduled job `perf_capture_timer` is responsible for kicking off Cap&U for the system.
It is split up into 2 parts:

1. Determine which resources (i.e.: `Host`, `Storage`, `Vm`) need Cap & U
2. Submits them into the queue for further processing. **this pr** - building upon #9477

This process is taking a long time and timing out before completed. This is causing VMs to never have cap&u performed.

This PR focuses on **part 2** and the themes is to access `perf_capture_now?`. It aims to not pull back all taggings for al tags. Which are 90% of all the records brought back in this job.

This method is split up into 2 the two ways an alert can be associated with a resource:

1. Alerts assigned to an individual resource. (e.g.: `/vm/tags/5`)
2. Alerts linked to a resource via a common tag (e.g.: `/environment/production`)

Those 2 parts have been refactored separately, and assigned a variable each.

Before, all the tags were looked up, downloaded, and each brought back tags of interest.
After, the parents themselves are joined into tags to bring back the tags of interest.

Another pr #9588 added specs to try and avoid regressions.


|       ms |   bytes | objects |    queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|     ---:|     ---:|      ---:| ---
|  2,342.9 | 83,456,901* | 2,000,870 |     967 |   646.6 |   11,235 |`before-1`
|  1,952.9 | 59,767,319* | 1,231,726 |     862 |   529.9 |    1,210 |`after-1`

note: * some objects were freed, so bytes used is not accurate but more of a guide. objects is more accurate.
