### PR TITLE
[Darga] Upgrade to ovirt 0.11.0

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -38,7 +38,7 @@ gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=1.1.0",            :require => false
 gem "openscap",                "~>0.4.3",           :require => false
-gem "ovirt",                   "~>0.10.0",          :require => false
+gem "ovirt",                   "~>0.11.0",          :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false


### PR DESCRIPTION
# Purpose

This PR updates the _oVirt_ provider to use version 0.11.0 of the `ovirt` gem, as that is necessary in order to calculate correctly the `ems_ref` attributes of inventory items retrieved from version 4 of _oVirt_.

Note that the commit in this PR was already part of [another PR](https://github.com/ManageIQ/manageiq/pull/9667) merged to the master branch, but that can't (I guess) be back-ported to the _darga_ branch, as it contains other changes shouldn't be back-ported.

# Links

This PR is part of the fix for the following bug:

* [Inventory refresh doesn't work with version 4 of oVirt](https://bugzilla.redhat.com/1352967)