### PR TITLE
Use SupportsFeatureMixin for querying VM for "resize" operation

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -343,7 +343,7 @@ module ApplicationController::CiProcessing
     recs = find_checked_items
     recs = [params[:id].to_i] if recs.blank?
     @record = find_by_id_filtered(VmOrTemplate, recs.first) # Set the VM object
-    if @record.is_available?(:resize)
+    if @record.supports_resize?
       if @explorer
         resize
         @refresh_partial = "vm_common/resize"
@@ -354,7 +354,7 @@ module ApplicationController::CiProcessing
       add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {
         :instance => ui_lookup(:table => 'vm_cloud'),
         :name     => @record.name,
-        :details  => @record.is_available_now_error_message(:resize)}, :error)
+        :details  => @record.unsupported_reason(:resize)}, :error)
     end
   end
   alias instance_resize resizevms
@@ -372,7 +372,7 @@ module ApplicationController::CiProcessing
         :model => ui_lookup(:table => "vm_cloud"), :name => @record.name})
       @record = @sb[:action] = nil
     when "submit"
-      if @record.is_available?(:resize)
+      if @record.supports_resize?
         begin
           old_flavor = @record.flavor
           @record.resize(flavor)
@@ -391,7 +391,7 @@ module ApplicationController::CiProcessing
         add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {
           :instance => ui_lookup(:table => 'vm_cloud'),
           :name     => @record.name,
-          :details  => @record.is_avaiable_now_error_message(:resize)}, :error)
+          :details  => @record.unsupported_reason(:resize)}, :error)
       end
       params[:id] = @record.id.to_s # reset id in params for show
       @record = nil

--- a/app/helpers/application_helper/button/instance_reconfigure.rb
+++ b/app/helpers/application_helper/button/instance_reconfigure.rb
@@ -1,10 +1,10 @@
 class ApplicationHelper::Button::InstanceReconfigure < ApplicationHelper::Button::Basic
   def calculate_properties
     super
-    self[:title] = @record.is_available_now_error_message(:resize) if disabled?
+    self[:title] = @record.unsupported_reason(:resize) if disabled?
   end
 
   def disabled?
-    !@record.is_available?(:resize)
+    !@record.supports_resize?
   end
 end

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -76,10 +76,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     {:available => true, :message => nil}
   end
 
-  def validate_resize
-    validate_unsupported(_("Resize"))
-  end
-
   def disconnect_ems(e = nil)
     self.availability_zone = nil if e.nil? || ext_management_system == e
     super

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
@@ -3,8 +3,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
 
   included do
     supports :resize do
-      msg = validate_vm_control
-      unsupported_reason_add(:resize, msg[1]) unless msg.nil?
+      unsupported_reason_add(:resize, unsupported_reason(:control)) unless supports_control?
       unless %w(ACTIVE SHUTOFF).include?(raw_power_state)
         unsupported_reason_add(:resize, _("The Instance cannot be resized, current state has to be active or shutoff."))
       end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
@@ -1,9 +1,14 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
-  def validate_resize
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
-    return {:available => true, :message => nil} if %w(ACTIVE SHUTOFF).include?(raw_power_state)
-    {:available => false, :message => _("The Instance cannot be resized, current state has to be active or shutoff.")}
+  extend ActiveSupport::Concern
+
+  included do
+    supports :resize do
+      msg = validate_vm_control
+      unsupported_reason_add(:resize, msg[1]) unless msg.nil?
+      unless %w(ACTIVE SHUTOFF).include?(raw_power_state)
+        unsupported_reason_add(:resize, _("The Instance cannot be resized, current state has to be active or shutoff."))
+      end
+    end
   end
 
   def raw_resize(new_flavor)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -128,6 +128,8 @@ class VmOrTemplate < ApplicationRecord
 
   acts_as_miq_taggable
 
+  supports_not :resize
+
   virtual_column :is_evm_appliance,                     :type => :boolean,    :uses => :miq_server
   virtual_column :os_image_name,                        :type => :string,     :uses => [:operating_system, :hardware]
   virtual_column :platform,                             :type => :string,     :uses => [:operating_system, :hardware]

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
@@ -6,7 +6,7 @@ module MiqAeMethodService
     expose :resize_confirm, :override_return => nil
     expose :resize_revert,  :override_return => nil
 
-    expose :validate_resize
+    expose :supports_resize?
     expose :validate_resize_confirm
     expose :validate_resize_revert
 
@@ -18,5 +18,8 @@ module MiqAeMethodService
       sync_or_async_ems_operation(options[:sync], "detach_volume", [volume_id])
     end
 
+    def validate_resize
+      {:available => supports_resize?, :message => unsupported_reason(:resize)}
+    end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -134,7 +134,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
     it "initiate resize process" do
       service = double
       allow(ems).to receive(:connect).and_return(service)
-      expect(vm.validate_resize[:available]).to be_truthy
+      expect(vm.supports_resize?).to be_truthy
       expect(vm.validate_resize_confirm).to be false
       expect(service).to receive(:resize_server).with(vm.ems_ref, flavor.ems_ref)
       expect(MiqQueue).to receive(:put)
@@ -145,7 +145,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       vm.raw_power_state = 'VERIFY_RESIZE'
       service = double
       allow(ems).to receive(:connect).and_return(service)
-      expect(vm.validate_resize[:available]).to be_falsey
+      expect(vm.supports_resize?).to be_falsey
       expect(vm.validate_resize_confirm).to be true
       expect(service).to receive(:confirm_resize_server).with(vm.ems_ref)
       vm.resize_confirm
@@ -155,7 +155,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       vm.raw_power_state = 'VERIFY_RESIZE'
       service = double
       allow(ems).to receive(:connect).and_return(service)
-      expect(vm.validate_resize[:available]).to be_falsey
+      expect(vm.supports_resize?).to be_falsey
       expect(vm.validate_resize_revert).to be true
       expect(service).to receive(:revert_resize_server).with(vm.ems_ref)
       vm.resize_revert


### PR DESCRIPTION
Purpose:
SupportsFeatureMixin provides convenient way to specify if a particular provider has support for a feature. This pull request removes validate_resize (old usage) and makes checking feature support by calling supports_resize possible.


Relevant previous PRs:
Similar changes in: 
1. https://github.com/h-kataria/manageiq/pull/8/files
2. https://github.com/ManageIQ/manageiq/pull/9271/files


Steps for Testing/QA
--------------------
Rspec output:
bundle exec rspec spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb

Randomized with seed 23687
.........................

Finished in 3.97 seconds (files took 5.69 seconds to load)
25 examples, 0 failures

Randomized with seed 23687

