### PR TITLE
update rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,6 @@ AllCops:
   Exclude:
     - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
     - db/schema.rb
-    - db/migrate/*.rb
     - vendor/**/*
 ClassAndModuleCamelCase:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ GlobalVars:
 AllCops:
   Exclude:
     - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
+    - db/schema.rb
+    - db/migrate/*.rb
+    - vendor/**/*
 ClassAndModuleCamelCase:
   Exclude:
     - lib/miq_automation_engine/service_models/*.rb


### PR DESCRIPTION
Purpose or Intent
-----------------
> Working on removing some rubocop issues and noticed that `db/schema.rb`, ~~`db/migrate`~~ and `vendor/` are not ignored.
> * `db/schema.rb`: 2050 violations
> * ~~`db/migrate`: 414 offenses~~
> * `vendor`: 11 violations
> 
> While `vendor` should definitely be skipped, wanted to discuss whether we wanted to go as far as removing violations in~~`db/migrate`~~ or just ignore them cc: @Fryguy @chriskacerguis 

