### PR TITLE
Cleanup catalog removal menu

### DIFF
--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -26,8 +26,8 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
         button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Item from the VMDB'),
-          N_('Remove Item from the VMDB'),
+          N_('Remove this Catalog Item'),
+          N_('Remove Catalog Item'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: This Catalog Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Catalog Item?")),
       ]

--- a/app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb
@@ -16,8 +16,8 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogCenter < ApplicationHelp
         button(
           :st_catalog_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Item from the VMDB'),
-          N_('Remove Item from the VMDB'),
+          N_('Remove this Catalog'),
+          N_('Remove Catalog'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: This Catalog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Catalog?")),
       ]

--- a/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
@@ -22,8 +22,8 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogsCenter < ApplicationHel
         button(
           :st_catalog_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Items from the VMDB'),
-          N_('Remove Items from the VMDB'),
+          N_('Remove selected Catalog Items'),
+          N_('Remove Catalog Items'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Items will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/servicetemplates_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplates_center.rb
@@ -27,8 +27,8 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
         button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Items from the VMDB'),
-          N_('Remove Items from the VMDB'),
+          N_('Remove selected Catalog Items'),
+          N_('Remove Catalog Items'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
           :enabled   => false,


### PR DESCRIPTION
Simplifies the UI for removing catalog items, as telling the user about the VMDB is not necessary.  

 https://bugzilla.redhat.com/show_bug.cgi?id=1354044