### PR TITLE
Automate - Fix for Amazon retirement process.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
@@ -19,7 +19,8 @@ if vm
     # If never then this VM is a template so exit the retirement state machine
     $evm.root['ae_result'] = 'error'
   else
-    $evm.root['ae_result']     = 'retry'
+    vm.refresh
+    $evm.root['ae_result']         = 'retry'
     $evm.root['ae_retry_interval'] = '60.seconds'
   end
 end

--- a/spec/automation/unit/method_validation/check_amazon_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/check_amazon_pre_retirement_spec.rb
@@ -23,6 +23,7 @@ describe "amazon_check_pre_retirement Method Validation" do
   end
 
   it "returns 'retry' for running ebs instances" do
+    expect_any_instance_of(Vm).to receive(:refresh_ems).and_return({})
     @vm.hardware = @ebs_hardware
     ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
     expect(ws.root['ae_result']).to eq('retry')


### PR DESCRIPTION
Purpose or Intent
-----------------
> The automate method amazon_check_pre_retirement was not getting updated information from the Amazon provider while trying to retire an instance. This caused the method to be stuck in a retry loop.
> 
> 
Links
-----
> https://bugzilla.redhat.com/show_bug.cgi?id=1351262

Added a vm refresh in Amazon retirement requests.

Modified spec to allow refresh.

