### PR TITLE
Fix the  PDF export of Ansible Tower InventoryGroup Summary page

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -229,7 +229,7 @@ class ProviderForemanController < ApplicationController
     @record = if configuration_profile_record?
                 find_record(ConfigurationProfile, id || params[:id])
               elsif inventory_group_record?
-                find_record(InventoryRootGroup, id || params[:id])
+                find_record(ManageIQ::Providers::ConfigurationManager::InventoryGroup, id || params[:id])
               else
                 find_record(ConfiguredSystem, id || params[:id])
               end

--- a/app/views/layouts/_show_pdf.html.haml
+++ b/app/views/layouts/_show_pdf.html.haml
@@ -4,5 +4,7 @@
   = render_quadicon(@record, :mode => :icon, :size => 72)
 - if @record.kind_of?(ConfigurationProfile)
   = render :partial => "#{controller}/main_configuration_profile"
+- elsif @record.kind_of?(ManageIQ::Providers::ConfigurationManager::InventoryGroup)
+  = render :partial => "#{controller}/main_inventory_group"
 - else
   = render :partial => "#{controller}/main"


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix the  PDF export of Ansible Tower InventoryGroup Summary page

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1350311

Steps for Testing/QA
--------------------
The Pdf generator Prince package is required to reproduce this.


Before:

![screenshot from 2016-07-11 16-43-03](https://cloud.githubusercontent.com/assets/12769982/16746322/d033bb3e-4787-11e6-9b5f-7e423ac3c63e.png)


After: 
![screenshot from 2016-07-11 16-51-47](https://cloud.githubusercontent.com/assets/12769982/16746331/d9e2bbee-4787-11e6-8c92-00a04201d56b.png)
