### PR TITLE
removing all hash syntax rubocop violations

### DIFF
--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -198,8 +198,8 @@ describe OpsController do
 
           expect(assigns(:flash_array)).to eq [
             {
-              :message  => 'EVM Server no longer exists',
-              :level    => :error
+              :message => 'EVM Server no longer exists',
+              :level   => :error
             }
           ]
         end
@@ -207,15 +207,15 @@ describe OpsController do
 
       context "server doesn't exist" do
         it 'should set the flash saying that server no longer exists' do
-          controller.instance_variable_set(:@sb, { :diag_selected_id => -100500 })
+          controller.instance_variable_set(:@sb, :diag_selected_id => -100500)
           expect(controller).to receive :refresh_screen
 
           controller.send(:delete_server)
 
           expect(assigns(:flash_array)).to eq [
             {
-              :message  => 'The selected EVM Server was deleted',
-              :level    => :success
+              :message => 'The selected EVM Server was deleted',
+              :level   => :success
             }
           ]
         end

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -198,8 +198,8 @@ describe OpsController do
 
           expect(assigns(:flash_array)).to eq [
             {
-              message: 'EVM Server no longer exists',
-              level: :error
+              :message  => 'EVM Server no longer exists',
+              :level    => :error
             }
           ]
         end
@@ -207,15 +207,15 @@ describe OpsController do
 
       context "server doesn't exist" do
         it 'should set the flash saying that server no longer exists' do
-          controller.instance_variable_set(:@sb, { diag_selected_id: -100500 })
+          controller.instance_variable_set(:@sb, { :diag_selected_id => -100500 })
           expect(controller).to receive :refresh_screen
 
           controller.send(:delete_server)
 
           expect(assigns(:flash_array)).to eq [
             {
-              message: 'The selected EVM Server was deleted',
-              level: :success
+              :message  => 'The selected EVM Server was deleted',
+              :level    => :success
             }
           ]
         end
@@ -223,7 +223,7 @@ describe OpsController do
 
       context "server does exist, but something goes wrong during deletion" do
         it 'should set the flash saying that server no longer exists' do
-          controller.instance_variable_set(:@sb, { diag_selected_id: @miq_server.id })
+          controller.instance_variable_set(:@sb, { :diag_selected_id => @miq_server.id })
           expect(controller).to receive :refresh_screen
           expect_any_instance_of(MiqServer).to receive(:destroy).and_raise 'boom'
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_copy_spec.rb
@@ -101,7 +101,7 @@ describe MiqAeClassCopy do
       fqname = 'test1'
       ids    = [1, 2, 3]
       miq_ae_class_copy = double(MiqAeClassCopy)
-      miq_ae_class = double(MiqAeClass, id: 1)
+      miq_ae_class = double(MiqAeClass, :id => 1)
       new_ids = [miq_ae_class.id] * ids.length
       expect(miq_ae_class_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_class }
       expect(miq_ae_class).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }

--- a/spec/lib/miq_automation_engine/models/miq_ae_instance_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_instance_copy_spec.rb
@@ -98,7 +98,7 @@ describe MiqAeInstanceCopy do
       fqname = 'test1'
       ids    = [1, 2, 3]
       ins_copy = double(MiqAeInstanceCopy)
-      ins = double(MiqAeInstance, id: 1)
+      ins = double(MiqAeInstance, :id => 1)
       expect(ins_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { ins }
       new_ids = [ins.id] * ids.length
       expect(ins).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }

--- a/spec/lib/miq_automation_engine/models/miq_ae_method_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_method_copy_spec.rb
@@ -88,7 +88,7 @@ describe MiqAeMethodCopy do
       fqname = 'test1'
       ids    = [1, 2, 3]
       miq_ae_method_copy = double(MiqAeMethodCopy)
-      miq_ae_method = double(MiqAeMethod, id: 1)
+      miq_ae_method = double(MiqAeMethod, :id => 1)
       expect(miq_ae_method_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_method }
       new_ids = [miq_ae_method.id] * ids.length
       expect(miq_ae_method).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }

--- a/spec/views/host/_show.html.haml_spec.rb
+++ b/spec/views/host/_show.html.haml_spec.rb
@@ -44,7 +44,7 @@ describe "host/show.html.haml" do
       assign(:lastaction, "host_services")
       assign(:view, OpenStruct.new(:table => OpenStruct.new(:data => [])))
       render
-      expect(view).to render_template(partial: 'layouts/gtl', :locals => {:action_url => 'host_services'})
+      expect(view).to render_template(:partial => 'layouts/gtl', :locals => {:action_url => 'host_services'})
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
> Removes all remaining Hash Syntax violations (when #9723 is applied)

Steps for Testing/QA
--------------------
> `rubocop --only HashSyntax` 

