### PR TITLE
cap&u - remove extra host lookup

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -98,15 +98,7 @@ class MiqAlert < ApplicationRecord
   end
 
   def self.target_needs_realtime_capture?(target)
-    result = !assigned_to_target(target, "#{target.class.base_model.name.underscore}_perf_complete").empty?
-    return result if result
-
-    # Need to special case Host to look for alerts assigned to parent cluster
-    if target.kind_of?(Host) && target.ems_cluster
-      result = !assigned_to_target(target.ems_cluster, "#{target.ems_cluster.class.name.underscore}_perf_complete").empty?
-    end
-
-    result
+    !assigned_to_target(target, "#{target.class.base_model.name.underscore}_perf_complete").empty?
   end
 
   def self.evaluate_alerts(target, event, inputs = {})

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -267,6 +267,14 @@ describe MiqAlert do
       expect(MiqAlert.target_needs_realtime_capture?(host)).to be_truthy
     end
 
+    it "detects true with a Host's cluster assigned to a realtime C&U alert" do
+      cluster = FactoryGirl.create(:ems_cluster)
+      host = FactoryGirl.create(:host, :ems_cluster => cluster)
+      host_alert_set.assign_to_objects(cluster)
+
+      expect(MiqAlert.target_needs_realtime_capture?(host)).to be_truthy
+    end
+
     it "detects false with a Host NOT assigned to a realtime C&U alert" do
       host = FactoryGirl.create(:host)
 


### PR DESCRIPTION
Currently, `assigned_to_target` already checks the presence of
a tag for all parent nodes, including the `ems_cluster`.

No reason to run this twice.

This only performs ~1 fewer query per host. But removing the code tightens it up.
@gtanzillo and I saw this and thought it wouldn't be necessary. I added the test to ensure
and went from there

before
----

|       ms |   bytes | objects |    queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|     ---:|       ---:|      ---:| ---
|  2,190.8 | 82,528,460* | 1,973,298 |     1,052 |   759.5 |   11,168 |`before`

after
----

|       ms |   bytes | objects |    queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|     ---:|      ---:|      ---:| ---
|  2,249.4 | 82,486,408* | 1,969,429 |     1,050 |   705.8 |   11,168 |`after`
