### PR TITLE
Fix hawkular metrics reading regression

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
@@ -13,7 +13,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawkul
     URI::HTTPS.build(
       :host => hawkular_endpoint_empty ? @ext_management_system.hostname : hawkular_endpoint.hostname,
       :port => hawkular_endpoint_empty ? worker_class.worker_settings[:metrics_port] : hawkular_endpoint.port,
-      :path => worker_class.worker_settings[:metrics_path])
+      :path => worker_class.worker_settings[:metrics_path]).to_s
   end
 
   def hawkular_credentials


### PR DESCRIPTION
The current call for hawkular-client initializer uses a URI object, in v2.2.0 it requires an implicit conversion to string.

When reading metrics with hawkular-client v2.2.0 we get the error:
```
NoMethodError: undefined method `gsub' for #<URI::HTTPS:0x00557242b2f278>
	from /usr/local/lib/ruby/gems/2.2.0/gems/hawkular-client-2.2.0/lib/hawkular/base_client.rb:142:in `normalize_entrypoint_url'
```
This is fixed by sending a url as string and not as a URI object.

Issue:
https://github.com/ManageIQ/manageiq/issues/9624
