### PR TITLE
Fixed the way link to Security Groups is being built for Cloud Provider

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -122,7 +122,14 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_security_groups
-    @record.security_groups
+    label = ui_lookup(:tables => "security_groups")
+    num = @ems.number_of(:security_groups)
+    h = {:label => label, :image => "security_group", :value => num}
+    if num > 0 && role_allows(:feature => "security_group_show_list")
+      h[:link] = ems_cloud_path(@ems.id, :display => 'security_groups')
+      h[:title] = _("Show all %{label}") % {:label => label}
+    end
+    h
   end
 
   def textual_zone

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -18,5 +18,10 @@ describe EmsCloudHelper::TextualSummary do
 
       expect(textual_images[:link]).to eq("/ems_cloud/#{@ems.id}?display=images")
     end
+
+    it "sets correct path for security_groups on summary screen" do
+      FactoryGirl.create(:security_group, :name => "sq_1", :ext_management_system => @ems.network_manager)
+      expect(textual_security_groups[:link]).to eq("/ems_cloud/#{@ems.id}?display=security_groups")
+    end
   end
 end


### PR DESCRIPTION
Fixed the way link to Security Groups is being built on a Cloud Provider summary screen, existing way of building link to list of Security Groups builds a link to security groups that belong to cloud network, when clicking on the link it jumps to cloud network controller and no longer is in ems_cloud control which makes back button on summary screen to point to cloud network summary screen instead of ems_cloud summary screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1342231

@Ladas please review/test, made changes to build link in ems_cloud textual helper itself and make it go thru https://github.com/ManageIQ/manageiq/blob/master/app/helpers/textual_summary_helper.rb#L114 instead of code block in elsif here https://github.com/ManageIQ/manageiq/blob/master/app/helpers/textual_summary_helper.rb#L116