### PR TITLE
Preparation work to block duplicated events

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -1,9 +1,12 @@
 require 'thread'
 require 'concurrent/atomic/event'
+require 'util/duplicate_blocker'
 
 class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runner
   class EventCatcherHandledException < StandardError
   end
+
+  include DuplicateBlocker
 
   self.wait_for_worker_monitor = false
 
@@ -20,8 +23,43 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     _log.info "#{log_prefix} Event Catcher skipping the following events:"
     $log.log_hashes(@filtered_events)
 
+    configure_event_flooding_prevention if worker_settings.try(:[], :flooding_monitor_enabled)
+
     # Global Work Queue
     @queue = Queue.new
+  end
+
+  def configure_event_flooding_prevention
+    flood_handler = self.class.dedup_handler
+
+    flood_handler.duplicate_window    = 1.minute
+    flood_handler.window_slot_width   = 6.seconds
+    flood_handler.progress_threshold  = 100
+    flood_handler.duplicate_threshold = worker_settings[:flooding_events_per_minute]
+    flood_handler.throw_exception_when_blocked = false
+
+    flood_handler.logger = _log
+    flood_handler.descriptor    = ->(_meth, *args) { event_dedup_descriptor(args[0]) }
+    flood_handler.key_generator = ->(_meth, *args) { event_dedup_key(args[0]) }
+
+    self.class.dedup_instance_method(:queue_event)
+
+    _log.info("Event flood_handler settings:")
+    _log.info("  duplicate_window #{flood_handler.duplicate_window}")
+    _log.info("  duplicate_threshold #{flood_handler.duplicate_threshold}")
+    _log.info("  window_slot_width #{flood_handler.window_slot_width}")
+    _log.info("  progress_threshold #{flood_handler.progress_threshold}")
+  end
+
+  # Extract a key to represent an event. Events with the same key are considered duplicates and
+  # might be subjected to be blocked to prevent flooding
+  def event_dedup_key(_event)
+    raise NotImplementedError, _("must be implemented in subclass")
+  end
+
+  # A string representation for an event. This is used for logging the blocked events
+  def event_dedup_descriptor(_event)
+    raise NotImplementedError, _("must be implemented in subclass")
   end
 
   def do_before_work_loop
@@ -84,7 +122,7 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     raise NotImplementedError, _("must be implemented in subclass")
   end
 
-  # This method has been refactored to go through two steps, namely filetered? and queue_event.
+  # This method has been refactored to go through two steps, namely filtered? and queue_event.
   # Therefore every subclass should override filtered? and queue_event
   #
   # For historical reason existing providers still directly implement process_event

--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -84,8 +84,22 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     raise NotImplementedError, _("must be implemented in subclass")
   end
 
-  def process_event(_event)
+  # This method has been refactored to go through two steps, namely filetered? and queue_event.
+  # Therefore every subclass should override filtered? and queue_event
+  #
+  # For historical reason existing providers still directly implement process_event
+  # They should be eventually refactored following the example of VMWare provider.
+  def process_event(event)
+    queue_event(event) unless filtered?(event)
+  end
+
+  def queue_event(_event)
     raise NotImplementedError, _("must be implemented in subclass")
+  end
+
+  # default implementation: none event is skipped
+  def filtered?(_event)
+    false
   end
 
   def event_monitor_running

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1109,6 +1109,8 @@
       :thread_shutdown_timeout: 10.seconds
     :event_catcher:
       :defaults:
+        :flooding_events_per_minute: 30
+        :flooding_monitor_enabled: false
         :ems_event_page_size: 100
         :ems_event_thread_shutdown_timeout: 10.seconds
         :memory_threshold: 2.gigabytes


### PR DESCRIPTION
Purpose or Intent
-----------------
This is a replacement for closed #3227.

The purpose is to block provider events when too many duplicates are received in a short time. The particular method we monitored is `queue_event`. Duplicated events will not be placed to the queue.

What defines "too many" and "short time" is configured in settings. The committed settings initially are just a placeholder. They are not optimized for real use.
    
Also the feature is turned off in the settings by default. This work only reads the settings in base_manager. Each provider still needs to turn on the feature and define how to identify duplicates.

Links
-----
> #3227


Updates
--------------------
After some of the review comments, the settings are simplified. There is only one parameter, i.e., flooding_events_per_minutes. The initial value is 30 which means an event is subjected to be blocked if it appears 30 times in one minutes.

Initially this feature is disabled for all providers because each provider needs to implement `event_dedup_key` and `event_dedup_descriptor` for the event blocking to work properly.