### PR TITLE
allow supports_not without a reason

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -74,7 +74,7 @@ module SupportsFeatureMixin
       send(:define_supports_methods, feature, true, &block)
     end
 
-    def supports_not(feature, reason)
+    def supports_not(feature, reason = nil)
       send(:define_supports_methods, feature, false, reason)
     end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Sometimes, we don't want to explicitly say, why it's not supported. Because the reason would probably never be displayed. 

Like [here](https://github.com/ManageIQ/manageiq/pull/8951/files#diff-31c78637d31f98511250c1e6318e769cR43) - In this case all CloudManagers don't support discovery by default, because it has to be implemented. And the UI would only show CloudManagers that support it.

Adding a reason like "It's not supported because it's not implemented" would just generate noise.

@miq-bot add_label darga/no

@Fryguy @chessbyte review and merge?