### PR TITLE
Trivial Catalog UI Cleanup

### DIFF
--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -26,8 +26,8 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
         button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Item from the VMDB'),
-          N_('Remove Item from the VMDB'),
+          N_('Remove this Catalog Item'),
+          N_('Remove Catalog Item'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: This Catalog Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Catalog Item?")),
       ]

--- a/app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb
@@ -16,8 +16,8 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogCenter < ApplicationHelp
         button(
           :st_catalog_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Item from the VMDB'),
-          N_('Remove Item from the VMDB'),
+          N_('Remove this Catalog'),
+          N_('Remove Catalog'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: This Catalog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Catalog?")),
       ]

--- a/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
@@ -22,8 +22,8 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogsCenter < ApplicationHel
         button(
           :st_catalog_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Items from the VMDB'),
-          N_('Remove Items from the VMDB'),
+          N_('Remove selected Catalog Items'),
+          N_('Remove Catalog Items'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Items will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/servicetemplates_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplates_center.rb
@@ -27,8 +27,8 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
         button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Items from the VMDB'),
-          N_('Remove Items from the VMDB'),
+          N_('Remove selected Catalog Items'),
+          N_('Remove Catalog Items'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
           :enabled   => false,

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -104,7 +104,7 @@
                 $(":file").filestyle({icon: false, placeholder: "No file chosen"});
             .col-md-6
               = submit_tag(_("Upload"), :id => "upload", :class => "upload btn btn-default")
-              = _('* Requirements: File-type - PNG; Dimensions - 350x70.')
+              = _('* Requires image file in .png or .jpg format')
     - if @record.display && !@record.prov_type.try(:start_with?, "generic_")
       = miq_tab_content('details') do
         %h3


### PR DESCRIPTION
Addresses UI item where the Catalog Item removal is overly complicated as telling the user about the VMDB is not necessary.      https://bugzilla.redhat.com/show_bug.cgi?id=1354044

Fixes the description on the image upload as it does not need to be 350x70 pixels and can be in either png or jpg format.    https://bugzilla.redhat.com/show_bug.cgi?id=1354026