### PR TITLE
Remove use of args_selector from Job#queue_signal 

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -150,16 +150,15 @@ class Job < ApplicationRecord
 
   def timeout!
     MiqQueue.put_unless_exists(
-      :class_name    => self.class.base_class.name,
-      :instance_id   => id,
-      :method_name   => "signal",
-      :args_selector => ->(args) { args.kind_of?(Array) && args.first == :abort },
-      :role          => "smartstate",
-      :zone          => MiqServer.my_zone
+      :class_name  => self.class.base_class.name,
+      :instance_id => id,
+      :method_name => "signal_abort",
+      :role        => "smartstate",
+      :zone        => MiqServer.my_zone
     ) do |_msg, find_options|
       message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{current_job_timeout} seconds]"
       _log.warn("Job: guid: [#{guid}], #{message}, aborting")
-      find_options.merge(:args => [:abort, message, "error"])
+      find_options.merge(:args => [message, "error"])
     end
   end
 

--- a/app/models/job/state_machine.rb
+++ b/app/models/job/state_machine.rb
@@ -22,6 +22,10 @@ class Job
       !!next_state
     end
 
+    def signal_abort(*args)
+      signal(:abort, *args)
+    end
+
     def signal(signal, *args)
       signal = :abort_job if signal == :abort
       if transit_state(signal)

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -152,8 +152,13 @@ class JobProxyDispatcher
 
       default_opts[:zone] = job.zone if job.zone
       options = default_opts.merge(options)
+      # special case signal(:abort) - so we can easily pull off the queue
+      if (sig = options[:args].first) == :abort
+        options[:args].shift # remove :abort from args
+        options[:method_name] = "signal_abort"
+      end
       MiqQueue.put_unless_exists(options) do |msg|
-        _log.warn("Previous Job signal [#{options[:args].first}] for Job: [#{job.guid}] is still running, skipping...") unless msg.nil?
+        _log.warn("Previous Job signal [#{sig}] for Job: [#{job.guid}] is still running, skipping...") unless msg.nil?
       end
     end
   end


### PR DESCRIPTION
High Level
--------

This is a strategic move to use less ruby in our queue implementation.
Full explanation of this thread can be found here https://github.com/ManageIQ/manageiq/pull/9232

**before:**

When a job is aborted, we want to only put one abort signal into the queue.
Since the signal name is part of `args` we fetch all signals for the job and determine if an abort is present.

**after:**

When putting an abort job onto the queue, use `method` of `signal_abort` (was `signal`). To determine uniqueness. we only look at the `method` and don't need to look at all the `args`. This allows us to determine uniqueness fully in the db/queue.

low level
-------

1. `signal_queue(:signal, [:abort, *args])` changed to `signal_queue(:signal_abort, args)`
2. `job_proxy_dispatcher` handles `signal_abort`. Implemention is just to call `signal(:abort)`
3. change `put_unless_exists` to look for `message=:signal_abort` and not in the `args`.

/cc @gmcculloug think we've spoken about this before (2 years ago?) - seem reasonable?
/cc @Fryguy you merged the last PR with this change - could you verify the design?