### PR TITLE
Fix duplicated DOM id 'main_div' in Dashboard editing.

### DIFF
--- a/app/views/report/_db_show.html.haml
+++ b/app/views/report/_db_show.html.haml
@@ -1,24 +1,23 @@
-#main_div
-  %h3
-    = _('Basic Information')
-  .form-horizontal.static
-    .form-group
-      %label.control-label.col-md-2
-        = _('Name')
-      .col-md-8
-        %p.form-control-static
-          = h(widget.name)
-    .form-group
-      %label.control-label.col-md-2
-        = _('Tab Title')
-      .col-md-8
-        %p.form-control-static
-          = h(widget.description)
-    .form-group
-      %label.control-label.col-md-2
-        = _('Locked')
-      .col-md-8
-        %p.form-control-static
-          = h(widget.set_data[:locked])
-  %hr
-  = render :partial => 'db_widgets', :locals => {:widget => widget}
+%h3
+  = _('Basic Information')
+.form-horizontal.static
+  .form-group
+    %label.control-label.col-md-2
+      = _('Name')
+    .col-md-8
+      %p.form-control-static
+        = h(widget.name)
+  .form-group
+    %label.control-label.col-md-2
+      = _('Tab Title')
+    .col-md-8
+      %p.form-control-static
+        = h(widget.description)
+  .form-group
+    %label.control-label.col-md-2
+      = _('Locked')
+    .col-md-8
+      %p.form-control-static
+        = h(widget.set_data[:locked])
+%hr
+= render :partial => 'db_widgets', :locals => {:widget => widget}


### PR DESCRIPTION
Remove duplicated DOM id.
-----------------
The content of the partial is places inside #main_div. So it should not
contain a #main_div.

Steps for Testing/QA
--------------------
Try this on master: Open the javascript console. Go to cloud inteligence --> reports --> dashboards. Edit a dashboard (the screen with drag-n-drop).

See the warnings in the javascript console.

Then try with this branch. (No warnings in the javascript console).


