### PR TITLE
fix methods not found by adding reference yaml

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_vm.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_vm.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: PreProvision_Clone_to_VM
+    inherits:
+    description:
+  fields:
+  - amazon_meth1:
+      value: amazon_PreProvision_clone_to_vm
+  - openstack_meth1:
+      value: openstack_PreProvision_clone_to_vm


### PR DESCRIPTION
## Purpose or Intent

Fix methods not found error while _colonning_ a vm by adding a reference yaml
as the file is finding this:
https://github.com/zhitongLBN/manageiq/blob/af6617fd8978308bac3c38bcfc6391147d5a7d05/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/clone_to_vm.yaml#L12
