### PR TITLE
use_agent is a supported option since net-ssh 2.9.0, use it

### DIFF
--- a/gems/pending/util/MiqSshUtilV2.rb
+++ b/gems/pending/util/MiqSshUtilV2.rb
@@ -1,17 +1,5 @@
 require 'util/extensions/miq-string.rb'
 
-module Net
-  module SSH
-    module Authentication
-      class KeyManager
-        def use_agent?
-          false
-        end
-      end
-    end
-  end
-end
-
 class MiqSshUtil
   attr_reader :status, :host
 
@@ -34,6 +22,9 @@ class MiqSshUtil
 
     # Obsolete, delete if passed in
     @options.delete(:authentication_prompt_delay)
+
+    # don't use the ssh-agent
+    @options[:use_agent] = false
 
     # Set logging to use our default handle if it exists and one was not passed in
     unless @options.key?(:logger)


### PR DESCRIPTION
Purpose or Intent
-----------------

net-ssh before 2.9.0 didn't support disabling the ssh-agent via an option `use_agent`, so we monkey patched net-ssh to do this hackily.  2.9.0 added this option so this patch isn't needed anymore.

Links
-----

See: https://github.com/net-ssh/net-ssh/commit/6232252c8e26788c9a00ff0bccd0ff47d5a8f7ef

This HACK was originally added before net/ssh supported use_agent here:
46ec150339b66902a868f98fb91b4d3816883982

We've been using net/ssh 2.9.0+ since:
https://github.com/ManageIQ/manageiq/pull/550

Fixes #857


Steps for Testing/QA
--------------------

Note, net-ssh has tests for this [here](https://github.com/net-ssh/net-ssh/blob/1739e0378f20b81c71dac9401b090c67f6962972/test/authentication/test_key_manager.rb#L38)

