### PR TITLE
Change order of dialog fields so entry point is before refresh

### DIFF
--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -59,8 +59,11 @@
   - unless @edit[:field_typ].nil?
     %h3
       = _('Options')
-
     .form-horizontal
+      - if @edit[:field_dynamic] == true
+        = render :partial => 'dialog_field_form_dynamic_options'
+      - else
+        = render :partial => 'dialog_field_form_non_dynamic_options'
       .form-group
         %label.col-md-2.control-label
           = _('Auto Refresh other fields when modified')
@@ -68,11 +71,6 @@
           = check_box_tag('field_trigger_auto_refresh', '1',
                           @edit[:field_trigger_auto_refresh],
                           'data-miq_observe_checkbox' => {:url => url}.to_json)
-
-      - if @edit[:field_dynamic] == true
-        = render :partial => 'dialog_field_form_dynamic_options'
-      - else
-        = render :partial => 'dialog_field_form_non_dynamic_options'
 
   - if @edit[:field_typ] =~ /Drop|Radio/ && !@edit[:field_dynamic]
     = render :partial => 'field_values', :locals => {:entry => nil}

--- a/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
@@ -2,6 +2,14 @@
 
 .form-group
   %label.col-md-2.control-label
+    = _('Entry Point (NS/Cls/Inst)')
+  .col-md-8
+    = text_field_tag('field_entry_point',
+                      @edit[:field_entry_point],
+                      :class => "form-control",
+                      :onFocus => 'miqShowAE_Tree("field_entry_point");')
+.form-group
+  %label.col-md-2.control-label
     = _('Auto refresh')
   .col-md-8
     = check_box_tag('field_auto_refresh', '1',
@@ -24,12 +32,3 @@
       = check_box_tag('field_load_on_init', '1',
                       @edit[:field_load_on_init],
                       'data-miq_observe_checkbox' => {:url => url}.to_json)
-
-.form-group
-  %label.col-md-2.control-label
-    = _('Entry Point (NS/Cls/Inst)')
-  .col-md-8
-    = text_field_tag('field_entry_point',
-                      @edit[:field_entry_point],
-                      :class => "form-control",
-                      :onFocus => 'miqShowAE_Tree("field_entry_point");')

--- a/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
@@ -8,21 +8,6 @@
                       @edit[:field_entry_point],
                       :class => "form-control",
                       :onFocus => 'miqShowAE_Tree("field_entry_point");')
-.form-group
-  %label.col-md-2.control-label
-    = _('Auto refresh')
-  .col-md-8
-    = check_box_tag('field_auto_refresh', '1',
-                    @edit[:field_auto_refresh],
-                    'data-miq_observe_checkbox' => {:url => url}.to_json)
-
-.form-group
-  %label.col-md-2.control-label
-    = _('Show Refresh Button')
-  .col-md-8
-    = check_box_tag('field_show_refresh_button', '1',
-                  @edit[:field_show_refresh_button],
-                  'data-miq_observe_checkbox' => {:url => url}.to_json)
 
 - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
   .form-group
@@ -32,3 +17,18 @@
       = check_box_tag('field_load_on_init', '1',
                       @edit[:field_load_on_init],
                       'data-miq_observe_checkbox' => {:url => url}.to_json)
+.form-group
+  %label.col-md-2.control-label
+    = _('Show Refresh Button')
+  .col-md-8
+    = check_box_tag('field_show_refresh_button', '1',
+                  @edit[:field_show_refresh_button],
+                  'data-miq_observe_checkbox' => {:url => url}.to_json)
+.form-group
+  %label.col-md-2.control-label
+    = _('Auto refresh')
+  .col-md-8
+    = check_box_tag('field_auto_refresh', '1',
+                    @edit[:field_auto_refresh],
+                    'data-miq_observe_checkbox' => {:url => url}.to_json)
+


### PR DESCRIPTION
Order before adding visible: entry point then refresh fields. This PR fixes the changes in order introduced in the visibility add. 
