### PR TITLE
Fixed code that sets target_class to fetch records for drop down

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -84,7 +84,7 @@ module ApplicationController::Automate
     end
     if @edit[:new][:target_class]
       @resolve[:new][:target_class] = Hash[*@resolve[:target_classes].flatten][@edit[:new][:target_class]]
-      target_class = @resolve[:target_classes].detect { |ui_name, _| @edit[:new][:target_class] == ui_name }.first
+      target_class = @resolve[:target_classes].detect { |ui_name, _| @edit[:new][:target_class] == ui_name }.last
       targets = target_class.constantize.all
       @resolve[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
       @resolve[:new][:target_id] = nil

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -96,15 +96,7 @@ module MiqAeCustomizationController::CustomButtons
         @resolve[:new][:target_class] = @sb[:target_classes].invert[@nodetype[0].split('-').last]
       else
         # selected button is under assigned folder
-        kls = case @nodetype[1]
-              when "Host"
-                _("Host / Node")
-              when "EmsCluster"
-                _("Cluster / Deployment Role")
-              else
-                @nodetype[1]
-              end
-        @resolve[:new][:target_class] = @sb[:target_classes].invert[kls]
+        @resolve[:new][:target_class] = @sb[:target_classes].invert[@nodetype[1]]
       end
       @right_cell_text = _("Button \"%{name}\"") % {:name => @custom_button.name}
     else                # assigned buttons node/folder

--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -2,19 +2,27 @@ describe MiqAeCustomizationController, "ApplicationController::Automate" do
   context "#resolve" do
     before(:each) do
       set_user_privileges
-    end
-    it "Simulate button from custom buttons should redirect to resolve" do
-      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+      @custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
       target_classes = {}
       CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
       resolve = {
-        :new            => {:target_class => custom_button.applies_to_class},
-        :target_classes => target_classes
+        :new            => {:target_class => "Host / Node"},
+        :target_classes => Array(target_classes.invert).sort
       }
       session[:resolve] = resolve
       controller.instance_variable_set(:@resolve, resolve)
-      post :resolve, :params => { :button => "simulate", :id => custom_button.id }
+    end
+
+    it "Simulate button from custom buttons should redirect to resolve" do
+      post :resolve, :params => {:button => "simulate", :id => @custom_button.id}
       expect(response.body).to include("miq_ae_tools/resolve?escape=false&simulate=simulate")
+    end
+
+    it "targets should be set correctly when simulate button is pressed from custom button summary screen" do
+      host = FactoryGirl.create(:host)
+      expect(controller).to receive(:render)
+      controller.send(:resolve_button_simulate)
+      expect(assigns(:resolve)[:targets]).to eq([[host.name, host.id.to_s]])
     end
   end
 end

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -7,10 +7,10 @@ describe MiqAeCustomizationController do
       it "correct target class gets set when assigned button node is clicked" do
         custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host", :name => "Some Name")
         target_classes = {}
-        CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
+        CustomButton.button_classes.each { |db| target_classes[ui_lookup(:model => db)] = db }
         controller.instance_variable_set(:@sb, :target_classes => target_classes)
         controller.send(:ab_get_node_info, "xx-ab_Host_cbg-10r95_cb-#{custom_button.id}")
-        expect(assigns(:resolve)[:new][:target_class]).to eq("Host")
+        expect(assigns(:resolve)[:new][:target_class]).to eq("Host / Node")
       end
     end
   end


### PR DESCRIPTION
- Fixed code that sets target_class to fetch records for drop down, target_class was incorrectly being set to "Host / Node" which led to failure while trying to do target_class.constantize
- Also fixed code to set @resolve[:new][:target_class] correctly to display value of Type field correctly in Object Attributes box on Assigned custom button summary screen, this broke with changes to show "Host /Node" & "Cluster / Deployment Role" for EmsCluster/Host CIs. Worked fine for other CIs
- Adjusted existing spec test and added a new spec test to verify fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1352818

@dclarizio please review.

screenshot below shows value of Type field being displayed correctly for Assigned "Cluster / Deployment Role" custom button.

before:
![before](https://cloud.githubusercontent.com/assets/3450808/16662497/ed748286-4445-11e6-993e-217441065fd0.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/16662481/d6d43724-4445-11e6-89c1-56eb4e3df58e.png)
