### PR TITLE
Block duplicated events vmware

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -1,9 +1,12 @@
 require 'thread'
 require 'concurrent/atomic/event'
+require 'util/duplicate_blocker'
 
 class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runner
   class EventCatcherHandledException < StandardError
   end
+
+  include DuplicateBlocker
 
   self.wait_for_worker_monitor = false
 
@@ -20,8 +23,43 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     _log.info "#{log_prefix} Event Catcher skipping the following events:"
     $log.log_hashes(@filtered_events)
 
+    configure_event_flooding_prevention if worker_settings.try(:[], :flooding_monitor_enabled)
+
     # Global Work Queue
     @queue = Queue.new
+  end
+
+  def configure_event_flooding_prevention
+    flood_handler = self.class.dedup_handler
+
+    flood_handler.duplicate_window    = 1.minute
+    flood_handler.window_slot_width   = 6.seconds
+    flood_handler.progress_threshold  = 100
+    flood_handler.duplicate_threshold = worker_settings[:flooding_events_per_minute]
+    flood_handler.throw_exception_when_blocked = false
+
+    flood_handler.logger = _log
+    flood_handler.descriptor    = ->(_meth, *args) { event_dedup_descriptor(args[0]) }
+    flood_handler.key_generator = ->(_meth, *args) { event_dedup_key(args[0]) }
+
+    self.class.dedup_instance_method(:queue_event)
+
+    _log.info("Event flood_handler settings:")
+    _log.info("  duplicate_window #{flood_handler.duplicate_window}")
+    _log.info("  duplicate_threshold #{flood_handler.duplicate_threshold}")
+    _log.info("  window_slot_width #{flood_handler.window_slot_width}")
+    _log.info("  progress_threshold #{flood_handler.progress_threshold}")
+  end
+
+  # Extract a key to represent an event. Events with the same key are considered duplicates and
+  # might be subjected to be blocked to prevent flooding
+  def event_dedup_key(_event)
+    raise NotImplementedError, _("must be implemented in subclass")
+  end
+
+  # A string representation for an event. This is used for logging the blocked events
+  def event_dedup_descriptor(_event)
+    raise NotImplementedError, _("must be implemented in subclass")
   end
 
   def do_before_work_loop
@@ -84,7 +122,7 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     raise NotImplementedError, _("must be implemented in subclass")
   end
 
-  # This method has been refactored to go through two steps, namely filetered? and queue_event.
+  # This method has been refactored to go through two steps, namely filtered? and queue_event.
   # Therefore every subclass should override filtered? and queue_event
   #
   # For historical reason existing providers still directly implement process_event

--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -84,8 +84,22 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     raise NotImplementedError, _("must be implemented in subclass")
   end
 
-  def process_event(_event)
+  # This method has been refactored to go through two steps, namely filetered? and queue_event.
+  # Therefore every subclass should override filtered? and queue_event
+  #
+  # For historical reason existing providers still directly implement process_event
+  # They should be eventually refactored following the example of VMWare provider.
+  def process_event(event)
+    queue_event(event) unless filtered?(event)
+  end
+
+  def queue_event(_event)
     raise NotImplementedError, _("must be implemented in subclass")
+  end
+
+  # default implementation: none event is skipped
+  def filtered?(_event)
+    false
   end
 
   def event_monitor_running

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1119,6 +1119,7 @@
       :event_catcher_redhat:
         :poll: 15.seconds
       :event_catcher_vmware:
+        :flooding_monitor_enabled: true
         :poll: 1.seconds
         :ems_event_max_wait: 60
       :event_catcher_openstack:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1109,6 +1109,8 @@
       :thread_shutdown_timeout: 10.seconds
     :event_catcher:
       :defaults:
+        :flooding_events_per_minute: 30
+        :flooding_monitor_enabled: false
         :ems_event_page_size: 100
         :ems_event_thread_shutdown_timeout: 10.seconds
         :memory_threshold: 2.gigabytes

--- a/spec/models/manageiq/providers/vmware/infra_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/event_catcher/runner_spec.rb
@@ -1,0 +1,125 @@
+require "spec_helper"
+require "timecop"
+
+describe ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner do
+  let(:ems)      { FactoryGirl.create(:ems_vmware, :hostname => "hostname") }
+  let(:catcher)  { ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner.new(:ems_id => ems.id) }
+  let(:settings) { {:flooding_monitor_enabled => false} }
+
+  # TODO: need a better way to create a runner for testing without the following mocks
+  # And the runner can be reloaded between tests
+  before do
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
+    allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
+    allow_any_instance_of(MiqWorker::Runner).to receive(:worker_settings).and_return(settings)
+  end
+
+  let(:test_event1) do
+    {
+      "key"                  => "9418",
+      "chainId"              => "9418",
+      "createdTime"          => "2015-12-10T17:11:26.485713Z",
+      "userName"             => "root",
+      "datacenter"           => {"name" => "VC0DC0",       "datacenter"      => "datacenter-2"},
+      "computeResource"      => {"name" => "VC0DC0_C7",    "computeResource" => "domain-c842"},
+      "host"                 => {"name" => "VC0DC0_C7_H2", "host"            => "host-849"},
+      "fullFormattedMessage" => "Task: Power On virtual machine",
+      "eventType"            => "TaskEvent",
+      "vm"                   =>
+        {
+          "name" => "VC0DC0_C7_RP4_VM12",
+          "vm"   => "vm-952",
+          "path" => "[GlobalDS_0] VC0DC0_C7_RP4_VM12/VC0DC0_C7_RP4_VM12.vmx"
+        },
+      "info"                 =>
+        {
+          "key"           => "task-575",
+          "task"          => "task-575",
+          "name"          => "PowerOnVM_Task",
+          "descriptionId" => "VirtualMachine.powerOn",
+          "entity"        => "vm-952",
+          "entityName"    => "VC0DC0_C7_RP4_VM12",
+          "state"         => "queued",
+          "cancelled"     => "false",
+          "cancelable"    => "false",
+          "reason"        => {"userName" => "root"},
+          "queueTime"     => "2015-12-10T17:11:26.479554Z",
+          "eventChainId"  => "9418"
+        }
+    }
+  end
+
+  let(:test_event2) do
+    test_event1.tap do |event|
+      event.merge(
+        "key"         => "9419",
+        "chainId"     => "9419",
+        "createdTime" => "2015-12-10T17:12:26.485713Z",
+      )
+      event["info"].merge(
+        "key"          => "task-576",
+        "task"         => "task-576",
+        "queueTime"    => "2015-12-10T17:11:27.479554Z",
+        "eventChainId" => "9419"
+      )
+    end
+  end
+
+  let(:test_event3) do
+    test_event1.tap do |event|
+      event["userName"] = "admin"
+    end
+  end
+
+  describe "#event_dedup_key" do
+    context "events differ only from neglected attributes" do
+      it "creates the same dedup key" do
+        expect(catcher.event_dedup_key(test_event1)).to eq(catcher.event_dedup_key(test_event2))
+      end
+    end
+
+    context "events differ from non-neglected attributes" do
+      it "creates different dedup keys" do
+        expect(catcher.event_dedup_key(test_event1)).not_to eq(catcher.event_dedup_key(test_event3))
+      end
+    end
+  end
+
+  describe "#queue_event" do
+    # TODO: once we have better way to initialize a runner and automatically reload before every test
+    # the following code can be removed. Here the runner is forced to reload because the class level
+    # settings need to be changed between tests.
+    before do
+      ManageIQ::Providers::Vmware::InfraManager::EventCatcher.send(:remove_const, :Runner)
+      load 'app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb'
+      Timecop.freeze(0)
+    end
+
+    after { Timecop.return }
+
+    context "event flooding monitor is enabled" do
+      let(:settings) do
+        {
+          :flooding_monitor_enabled   => true,
+          :flooding_events_per_minute => 1
+        }
+      end
+
+      it "block duplicates events by not placing it to the queue" do
+        expect(EmsEvent).to receive(:add_queue).once
+        catcher.queue_event(test_event1)
+        Timecop.freeze(10)
+        catcher.queue_event(test_event1)
+      end
+    end
+
+    context "event flooding monitor is disabled" do
+      it "places every event to the queue" do
+        expect(EmsEvent).to receive(:add_queue).twice
+        catcher.queue_event(test_event1)
+        Timecop.freeze(10)
+        catcher.queue_event(test_event1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------    
Implement required methods to make duplicated VMWare events blockable.

This serves as the sample implementation to enable blocking of duplicated events for a particular provider.
Links
-----
1. It has dependency on #9616. Will need rebase after #9616 is merged.
 
2. Original work in #3227 


Steps for Testing/QA
--------------------
