### PR TITLE
[DARGA] Perf cap u capture infra targets

### DIFF
--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -9,11 +9,7 @@ module Metric::Targets
   end
 
   def self.capture_infra_targets(zone, options)
-    # Preload all of the objects we are going to be inspecting.
-    includes = {:ext_management_systems => {:hosts => {:ems_cluster => :tags, :tags => {}}}}
-    includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
-    includes[:ext_management_systems][:hosts][:vms] = :ext_management_system unless options[:exclude_vms]
-    MiqPreloader.preload(zone, includes)
+    preload_infra_targets_data(zone, options)
     all_hosts = capture_host_targets(zone)
     targets = hosts = only_enabled(all_hosts)
     targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
@@ -58,6 +54,14 @@ module Metric::Targets
     end
 
     targets
+  end
+
+  def self.preload_infra_targets_data(zone, options)
+    # Preload all of the objects we are going to be inspecting.
+    includes = {:ext_management_systems => {:hosts => {:ems_cluster => :tags, :tags => {}}}}
+    includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
+    includes[:ext_management_systems][:hosts][:vms] = :ext_management_system unless options[:exclude_vms]
+    MiqPreloader.preload(zone, includes)
   end
 
   def self.capture_host_targets(zone)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -16,7 +16,7 @@ module Metric::Targets
 
     all_hosts = zone.ext_management_systems.flat_map(&:hosts)
     targets = all_hosts
-    targets += all_hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
+    targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
 
     targets = only_enabled(targets)
     targets += capture_vm_targets(targets, Host, options)
@@ -60,6 +60,14 @@ module Metric::Targets
     end
 
     targets
+  end
+
+  # @param [Host] all hosts that have an ems
+  # disabled hosts are passed in. this may change in the future
+  # @return [Array<Storage>] supported storages
+  # hosts preloaded storages and tags
+  def self.capture_storage_targets(hosts)
+    hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) }
   end
 
   def self.capture_vm_targets(targets, parent_class, options)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -14,8 +14,9 @@ module Metric::Targets
     includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
     MiqPreloader.preload(zone, includes)
 
-    targets = zone.hosts
-    targets += zone.storages.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
+    all_hosts = zone.ext_management_systems.flat_map(&:hosts)
+    targets = all_hosts
+    targets += all_hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
 
     targets = only_enabled(targets)
     targets += capture_vm_targets(targets, Host, options)

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -14,9 +14,7 @@ module Metric::Targets
     includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
     includes[:ext_management_systems][:hosts][:vms] = :ext_management_system unless options[:exclude_vms]
     MiqPreloader.preload(zone, includes)
-
-    # keeping all_hosts around because capture storage targets runs off of all hosts not enabled ones
-    all_hosts = zone.ext_management_systems.flat_map(&:hosts)
+    all_hosts = capture_host_targets(zone)
     targets = hosts = only_enabled(all_hosts)
     targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
     targets += capture_vm_targets(hosts) unless options[:exclude_vms]
@@ -60,6 +58,12 @@ module Metric::Targets
     end
 
     targets
+  end
+
+  def self.capture_host_targets(zone)
+    # keeping all_hosts around because capture storage targets runs off of all hosts and
+    # not just enabled ones. if that changes, then move the filtering into here.
+    zone.ext_management_systems.flat_map(&:hosts)
   end
 
   # @param [Host] all hosts that have an ems

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -15,7 +15,7 @@ module Metric::Targets
     MiqPreloader.preload(zone, includes)
 
     targets = zone.hosts
-    targets += zone.storages.select { |s| Storage::SUPPORTED_STORAGE_TYPES.include?(s.store_type) } unless options[:exclude_storages]
+    targets += zone.storages.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
 
     # If it can and does have a cluster, then ask that, otherwise, ask host itself.
     targets = targets.select do |t|

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -89,6 +89,11 @@ module Metric::Targets
             vm.association(:ems_cluster).target = host.ems_cluster if vm.ems_cluster_id
           end
         end
+        unless options[:exclude_storages]
+          host.storages.each do |storage|
+            storage.ext_management_system = ems
+          end
+        end
       end
     end
   end

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -17,14 +17,17 @@ module Metric::Targets
     targets = zone.hosts
     targets += zone.storages.select { |s| Storage.supports?(s.store_type) } unless options[:exclude_storages]
 
-    # If it can and does have a cluster, then ask that, otherwise, ask host itself.
-    targets = targets.select do |t|
-      t.respond_to?(:ems_cluster) && t.ems_cluster ? t.ems_cluster.perf_capture_enabled? : t.perf_capture_enabled?
-    end
-
+    targets = only_enabled(targets)
     targets += capture_vm_targets(targets, Host, options)
 
     targets
+  end
+
+  def self.only_enabled(targets)
+    # If it can and does have a cluster, then ask that, otherwise, ask host itself.
+    targets.select do |t|
+      t.respond_to?(:ems_cluster) && t.ems_cluster ? t.ems_cluster.perf_capture_enabled? : t.perf_capture_enabled?
+    end
   end
 
   # @return vms under all availability zones

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -12,14 +12,14 @@ module Metric::Targets
     # Preload all of the objects we are going to be inspecting.
     includes = {:ext_management_systems => {:hosts => {:ems_cluster => :tags, :tags => {}}}}
     includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
+    includes[:ext_management_systems][:hosts][:vms] = :ext_management_system unless options[:exclude_vms]
     MiqPreloader.preload(zone, includes)
 
+    # keeping all_hosts around because capture storage targets runs off of all hosts not enabled ones
     all_hosts = zone.ext_management_systems.flat_map(&:hosts)
-    targets = all_hosts
+    targets = hosts = only_enabled(all_hosts)
     targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
-
-    targets = only_enabled(targets)
-    targets += capture_vm_targets(targets, Host, options)
+    targets += capture_vm_targets(hosts, Host, options) unless options[:exclude_vms]
 
     targets
   end
@@ -67,22 +67,17 @@ module Metric::Targets
   # @return [Array<Storage>] supported storages
   # hosts preloaded storages and tags
   def self.capture_storage_targets(hosts)
-    hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) }
+    hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) & s.perf_capture_enabled? }
   end
 
   def self.capture_vm_targets(targets, parent_class, options)
-    vms = []
-    unless options[:exclude_vms]
-      enabled_parents = targets.select do |t|
-        t.kind_of?(parent_class) &&
+    enabled_parents = targets.select do |t|
+      t.kind_of?(parent_class) &&
         t.kind_of?(Metric::CiMixin) &&
         t.perf_capture_enabled? &&
         t.respond_to?(:vms)
-      end
-      MiqPreloader.preload(enabled_parents, :vms => :ext_management_system)
-      vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
     end
-    vms
+    enabled_parents.flat_map { |t| t.vms.select { |v| v.ext_management_system && v.state == 'on' } }
   end
 
   # If a Cluster, standalone Host, or Storage is not enabled, skip it.

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -879,4 +879,9 @@ class Storage < ApplicationRecord
   def tenant_identity
     ext_management_system.tenant_identity
   end
+
+  # @param [String, Storage] store_type upcased version of the storage type
+  def self.supports?(store_type)
+    Storage::SUPPORTED_STORAGE_TYPES.include?(store_type)
+  end
 end


### PR DESCRIPTION
This is the darga version of #9447 

The merge conflict
-----

#8450 had modified `capture_vm_targets` from `targets.rb`. This had not been backported since the changes were minor like removing a guard clause.

#9447 completely rewrote that method. But since the starting point is different on master and darga, there was a conflict.

The finished product
----

The end result from this PR is identical to #9447 - it just has a slightly different starting point for `capture_vm_targets`