### PR TITLE
path for 'gems/' should be relative to Gemfile directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "config",                          "~>1.1.0", :git => "git://github.com/Mana
 gem "deep_merge",                      "~>1.0.1", :git => "git://github.com/ManageIQ/deep_merge.git", :branch => "overwrite_arrays"
 
 # Local gems
-path "gems/" do
+path File.expand_path("gems/", __dir__) do
   gem "manageiq_foreman", :require => false
 end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
otherwise this breaks when including the Gemfile in a provider gem

related PR https://github.com/ManageIQ/manageiq-providers-amazon/pull/8

@miq-bot add_label darga/no

@Fryguy review and merge?
