### PR TITLE
Add OpenSCAP failed rules summary

### DIFF
--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -25,6 +25,10 @@ module ContainerImageHelper
       items.collect { |m| send("textual_#{m}") }.flatten.compact
     end
 
+    def textual_openscap_failed_rules
+      %i(openscap_failed_rules_low openscap_failed_rules_medium openscap_failed_rules_high)
+    end
+
     #
     # Items
     #
@@ -72,6 +76,25 @@ module ContainerImageHelper
           :display    => 'compliance_history')
       end
       h
+    end
+
+    def failed_rules_summary
+      @failed_rules_summary ||= @record.openscap_failed_rules_summary
+    end
+
+    def textual_openscap_failed_rules_low
+      low = failed_rules_summary[:Low]
+      {:label => _("Low"), :value => low} if low
+    end
+
+    def textual_openscap_failed_rules_medium
+      medium = failed_rules_summary[:Medium]
+      {:label => _("Medium"), :value => medium} if medium
+    end
+
+    def textual_openscap_failed_rules_high
+      high = failed_rules_summary[:High]
+      {:label => _("High"), :value => high} if high
     end
   end
 end

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -95,5 +95,9 @@ class ContainerImage < ApplicationRecord
     )
   end
 
+  def openscap_failed_rules_summary
+    openscap_rule_results.where(:result => "fail").group(:severity).count.symbolize_keys
+  end
+
   alias_method :perform_metadata_sync, :sync_stashed_metadata
 end

--- a/app/views/container_image/_main.html.haml
+++ b/app/views/container_image/_main.html.haml
@@ -12,3 +12,5 @@
                                                                   :items => textual_group_smart_management}
   = render :partial => "shared/summary/textual", :locals => {:title => _("Configuration"),
                                                              :items => textual_group_configuration}
+  = render :partial => "shared/summary/textual", :locals => {:title => _("OpenSCAP Failed Rules Summary"),
+                                                             :items => textual_openscap_failed_rules}


### PR DESCRIPTION
Summarize OpenSCAP failed rules according to their severity in the Container Image view:

![failed_rules](https://cloud.githubusercontent.com/assets/11769555/16615153/497c2b66-437d-11e6-84cd-8e2199199e10.png)
