### PR TITLE
fix block_storage_disk_capacity for no block_storage cluster

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/availability_zone.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/availability_zone.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::Openstack::CloudManager::AvailabilityZone < ::Availab
   # hosts that has the matching availability_zone configured in /etc/cinder/cinder.conf.
   def block_storage_disk_capacity
     cluster = ext_management_system.provider.infra_ems.ems_clusters.find { |c| c.block_storage? == true }
-    cluster.aggregate_disk_capacity
+    cluster.nil? ? 0 : cluster.aggregate_disk_capacity
   end
 
   def block_storage_disk_usage


### PR DESCRIPTION

block_storage_disk_capacity throws a nil-related error when there is no
cluster for which c.block_storage? == true.

This commit fixes the method to return 0 for capacity when there is no
block_storage cluster.