### PR TITLE
Bump Hawkular-client gem to 2.2.1 to fix a regression.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -27,7 +27,7 @@ gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.2",           :require => false
 gem "iniparse",                                     :require => false
 gem "kubeclient",              "=1.1.3",            :require => false
-gem "hawkular-client",         "=2.2.0",            :require => false
+gem "hawkular-client",         "=2.2.1",            :require => false
 gem "linux_admin",             "~>0.16.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false


### PR DESCRIPTION
Bump the hawkular client gem to 2.2.1 to fix a regression in CM

"Local" travis run
https://travis-ci.org/pilhuhn/manageiq/builds/143368233

Gem changelog:
https://github.com/hawkular/hawkular-client-ruby/blob/master/CHANGES.rdoc#v-221

Gem pull-request with the changes https://github.com/hawkular/hawkular-client-ruby/pull/107

@miq-bot add_label providers/hawkular, bug, darga/no

@yaacov please verify
@miq-bot assign @chessbyte 