### PR TITLE
Add the connection_configurations attribute to the providers api POST method.

### DIFF
--- a/app/controllers/api_controller/providers.rb
+++ b/app/controllers/api_controller/providers.rb
@@ -5,6 +5,7 @@ class ApiController
     CREDENTIALS_ATTR  = "credentials"
     AUTH_TYPE_ATTR    = "auth_type"
     DEFAULT_AUTH_TYPE = "default"
+    CONNECTION_ATTRS  = %w(connection_configurations).freeze
     ENDPOINT_ATTRS    = %w(hostname ipaddress port security_protocol).freeze
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"]
 
@@ -134,7 +135,7 @@ class ApiController
 
     def fetch_provider_data(provider_klass, data, options = {})
       provider_data = data.except(*RESTRICTED_ATTRS)
-      invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys - ENDPOINT_ATTRS
+      invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys - ENDPOINT_ATTRS - CONNECTION_ATTRS
       raise BadRequestError, "Invalid Provider attributes #{invalid_keys.join(', ')} specified" if invalid_keys.present?
 
       specify_zone(provider_data, data, options)


### PR DESCRIPTION
**Description** 
Add the `connection_configurations` optional attribute to the providers api POST method.

**Bugzilla**
https://bugzilla.redhat.com/show_bug.cgi?id=1355750
https://bugzilla.redhat.com/show_bug.cgi?id=1355785 

**Issue**
https://github.com/ManageIQ/manageiq/issues/9506

**Screenshots**
![post-providers](https://cloud.githubusercontent.com/assets/2181522/17206259/8927b96a-54b7-11e6-89b8-d813ba212718.jpg)

**Notes**
To do GET for the multiple endpoints and authentication users can do:
`http://<cfme-server-url>/api/providers/<id>?attributes=authentications,endpoints`