### PR TITLE
Ansible Configured Systems listed under Unassigned Foreman Configured System Node

### DIFF
--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -78,7 +78,8 @@ class TreeBuilderConfigurationManager < TreeBuilder
 
   def x_get_tree_cpf_kids(object, count_only)
     count_only_or_objects(count_only,
-                          rbac_filtered_objects(ConfiguredSystem.where(:configuration_profile_id => object[:id]),
+                          rbac_filtered_objects(ConfiguredSystem.where(:configuration_profile_id => object[:id],
+                                                                       :manager_id               => object[:manager_id]),
                                                 :match_via_descendants => ConfiguredSystem),
                           "hostname")
   end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -271,6 +271,17 @@ describe ProviderForemanController do
     expect(objects).to match_array(expected_objects)
   end
 
+  it "foreman unassigned configuration profile tree node does not list ansible configured systems" do
+    controller.send(:build_configuration_manager_tree, :providers, :configuration_manager_providers_tree)
+    tree_builder = TreeBuilderConfigurationManager.new("root", "", {})
+    unassigned_id = "#{ems_id_for_provider(@provider)}-unassigned"
+    unassigned_configuration_profile = ConfigurationProfile.new(:name       => "Unassigned Profiles Group|#{unassigned_id}",
+                                                                :manager_id => ems_id_for_provider(@provider))
+    objects = tree_builder.send(:x_get_tree_cpf_kids, unassigned_configuration_profile, false)
+    expected_objects = [@configured_system_unprovisioned]
+    expect(objects).to match_array(expected_objects)
+  end
+
   it "builds ansible tower job templates tree" do
     controller.send(:build_configuration_manager_tree, :configuration_scripts, :configuration_scripts_tree)
     tree_builder = TreeBuilderConfigurationManagerConfigurationScripts.new("root", "", {})

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -274,6 +274,9 @@ describe ProviderForemanController do
   it "foreman unassigned configuration profile tree node does not list ansible configured systems" do
     controller.send(:build_configuration_manager_tree, :providers, :configuration_manager_providers_tree)
     tree_builder = TreeBuilderConfigurationManager.new("root", "", {})
+    objects = tree_builder.send(:x_get_tree_objects, @inventory_group, nil, false, nil)
+    expected_objects = [@ans_configured_system, @ans_configured_system2a]
+    expect(objects).to match_array(expected_objects)
     unassigned_id = "#{ems_id_for_provider(@provider)}-unassigned"
     unassigned_configuration_profile = ConfigurationProfile.new(:name       => "Unassigned Profiles Group|#{unassigned_id}",
                                                                 :manager_id => ems_id_for_provider(@provider))


### PR DESCRIPTION
Purpose or Intent
-----------------
Fixed the node for Unassigned Configuration Profiles for Foreman Provider Configured Systems

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1350369

Steps for Testing/QA
--------------------
Add a Foreman provider with at least one unassigned configured system and one Ansible Tower  provider.  Ansible Tower configured systems shoudl not be listed as nodes under the unassigned Foreman configured systems.