### PR TITLE
Create bottleneck events during Storage#perf_capture

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -847,6 +847,12 @@ class Storage < ApplicationRecord
       Benchmark.realtime_block(:process_perfs_tag) { VimPerformanceTagValue.build_from_performance_record(perf) }
 
       update_attribute(:last_perf_capture_on, hour)
+
+      # We don't rollup realtime to Storage, so we need to manually create bottlenecks
+      # when we capture hourly storage.
+      # See: https://github.com/ManageIQ/manageiq/blob/96753f2473391e586d0a563fad9cf7153deab671/app/models/metric/ci_mixin/rollup.rb#L102
+      Benchmark.realtime_block(:process_bottleneck) { BottleneckEvent.generate_future_events(self) } if interval_name == 'hourly'
+
       perf_rollup_to_parents(interval_name, hour)
     end
 

--- a/db/fixtures/miq_event_definitions.yml
+++ b/db/fixtures/miq_event_definitions.yml
@@ -188,6 +188,7 @@
       - :EmsCluster
       - :ExtManagementSystem
       - :MiqEnterprise
+      - :Storage
       :event: 
         :event_type: DiskUsage
         :severity: 1
@@ -210,6 +211,7 @@
       - :EmsCluster
       - :ExtManagementSystem
       - :MiqEnterprise
+      - :Storage
       :event: 
         :event_type: DiskUsage
         :severity: 1
@@ -232,6 +234,7 @@
       - :EmsCluster
       - :ExtManagementSystem
       - :MiqEnterprise
+      - :Storage
       :event: 
         :event_type: DiskUsage
         :severity: 2
@@ -254,6 +257,7 @@
       - :EmsCluster
       - :ExtManagementSystem
       - :MiqEnterprise
+      - :Storage
       :event: 
         :event_type: DiskUsage
         :severity: 3


### PR DESCRIPTION
Purpose or Intent
-----------------

Before this pull request, we did not raise bottleneck events visible in Optimize -> Bottlenecks for Storages and stored in the bottleneck_events table.

We don't rollup realtime metrics to Storage, so, we never create BottleneckEvents
for storage [here](https://github.com/ManageIQ/manageiq/blob/96753f2473391e586d0a563fad9cf7153deab671/app/models/metric/ci_mixin/rollup.rb#L102
).  We need to manually create bottleneck events in
Storage#perf_capture.  This method captures hourly storage metrics based on the
C&U storage data we find while processing vms, hosts, etc. that reside or have
access to storages.

Additionally, we need to update disk_usage_50 event definitions and friends to
include Storage in their "applies to" field.

https://bugzilla.redhat.com/show_bug.cgi?id=1181342

Steps for Testing/QA
--------------------

This is what you should see after this pull request and you've given it enough time to collect the hourly data for storage:

![image](https://cloud.githubusercontent.com/assets/19339/16707654/278209ee-45a4-11e6-9146-386768202240.png)

```
irb(main):003:0> pp BottleneckEvent.where(:resource_type => "Storage").collect {|be| [be.resource_name, be.message]}
[["rhevm35_data",
  "Disk Space Max Used is projected to reach 124.5 GB (50% of Capacity - Total Space (B))"],
 ["rhev35-nested-export",
  "Disk Space Max Used is projected to reach 237 GB (100% of Capacity - Total Space (B))"],
 ["rhev35-nested-export",
  "Disk Space Max Used is projected to reach 213.3 GB (90% of Capacity - Total Space (B))"],
 ["rhev35-nested-export",
  "Disk Space Max Used is projected to reach 177.8 GB (75% of Capacity - Total Space (B))"],
 ["rhev35-nested-export",
  "Disk Space Max Used is projected to reach 118.5 GB (50% of Capacity - Total Space (B))"],
 ["ISO_DOMAIN",
  "Disk Space Max Used is projected to reach 48 GB (100% of Capacity - Total Space (B))"],
 ["ISO_DOMAIN",
  "Disk Space Max Used is projected to reach 43.2 GB (90% of Capacity - Total Space (B))"],
 ["ISO_DOMAIN",
  "Disk Space Max Used is projected to reach 36 GB (75% of Capacity - Total Space (B))"],
 ["ISO_DOMAIN",
  "Disk Space Max Used is projected to reach 24 GB (50% of Capacity - Total Space (B))"],
 ["nested_rhevm34_export",
  "Disk Space Max Used is projected to reach 177.8 GB (75% of Capacity - Total Space (B))"],
 ["nested_rhevm34_export",
  "Disk Space Max Used is projected to reach 118.5 GB (50% of Capacity - Total Space (B))"],
 ["rhevm34_data",
  "Disk Space Max Used is projected to reach 249 GB (100% of Capacity - Total Space (B))"],
 ["rhevm34_data",
  "Disk Space Max Used is projected to reach 224.1 GB (90% of Capacity - Total Space (B))"],
 ["rhevm34_data",
  "Disk Space Max Used is projected to reach 186.8 GB (75% of Capacity - Total Space (B))"],
 ["rhevm34_data",
  "Disk Space Max Used is projected to reach 124.5 GB (50% of Capacity - Total Space (B))"]]
```

![image](https://cloud.githubusercontent.com/assets/19339/16707671/d4c00796-45a4-11e6-990f-125c696f8b1c.png)


