### PR TITLE
Fix toolbar filename for the foreman configured system

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -25,6 +25,14 @@ class ProviderForemanController < ApplicationController
     end
   end
 
+  def self.model_to_type_name(provmodel)
+    if provmodel.include?("ManageIQ::Providers::AnsibleTower")
+      'ansible_tower'
+    elsif provmodel.include?("ManageIQ::Providers::Foreman")
+      'foreman'
+    end
+  end
+
   def self.model_to_cs_name(provmodel)
     if provmodel.include?("ManageIQ::Providers::AnsibleTower")
       ui_lookup(:ui_title => 'Ansible Tower Job Template')
@@ -37,6 +45,10 @@ class ProviderForemanController < ApplicationController
 
   def model_to_cs_name(provmodel)
     ProviderForemanController.model_to_cs_name(provmodel)
+  end
+
+  def model_to_type_name(provmodel)
+    ProviderForemanController.model_to_type_name(provmodel)
   end
 
   def index
@@ -396,7 +408,7 @@ class ProviderForemanController < ApplicationController
     end
 
     if @record.kind_of?(ConfiguredSystem)
-      rec_cls = "#{model_to_name(@record.class.to_s).downcase.tr(' ', '_')}_configured_system"
+      rec_cls = "#{model_to_type_name(@record.ext_management_system.class.to_s)}_configured_system"
     end
     return unless %w(download_pdf main).include?(@display)
     @showtype     = "main"


### PR DESCRIPTION
Purpose or Intent
-----------------
Do not use downstream names to refer to the toolbar files for Foreman and Ansible Configured Systems

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1350299

Steps for Testing/QA
--------------------
With productization linked, click on a Foreman Configured Systems 

Clicking on a Sattelite Configured System:

Before:

![screenshot from 2016-07-11 17-12-28](https://cloud.githubusercontent.com/assets/12769982/16747000/f48dc080-478a-11e6-9e84-b2840701fe84.png)

After:
![screenshot from 2016-07-11 17-13-56](https://cloud.githubusercontent.com/assets/12769982/16747014/ff4b1de2-478a-11e6-973f-79a04c9ef92f.png)


