### PR TITLE
Remove redundant `@config`

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -142,7 +142,6 @@ class ApiController < ApplicationController
   delegate :user_token_service, :to => self
 
   def initialize
-    @config          = Api::Settings.data
     @module          = base_config[:module]
     @name            = base_config[:name]
     @description     = base_config[:description]


### PR DESCRIPTION
It was not noticed that this ivar is currently assigned `nil` with the
change to make `Api::Settings` a `Config::Options` instance. Since the
only consumer of this was deleted in 2dc77ef33a6c, this can be removed.

@miq-bot add-label api
@miq-bot assign @abellotti 