### PR TITLE
Fix styling bug in menu editor

### DIFF
--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -8,7 +8,12 @@ textarea { width: 98.5%; border: 1px solid #d1d1d1; padding: 7px; line-height: 1
   opacity:0.4 !important;
   filter:alpha(opacity=40);
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
-  cursor: default;
+}
+
+/* disables mouse events on disabled/blocked DIVS */
+
+div.disabled {
+  pointer-events: none;
 }
 
 /* end modified Patternfly code */
@@ -154,9 +159,6 @@ img.timeline-event-bubble-image { width: 64px; height: 64px;}
   border: 1px solid #999;
   background:#f0f0f0;
 }
-
-fieldset.role_list{ width:400px; height: 450px;}
-div.role_list { margin: 0 0 0 44px;width:400px; height:400px;}
 
 /*Lightbox background */
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -768,7 +768,8 @@ class ReportController < ApplicationController
         end
         presenter.update(:main_div, r[:partial => partial])
         presenter[:element_updates][:menu1_legend] = {:legend => fieldset_title}
-        presenter.show(:menu_div1, :treeStatus).hide(:menu_div2, :flash_msg_div_menu_list)
+        presenter.addClass(:menu_roles_treebox, 'disabled')
+        presenter.show(:menu_div1).hide(:menu_div2, :flash_msg_div_menu_list)
         presenter[:element_updates][:folder_top]      = {:title => img_title_top}
         presenter[:element_updates][:folder_up]       = {:title => img_title_up}
         presenter[:element_updates][:folder_down]     = {:title => img_title_down}
@@ -783,19 +784,21 @@ class ReportController < ApplicationController
         unless @sb[:role_list_flag]
           # we dont need to show the overlay on first time load
           @sb[:role_list_flag] = true
-          presenter.show(:treeStatus)
+          presenter.addClass(:menu_roles_treebox, 'disabled')
         end
         presenter.hide(:menu_div1, :menu_div2).show(:menu_div3)
       end
     elsif nodetype == "menu_default" || nodetype == "menu_reset"
       presenter.update(:main_div, r[:partial => partial])
       presenter.replace(:menu_div1, r[:partial => "menu_form1", :locals => {:folders => @grid_folders}])
-      presenter.hide(:menu_div1, :menu_div2).show(:menu_div3).hide(:treeStatus)
+      presenter.removeClass(:menu_roles_treebox, 'disabled')
+      presenter.hide(:menu_div1, :menu_div2).show(:menu_div3)
       # set changed to true if menu has been set to default
       session[:changed] = @sb[:menu_default] ? true : (@edit[:new] != @edit[:current])
     elsif nodetype == "menu_edit_reports"
       presenter.replace(:flash_msg_div_menu_list, r[:partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}]) if @flash_array
-      presenter.show(:menu_div1, :treeStatus)
+      presenter.addClass(:menu_roles_treebox, 'disabled')
+      presenter.show(:menu_div1)
       presenter.replace(:menu_div2, r[:partial => "menu_form2"])
       presenter.hide(:menu_div1, :menu_div3).show(:menu_div2)
     elsif nodetype == "menu_commit_reports"
@@ -816,7 +819,7 @@ class ReportController < ApplicationController
         else
           presenter.hide(:menu_div1, :menu_div3).show(:menu_div2)
         end
-        presenter.hide(:treeStatus)
+        presenter.removeClass(:menu_roles_treebox, 'disabled')
       end
     elsif nodetype == 'menu_commit_folders'
       # Hide flash_msg if it's being shown from New folder add event
@@ -831,13 +834,15 @@ class ReportController < ApplicationController
         presenter.show(:menu_div1).hide(:menu_div2, :menu_div3)
       else
         presenter.replace(:menu_roles_div, r[:partial => "role_list"])
-        presenter.hide(:menu_div1, :menu_div2).show(:menu_div3).hide(:treeStatus)
+        presenter.removeClass(:menu_roles_treebox, 'disabled')
+        presenter.hide(:menu_div1, :menu_div2).show(:menu_div3)
       end
       @sb[:tree_err] = false
     elsif nodetype == 'menu_discard_folders' || nodetype == 'menu_discard_reports'
       presenter.replace(:flash_msg_div_menu_list, r[:partial => 'layouts/flash_msg', :locals => {:div_num => '_menu_list'}])
       presenter.replace(:menu_div1,               r[:partial => 'menu_form1', :locals => {:folders => @grid_folders}])
-      presenter.hide(:menu_div1, :menu_div2).show(:menu_div3).hide(:treeStatus)
+      presenter.removeClass(:menu_roles_treebox, 'disabled')
+      presenter.hide(:menu_div1, :menu_div2).show(:menu_div3)
     end
 
     if x_active_tree == :roles_tree && x_node != "root"

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -42,12 +42,16 @@ class ExplorerPresenter
   #   element_updates           -- do we need all 3 of the above?
   #   set_visible_elements      -- elements to cal 'set_visible' on
   #   reload_toolbars
+  #   add_element_class         -- add class to div/element
+  #   remove_element_class      -- remove class from div/element
   #
 
   def initialize(options = {})
     @options = {
       :lock_unlock_trees    => {},
       :set_visible_elements => {},
+      :add_element_class    => {},
+      :remove_element_class => {},
       :update_partials      => {},
       :element_updates      => {},
       :replace_partials     => {},
@@ -95,6 +99,14 @@ class ExplorerPresenter
 
   def show(*elements)
     set_visibility(true, *elements)
+  end
+
+  def addClass(el, cls)
+    @options[:add_element_class][el] = cls
+  end
+
+  def removeClass(el,cls)
+    @options[:remove_element_class][el] = cls
   end
 
   def reload_toolbars(toolbars)
@@ -234,6 +246,14 @@ class ExplorerPresenter
 
     if @options[:focus]
       @out << "if ($('##{@options[:focus]}').length) $('##{@options[:focus]}').focus();"
+    end
+
+    @options[:add_element_class].each do |el, cls|
+      @out << "$('##{el}').addClass('#{cls}');"
+    end
+
+    @options[:remove_element_class].each do |el, cls|
+      @out << "$('##{el}').removeClass('#{cls}');"
     end
 
     @out << "$('#clear_search').#{@options[:clear_search_show_or_hide]}();" if @options[:clear_search_show_or_hide]

--- a/app/views/report/_menu_form1.html.haml
+++ b/app/views/report/_menu_form1.html.haml
@@ -1,6 +1,6 @@
 #menu_div1
   - url = url_for(:action => 'menu_field_changed')
-  %fieldset
+  .col-sm-7
     %h3
       %span#menu1_legend
         = _('Manage Accordions')
@@ -74,11 +74,11 @@
                 = _('Discard')
 
 #menu_div3{:style => "display: none;"}
-  %fieldset{:style => "width: 300px; height: 450px;"}
+  .col-sm-7
     %h3
       = _('Manage Accordions & Folders')
     %table{:cellspacing => "1"}
       %tr
         %td{:align => "left"}
           %span{:style => "color: #4b4b4b; font-size: 14px; font-weight: bold; line-height: 22px;"}
-            = _("Please select a node at left to edit.")
+            = _("Please select a node from the tree to edit.")

--- a/app/views/report/_menu_form2.html.haml
+++ b/app/views/report/_menu_form2.html.haml
@@ -1,7 +1,7 @@
 #menu_div2
   - if @selected && @selected[1] && (!@edit[:selected_reports].blank? || !@edit[:available_reports].blank?)
     - url = url_for(:action => 'menu_field_changed')
-    %fieldset{:style => "height: 450px;"}
+    .col-sm-6
       %h3
         = _('Manage Reports')
       #column_lists
@@ -18,10 +18,10 @@
               = select_tag('available_reports[]',
                 options_for_select(@edit[:available_reports].sort),
                 :multiple => true,
-                :style    => "width: 280px; height: 310px;",
+                :style    => "height: 310px;",
                 :id       => "available_reports")
 
-            %td.text-center{:width => "40"}
+            %td.text-center
               .btn-group-vertical
 
                 - if @edit[:available_reports].empty?
@@ -106,7 +106,7 @@
               = select_tag('selected_reports[]',
                 options_for_select(@edit[:selected_reports], @selected_reps),
                 :multiple => true,
-                :style    => "width: 280px; height: 310px;",
+                :style    => "height: 310px;",
                 :id       => "selected_reports")
           %tr
             %td{:colspan => "3", :align => "right"}

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -2,36 +2,30 @@
   - if @sb[:active_accord] == :roles
     - if @menu_roles_tree
       = render :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}
-      %table
-        %tr
-          %td{:valign => "top", :width => "315"}
-            %fieldset.role_list
-              %h3
-                = _("Reports")
-              .role_list.flobj
-              #menu_roles_treebox.flobj{:style => "width: 280px; height: 370px; margin-right: 30px;"}
-              #treeStatus.flobj{:style => "display: none;"}
-                %div{:style => "background-color: rgba(255, 255, 255, 0.5); height: 370px; width:270px"}
-            = render(:partial => "layouts/dynatree",
-              :locals         => {:tree_id => 'menu_roles_treebox',
-                :tree_name                 => 'menu_roles_tree',
-                :json_tree                 => @menu_roles_tree,
-                :id_prefix                 => 'menu_roles_',
-                :click_url                 => '/report/menu_editor/',
-                :onclick                   => 'miqMenuEditor',
-                :div_width                 => '216px',
-                :div_height                => '328px',
-                :div_cursor                => 'hand',
-                :exp_tree                  => false,
-                :no_base_exp               => false,
-                :base_id                   => "b__Report Menus for #{session[:role_choice]}",
-                :highlighting              => true,
-                :cookie_id_prefix          => "edit_treeOpenStatex",
-                :tree_state                => true,
-                :multi_lines               => true})
-          %td{:valign => "top"}
-            = render :partial => "report/menu_form1", :locals => {:folders => @grid_folders}
-            = render :partial => "report/menu_form2"
+      .col-sm-5
+        %h3
+          = _("Reports")
+        #menu_roles_treebox{:style => "overflow-y: hidden !important;"}
+      = render(:partial => "layouts/dynatree",
+        :locals         => {:tree_id => 'menu_roles_treebox',
+          :tree_name                 => 'menu_roles_tree',
+          :json_tree                 => @menu_roles_tree,
+          :id_prefix                 => 'menu_roles_',
+          :click_url                 => '/report/menu_editor/',
+          :onclick                   => 'miqMenuEditor',
+          :div_width                 => '216px',
+          :div_height                => '328px',
+          :div_cursor                => 'hand',
+          :exp_tree                  => false,
+          :no_base_exp               => false,
+          :base_id                   => "b__Report Menus for #{session[:role_choice]}",
+          :highlighting              => true,
+          :cookie_id_prefix          => "edit_treeOpenStatex",
+          :tree_state                => true,
+          :multi_lines               => true})
+
+      = render :partial => "report/menu_form1", :locals => {:folders => @grid_folders}
+      = render :partial => "report/menu_form2"
     - elsif @sb[:menu]
       = render :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}
       - if @sb[:menu].empty?


### PR DESCRIPTION
The fix allows the Reports tree in the Menu Editor to expand fully by replacing the fieldsets and sized DIVs with responsive columns.

https://bugzilla.redhat.com/show_bug.cgi?id=1346765

Old
<img width="1161" alt="screen shot 2016-07-07 at 9 46 53 am" src="https://cloud.githubusercontent.com/assets/1287144/16655384/0ec5c45e-4428-11e6-8be0-1f6053e7df7a.png">

New
<img width="1045" alt="screen shot 2016-07-07 at 9 47 49 am" src="https://cloud.githubusercontent.com/assets/1287144/16655385/0ec9dbd4-4428-11e6-914e-280cedb7aed3.png">