### PR TITLE
 Introduce class ApiController::CollectionConfig

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -136,7 +136,7 @@ class ApiController < ApplicationController
   end
 
   def collection_config
-    @collection_config ||= CollectionConfig.new(Api::Settings.collections)
+    @collection_config ||= CollectionConfig.new
   end
 
   delegate :user_token_service, :to => self

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -136,7 +136,7 @@ class ApiController < ApplicationController
   end
 
   def collection_config
-    Api::Settings.collections
+    @collection_config ||= CollectionConfig.new(Api::Settings.collections)
   end
 
   delegate :user_token_service, :to => self

--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -142,7 +142,7 @@ class ApiController
         "name"        => details[:name],
         "description" => details[:description]
       }
-      collection, method, action = referenced_identifiers[ident_str]
+      collection, method, action = collection_config.what_refers_to_feature(ident_str)
       collections = collection_config.names_for_feature(ident_str)
       res["href"] = "#{@req.api_prefix}/#{collections.first}" if collections.one?
       res["action"] = api_action_details(collection, method, action) if collection.present?
@@ -156,24 +156,6 @@ class ApiController
         "method" => method,
         "href"   => "#{@req.api_prefix}/#{collection}"
       }
-    end
-
-    def referenced_identifiers
-      @referenced_identifiers ||= begin
-        identifiers = {}
-        collection_config.each do |collection, cspec|
-          next unless cspec[:collection_actions].present?
-          cspec[:collection_actions].each do |method, action_definitions|
-            next unless action_definitions.present?
-            action_definitions.each do |action|
-              identifier = action[:identifier]
-              next if action[:disabled] || identifiers.key?(identifier)
-              identifiers[identifier] = [collection, method, action]
-            end
-          end
-        end
-        identifiers
-      end
     end
 
     def api_token_mgr

--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -144,7 +144,7 @@ class ApiController
       }
       collection, method, action = referenced_identifiers[ident_str]
       hrefs = get_hrefs_for_identifier(ident_str)
-      res["href"] = hrefs.first if hrefs.one?
+      res["href"] = "#{@req.api_prefix}/#{hrefs.first}" if hrefs.one?
       res["action"] = api_action_details(collection, method, action) if collection.present?
       res["children"] = children if children.present?
       pf_result[ident_str] = res
@@ -185,8 +185,7 @@ class ApiController
       collection_config.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(collection, cspec), result|
         ident = cspec[:identifier]
         next unless ident
-        href = "#{@req.api_prefix}/#{collection}"
-        result[ident] << href
+        result[ident] << collection
       end
     end
 

--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -143,8 +143,8 @@ class ApiController
         "description" => details[:description]
       }
       collection, method, action = referenced_identifiers[ident_str]
-      hrefs = get_hrefs_for_identifier(ident_str)
-      res["href"] = "#{@req.api_prefix}/#{hrefs.first}" if hrefs.one?
+      collections = collection_config.names_for_feature(ident_str)
+      res["href"] = "#{@req.api_prefix}/#{collections.first}" if collections.one?
       res["action"] = api_action_details(collection, method, action) if collection.present?
       res["children"] = children if children.present?
       pf_result[ident_str] = res
@@ -173,19 +173,6 @@ class ApiController
           end
         end
         identifiers
-      end
-    end
-
-    def get_hrefs_for_identifier(identifier)
-      @collection_hrefs ||= generate_collection_hrefs
-      @collection_hrefs[identifier]
-    end
-
-    def generate_collection_hrefs
-      collection_config.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(collection, cspec), result|
-        ident = cspec[:identifier]
-        next unless ident
-        result[ident] << collection
       end
     end
 

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -5,6 +5,10 @@ class ApiController
       cspec && cspec[:options].include?(:custom_actions)
     end
 
+    def show_as_collection?(collection_name)
+      self[collection_name.to_sym][:options].include?(:show_as_collection)
+    end
+
     def names_for_feature(product_feature_name)
       names_for_features[product_feature_name]
     end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -1,32 +1,40 @@
 class ApiController
-  class CollectionConfig < Config::Options
+  class CollectionConfig
+    def initialize
+      @cfg = Api::Settings.collections
+    end
+
+    def [](collection_name)
+      @cfg[collection_name.to_sym]
+    end
+
     def collection?(collection_name)
-      c(collection_name)[:options].include?(:collection)
+      self[collection_name][:options].include?(:collection)
     end
 
     def custom_actions?(collection_name)
-      cspec = c(collection_name)
+      cspec = self[collection_name]
       cspec && cspec[:options].include?(:custom_actions)
     end
 
     def primary?(collection_name)
-      c(collection_name)[:options].include?(:primary)
+      self[collection_name][:options].include?(:primary)
     end
 
     def show?(collection_name)
-      c(collection_name)[:options].include?(:show)
+      self[collection_name][:options].include?(:show)
     end
 
     def show_as_collection?(collection_name)
-      c(collection_name)[:options].include?(:show_as_collection)
+      self[collection_name][:options].include?(:show_as_collection)
     end
 
     def supports_http_method?(collection_name, method)
-      Array(c(collection_name)[:verbs]).include?(method)
+      Array(self[collection_name][:verbs]).include?(method)
     end
 
     def subcollections(collection_name)
-      Array(c(collection_name)[:subcollections])
+      Array(self[collection_name][:subcollections])
     end
 
     def subcollection?(collection_name, subcollection_name)
@@ -34,15 +42,16 @@ class ApiController
     end
 
     def subcollection_denied?(collection_name, subcollection_name)
-      c(collection_name)[:subcollections] && !c(collection_name)[:subcollections].include?(subcollection_name.to_sym)
+      self[collection_name][:subcollections] &&
+        !self[collection_name][:subcollections].include?(subcollection_name.to_sym)
     end
 
     def typed_collection_actions(collection_name, target)
-      c(collection_name)["#{target}_actions".to_sym]
+      self[collection_name]["#{target}_actions".to_sym]
     end
 
     def typed_subcollection_actions(collection_name, subcollection_name)
-      c(collection_name)["#{subcollection_name}_subcollection_actions".to_sym]
+      self[collection_name]["#{subcollection_name}_subcollection_actions".to_sym]
     end
 
     def typed_subcollection_action(collection_name, subcollection_name, method)
@@ -54,11 +63,11 @@ class ApiController
     end
 
     def klass(collection_name)
-      c(collection_name)[:klass].constantize
+      self[collection_name][:klass].constantize
     end
 
     def name_for_klass(resource_klass)
-      detect do |_, spec|
+      @cfg.detect do |_, spec|
         spec[:klass] && spec[:klass].constantize == resource_klass
       end.try(:first)
     end
@@ -68,7 +77,7 @@ class ApiController
     end
 
     def collections_with_description
-      each_with_object({}) do |(collection, cspec), result|
+      @cfg.each_with_object({}) do |(collection, cspec), result|
         result[collection] = cspec[:description] if cspec[:options].include?(:collection)
       end
     end
@@ -76,7 +85,7 @@ class ApiController
     private
 
     def names_for_features
-      @names_for_features ||= each_with_object(Hash.new { |h, k| h[k] = [] }) do |(collection, cspec), result|
+      @names_for_features ||= @cfg.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(collection, cspec), result|
         ident = cspec[:identifier]
         next unless ident
         result[ident] << collection
@@ -84,7 +93,7 @@ class ApiController
     end
 
     def referenced_identifiers
-      @referenced_identifiers ||= each_with_object({}) do |(collection, cspec), result|
+      @referenced_identifiers ||= @cfg.each_with_object({}) do |(collection, cspec), result|
         next unless cspec[:collection_actions].present?
         cspec[:collection_actions].each do |method, action_definitions|
           next unless action_definitions.present?
@@ -95,10 +104,6 @@ class ApiController
           end
         end
       end
-    end
-
-    def c(collection_name)
-      self[collection_name.to_sym]
     end
   end
 end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -1,4 +1,8 @@
 class ApiController
   class CollectionConfig < Config::Options
+    def custom_actions?(collection_name)
+      cspec = self[collection_name.to_sym]
+      cspec && cspec[:options].include?(:custom_actions)
+    end
   end
 end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -51,6 +51,12 @@ class ApiController
       referenced_identifiers[product_feature_name]
     end
 
+    def collections_with_description
+      each_with_object({}) do |(collection, cspec), result|
+        result[collection] = cspec[:description] if cspec[:options].include?(:collection)
+      end
+    end
+
     private
 
     def names_for_features

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -4,5 +4,19 @@ class ApiController
       cspec = self[collection_name.to_sym]
       cspec && cspec[:options].include?(:custom_actions)
     end
+
+    def names_for_feature(product_feature_name)
+      names_for_features[product_feature_name]
+    end
+
+    private
+
+    def names_for_features
+      @names_for_features ||= each_with_object(Hash.new { |h, k| h[k] = [] }) do |(collection, cspec), result|
+        ident = cspec[:identifier]
+        next unless ident
+        result[ident] << collection
+      end
+    end
   end
 end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -1,0 +1,4 @@
+class ApiController
+  class CollectionConfig < Config::Options
+  end
+end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -1,12 +1,28 @@
 class ApiController
   class CollectionConfig < Config::Options
+    def collection?(collection_name)
+      c(collection_name)[:options].include?(:collection)
+    end
+
     def custom_actions?(collection_name)
       cspec = c(collection_name)
       cspec && cspec[:options].include?(:custom_actions)
     end
 
+    def primary?(collection_name)
+      c(collection_name)[:options].include?(:primary)
+    end
+
+    def show?(collection_name)
+      c(collection_name)[:options].include?(:show)
+    end
+
     def show_as_collection?(collection_name)
       c(collection_name)[:options].include?(:show_as_collection)
+    end
+
+    def supports_http_method?(collection_name, method)
+      Array(c(collection_name)[:verbs]).include?(method)
     end
 
     def subcollections(collection_name)

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -1,20 +1,20 @@
 class ApiController
   class CollectionConfig < Config::Options
     def custom_actions?(collection_name)
-      cspec = self[collection_name.to_sym]
+      cspec = c(collection_name)
       cspec && cspec[:options].include?(:custom_actions)
     end
 
     def show_as_collection?(collection_name)
-      self[collection_name.to_sym][:options].include?(:show_as_collection)
+      c(collection_name)[:options].include?(:show_as_collection)
     end
 
     def subcollection?(collection_name, subcollection_name)
-      Array(self[collection_name.to_sym][:subcollections]).include?(subcollection_name.to_sym)
+      Array(c(collection_name)[:subcollections]).include?(subcollection_name.to_sym)
     end
 
     def subcollection_denied?(collection_name, subcollection_name)
-      self[collection_name.to_sym][:subcollections] && !self[collection_name.to_sym][:subcollections].include?(subcollection_name.to_sym)
+      c(collection_name)[:subcollections] && !c(collection_name)[:subcollections].include?(subcollection_name.to_sym)
     end
 
     def names_for_feature(product_feature_name)
@@ -57,6 +57,10 @@ class ApiController
           end
         end
       end
+    end
+
+    def c(collection_name)
+      self[collection_name.to_sym]
     end
   end
 end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -9,6 +9,14 @@ class ApiController
       self[collection_name.to_sym][:options].include?(:show_as_collection)
     end
 
+    def subcollection?(collection_name, subcollection_name)
+      Array(self[collection_name.to_sym][:subcollections]).include?(subcollection_name.to_sym)
+    end
+
+    def subcollection_denied?(collection_name, subcollection_name)
+      self[collection_name.to_sym][:subcollections] && !self[collection_name.to_sym][:subcollections].include?(subcollection_name.to_sym)
+    end
+
     def names_for_feature(product_feature_name)
       names_for_features[product_feature_name]
     end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -13,6 +13,16 @@ class ApiController
       names_for_features[product_feature_name]
     end
 
+    def klass(collection_name)
+      c(collection_name)[:klass].constantize
+    end
+
+    def name_for_klass(resource_klass)
+      detect do |_, spec|
+        spec[:klass] && spec[:klass].constantize == resource_klass
+      end.try(:first)
+    end
+
     private
 
     def names_for_features

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -17,6 +17,18 @@ class ApiController
       c(collection_name)[:subcollections] && !c(collection_name)[:subcollections].include?(subcollection_name.to_sym)
     end
 
+    def typed_collection_actions(collection_name, target)
+      c(collection_name)["#{target}_actions".to_sym]
+    end
+
+    def typed_subcollection_actions(collection_name, subcollection_name)
+      c(collection_name)["#{subcollection_name}_subcollection_actions".to_sym]
+    end
+
+    def typed_subcollection_action(collection_name, subcollection_name, method)
+      c(collection_name).fetch_path("#{subcollection_name}_subcollection_actions".to_sym, method.to_sym)
+    end
+
     def names_for_feature(product_feature_name)
       names_for_features[product_feature_name]
     end

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -9,8 +9,12 @@ class ApiController
       c(collection_name)[:options].include?(:show_as_collection)
     end
 
+    def subcollections(collection_name)
+      Array(c(collection_name)[:subcollections])
+    end
+
     def subcollection?(collection_name, subcollection_name)
-      Array(c(collection_name)[:subcollections]).include?(subcollection_name.to_sym)
+      subcollections(collection_name).include?(subcollection_name.to_sym)
     end
 
     def subcollection_denied?(collection_name, subcollection_name)
@@ -26,7 +30,7 @@ class ApiController
     end
 
     def typed_subcollection_action(collection_name, subcollection_name, method)
-      c(collection_name).fetch_path("#{subcollection_name}_subcollection_actions".to_sym, method.to_sym)
+      typed_subcollection_actions(collection_name, subcollection_name).try(:fetch_path, method.to_sym)
     end
 
     def names_for_feature(product_feature_name)

--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -23,6 +23,10 @@ class ApiController
       end.try(:first)
     end
 
+    def what_refers_to_feature(product_feature_name)
+      referenced_identifiers[product_feature_name]
+    end
+
     private
 
     def names_for_features
@@ -30,6 +34,20 @@ class ApiController
         ident = cspec[:identifier]
         next unless ident
         result[ident] << collection
+      end
+    end
+
+    def referenced_identifiers
+      @referenced_identifiers ||= each_with_object({}) do |(collection, cspec), result|
+        next unless cspec[:collection_actions].present?
+        cspec[:collection_actions].each do |method, action_definitions|
+          next unless action_definitions.present?
+          action_definitions.each do |action|
+            identifier = action[:identifier]
+            next if action[:disabled] || result.key?(identifier)
+            result[identifier] = [collection, method, action]
+          end
+        end
       end
     end
   end

--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -28,15 +28,13 @@ class ApiController
     end
 
     def entrypoint_collections
-      collection_config.sort.collect do |collection_name, collection_specification|
-        if collection_specification[:options].include?(:collection)
-          {
-            :name        => collection_name,
-            :href        => collection_name,
-            :description => collection_specification[:description]
-          }
-        end
-      end.compact
+      collection_config.collections_with_description.sort.collect do |collection_name, description|
+        {
+          :name        => collection_name,
+          :href        => collection_name,
+          :description => description
+        }
+      end
     end
   end
 end

--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -42,14 +42,12 @@ class ApiController
     # Same signature.
     #
     def add_resource(type, _id, data)
-      cspec = collection_config[type]
       klass = collection_class(type)
       if data.key?("id") || data.key?("href")
         raise BadRequestError,
               "Resource id or href should not be specified for creating a new #{type} resource"
       end
-      subcollections     = cspec[:subcollections]
-      subcollection_data = Array(subcollections).each_with_object({}) do |sc, hash|
+      subcollection_data = collection_config.subcollections(type).each_with_object({}) do |sc, hash|
         if data.key?(sc.to_s)
           hash[sc] = data[sc.to_s]
           data.delete(sc.to_s)

--- a/app/controllers/api_controller/manager.rb
+++ b/app/controllers/api_controller/manager.rb
@@ -89,7 +89,7 @@ class ApiController
         typed_target = "#{target}_#{type}"
         return typed_target if respond_to?(typed_target)
         return target if respond_to?(target)
-        resource_can_have_custom_actions(type) ? "custom_action_resource" : "undefined_api_method"
+        collection_config.custom_actions?(type) ? "custom_action_resource" : "undefined_api_method"
       end
     end
 

--- a/app/controllers/api_controller/manager.rb
+++ b/app/controllers/api_controller/manager.rb
@@ -25,7 +25,7 @@ class ApiController
     end
 
     def collection_class(type)
-      (@collection_klasses[type.to_sym] || collection_config[type.to_sym][:klass]).constantize
+      @collection_klasses[type.to_sym] || collection_config.klass(type)
     end
 
     def put_resource(type, id)

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -239,7 +239,7 @@ class ApiController
       if @req.collection
         cname = @req.collection
         ctype = "Collection"
-        raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config[cname.to_sym]
+        raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config[cname]
         if collection_config.primary?(cname)
           if "#{@req.c_id}#{@req.subcollection}#{@req.s_id}".present?
             raise BadRequestError, "Invalid request for #{ctype} #{cname} specified"

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -21,8 +21,7 @@ class ApiController
       # Method Validation for the collection or sub-collection specified
       if cname && ctype
         mname = @req.method
-        cent  = collection_config[cname.to_sym]  # For Sub-Collection
-        unless Array(cent[:verbs]).include?(mname)
+        unless collection_config.supports_http_method?(cname, mname)
           raise BadRequestError, "Unsupported HTTP Method #{mname} for the #{ctype} #{cname} specified"
         end
       end
@@ -241,13 +240,12 @@ class ApiController
         cname = @req.collection
         ctype = "Collection"
         raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config[cname.to_sym]
-        cspec = collection_config[cname.to_sym]
-        if cspec[:options].include?(:primary)
+        if collection_config.primary?(cname)
           if "#{@req.c_id}#{@req.subcollection}#{@req.s_id}".present?
             raise BadRequestError, "Invalid request for #{ctype} #{cname} specified"
           end
         else
-          raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless cspec[:options].include?(:collection)
+          raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config.collection?(cname)
         end
         [cname, ctype]
       end

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -100,11 +100,6 @@ class ApiController
       href.match(%r{^.*/#{collection}/([0-9]+)$}) && Regexp.last_match(1) if href.present?
     end
 
-    def resource_can_have_custom_actions(type)
-      cspec = collection_config[type.to_sym]
-      cspec && cspec[:options].include?(:custom_actions)
-    end
-
     def parse_by_attr(resource, type, attr_list)
       klass = collection_class(type)
       objs = attr_list.map { |attr| klass.send("find_by_#{attr}", resource[attr]) if resource[attr] }.compact
@@ -230,7 +225,7 @@ class ApiController
       aspec = cspec[aspecnames.to_sym]
       action_hash = fetch_action_hash(aspec, mname, aname)
       if action_hash.blank?
-        unless type == :resource && resource_can_have_custom_actions(cname)
+        unless type == :resource && collection_config.custom_actions?(cname)
           raise BadRequestError, "Unsupported Action #{aname} for the #{cname} #{type} specified"
         end
       end

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -100,8 +100,8 @@ class ApiController
       href.match(%r{^.*/#{collection}/([0-9]+)$}) && Regexp.last_match(1) if href.present?
     end
 
-    def resource_can_have_custom_actions(type, cspec = nil)
-      cspec ||= collection_config[type.to_sym] if collection_config[type.to_sym]
+    def resource_can_have_custom_actions(type)
+      cspec = collection_config[type.to_sym]
       cspec && cspec[:options].include?(:custom_actions)
     end
 
@@ -230,7 +230,7 @@ class ApiController
       aspec = cspec[aspecnames.to_sym]
       action_hash = fetch_action_hash(aspec, mname, aname)
       if action_hash.blank?
-        unless type == :resource && resource_can_have_custom_actions(cname, cspec)
+        unless type == :resource && resource_can_have_custom_actions(cname)
           raise BadRequestError, "Unsupported Action #{aname} for the #{cname} #{type} specified"
         end
       end

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -41,7 +41,7 @@ class ApiController
           raise BadRequestError, "Management of #{cname} is unsupported for the Provider class"
         end
       end
-      @collection_klasses[:providers] = "Provider"
+      @collection_klasses[:providers] = Provider
     end
 
     def validate_api_action

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -260,22 +260,20 @@ class ApiController
       # Sub-Collection Validation for the specified Collection
       if cname && @req.subcollection
         return [cname, ctype] if collection_option?(:arbitrary_resource_path)
-        cent  = collection_config[cname.to_sym]  # For Collection
-        cname = @req.subcollection
         ctype = "Sub-Collection"
-        unless Array(cent[:subcollections]).include?(cname.to_sym)
-          raise BadRequestError, "Unsupported #{ctype} #{cname} specified"
+        unless collection_config.subcollection?(cname, @req.subcollection)
+          raise BadRequestError, "Unsupported #{ctype} #{@req.subcollection} specified"
         end
+        cname = @req.subcollection
       end
       [cname, ctype]
     end
 
     def validate_post_api_action_as_subcollection(cname, mname, aname)
       return if cname == @req.collection
+      return if collection_config.subcollection_denied?(@req.collection, cname)
 
       cspec = collection_config[@req.collection.to_sym]
-      return if cspec[:subcollections] && !cspec[:subcollections].include?(cname.to_sym)
-
       aspec = cspec["#{cname}_subcollection_actions".to_sym]
       return unless aspec
 

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -381,7 +381,7 @@ class ApiController
     # Let's expand a subcollection
     #
     def expand_subcollection(json, sc, sctype, subresources)
-      if collection_config[sc.to_sym][:options].include?(:show_as_collection)
+      if collection_config.show_as_collection?(sc)
         copts = {
           :count            => subresources.length,
           :is_subcollection => true,

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -100,9 +100,7 @@ class ApiController
 
       rclass = resource.class
       if collection_class(type) != rclass
-        matched_type, = collection_config.detect do |_collection, spec|
-          spec[:klass] && spec[:klass].constantize == rclass
-        end
+        matched_type = collection_config.name_for_klass(rclass)
       end
       matched_type || reftype
     end

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -228,7 +228,7 @@ class ApiController
     end
 
     def expand_subcollection?(sc, target)
-      respond_to?(target) && (@req.expand?(sc) || collection_config[sc.to_sym][:options].include?(:show))
+      respond_to?(target) && (@req.expand?(sc) || collection_config.show?(sc))
     end
 
     #

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -352,7 +352,7 @@ class ApiController
     end
 
     def expand_resource_custom_actions(resource, json, type)
-      return unless render_actions(resource) && resource_can_have_custom_actions(type)
+      return unless render_actions(resource) && collection_config.custom_actions?(type)
 
       href = json.attributes!["href"]
       json.actions do |js|

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -217,9 +217,7 @@ class ApiController
     # Let's expand subcollections for objects if asked for
     #
     def expand_subcollections(json, type, resource)
-      scs = collection_config[type.to_sym][:subcollections]
-      return unless scs
-      scs.each do |sc|
+      collection_config.subcollections(type).each do |sc|
         target = "#{sc}_query_resource"
         next unless expand_subcollection?(sc, target)
         if Array(attribute_selection).include?(sc.to_s)

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -451,9 +451,7 @@ class ApiController
 
     def fetch_typed_subcollection_actions(method, is_subcollection)
       return unless is_subcollection
-      ctype = @req.collection.to_sym
-      sakey = "#{@req.subcollection}_subcollection_actions".to_sym
-      collection_config.fetch_path(ctype, sakey, method.to_sym)
+      collection_config.typed_subcollection_action(@req.collection, @req.subcollection, method)
     end
 
     def api_user_role_allows?(action_identifier)


### PR DESCRIPTION
Intent
-----------------
The `config/api.yml` is complex. We have a code parsing this config all over the API controllers. That means we have config-parsing-logic and controller(renderer/parser/manager) logic are closely bound. 

This is first cut to put config parsing logic into a separate class. This can buy us not only the encapsulation, but also we get a place where we can start documenting semantics of the config itself.

/cc @abellotti, @imtayadeway 
@miq-bot add_label api, refactoring, darga/no