### PR TITLE
Toolbars: remove eval calls.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -105,9 +105,9 @@ class ApplicationHelper::ToolbarBuilder
     )
 
     button[:enabled]   = input[:enabled]
-    button[:title]     = safer_eval(input[:title])   unless input[:title].blank?
-    button[:text]      = safer_eval(input[:text])    unless input[:text].blank?
-    button[:confirm]   = safer_eval(input[:confirm]) unless input[:confirm].blank?
+    button[:title]     = input[:title]   unless input[:title].blank?
+    button[:text]      = input[:text]    unless input[:text].blank?
+    button[:confirm]   = input[:confirm] unless input[:confirm].blank?
     button[:url_parms] = update_url_parms(safer_eval(input[:url_parms])) unless input[:url_parms].blank?
 
     if input[:popup] # special behavior: button opens window_url in a new window


### PR DESCRIPTION
Remove eval calls obsoleted by recent i18n work in toolbars
-------------------------
These 3 'eval' calls should be no longer needed as the corresponding
keys now can contain a 'proc', that is evaluated in the scope of the
button.

Remaining eval call for the `:url_parms` key to be addressed separately:
https://github.com/ManageIQ/manageiq/issues/9711

Steps for Testing/QA
--------------------
Check the buttons interpolations and i18n in multiple toolbars.

Shall go to Darga with all the other Toolbar i18n fixes.