### PR TITLE
Alert specs

### DIFF
--- a/spec/factories/miq_alert.rb
+++ b/spec/factories/miq_alert.rb
@@ -1,10 +1,16 @@
 FactoryGirl.define do
   factory :miq_alert do
-    description     "Test Alert"
+    sequence(:description) { |n| "Test Alert #{n}" }
+    enabled         true
   end
 
-  factory :miq_alert_vm, :class => :MiqAlert do
+  factory :miq_alert_vm, :parent => :miq_alert do
     options         :notifications => {}
     db              "Vm"
+  end
+
+  factory :miq_alert_host, :parent => :miq_alert do
+    options         :notifications => {}
+    db              "Host"
   end
 end

--- a/spec/factories/miq_alert_set.rb
+++ b/spec/factories/miq_alert_set.rb
@@ -1,6 +1,23 @@
 FactoryGirl.define do
   factory :miq_alert_set do
+    transient { alerts nil }
     sequence(:name)         { |n| "alert_profile_#{seq_padded_for_sorting(n)}" }
     sequence(:description)  { |n| "alert_profile_#{seq_padded_for_sorting(n)}" }
+
+    after(:create) do |alert_set, builder|
+      if builder.alerts
+        builder.alerts.each do |alert|
+          alert_set.add_member(alert)
+        end
+      end
+    end
+  end
+
+  factory :miq_alert_set_vm, :parent => :miq_alert_set do
+    mode "VmOrTemplate" # VmOrTemplate.base_model.name
+  end
+
+  factory :miq_alert_set_host, :parent => :miq_alert_set do
+    mode "Host" # Host.base_model.name
   end
 end

--- a/spec/models/miq_alert_eval_internal_spec.rb
+++ b/spec/models/miq_alert_eval_internal_spec.rb
@@ -20,7 +20,7 @@ describe "MiqAlert Evaluation Internal" do
             :freq_threshold => 3,
             :time_threshold => 3.days}}
         @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal Event Threshold Profile", :mode => @vm.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set_vm)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
       end
@@ -50,7 +50,7 @@ describe "MiqAlert Evaluation Internal" do
             :trend_direction   => 'none',
             :debug_trace       => 'false'}}
         @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal RT Perf Profile", :mode => @vm.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set_vm)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
       end
@@ -71,7 +71,7 @@ describe "MiqAlert Evaluation Internal" do
             :operator => "Changed",
             :hdw_attr => :cpu_affinity}}
         @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal Changed VM Value Profile", :mode => @vm.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set_vm)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
       end
@@ -92,7 +92,7 @@ describe "MiqAlert Evaluation Internal" do
             :operator => "Decreased",
             :hdw_attr => "memory_mb"}}
         @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal Reconfigured Hardware Value Profile", :mode => @vm.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set_vm)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
       end
@@ -119,7 +119,7 @@ describe "MiqAlert Evaluation Internal" do
             :time_threshold                 => 86400,
             :event_log_level                => "fatal"}}
         @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal VM Event Log Threshold Profile", :mode => @vm.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set_vm)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
       end
@@ -141,7 +141,7 @@ describe "MiqAlert Evaluation Internal" do
             :ems_alarm_mor  => "alarm-7"
           }}
         @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal VM Alarm Threshold Profile", :mode => @vm.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set_vm)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
       end
@@ -172,7 +172,7 @@ describe "MiqAlert Evaluation Internal" do
             :time_threshold                 => 86400,
             :event_log_level                => "warn"}}
         @alert = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal VM Alarm Threshold Profile", :mode => @host.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set_host)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@host)
       end
@@ -193,7 +193,7 @@ describe "MiqAlert Evaluation Internal" do
       before(:each) do
         expression = {:eval_method => "nothing"}
         @alert = FactoryGirl.create(:miq_alert_vm, :expression => expression)
-        @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal MiqServer with no Expression Profile", :mode => @server.class.name)
+        @alert_prof = FactoryGirl.create(:miq_alert_set, :mode => @server.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@server)
       end

--- a/spec/models/miq_alert_eval_internal_spec.rb
+++ b/spec/models/miq_alert_eval_internal_spec.rb
@@ -19,7 +19,7 @@ describe "MiqAlert Evaluation Internal" do
             :event_types    => ["MigrateVM_Task_Complete"],
             :freq_threshold => 3,
             :time_threshold => 3.days}}
-        @alert      = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal Event Threshold", :expression => expression)
+        @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal Event Threshold Profile", :mode => @vm.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
@@ -49,7 +49,7 @@ describe "MiqAlert Evaluation Internal" do
             :rt_time_threshold => 60,
             :trend_direction   => 'none',
             :debug_trace       => 'false'}}
-        @alert      = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal RT Perf", :expression => expression)
+        @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal RT Perf Profile", :mode => @vm.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
@@ -70,7 +70,7 @@ describe "MiqAlert Evaluation Internal" do
           :options     => {
             :operator => "Changed",
             :hdw_attr => :cpu_affinity}}
-        @alert      = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal Changed VM Value", :expression => expression)
+        @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal Changed VM Value Profile", :mode => @vm.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
@@ -91,7 +91,7 @@ describe "MiqAlert Evaluation Internal" do
           :options     => {
             :operator => "Decreased",
             :hdw_attr => "memory_mb"}}
-        @alert      = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal Reconfigured Hardware Value", :expression => expression)
+        @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal Reconfigured Hardware Value Profile", :mode => @vm.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
@@ -118,7 +118,7 @@ describe "MiqAlert Evaluation Internal" do
             :event_log_event_id             => "12345",
             :time_threshold                 => 86400,
             :event_log_level                => "fatal"}}
-        @alert      = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal VM Event Log Threshold", :expression => expression)
+        @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal VM Event Log Threshold Profile", :mode => @vm.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
@@ -140,7 +140,7 @@ describe "MiqAlert Evaluation Internal" do
             :ems_alarm_name => "GT VM CPU Usage",
             :ems_alarm_mor  => "alarm-7"
           }}
-        @alert      = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal VM Alarm Threshold", :expression => expression)
+        @alert      = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal VM Alarm Threshold Profile", :mode => @vm.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@vm)
@@ -171,7 +171,7 @@ describe "MiqAlert Evaluation Internal" do
             :event_log_message_filter_value => "exceeds soft limit",
             :time_threshold                 => 86400,
             :event_log_level                => "warn"}}
-        @alert = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal Hostd Log Threshold", :expression => expression)
+        @alert = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal VM Alarm Threshold Profile", :mode => @host.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@host)
@@ -192,7 +192,7 @@ describe "MiqAlert Evaluation Internal" do
     context "evaluating an alert with no expression" do
       before(:each) do
         expression = {:eval_method => "nothing"}
-        @alert = FactoryGirl.create(:miq_alert_vm, :description => "Alert Internal MiqServer with no Expression", :expression => expression)
+        @alert = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Internal MiqServer with no Expression Profile", :mode => @server.class.name)
         @alert_prof.add_member(@alert)
         @alert_prof.assign_to_objects(@server)

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -10,8 +10,7 @@ describe MiqAlert do
         next(arr) if a.responds_to_events.nil?
         next(arr) unless a.db == "Vm"
 
-        ap = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for #{a.id}", :mode => @vm.class.base_model.name)
-        ap.add_member(a)
+        ap = FactoryGirl.create(:miq_alert_set_vm, :alerts => [a])
         ap.assign_to_objects(@vm)
 
         events = a.responds_to_events.split(",")
@@ -199,8 +198,7 @@ describe MiqAlert do
       @c.assign_entry_to(@vm)
 
       @alert = FactoryGirl.create(:miq_alert_vm)
-      @ap    = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for #{@alert.id}", :mode => @mode)
-      @ap.add_member(@alert)
+      @ap    = FactoryGirl.create(:miq_alert_set_vm, :alerts =>[@alert])
       @ap.assign_to_tags([@c.id], @mode)
 
       expect(MiqAlert.assigned_to_target(@vm)).to eq([@alert])
@@ -214,20 +212,12 @@ describe MiqAlert do
 
     let(:vm_alert_set) do
       alert = FactoryGirl.create(:miq_alert_vm, :responds_to_events => "xxx|vm_perf_complete|zzz")
-      alert_prof = FactoryGirl.create(:miq_alert_set,
-                                      :description => "Alert Profile for Alert Id: #{alert.id}",
-                                      :mode        => VmOrTemplate.base_model.name)
-      alert_prof.add_member(alert)
-      alert_prof
+      FactoryGirl.create(:miq_alert_set_vm, :alerts => [alert])
     end
 
     let(:host_alert_set) do
       alert = FactoryGirl.create(:miq_alert_host, :responds_to_events => "xxx|host_perf_complete|zzz")
-      alert_prof = FactoryGirl.create(:miq_alert_set,
-                                      :description => "Alert Profile for Alert Id: #{alert.id}",
-                                      :mode        => Host.base_model.name)
-      alert_prof.add_member(alert)
-      alert_prof
+      FactoryGirl.create(:miq_alert_set_host, :alerts => [alert])
     end
 
     it "detects true with a VM assigned to a realtime C&U alert" do
@@ -324,8 +314,7 @@ describe MiqAlert do
       @ems        = FactoryGirl.create(:ems_vmware, :zone => @miq_server.zone)
       @ems_other  = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone, :name => 'other'))
       @alert      = FactoryGirl.create(:miq_alert, :responds_to_events => "_hourly_timer_")
-      @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for Alert Id: #{@alert.id}")
-      @alert_prof.add_member(@alert)
+      @alert_prof = FactoryGirl.create(:miq_alert_set, :alerts => [@alert])
     end
 
     it "evaluates for ext_management_system" do
@@ -385,13 +374,8 @@ describe MiqAlert do
         :expression         => {:eval_method => "nothing", :mode => "internal", :options => {}},
         :responds_to_events => "request_vm_poweroff"
       )
-      @alert_prof = FactoryGirl.create(
-        :miq_alert_set,
-        :description => "Alert Profile for Alert Id: #{@alert.id}",
-        :mode        => @vm.class.base_model.name
-      )
-      @alert_prof.add_member(@alert)
-      @alert_prof.assign_to_objects(@vm.id, "Vm")
+      @alert_prof = FactoryGirl.create(:miq_alert_set_vm, :alerts => [@alert])
+      @alert_prof.assign_to_objects(@vm)
     end
 
     it 'queues evaluation of alert' do

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -9,12 +9,12 @@ describe AssignmentMixin do
 
     it "detects tags on alert_set" do
       ct1 = ctag("environment", "test")
-      alert_set = FactoryGirl.create(:miq_alert_set, :mode => "VmOrTemplate")
+      alert_set = FactoryGirl.create(:miq_alert_set_vm)
       alert_set.assign_to_tags([ct1], "vm")
       alert_set.reload # reload ensures the tag is set
 
       ct2 = ctag("environment", "staging")
-      alert_set2 = FactoryGirl.create(:miq_alert_set, :mode => "VmOrTemplate")
+      alert_set2 = FactoryGirl.create(:miq_alert_set_vm)
       alert_set2.assign_to_tags([ct2], "vm")
       alert_set2.reload # reload ensures the tag is set
 


### PR DESCRIPTION
Purpose or Intent
-----------------
When putting specs together around alerts, I noticed that I was creating helper methods to do something as simple as creating an alert and alert profile.

So I changed the alert and alert profile (alert_set) factories to be easier to work with