### PR TITLE
Refactor API spec helper expect_bad_request

### DIFF
--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -172,10 +172,8 @@ module ApiSpecHelper
 
   # Rest API Expects
 
-  def expect_bad_request(error_message = nil)
+  def expect_bad_request(error_message)
     expect(response).to have_http_status(:bad_request)
-    return if error_message.blank?
-
     expect(response_hash).to have_key("error")
     expect(response_hash["error"]["message"]).to match(error_message)
   end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -173,8 +173,8 @@ module ApiSpecHelper
   # Rest API Expects
 
   def expect_bad_request(error_message)
-    expect(response).to have_http_status(:bad_request)
     expect(response_hash).to include("error" => hash_including("message" => a_string_matching(error_message)))
+    expect(response).to have_http_status(:bad_request)
   end
 
   def expect_result_resources_to_include_data(collection, data)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -174,8 +174,7 @@ module ApiSpecHelper
 
   def expect_bad_request(error_message)
     expect(response).to have_http_status(:bad_request)
-    expect(response_hash).to have_key("error")
-    expect(response_hash["error"]["message"]).to match(error_message)
+    expect(response_hash).to include("error" => hash_including("message" => a_string_matching(error_message)))
   end
 
   def expect_result_resources_to_include_data(collection, data)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -170,10 +170,14 @@ module ApiSpecHelper
     include("actions" => a_collection_including(*names.map { |name| a_hash_including("name" => name) }))
   end
 
+  def include_error_with_message(error_message)
+    include("error" => hash_including("message" => a_string_matching(error_message)))
+  end
+
   # Rest API Expects
 
   def expect_bad_request(error_message)
-    expect(response_hash).to include("error" => hash_including("message" => a_string_matching(error_message)))
+    expect(response_hash).to include_error_with_message(error_message)
     expect(response).to have_http_status(:bad_request)
   end
 


### PR DESCRIPTION
Makes a few changes to:

- Make the error message in this method required, so preferred `have_http_status` is enforced where we're not checking the content of the response
- Refactor the expectations within this method into one for the response body
- Puts the expectation on the response body first for better feedback
- Extracts matcher `include_error_with_message`

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 