### PR TITLE
Move legend in C3 charts to the right

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1693,8 +1693,8 @@ function chartData(type, data, data2) {
       data.tooltip.format =  { title: function (x) { return tooltips[x]; }}
     }
   }
-
-  return _.defaultsDeep({}, data, config, data2);
+ var ret = _.defaultsDeep({}, data, config, data2);
+  return ret;
 }
 
 $(function () {

--- a/app/assets/javascripts/miq_c3_config.js
+++ b/app/assets/javascripts/miq_c3_config.js
@@ -128,6 +128,7 @@
         axis : {x:{type: 'category'},
                        rotated: true},
         data : {type: 'bar'},
+        legend: { show: true, position: 'right'}
       }, c3mixins.pfColorPattern,
       $().c3ChartDefaults().getDefaultGroupedBarConfig()
     ),
@@ -136,6 +137,7 @@
       {
         axis : {x:{type: 'category'}},
         data : {type: 'bar'},
+        legend: { show: true, position: 'right'}
       }, c3mixins.pfColorPattern,
       $().c3ChartDefaults().getDefaultGroupedBarConfig()
     ),
@@ -162,6 +164,7 @@
       {
         axis : {x:{type: 'category'}},
         data : {type: 'line'},
+        legend: { show: true, position: 'right'}
       }, c3mixins.pfColorPattern,
       $().c3ChartDefaults().getDefaultLineConfig()
     ),
@@ -169,6 +172,7 @@
       {
         axis : {x:{type: 'category'}},
         data : {type: 'area'},
+        legend: { show: true, position: 'right'}
       }, c3mixins.pfColorPattern,
       $().c3ChartDefaults().getDefaultAreaConfig()
     ),
@@ -176,6 +180,7 @@
      {
        axis : {x:{type: 'category'}},
        data : {type: 'area'},
+       legend: { show: true, position: 'right'}
      }, c3mixins.pfColorPattern,
      $().c3ChartDefaults().getDefaultAreaConfig()
    ),

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -77,6 +77,9 @@ module ReportFormatter
 
       # C&U chart
       if graph_options[:chart_type] == :performance
+        unless mri.graph[:type] == 'Donut' || mri.graph[:type] == 'Pie'
+          mri.chart[:legend] = {:position => 'bottom'}
+        end
         format, options = javascript_format(mri.graph[:columns][0], nil)
         return unless format
 


### PR DESCRIPTION
Move legend to the right for all charts except C&U line/area charts.
![firefox_screenshot_2016-07-08t07-37-10 671z](https://cloud.githubusercontent.com/assets/9535558/16681129/30d26054-44f3-11e6-816b-27a7aacfdf9e.png)
![firefox_screenshot_2016-07-08t07-37-24 310z](https://cloud.githubusercontent.com/assets/9535558/16681128/30d20b9a-44f3-11e6-8dd6-bb45e409fc16.png)
![firefox_screenshot_2016-07-08t07-37-30 814z](https://cloud.githubusercontent.com/assets/9535558/16681132/30eed4be-44f3-11e6-81a0-f2c787f5a863.png)
![firefox_screenshot_2016-07-08t07-37-36 767z](https://cloud.githubusercontent.com/assets/9535558/16681133/30eee1b6-44f3-11e6-848d-7e548dbf726b.png)
![firefox_screenshot_2016-07-08t07-38-27 679z](https://cloud.githubusercontent.com/assets/9535558/16681135/30f0140a-44f3-11e6-9fc0-88b656ea1eb7.png)
![firefox_screenshot_2016-07-08t07-38-33 630z](https://cloud.githubusercontent.com/assets/9535558/16681130/30e4d3f6-44f3-11e6-874d-96d33439fd94.png)
![firefox_screenshot_2016-07-08t07-38-40 833z](https://cloud.githubusercontent.com/assets/9535558/16681131/30e8ea0e-44f3-11e6-9ea0-9429314c34c9.png)
![firefox_screenshot_2016-07-08t07-38-47 662z](https://cloud.githubusercontent.com/assets/9535558/16681136/30f87596-44f3-11e6-9595-2b7e765e78ca.png)
![firefox_screenshot_2016-07-08t07-38-54 606z](https://cloud.githubusercontent.com/assets/9535558/16681138/3102f318-44f3-11e6-9fd8-de3a90419475.png)
![firefox_screenshot_2016-07-08t07-55-36 015z](https://cloud.githubusercontent.com/assets/9535558/16681137/3101e662-44f3-11e6-9863-2c5e5df4b8ee.png)
![firefox_screenshot_2016-07-08t07-58-25 151z](https://cloud.githubusercontent.com/assets/9535558/16681139/3106d2b2-44f3-11e6-863f-af7e95c001e6.png)

Last chart is related to chart interactivity which is fixed in  #9537.










