### PR TITLE
Handle a deleted provider for an existing catalog item edit

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -905,6 +905,7 @@ class MiqRequestWorkflow
   end
 
   def get_ems_respool(node, dh = {}, full_path = "")
+    return if node.nil?
     if node.kind_of?(XmlHash::Element)
       folder = node.attributes[:object]
       if node.name == :ResourcePool
@@ -971,6 +972,7 @@ class MiqRequestWorkflow
 
   def get_ems_metadata_tree(src)
     @ems_metadata_tree ||= begin
+      return if src[:ems].nil?
       st = Time.zone.now
       result = load_ar_obj(src[:ems]).fulltree_arranged(:except_type => "VmOrTemplate")
       ems_metadata_tree_add_hosts_under_clusters!(result)
@@ -1057,7 +1059,7 @@ class MiqRequestWorkflow
   end
 
   def allowed_hosts_obj(_options = {})
-    return [] if (src = resources_for_ui).blank?
+    return [] if (src = resources_for_ui).blank? || src[:ems].nil?
 
     rails_logger('allowed_hosts_obj', 0)
     st = Time.now
@@ -1078,7 +1080,7 @@ class MiqRequestWorkflow
   end
 
   def allowed_storages(_options = {})
-    return [] if (src = resources_for_ui).blank?
+    return [] if (src = resources_for_ui).blank? || src[:ems].nil?
     hosts = src[:host].nil? ? allowed_hosts_obj({}) : [load_ar_obj(src[:host])]
     return [] if hosts.blank?
 

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -185,6 +185,7 @@ describe MiqRequestWorkflow do
     let(:cluster)       { FactoryGirl.create(:ems_cluster, :ems_id => ems.id) }
     let(:ems)           { FactoryGirl.create(:ext_management_system) }
     let(:resource_pool) { FactoryGirl.create(:resource_pool, :ems_id => ems.id) }
+    let(:host)          { FactoryGirl.create(:host, :ems_id => ems.id) }
 
     before { allow_any_instance_of(User).to receive(:get_timezone).and_return("UTC") }
 
@@ -225,6 +226,24 @@ describe MiqRequestWorkflow do
         expect(workflow).to receive(:allowed_ci).with(:respool, [:cluster, :host, :folder], [resource_pool.id])
 
         workflow.allowed_resource_pools
+      end
+    end
+
+    context "#allowed_hosts does not fail for a deleted provider" do
+      it "allowed_hosts with a missing provider" do
+        host
+        allow(workflow).to receive(:get_source_and_targets).and_return(:ems => nil)
+        expect(workflow).to receive(:allowed_ci).with(:host, [:cluster, :respool, :folder], [])
+        workflow.allowed_hosts
+      end
+    end
+
+    context "#allowed_clusters does not fail for a deleted provider" do
+      it "with deleted provider" do
+        cluster
+        allow(workflow).to receive(:get_source_and_targets).and_return(:ems => nil)
+        expect(workflow).to receive(:allowed_ci).with(:cluster, [:respool, :host, :folder], [])
+        workflow.allowed_clusters
       end
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Handle a deleted provider and allow catalogs items created based on it to be edited

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1210541


Steps for Testing/QA
--------------------
Add a catalog item for a VMWare provider  - fill environment details, do not use autoplacement
Delete the provider - then try to display/edit the catalog item 