### PR TITLE
[Darga] Fix API request specs

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -610,6 +610,14 @@
     - :collection
     :methods: *70174834086080
     :klass: MiqRequest
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show
   :resource_actions:
     :description: Resource Actions
     :options:

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -135,6 +135,7 @@ describe ApiController do
 
     it "query Requests" do
       FactoryGirl.create(:vm_migrate_request, :requester => @user)
+      api_basic_authorize collection_action_identifier(:requests, :read, :get)
       test_collection_query(:requests, requests_url, MiqRequest)
     end
 


### PR DESCRIPTION
(cherry picked from commit b4b57c4)

The request specs are broken because they depended on the above commit, which is not present in Darga.

@miq-bot assign @gtanzillo 
/cc @chessbyte 