### PR TITLE
Initialize data type for TextBox field to be string by default.

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -890,6 +890,11 @@ module MiqAeCustomizationController::Dialogs
       @edit[:field_default_value] = key[:default_value] = nil
     end
 
+    # initialize data type for textbox
+    if params[:field_typ] == 'TextBox'
+      @edit[:field_data_typ] = key[:data_typ] = "string"
+    end
+
     @edit[:field_values] ||= key[:values] = []
 
     copy_field_param.call(:entry_point)


### PR DESCRIPTION
Data type for TextBox field was being set to to nil by default, this was causing validation issues when dialog was submitted.

https://bugzilla.redhat.com/show_bug.cgi?id=1319781
https://bugzilla.redhat.com/show_bug.cgi?id=1348638

@dclarizio please review. This PR initializes default data type for TextBox field to string, prior to this change field type was being set to nil but UI was showing "Integer" as selected in the pull down because that was the first entry in the pull down. @bzwei suggested that string should be the default data type for TextBox fields.

validation message after the fix
![after](https://cloud.githubusercontent.com/assets/3450808/16670176/01c9c3ce-4467-11e6-9a26-edc51ee6578c.png)

