### PR TITLE
Improve handling of datastores with different ems_refs when provisioning

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -105,11 +105,13 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
 
     [:transform, :config, :customization, :linked_clone].each { |key| vim_clone_options[key] = clone_options[key] }
 
-    [:folder, :host, :datastore, :pool, :snapshot].each do |key|
+    [:folder, :host, :pool, :snapshot].each do |key|
       ci = clone_options[key]
       next if ci.nil?
       vim_clone_options[key] = ci.ems_ref_obj
     end
+
+    vim_clone_options[:datastore] = clone_options[:host].host_storages.find_by(:storage_id => clone_options[:datastore].id).ems_ref
 
     task_mor = clone_vm(vim_clone_options)
     _log.info("Provisioning completed for [#{vim_clone_options[:name]}] from source [#{source.name}]") if MiqProvision::CLONE_SYNCHRONOUS

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -736,7 +736,8 @@ module ManageIQ::Providers
 
           result << {
             :storage   => storage_uids[s_mor],
-            :read_only => read_only
+            :read_only => read_only,
+            :ems_ref   => s_mor
           }
         end
 

--- a/db/migrate/20160701134322_add_ems_ref_to_host_storages.rb
+++ b/db/migrate/20160701134322_add_ems_ref_to_host_storages.rb
@@ -1,0 +1,5 @@
+class AddEmsRefToHostStorages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :host_storages, :ems_ref, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1338,6 +1338,7 @@ host_storages:
 - host_id
 - read_only
 - id
+- ems_ref
 host_switches:
 - id
 - host_id


### PR DESCRIPTION
Purpose or Intent
-----------------
When provisioning a VM you must provide the destination datastore's MOR in the VMware task, there are situations where the same storage will have different MORs (e.g.: same storage 2 datacenters, or same storage 2 vCenters), but we only store 1 ems_ref for a storage.

This leads to situations where provisioning tries to use the wrong MOR and the task will fail (classic `The object has been deleted or has not been completely created` error).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1280402

This change adds an ems_ref to the host-storage relationship make sure that the correct MOR is used.  A host can only be in 1 datacenter so this ensures that the correct datastore MOR will be used for provisioning to that host.


Steps for Testing/QA
--------------------

1. Mount the same NFS share to hosts in two datacenters
2. Use the ManagedObjectBrowser (`https://vc_ip_addr/mob`) to confirm the different MORs
3. Run inventory refresh
4. Confirm 1 Storage record is created and two HostStorage records with different ems_refs
