### PR TITLE
[WIP] Provide a convenience method to re-enable the UI login

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -167,6 +167,15 @@ module MiqServer::RoleManagement
     assigned_server_role
   end
 
+  LOGIN_ROLES = %w(user_interface web_services).freeze
+  def reset_login_roles
+    LOGIN_ROLES.each { |r| assign_role(r, 1) }
+  end
+
+  def self.reset_login_roles
+    MiqServer.my_server.reset_login_roles
+  end
+
   def inactive_role_names
     inactive_roles.collect(&:name).sort
   end


### PR DESCRIPTION
## Purpose or Intent

If people accidentally disable the user interface role, the way to re-enable it
is not very intuitive.  This new method can be run from rails console or possibly
the appliance console and will re-enable the appropriate roles.
## Steps for Testing/QA

Disable the user interface role, verify you can't access the UI, and then run MiqServer.reset_login_roles from rails console.
