### PR TITLE
Fix inconsistent Normal Operating Range values

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -771,16 +771,16 @@ module VmHelper::TextualSummary
 
   def textual_normal_operating_ranges_cpu
     h = {:label => _("CPU"), :value => []}
-    [:high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
+    [:max, _("Max"), :high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
       value = @record.send("cpu_usagemhz_rate_average_#{key}_over_time_period")
-      h[:value] << {:label => label, :value => (value.nil? ? _("Not Available") : mhz_to_human_size(value))}
+      h[:value] << {:label => label, :value => (value.nil? ? _("Not Available") : mhz_to_human_size(value, 2))}
     end
     h
   end
 
   def textual_normal_operating_ranges_cpu_usage
     h = {:label => _("CPU Usage"), :value => []}
-    [:high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
+    [:max, _("Max"), :high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
       value = @record.send("max_cpu_usage_rate_average_#{key}_over_time_period")
       h[:value] << {:label => label,
                     :value => (value.nil? ? _("Not Available") : number_to_percentage(value, :precision => 2))}
@@ -790,7 +790,7 @@ module VmHelper::TextualSummary
 
   def textual_normal_operating_ranges_memory
     h = {:label => _("Memory"), :value => []}
-    [:high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
+    [:max, _("Max"), :high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
       value = @record.send("derived_memory_used_#{key}_over_time_period")
       h[:value] << {:label => label,
                     :value => (value.nil? ? _("Not Available") : number_to_human_size(value.megabytes,
@@ -801,7 +801,7 @@ module VmHelper::TextualSummary
 
   def textual_normal_operating_ranges_memory_usage
     h = {:label => _("Memory Usage"), :value => []}
-    [:high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
+    [:max, _("Max"), :high, _("High"), :avg, _("Average"), :low, _("Low")].each_slice(2) do |key, label|
       value = @record.send("max_mem_usage_absolute_average_#{key}_over_time_period")
       h[:value] << {:label => label,
                     :value => (value.nil? ? _("Not Available") : number_to_percentage(value, :precision => 2))}

--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -14,6 +14,8 @@
           = _("High")
         %th
           = _("Average")
+        %th
+          = _("Low")
     %tbody
       %tr
         %td= _('CPU')
@@ -30,6 +32,11 @@
         %td
           - if @record.cpu_usagemhz_rate_average_avg_over_time_period
             = mhz_to_human_size(@record.cpu_usagemhz_rate_average_avg_over_time_period, 2)
+          - else
+            = notavail
+        %td
+          - if @record.cpu_usagemhz_rate_average_low_over_time_period
+            = mhz_to_human_size(@record.cpu_usagemhz_rate_average_low_over_time_period, 2)
           - else
             = notavail
       %tr
@@ -49,6 +56,11 @@
             = number_to_percentage(@record.max_cpu_usage_rate_average_avg_over_time_period, :precision => 2)
           - else
             = notavail
+        %td
+          - if @record.max_cpu_usage_rate_average_low_over_time_period
+            = number_to_percentage(@record.max_cpu_usage_rate_average_low_over_time_period, :precision => 2)
+          - else
+            = notavail
       %tr
         %td= _("Memory")
         %td
@@ -66,6 +78,11 @@
             = number_to_human_size(@record.derived_memory_used_avg_over_time_period * 1024 * 1024, :precision => 2)
           - else
             = notavail
+        %td
+          - if @record.derived_memory_used_low_over_time_period
+            = number_to_human_size(@record.derived_memory_used_low_over_time_period * 1024 * 1024, :precision => 2)
+          - else
+            = notavail
       %tr
         %td= _('Memory Usage')
         %td
@@ -81,6 +98,11 @@
         %td
           - if @record.max_mem_usage_absolute_average_avg_over_time_period
             = number_to_percentage(@record.max_mem_usage_absolute_average_avg_over_time_period, :precision => 2)
+          - else
+            = notavail
+        %td
+          - if @record.max_mem_usage_absolute_average_low_over_time_period
+            = number_to_percentage(@record.max_mem_usage_absolute_average_low_over_time_period, :precision => 2)
           - else
             = notavail
 


### PR DESCRIPTION
Purpose or Intent
-----------------
NOR values displayed on VM Summary pages and Right Size Recomendation pages displayed different columns and the values used varying degrees of precision.

https://bugzilla.redhat.com/show_bug.cgi?id=1305117