### PR TITLE
Display only the Providers with hosts in the dropdown for certain action types in Schedule Editor

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -321,7 +321,12 @@ module OpsController::Settings::Schedules
     when "container_image"
       filtered_item_list = find_filtered(ContainerImage).sort_by { |ci| ci.name.downcase }.collect(&:name).uniq
     when "ems"
-      filtered_item_list = find_filtered(ExtManagementSystem).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
+      if action_type == "host" || "host_check_compliance"
+        filtered_item_list = find_filtered(ExtManagementSystem).collect{|ems| ems.name if ems.number_of(:hosts) > 0}
+                                 .delete_if {|ems| ems.blank? }.sort_by { |ems| ems.downcase }
+      else
+        filtered_item_list = find_filtered(ExtManagementSystem).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
+      end
     when "cluster"
       filtered_item_list = find_filtered(EmsCluster).collect do |cluster|
         [cluster.name + "__" + cluster.v_parent_datacenter, cluster.v_qualified_desc]
@@ -600,7 +605,7 @@ module OpsController::Settings::Schedules
 
     @host_options_for_select = [
       [_("All Hosts"), "all"],
-      [_("All Hosts for %{table}") % {:table => ui_lookup(:table => "ext_management_systems")}, "ems"],
+      [_("All Hosts for %{table}") % {:table => ui_lookup(:table => "ems_infra")}, "ems"],
       [_("All Hosts for %{table}") % {:table => ui_lookup(:table => "ems_clusters")}, "cluster"],
       [_("A single Host"), "host"]
     ] +

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -321,7 +321,7 @@ module OpsController::Settings::Schedules
     when "container_image"
       filtered_item_list = find_filtered(ContainerImage).sort_by { |ci| ci.name.downcase }.collect(&:name).uniq
     when "ems"
-      if action_type == "host" || "host_check_compliance"
+      if %w(emscluster host host_check_compliance storage).include?(action_type)
         filtered_item_list = find_filtered(ExtManagementSystem).collect{|ems| ems.name if ems.number_of(:hosts) > 0}
                                  .delete_if {|ems| ems.blank? }.sort_by { |ems| ems.downcase }
       else
@@ -621,7 +621,7 @@ module OpsController::Settings::Schedules
 
     @cluster_options_for_select = [
       [_("All Clusters"), "all"],
-      [_("All Clusters for %{table}") % {:table => ui_lookup(:table => "ext_management_systems")}, "ems"],
+      [_("All Clusters for %{table}") % {:table => ui_lookup(:table => "ems_infra")}, "ems"],
       [_("A single Cluster"), "cluster"]
     ] +
                                   (@cluster_global_filters.empty? ? [] : [[_("Global Filters"), "global"]]) +
@@ -630,7 +630,7 @@ module OpsController::Settings::Schedules
     @storage_options_for_select = [
       [_("All Datastores"), "all"],
       [_("All Datastores for Host"), "host"],
-      [_("All Datastores for %{table}") % {:table => ui_lookup(:table => "ext_management_systems")}, "ems"],
+      [_("All Datastores for %{table}") % {:table => ui_lookup(:table => "ems_infra")}, "ems"],
       [_("A single Datastore"), "storage"]
     ] +
                                   (@storage_global_filters.empty? ? [] : [[_("Global Filters"), "global"]]) +

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -322,8 +322,8 @@ module OpsController::Settings::Schedules
       filtered_item_list = find_filtered(ContainerImage).sort_by { |ci| ci.name.downcase }.collect(&:name).uniq
     when "ems"
       if %w(emscluster host host_check_compliance storage).include?(action_type)
-        filtered_item_list = find_filtered(ExtManagementSystem).collect{|ems| ems.name if ems.number_of(:hosts) > 0}
-                                 .delete_if {|ems| ems.blank? }.sort_by { |ems| ems.downcase }
+        filtered_item_list = find_filtered(ExtManagementSystem).collect { |ems| ems.name if ems.number_of(:hosts) > 0 }
+                                                               .delete_if(&:blank?).sort_by(&:downcase)
       else
         filtered_item_list = find_filtered(ExtManagementSystem).sort_by { |vm| vm.name.downcase }.collect(&:name).uniq
       end

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -144,5 +144,16 @@ describe OpsController do
       filtered_list = controller.send(:build_filtered_item_list, "storage", "storage")
       expect(filtered_list.first).to include(storage.name)
     end
+
+    it "returns a filtered item list for ems providers that have hosts" do
+      controller.instance_variable_set(:@settings, settings)
+      ems_cloud = FactoryGirl.create(:ems_cloud)
+      ems_infra_no_hosts = FactoryGirl.create(:ems_openstack_infra)
+      ems_infra_with_hosts = FactoryGirl.create(:ems_openstack_infra_with_stack)
+      filtered_list = controller.send(:build_filtered_item_list, "host", "ems")
+      expect(filtered_list).not_to include(ems_cloud.name)
+      expect(filtered_list).not_to include(ems_infra_no_hosts.name)
+      expect(filtered_list.first).to include(ems_infra_with_hosts.name)
+    end
   end
 end


### PR DESCRIPTION
For action types `host`, `host_check_compliance`, `emscluster` and `storage` display only those Providers in the dropdown that have hosts associated with them.

https://bugzilla.redhat.com/show_bug.cgi?id=1300473