### PR TITLE
Trivial UI Fixes

### DIFF
--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -26,8 +26,8 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
         button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Item from the VMDB'),
-          N_('Remove Item from the VMDB'),
+          N_('Remove this Catalog Item'),
+          N_('Remove Catalog Item'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: This Catalog Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Catalog Item?")),
       ]

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -104,7 +104,7 @@
                 $(":file").filestyle({icon: false, placeholder: "No file chosen"});
             .col-md-6
               = submit_tag(_("Upload"), :id => "upload", :class => "upload btn btn-default")
-              = _('* Requirements: File-type - PNG; Dimensions - 350x70.')
+              = _('* Requires PNG or JPG image format')
     - if @record.display && !@record.prov_type.try(:start_with?, "generic_")
       = miq_tab_content('details') do
         %h3


### PR DESCRIPTION
The current image upload descriptive text is not accurate and was probably duplicated from another area. Images can be of various sizes as they will be resized accordingly provided they are in either .png or .jpg format.

https://bugzilla.redhat.com/show_bug.cgi?id=1354026


In addition the current text to remove Catalog Items, refers to the VMDB which is unnecessary and confusing.
