### PR TITLE
Move MiqTask#human_status into it's own module

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -1,15 +1,7 @@
 class MiqTask < ApplicationRecord
-  serialize :context_data
-  STATE_INITIALIZED = 'Initialized'.freeze
-  STATE_QUEUED      = 'Queued'.freeze
-  STATE_ACTIVE      = 'Active'.freeze
-  STATE_FINISHED    = 'Finished'.freeze
+  include HumanStatus
 
-  STATUS_OK         = 'Ok'.freeze
-  STATUS_WARNING    = 'Warn'.freeze
-  STATUS_ERROR      = 'Error'.freeze
-  STATUS_TIMEOUT    = 'Timeout'.freeze
-  STATUS_EXPIRED    = 'Expired'.freeze
+  serialize :context_data
   validates_inclusion_of :state,  :in => [STATE_INITIALIZED, STATE_QUEUED, STATE_ACTIVE, STATE_FINISHED]
   validates_inclusion_of :status, :in => [STATUS_OK, STATUS_WARNING, STATUS_ERROR, STATUS_TIMEOUT]
 
@@ -136,23 +128,6 @@ class MiqTask < ApplicationRecord
 
   def state_finished
     update_attributes(:state => STATE_FINISHED)
-  end
-
-  def human_status
-    case state
-    when STATE_INITIALIZED then "Initialized"
-    when STATE_QUEUED      then "Queued"
-    when STATE_ACTIVE      then "Running"
-    when STATE_FINISHED
-      case status
-      when STATUS_OK      then "Complete"
-      when STATUS_WARNING then "Finished with Warnings"
-      when STATUS_ERROR   then "Error"
-      when STATUS_TIMEOUT then "Timed Out"
-      else raise _("Unknown status of: %{task_status}") % {:task_status => status.inspect}
-      end
-    else raise _("Unknown state of: %{task_status}") % {:task_status => state.inspect}
-    end
   end
 
   def results_ready?

--- a/app/models/mixins/human_status.rb
+++ b/app/models/mixins/human_status.rb
@@ -1,0 +1,32 @@
+# Makes the `human_status` method available to models that respond to a
+# `state` and `status` method.
+
+module HumanStatus
+  STATE_INITIALIZED = 'Initialized'.freeze
+  STATE_QUEUED      = 'Queued'.freeze
+  STATE_ACTIVE      = 'Active'.freeze
+  STATE_FINISHED    = 'Finished'.freeze
+
+  STATUS_OK         = 'Ok'.freeze
+  STATUS_WARNING    = 'Warn'.freeze
+  STATUS_ERROR      = 'Error'.freeze
+  STATUS_TIMEOUT    = 'Timeout'.freeze
+  STATUS_EXPIRED    = 'Expired'.freeze
+
+  def human_status
+    case state
+    when STATE_INITIALIZED then "Initialized"
+    when STATE_QUEUED      then "Queued"
+    when STATE_ACTIVE      then "Running"
+    when STATE_FINISHED
+      case status
+      when STATUS_OK      then "Complete"
+      when STATUS_WARNING then "Finished with Warnings"
+      when STATUS_ERROR   then "Error"
+      when STATUS_TIMEOUT then "Timed Out"
+      else raise _("Unknown status of: %{task_status}") % {:task_status => status.inspect}
+      end
+    else raise _("Unknown state of: %{task_status}") % {:task_status => state.inspect}
+    end
+  end
+end

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -290,4 +290,63 @@ describe MiqTask do
       expect(@miq_task.results_ready?).to be_truthy
     end
   end
+
+  describe "human_status" do
+    subject { MiqTask.new }
+
+    context "when state is nil" do
+      it "raises an error" do
+        expect { subject.human_status }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when state is STATE_INITIALIZED" do
+      it "returns 'Initialized'" do
+        subject.state = MiqTask::STATE_INITIALIZED
+        expect(subject.human_status).to eq('Initialized')
+      end
+    end
+
+    context "when state is STATE_QUEUED" do
+      it "returns 'Queued'" do
+        subject.state = MiqTask::STATE_QUEUED
+        expect(subject.human_status).to eq('Queued')
+      end
+    end
+
+    context "when state is STATE_ACTIVE" do
+      it "returns 'Running'" do
+        subject.state = MiqTask::STATE_ACTIVE
+        expect(subject.human_status).to eq('Running')
+      end
+    end
+
+    context "when state is STATE_FINISHED" do
+      subject { MiqTask.new :state => MiqTask::STATE_FINISHED }
+
+      it "raises an error when status is nil" do
+        expect { subject.human_status }.to raise_error(RuntimeError)
+      end
+
+      it "returns 'Complete' when status is 'Ok'" do
+        subject.status = MiqTask::STATUS_OK
+        expect(subject.human_status).to eq('Complete')
+      end
+
+      it "returns 'Finished with Warnings' when status is 'Warn'" do
+        subject.status = MiqTask::STATUS_WARNING
+        expect(subject.human_status).to eq('Finished with Warnings')
+      end
+
+      it "returns 'Error' when status is 'Error'" do
+        subject.status = MiqTask::STATUS_ERROR
+        expect(subject.human_status).to eq('Error')
+      end
+
+      it "returns 'Timed Out' when status is 'Timeout'" do
+        subject.status = MiqTask::STATUS_TIMEOUT
+        expect(subject.human_status).to eq('Timed Out')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
To be used with Manageiq/manageiq#9559, this will allow the code for other models to reuse the `human_status` display logic, assuming they implement the methods `state` and `status`.  There is currently no enforcement requiring that those methods exist for this to be included in a class though.


Links
-----
* https://github.com/ManageIQ/manageiq/pull/9559


Steps for Testing/QA
--------------------
Added tests around the logic for `MiqTask::human_status`, so that should suffice for testing beyond checking in the app/UI in common functionality around MiqTasks still works.