### PR TITLE
Use a hash for AssignmentMixin#assignments

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -132,8 +132,7 @@ class MiqAlert < ApplicationRecord
 
     # Get list of targets from assigned profiles
     targets = []
-    assignments.each do |ass|
-      prof = ass[:assigned]
+    assignments.values.flatten.uniq.each do |prof|
       prof.miq_alerts.each do |a|
         next unless a.enabled? && a.responds_to_events && a.responds_to_events.include?(HOURLY_TIMER_EVENT)
 

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -4,7 +4,7 @@ describe AssignmentMixin do
 
   describe '#assignments' do
     it "finds no assignments" do
-      expect(test_class.assignments).to eq([])
+      expect(test_class.assignments).to eq({})
     end
 
     it "detects tags on alert_set" do
@@ -18,11 +18,9 @@ describe AssignmentMixin do
       alert_set2.assign_to_tags([ct2], "vm")
       alert_set2.reload # reload ensures the tag is set
 
-      expect(test_class.assignments).to match_array(
-        [
-          {:assigned => alert_set, :assigned_to => "vm/tag/managed/environment/test"},
-          {:assigned => alert_set2, :assigned_to => "vm/tag/managed/environment/staging"},
-        ]
+      expect(test_class.assignments).to eq(
+        "vm/tag/managed/environment/test"    => [alert_set],
+        "vm/tag/managed/environment/staging" => [alert_set2],
       )
     end
   end


### PR DESCRIPTION
Follow up to look up tags/alerts more efficiently for cap&u assignments detection

@Fryguy You had mentioned using sets for lookups. This seems better to me. What is your take?

There are comments in the commit of interest:

```
store assigned as a hash of arrays
since these are looked up by key, makes more sense.

---

This may be overkill, storing as a hash of objects
may make more sense.

Alerts do not need an array. It just cares about presence
but chargebacks seem to want an array of objects
```