### PR TITLE
Soft reboot of an Azure instance

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -105,4 +105,10 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
+
+  def vm_reboot_guest(vm, _options = {})
+    vm.reboot_guest
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -22,4 +22,9 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
     provider_service.restart(name, resource_group)
     update_attributes!(:raw_power_state => "VM starting")
   end
+
+  def reboot_guest
+    provider_service.restart(name, resource_group)
+    update_attributes!(:raw_power_state => "VM starting")
+  end
 end


### PR DESCRIPTION
When the user selects an Azure instance and launches the 'Power->Soft Reboot' menu item an exception will be written to the logs and the instance will not be rebooted. This is because this functionality is not yet supported in our Azure integration. This PR is being made for the implementation of the `vm_reboot_guest` method to address this.

This wikipedia page describes the difference between hard and soft reboots:
https://en.wikipedia.org/wiki/Reboot_(computing)

The BZ ticket that corresponds to this PR:
https://bugzilla.redhat.com/show_bug.cgi?id=1349146

The 'Power-> Hard Reboot' is also not implemented but since there is no way to perform a hard reset on an Azure instance I have requested this menu item be disabled: https://github.com/ManageIQ/manageiq/issues/9684 

![disableazurehardreset](https://cloud.githubusercontent.com/assets/4379675/16694792/21416b5a-450a-11e6-9dcf-f00456614fba.png)

