### PR TITLE
Add SupportsFeatureMixin to Provider::BaseManager

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -2,6 +2,8 @@ module ManageIQ::Providers
   class BaseManager < ExtManagementSystem
     require_nested :Refresher
 
+    include SupportsFeatureMixin
+
     def self.metrics_collector_queue_name
       self::MetricsCollectorWorker.default_queue_name
     end


### PR DESCRIPTION
this is not added to ExtManagementSystem because the long term
goal is to remove that class. This way we can spot occurances
in the code, where it still gets called.

It's required by https://github.com/ManageIQ/manageiq-providers-amazon/pull/16 and https://github.com/ManageIQ/manageiq/pull/8351
Unfortunately it can't be included in either of both PRs, because they have a cyclic dependency :unamused: 

@miq-bot add_label darga/no, providers, refactoring