### PR TITLE
[DARGA] Fix bug with common datastore across datacenters

### DIFF
--- a/app/models/host_storage.rb
+++ b/app/models/host_storage.rb
@@ -1,4 +1,8 @@
 class HostStorage < ApplicationRecord
   belongs_to :host
   belongs_to :storage
+
+  include ReservedMixin
+
+  reserve_attribute :ems_ref, :string
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -105,11 +105,13 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
 
     [:transform, :config, :customization, :linked_clone].each { |key| vim_clone_options[key] = clone_options[key] }
 
-    [:folder, :host, :datastore, :pool, :snapshot].each do |key|
+    [:folder, :host, :pool, :snapshot].each do |key|
       ci = clone_options[key]
       next if ci.nil?
       vim_clone_options[key] = ci.ems_ref_obj
     end
+
+    vim_clone_options[:datastore] = clone_options[:host].host_storages.find_by(:storage_id => clone_options[:datastore].id).ems_ref
 
     task_mor = clone_vm(vim_clone_options)
     _log.info("Provisioning completed for [#{vim_clone_options[:name]}] from source [#{source.name}]") if MiqProvision::CLONE_SYNCHRONOUS

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -736,7 +736,8 @@ module ManageIQ::Providers
 
           result << {
             :storage   => storage_uids[s_mor],
-            :read_only => read_only
+            :read_only => read_only,
+            :ems_ref   => s_mor
           }
         end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -220,6 +220,58 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           expect(@vm_prov.dest_resource_pool).to eq(dest_host.default_resource_pool)
         end
       end
+
+      context "#start_clone" do
+        before(:each) do
+          ds_mor = "datastore-0"
+          storage = FactoryGirl.create(:storage_nfs, :ems_ref => ds_mor, :ems_ref_obj => ds_mor)
+
+          Array.new(2) do |i|
+            host_mor = "host-#{i}"
+            host_props = {
+              :ext_management_system => @ems,
+              :ems_ref               => host_mor,
+              :ems_ref_obj           => host_mor
+            }
+
+            FactoryGirl.create(:host_vmware, host_props).tap do |host|
+              host.storages = [storage]
+              hs = host.host_storages.first
+              hs.ems_ref = "datastore-#{i}"
+              hs.save
+            end
+          end
+        end
+
+        it "uses the ems_ref for the correct host" do
+          dest_host_mor      = "host-1"
+          dest_datastore_mor = "datastore-1"
+          task_mor           = "task-1"
+
+          clone_opts = {
+            :name      => @target_vm_name,
+            :host      => Host.find_by(:ems_ref => dest_host_mor),
+            :datastore => Storage.first
+          }
+
+          expected_vim_clone_opts = {
+            :name          => @target_vm_name,
+            :wait          => false,
+            :template      => false,
+            :transform     => nil,
+            :config        => nil,
+            :customization => nil,
+            :linked_clone  => nil,
+            :host          => dest_host_mor,
+            :datastore     => dest_datastore_mor
+          }
+
+          allow(@vm_prov).to receive(:clone_vm).with(expected_vim_clone_opts).and_return(task_mor)
+
+          result = @vm_prov.start_clone clone_opts
+          expect(result).to eq(task_mor)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Backport of https://github.com/ManageIQ/manageiq/pull/9670 using `ReservedMixin` for the new `ems_ref` column in the `host_storages` table

This fixes an issue when you have a `Storage` that has multiple `ems_refs` causing provisioning to fail by using the wrong `ems_ref`.  This can happen when you mount the same NFS share to hosts in different datacenters and/or different vCenters.


Links
-----
* [Master PR #9670](https://github.com/ManageIQ/manageiq/pull/9670)
* https://bugzilla.redhat.com/show_bug.cgi?id=1337552


Steps for Testing/QA
--------------------
1. Mount the same NFS share to hosts in two datacenters
2. Use the ManagedObjectBrowser (`https://vc_ip_addr/mob`) to confirm the different MORs
3. Run inventory refresh
4. Confirm 1 Storage record is created and two HostStorage records with different ems_refs
