### PR TITLE
Add blueprint column to service_templates

### DIFF
--- a/db/migrate/20160707145200_add_blueprint_to_service_template.rb
+++ b/db/migrate/20160707145200_add_blueprint_to_service_template.rb
@@ -1,0 +1,6 @@
+class AddBlueprintToServiceTemplate < ActiveRecord::Migration[5.0]
+  def change
+    add_column :service_templates, :blueprint, :string
+    add_index  :service_templates, :blueprint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6045,6 +6045,7 @@ service_templates:
 - service_template_catalog_id
 - long_description
 - tenant_id
+- blueprint
 services:
 - id
 - name


### PR DESCRIPTION
Purpose or Intent
-----------------
Add `blueprint` column to `service_templates`. It is a string type with possible values:
- nil
- draft
- v### (published blueprint with a version number)
- internal (sub-items belonging to a blueprint)

Model changes will be included in a follow-up PR.