### PR TITLE
make reason for unsupported feature a keyword arg

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -5,15 +5,15 @@ module SupportsFeatureMixin
   #   class Post
   #     include SupportsFeatureMixin
   #     supports :publish
-  #     supports_not :fake, "We keep it real"
+  #     supports_not :fake, :reason => 'We keep it real'
   #     supports :archive do
-  #       unsupported_reason_add(:archive) = "Its too good" if featured?
+  #       unsupported_reason_add(:archive, 'Its too good') if featured?
   #     end
   #   end
   #
   # To make a feature conditionally supported, pass a block to the +supports+ method.
   # The block is evaluated in the context of the instance.
-  # If you call the private method +unsupported_reason_add+ whith the feature
+  # If you call the private method +unsupported_reason_add+ with the feature
   # and a reason, then the feature will be unsupported and the reason will be
   # accessible through
   #
@@ -28,6 +28,9 @@ module SupportsFeatureMixin
   #   Post.new(featured: true).supports_archive?   # => false
   #
   # To get a reason why a feature is unsupported use the +unsupported+ method
+  # Note: Because providing a reason for an unsupported feature is optional, you should
+  #       not rely on checking the reason to be nil for a feature to be unsupported.
+  #       You have to use +supports_feature?+
   #
   #   Post.unsupported_reason(:publish)                     # => nil
   #   Post.unsupported_reason(:fake)                        # => "We keep it real"
@@ -74,7 +77,7 @@ module SupportsFeatureMixin
       send(:define_supports_methods, feature, true, &block)
     end
 
-    def supports_not(feature, reason = nil)
+    def supports_not(feature, reason: nil)
       send(:define_supports_methods, feature, false, reason)
     end
 

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -2,7 +2,7 @@ module VmOrTemplate::Operations::Relocation
   extend ActiveSupport::Concern
 
   included do
-    supports_not :live_migrate, _("Live Migrate VM Operation is not available for VM or Template.")
+    supports_not :live_migrate, :reason => _("Live Migrate VM Operation is not available for VM or Template.")
   end
 
   def raw_live_migrate(_options = nil)

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -14,7 +14,8 @@ describe SupportsFeatureMixin do
 
       included do
         supports :archive
-        supports_not :fake, "We keep it real!"
+        supports_not :delete
+        supports_not :fake, :reason => 'We keep it real!'
       end
     end)
 
@@ -28,7 +29,7 @@ describe SupportsFeatureMixin do
 
       included do
         supports :fake do
-          unsupported_reason_add(:fake, "Need more money") unless bribe
+          unsupported_reason_add(:fake, 'Need more money') unless bribe
         end
       end
     end)
@@ -86,7 +87,7 @@ describe SupportsFeatureMixin do
       expect(Post.supports_fake?).to be false
     end
 
-    it "#supports_feature? is true" do
+    it "#supports_feature? is false" do
       expect(Post.new.supports_fake?).to be false
     end
 
@@ -96,6 +97,24 @@ describe SupportsFeatureMixin do
 
     it ".unsupported_reason(:feature) returns a reason" do
       expect(Post.unsupported_reason(:fake)).to eq "We keep it real!"
+    end
+  end
+
+  context "for an unsupported feature without a reason" do
+    it ".supports_feature? is false" do
+      expect(Post.supports_delete?).to be false
+    end
+
+    it "#supports_feature? is false" do
+      expect(Post.new.supports_delete?).to be false
+    end
+
+    it "#unsupported_reason(:feature) returns no reason" do
+      expect(Post.new.unsupported_reason(:delete)).to be_nil
+    end
+
+    it ".unsupported_reason(:feature) returns no reason" do
+      expect(Post.unsupported_reason(:delete)).to be_nil
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
this reads better and is more aligned with the way rails
does DSL style class methods

Before:
`supports_not :feature, 'because'`

Now:
`supports_not :feature, :reason => 'because'`

props to @chrisarcand for suggesting this

@miq-bot add_label refactoring, darga/no
@miq-bot assign Fryguy 