### PR TITLE
[Darga] Allow gtl view for Cloud Key Pairs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -164,14 +164,13 @@ module ApplicationHelper
 
   def url_for_record(record, action = "show") # Default action is show
     @id = to_cid(record.id)
-    db =
-      if record.kind_of?(VmOrTemplate)
-        controller_for_vm(model_for_vm(record))
-      elsif record.class.respond_to?(:db_name)
-        record.class.db_name
-      else
-        record.class.base_class.to_s
-      end
+    db  = if record.kind_of?(VmOrTemplate)
+            controller_for_vm(model_for_vm(record))
+          elsif record.class.respond_to?(:db_name)
+            record.class.db_name
+          else
+            record.class.base_class.to_s
+          end
     url_for_db(db, action, record)
   end
 
@@ -1069,7 +1068,8 @@ module ApplicationHelper
     "#{@options[:page_size] || "US-Legal"} #{@options[:page_layout]}"
   end
 
-  GTL_VIEW_LAYOUTS = %w(action availability_zone cim_base_storage_extent cloud_object_store_container
+  GTL_VIEW_LAYOUTS = %w(action availability_zone auth_key_pair_cloud
+                        cim_base_storage_extent cloud_object_store_container
                         cloud_object_store_object cloud_tenant cloud_volume cloud_volume_snapshot
                         condition container_group container_route container_project
                         container_replicator container_image container_image_registry

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -122,6 +122,9 @@ module QuadiconHelper
       elsif db == "FloatingIp"
         link_to(truncate_for_quad(item.address),
                 url_for_db(db, "show"), :title => h(item.address))
+      elsif db == "Authentication"
+        link_to(truncate_for_quad(row['name']),
+                url_for_db("auth_key_pair_cloud", "show"), :title => h(row['name']))
       else
         if @explorer
           column = case db

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -117,8 +117,11 @@ module QuadiconHelper
         content_tag(:a, truncate_for_quad(row['v_qualified_desc']),
                     :href => url_for_db("ems_cluster", "show"), :title => h(row['v_qualified_desc']))
       elsif db == "StorageManager"
-        content_tag(:a, truncate_for_quad(row['name']),
-                    :href => url_for_db("storage_manager", "show"), :title => h(row['name']))
+        link_to(truncate_for_quad(row['name']),
+                url_for_db("storage_manager", "show"), :title => h(row['name']))
+      elsif db == "FloatingIp"
+        link_to(truncate_for_quad(item.address),
+                url_for_db(db, "show"), :title => h(item.address))
       else
         if @explorer
           column = case db

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -34,6 +34,11 @@ class Authentication < ApplicationRecord
     "invalid"     => 3,
   ).freeze
 
+  # To address problem with url resolution when displayed as a quadicon
+  def self.db_name
+    "auth_key_pair_cloud"
+  end
+
   def status_severity
     STATUS_SEVERITY[status.to_s.downcase]
   end

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -21,6 +21,7 @@
   - else
     -# TODO: is this still even relevant? haven't seen it yet (--mhradil)
     -# substracting leftcol 219 from @winW to calculate width of div
+    -# FYI: found a screen here: /auth_key_pair_cloud/show_list (--@hayesr)
     #list_grid
       = render(:partial => 'layouts/list_grid',
         :locals  => {:options    => grid_options,

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -5,7 +5,7 @@ describe QuadiconHelper do
     subject { helper.render_quadicon(item, {}) }
 
     let(:item) do
-      FactoryGirl.create(:vm_vmware)#, :type => ManageIQ::Providers::Vmware::InfraManager::Vm.name)
+      FactoryGirl.create(:vm_vmware)
     end
 
     it "renders quadicon for a vmware vm" do
@@ -15,18 +15,38 @@ describe QuadiconHelper do
   end
 
   describe "#render_quadicon_text" do
+    before(:each) do
+      @settings = {:display => {:quad_truncate => "m"}}
+    end
+
     subject { helper.render_quadicon_text(item, row) }
 
-    let(:item) do
-      FactoryGirl.create(:vm_vmware)
-    end
-
     let(:row) do
-      Ruport::Data::Record.new(:id => 10000000000534)
+      Ruport::Data::Record.new(:id => 10000000000534, "name" => name)
     end
 
-    it "render text for a vmware vm" do
-      expect(subject).to have_selector('a')
+    context "text for a VM" do
+      let(:item) do
+        FactoryGirl.create(:vm_vmware, :name => "vm_0000000000001")
+      end
+
+      let(:name) { item.name }
+
+      it "renders text for a vmware vm" do
+        expect(subject).to have_link("vm_00...00001")
+      end
+    end
+
+    context "text for Floating IP" do
+      let(:item) do
+        FactoryGirl.create(:floating_ip_openstack)
+      end
+
+      let(:name) { nil }
+
+      it "renders a label for Floating IPs" do
+        expect(subject).to have_link(item.address)
+      end
     end
   end
 end


### PR DESCRIPTION
Addresses this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1348796

The gtl options were missing on the Cloud Key Pairs screen, this adds them.

Extracted from: #9367 

