### PR TITLE
Show hosts as archived when their EMS is deleted

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -281,7 +281,7 @@ module QuadiconHelper
       output << flobj_img_simple(size, "#{size}/base.png")
 
       output << flobj_p_simple("a#{size}", item.vms.size)
-      output << flobj_img_simple(size, "72/currentstate-#{h(item.state.downcase)}.png", "b#{size}") unless item.state.blank?
+      output << flobj_img_simple(size, "72/currentstate-#{h(item.normalized_state.downcase)}.png", "b#{size}")
       output << flobj_img_simple(size, img_for_host_vendor(item), "c#{size}")
       output << flobj_img_simple(size, img_for_auth_status(item), "d#{size}")
       output << flobj_img_simple(size, '100/shield.png', "g#{size}") unless item.get_policies.empty?

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1881,5 +1881,15 @@ class Host < ApplicationRecord
     storages.where(:host_storages => {:read_only => true})
   end
 
+  def archived?
+    ems_id.nil?
+  end
+
+  def normalized_state
+    return 'archived' if archived?
+    return power_state unless power_state.nil?
+    "unknown"
+  end
+
   include DeprecatedCpuMethodsMixin
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
When you remove an ExtManagementSystem VMs are marked as archived/orphaned but hosts still show their original power state, this makes them indistinguishable from active hosts.
This change will show hosts from deleted EMSs as archived in the host list.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1348604

Screenshots
-----
Hosts from a deleted EMS before the change:
![screenshot from 2016-07-06 12-21-49](https://cloud.githubusercontent.com/assets/12851112/16628160/778df6f0-437e-11e6-99f6-a92004965ab8.png)
Hosts from a deleted EMS after the change:
![screenshot from 2016-07-06 12-22-33](https://cloud.githubusercontent.com/assets/12851112/16628168/814e6684-437e-11e6-9d8c-6bb2455ae07e.png)

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1348604


Steps for Testing/QA
--------------------
1. Add an Infra provider and perform an inventory refresh
2. After the refresh completes, run `Configuration/Remove Infrastructure Provider from the VMDB`
3. Go to `Compute/Infrastructure/Hosts` and you should see an `A` instead of power state in the top right corner of the quadicon
