### PR TITLE
 Do not display the Survey Title if no Survey exists in the Configuration Script

### DIFF
--- a/app/views/provider_foreman/_configuration_script.html.haml
+++ b/app/views/provider_foreman/_configuration_script.html.haml
@@ -5,4 +5,5 @@
   .col-md-12.col-lg-8
     = render :partial => "shared/summary/textual_listview", :locals => {:title => _("Variables"), :items => textual_configuration_script_variables}
   .col-md-12.col-lg-8
-    = render :partial => "shared/summary/textual_listview", :locals => {:title => _("Surveys"), :items => textual_configuration_script_survey}
+    - if @record.survey_spec['spec']
+      = render :partial => "shared/summary/textual_listview", :locals => {:title => _("Surveys"), :items => textual_configuration_script_survey}


### PR DESCRIPTION
Purpose or Intent
-----------------
Do not display the Survey Title if no Survey exists in teh Configuration Script

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1350344

Steps for Testing/QA
--------------------
Ansible Tower Configuration scripts with and without survey specs


Before:

![screenshot from 2016-07-11 16-54-25](https://cloud.githubusercontent.com/assets/12769982/16746449/6ba31b14-4788-11e6-8a4c-259370f9732c.png)

After:

![screenshot from 2016-07-11 16-55-49](https://cloud.githubusercontent.com/assets/12769982/16746460/75fffd0c-4788-11e6-9a9b-c454040b7dbf.png)

![screenshot from 2016-07-11 16-57-02](https://cloud.githubusercontent.com/assets/12769982/16746479/84e1eb50-4788-11e6-8cc3-c0aa7dd3f8c6.png)


