### PR TITLE
Fixed typo in root_device_type check

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
@@ -12,7 +12,7 @@ if vm
   $evm.log('info', "Instance:<#{vm.name}> on EMS:<#{ems.try(:name)} has Power State:<#{power_state}>")
 
   # If VM is powered off or this instance is running on an instance store
-  if %w(off suspended terminated).include?(power_state) || vm.hardware.root_device_type == "instance_store"
+  if %w(off suspended terminated).include?(power_state) || vm.hardware.root_device_type == "instance-store"
     # Bump State
     $evm.root['ae_result'] = 'ok'
   elsif power_state == "never"

--- a/spec/automation/unit/method_validation/amazon_check_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/amazon_check_pre_retirement_spec.rb
@@ -1,0 +1,55 @@
+describe "amazon_check_pre_retirement Method Validation" do
+  let(:user) do
+    FactoryGirl.create(:user_with_group)
+  end
+
+  let(:method) do
+    "/Cloud/VM/Retirement/StateMachines/Methods/CheckPreRetirement"
+  end
+
+  let(:method_url) do
+    "#{method}?Vm::vm=#{vm.id}#amazon"
+  end
+
+  let(:ems) do
+    FactoryGirl.create(:ems_vmware, :zone => zone)
+  end
+
+  let(:zone) do
+    FactoryGirl.create(:zone)
+  end
+
+  let(:vm) do
+    FactoryGirl.create(:vm_amazon, :ems_id => ems.id)
+  end
+
+  let(:ebs_hardware) do
+    FactoryGirl.create(:hardware, :bitness             => 64,
+                                  :virtualization_type => 'paravirtual',
+                                  :root_device_type    => 'ebs')
+  end
+
+  let(:is_hardware) do
+    FactoryGirl.create(:hardware, :bitness             => 64,
+                                  :virtualization_type => 'paravirtual',
+                                  :root_device_type    => 'instance-store')
+  end
+
+  let(:ws) do
+    MiqAeEngine.instantiate(method_url, user)
+  end
+
+  it "instance-store instance ae_result should be ok" do
+    vm.hardware = is_hardware
+    vm.update_attribute(:raw_power_state, "running")
+
+    expect(ws.root['ae_result']).to eq("ok")
+  end
+
+  it "ebs instance ae_result should be retry" do
+    vm.hardware = ebs_hardware
+    vm.update_attribute(:raw_power_state, "running")
+
+    expect(ws.root['ae_result']).to eq("retry")
+  end
+end

--- a/spec/automation/unit/method_validation/amazon_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/amazon_pre_retirement_spec.rb
@@ -8,7 +8,7 @@ describe "amazon_pre_retirement Method Validation" do
                                                   :root_device_type    => 'ebs')
     @is_hardware  = FactoryGirl.create(:hardware, :bitness             => 64,
                                                   :virtualization_type => 'paravirtual',
-                                                  :root_device_type    => 'instance_store')
+                                                  :root_device_type    => 'instance-store')
     @vm   = FactoryGirl.create(:vm_amazon,
                                :name => "testVM", :raw_power_state => "running", :ems_id => @ems.id,
                                :registered => true)


### PR DESCRIPTION
Purpose or Intent
-----------------
> The automate method amazon_check_pre_retirement was trying to check the root_device_type with an incorrect value instance_store instead of instance-store. Causing the method to be stuck in a retry loop. Amazon instances which where on the "instance-store" could not be retired because of this issue.


Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1353632
>


Steps for Testing/QA
--------------------
Please ensure that the Amazon instance is on an instance store and not an ebs store. The following instance types use instance stores

["m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge", "g2.2xlarge", "g2.8xlarge", "r3.large", "r3.xlarge", "r3.2xlarge", "r3.4xlarge", "r3.8xlarge", "i2.xlarge", "i2.2xlarge", "i2.4xlarge", "i2.8xlarge", "d2.xlarge", "d2.2xlarge", "d2.4xlarge", "d2.8xlarge", "x1.32xlarge", "m1.small", "m1.medium", "m1.large", "m1.xlarge", "c1.medium", "c1.xlarge", "cc2.8xlarge", "cg1.4xlarge", "m2.xlarge", "m2.2xlarge", "m2.4xlarge", "cr1.8xlarge", "hi1.4xlarge", "hs1.8xlarge", "cc1.4xlarge"]

The following instance types use ebs store

["t2.nano", "t2.micro", "t2.small", "t2.medium", "t2.large", "m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge", "t1.micro"]
