### PR TITLE
Changes to pglogical replication for PostgreSQL 9.5

### DIFF
--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -14,13 +14,15 @@ class PgLogicalRaw
   #
   # @return [Boolean]
   def enabled?
-    installed? && connection.extension_enabled?("pglogical") && connection.extension_enabled?("pglogical_origin")
+    return false unless installed? && connection.extension_enabled?("pglogical")
+    return true if connection.postgresql_version >= 90_500
+    connection.extension_enabled?("pglogical_origin")
   end
 
   # Enables pglogical postgres extensions
   def enable
     connection.enable_extension("pglogical")
-    connection.enable_extension("pglogical_origin")
+    connection.enable_extension("pglogical_origin") if connection.postgresql_version < 90_500
   end
 
   # Monitoring

--- a/spec/replication/util/ar_pglogical_spec.rb
+++ b/spec/replication/util/ar_pglogical_spec.rb
@@ -10,11 +10,6 @@ describe "ar_pglogical extension" do
       connection.pglogical.enable
       expect(connection.extensions).to include("pglogical")
     end
-
-    it "enables the pglogical_origin extension" do
-      connection.pglogical.enable
-      expect(connection.extensions).to include("pglogical_origin")
-    end
   end
 
   context "with the extensions enabled" do


### PR DESCRIPTION
Don't consider the `pglogical_origin` extenstion when running postgresql 9.5 or later

This extenstion was only needed for postgres 9.4

This extension is not provided with the pglogical packages for 9.5 and will cause an error if we attempt to use it, but we want to be able to continue to use replication with postgresql 9.4 for now.