### PR TITLE
Default to API port 13000 for SSL-enabled Openstack Providers

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -281,6 +281,16 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
+  $scope.openstackSecurityProtocolChanged = function() {
+    if ($scope.emsCommonModel.emstype === 'openstack' || $scope.emsCommonModel.emstype === 'openstack_infra') {
+      if ($scope.emsCommonModel.default_security_protocol === 'non-ssl') {
+        $scope.emsCommonModel.default_api_port = "5000";
+      } else {
+        $scope.emsCommonModel.default_api_port = "13000";
+      }
+    }
+  };
+
   $scope.scvmmSecurityProtocolChanged = function() {
     $scope.note = "";
     if ($scope.emsCommonModel.emstype === 'scvmm' && $scope.emsCommonModel.default_security_protocol === 'kerberos') {

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -55,6 +55,7 @@
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",
                        "checkchange"                 => "",
                        "required"                    => defined?(security_protocol_not_required) ? false : true,
+                       "ng-change"                   => "openstackSecurityProtocolChanged()",
                        "selectpicker-for-select-tag" => "")
     .col-md-8{"ng-if" => "emsCommonModel.emstype == 'scvmm'"}
       = select_tag("#{prefix}_security_protocol",
@@ -83,4 +84,3 @@
       = _("Required")
     %span.help-block{"ng-show" => "angularForm.realm.$error.detectedSpaces"}
       = _("Spaces are prohibited")
-


### PR DESCRIPTION
"When choosing SSL or SSL without validation security protocol for Openstack providers the API port should be automatically set to 13000 which is the default SSL port for the SSL enabled keystone endpoint." -- https://bugzilla.redhat.com/show_bug.cgi?id=1302281 

This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1302281 by automatically setting the Openstack Provider API port to 13000 when SSL or SSL-without-verification are selected. If No SSL is selected, the default port is still 5000.

@tzumainn 