### PR TITLE
Update rubyrep to include nested transaction fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "ruport",                         "=1.7.0",                       :git => "g
 
 # Vendored but not required
 gem "net-ldap",                       "~>0.7.0",   :require => false
-gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-8"
+gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-9"
 gem "simple-rss",                     "~>1.3.1",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"
 


### PR DESCRIPTION
This was required because rubyrep would open a transaction per 1000 rows and also a transaction for each change it replicated.

If the inner transaction failed for any reason, the outer transaction would also be aborted because postgresql does not really support nested transactions.

This would cause the replicate process to timeout because no sql could then be processed in the aborted transaction.

https://github.com/ManageIQ/rubyrep/pull/9
https://bugzilla.redhat.com/show_bug.cgi?id=1348576