### PR TITLE
BZ1345832:  memory metric not being rolled up to OSP Availability zones

### DIFF
--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -59,6 +59,7 @@ module Metric::Rollup
     ],
     :AvailabilityZone_vms                 => [
       :cpu_usage_rate_average,
+      :derived_memory_used,
       :net_usage_rate_average,
       :disk_usage_rate_average
     ]


### PR DESCRIPTION
This PR adds derived_memory_used to metric rollups for Availability Zones. This resolves BZ #1345832: https://bugzilla.redhat.com/show_bug.cgi?id=1345832