### PR TITLE
Copy service_template into a blueprint

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -1,0 +1,90 @@
+class Blueprint < ApplicationRecord
+  has_many :service_templates
+  private  :service_templates, :service_templates=
+
+  # the top of the service_templates, a bundle that contains child items
+  def bundle
+    service_templates.find { |st| st.parent_services.blank? }
+  end
+
+  # The new blueprint is saved before returning
+  def deep_copy(new_attributes = {})
+    self.class.transaction do
+      dup.tap do |blueprint|
+        # TODO: there may be other attributes that need to be reset for the new template
+        new_attributes.reverse_merge(:status => nil).each do |attr, value|
+          blueprint.send("#{attr}=", value)
+        end
+        copy_service_template(blueprint, bundle, true)
+        blueprint.save!
+      end
+    end
+  end
+
+  private
+
+  # Copy a service template and link its blueprint;
+  # It can be used to copy service_templates into a new blueprint
+  # or copy the bundle from one blueprint to another
+  # The resulting service template is saved before returning;
+  # is_top is true only when copying the bundle of a blueprint
+  def copy_service_template(blueprint, service_template, is_top = false, new_attributes = {})
+    service_template.dup.tap do |new_template|
+      duplicate_resource_actions(service_template, new_template, is_top)
+      duplicate_service_resources(blueprint, service_template, new_template)
+      update_copied_service_template(blueprint, new_template, new_attributes)
+    end
+  end
+
+  def duplicate_resource_actions(old_template, new_template, is_top)
+    dialog_map = {}
+    new_template.resource_actions = old_template.resource_actions.collect do |old_action|
+      old_action.dup.tap do |new_action|
+        old_dialog = old_action.dialog
+        new_dialog = ensure_new_dialog(dialog_map, old_dialog) if old_dialog && is_top
+        new_action.dialog = new_dialog # either a new dialog or nil
+      end
+    end
+  end
+
+  def ensure_new_dialog(dialog_map, old_dialog)
+    new_dialog = dialog_map[old_dialog.id]
+    unless new_dialog
+      new_dialog = old_dialog.deep_copy(:name => random_dialog_name(old_dialog.name)).tap(&:save!)
+      dialog_map[old_dialog.id] = new_dialog
+    end
+    new_dialog
+  end
+
+  def random_dialog_name(prefix)
+    "#{prefix}_#{rand(36**8).to_s(36)}"
+  end
+
+  def duplicate_service_resources(blueprint, old_template, new_template)
+    new_template.service_resources = old_template.service_resources.collect do |sr|
+      sr.dup.tap do |new_sr|
+        resource = sr.resource
+        if resource.kind_of?(ServiceTemplate)
+          new_sr.resource = copy_service_template(blueprint, resource)
+        elsif !provider_resource?(resource)
+          new_sr.resource = resource.dup.tap(&:save!)
+        end
+      end
+    end
+  end
+
+  def provider_resource?(resource)
+    resource.respond_to?(:ems_ref) || resource.kind_of?(ExtManagementSystem)
+  end
+
+  def update_copied_service_template(blueprint, new_template, new_attributes)
+    new_template.blueprint = blueprint
+    new_template.display = false
+
+    new_attributes.each do |attr, value|
+      new_template.send("#{attr}=", value)
+    end
+
+    new_template.save!
+  end
+end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -7,6 +7,7 @@ class ServiceTemplate < ApplicationRecord
   include_concern 'Filter'
 
   belongs_to :tenant
+  belongs_to :blueprint
   # # These relationships are used to specify children spawned from a parent service
   # has_many   :child_services, :class_name => "ServiceTemplate", :foreign_key => :service_template_id
   # belongs_to :parent_service, :class_name => "ServiceTemplate", :foreign_key => :service_template_id

--- a/spec/factories/blueprint.rb
+++ b/spec/factories/blueprint.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :blueprint do
+    sequence(:name) { |n| "Blueprint #{n}" }
+  end
+end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -1,0 +1,78 @@
+describe Blueprint do
+  let(:subject) { FactoryGirl.create(:blueprint) }
+
+  let(:catalog_vm_provisioning) do
+    admin = FactoryGirl.create(:user_admin)
+    vm_template = FactoryGirl.create(:template)
+    ptr = FactoryGirl.create(:miq_provision_request_template, :requester => admin, :src_vm_id => vm_template.id)
+    FactoryGirl.create(:service_template, :name => 'Service Template Vm Provisioning').tap do |item|
+      add_and_save_service(item, ptr)
+      item.resource_actions = [FactoryGirl.create(:resource_action)]
+    end
+  end
+
+  let(:catalog_orchestration) do
+    FactoryGirl.create(:service_template, :name => 'Service Template Item').tap do |item|
+      add_and_save_service(item, FactoryGirl.create(:orchestration_template))
+      add_and_save_service(item, FactoryGirl.create(:ext_management_system))
+      item.resource_actions = [FactoryGirl.create(:resource_action)]
+    end
+  end
+
+  let(:dialog) do
+    dialog       = FactoryGirl.create(:dialog, :label => 'dialog')
+    dialog_tab   = FactoryGirl.create(:dialog_tab, :label => 'tab')
+    dialog_group = FactoryGirl.create(:dialog_group, :label => 'group')
+    dialog_field = FactoryGirl.create(:dialog_field, :label => 'field 1', :name => "field_1")
+
+    dialog.dialog_tabs << dialog_tab
+    dialog_tab.dialog_groups << dialog_group
+    dialog_group.dialog_fields << dialog_field
+
+    dialog_group.save
+    dialog_tab.save
+    dialog.save
+    dialog
+  end
+
+  context 'blueprint with a bundle' do
+    let!(:catalog_bundle) do
+      subject.update_attribute(:status, 'published')
+      catalog_vm_provisioning.update_attribute(:blueprint, subject)
+      catalog_orchestration.update_attribute(:blueprint, subject)
+      FactoryGirl.create(:service_template, :name => 'Service Template Bundle', :display => true, :blueprint => subject).tap do |bundle|
+        bundle.resource_actions =
+          [FactoryGirl.create(:resource_action, :dialog => dialog), FactoryGirl.create(:resource_action, :dialog => dialog)]
+        add_and_save_service(bundle, catalog_vm_provisioning)
+        add_and_save_service(bundle, catalog_orchestration)
+      end
+    end
+
+    describe '#bundle' do
+      it 'returns the top level service template as the bundle' do
+        expect(subject.bundle).to eq(catalog_bundle)
+      end
+    end
+
+    describe '#deep_copy' do
+      it "copies a blueprint and its service templates" do
+        new_bp = subject.deep_copy(:name => 'cloned bp')
+        expect(ExtManagementSystem.count).to eq(1)
+        expect(OrchestrationTemplate.count).to eq(1)
+        expect(ResourceAction.count).to eq(10)
+        expect(MiqRequest.count).to eq(2)
+        expect(ServiceResource.count).to eq(10)
+        expect(ServiceTemplate.count).to eq(6)
+        expect(Dialog.count).to eq(2)
+        expect(new_bp.bundle.name).to eq(catalog_bundle.name)
+        expect(new_bp.bundle.display).to be_falsey
+        expect(new_bp.status).to be_nil
+      end
+    end
+  end
+end
+
+def add_and_save_service(p, c)
+  p.add_resource(c)
+  p.service_resources.each(&:save)
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Copy a blueprint with its service templates
    
Copy all resources actions and service resources under each server template
The new blueprint and its associations are saved.
    
All service templates are marked as not displayable and belong to the new blueprint.

Links
-----
It has a dependency on #9697 

Steps for Testing/QA
--------------------