### PR TITLE
[WIP] Limit `/report/explorer` from showing nodes with > 1000 children

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -285,9 +285,16 @@ class TreeBuilder
        @options[:lazy] == false
       node[:expand] = true if options[:type] == :automate &&
                               Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key])
-      kids = x_get_tree_objects(object, options, false, parents).map do |o|
-        x_build_node(o, node[:key], options)
-      end
+
+      # If a block is provided, load the kids via that block, otherwise use the
+      # default method of loading the children
+      kids = if block_given?
+               yield parents, node[:key]
+             else
+               x_get_tree_objects(object, options, false, parents).map do |o|
+                 x_build_node(o, node[:key], options)
+               end
+             end
       node[:children] = kids unless kids.empty?
     else
       if x_get_tree_objects(object, options, true, parents) > 0

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -1,4 +1,24 @@
 class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
+
+  # Get the children of a dynatree node that is being expanded (autoloaded)
+  #
+  # This overwrites the method defined in app/presters/tree_builder.rb to not
+  # map the SQL query with the records before doing a `count`.  This allows us
+  # to check the size of the tree with a single quick query with out loading
+  # all of the records into memory.
+  def x_get_child_nodes(id)
+    parents = [] # FIXME: parent ids should be provided on autoload as well
+
+    object = node_by_tree_id(id)
+
+    # Save node as open
+    open_node(id)
+
+    tree_state = @tree_state.x_tree(@name)
+    tree_objects = x_get_tree_objects(object, tree_state, false, parents)
+    x_build_tree_with_limit(tree_objects, id, tree_state)
+  end
+
   private
 
   # Overwrites the x_build_node_dynatree method (which is just a wrapper around

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -1,6 +1,33 @@
 class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   private
 
+  # Overwrites the x_build_node_dynatree method (which is just a wrapper around
+  # `x_build_node`) to call `x_build_node` with a block for grabbing the kids
+  # that will return a simple array if over 1000 kids exists.
+  def x_build_node_dynatree(object, pid, options)
+    x_build_node(object, pid, options) do |parents, id|
+      tree_objects = x_get_tree_objects(object, options, false, parents)
+      x_build_tree_with_limit(tree_objects, id, options)
+    end
+  end
+
+  def x_build_tree_with_limit(tree_objects, id, tree_state)
+    if tree_objects.count > 1000
+      # Display a subtree with a single node saying the tree is too big to
+      # load.  This is a cheaper solution than instanciating a dummy
+      # TreeNodeBuilder just to use the generic_node method.
+      [{ :key   => nil,
+         :title => 'Tree to large to load!',
+         :icon  => ActionController::Base.helpers.image_path('100/x.png'),
+         :tooltip => 'Use table to the right to view reports'
+      }]
+    else
+      tree_objects.map do |o|
+        x_build_node(o, id, tree_state)
+      end
+    end
+  end
+
   def tree_init_options(tree_name)
     {
       :full_ids => true,


### PR DESCRIPTION
Purpose or Intent
-----------------
Prevent massive rendering times on large subtrees by simply not loading them.  A perfectly usable and fast paginated table exists on the same page, and can be used to traverse those large trees, and sorted on.

More details can be found in the individual commits, but essentially we are overwriting the tree rendering methods to bail out early and display a message that the tree is too large to load, and the user should use the table view on the left.

![miq_reports_screenshot](https://cloud.githubusercontent.com/assets/314014/16738919/5ed9ce26-475d-11e6-93a7-47ffa154346e.png)


Links
-----
* Related PRs
  - https://github.com/ManageIQ/manageiq/pull/9559
  - https://github.com/ManageIQ/manageiq/pull/9698


Steps for Testing/QA
--------------------
Build a large reports subtree (over 1k nodes) and make sure that both ajaxing in the subtree and reloading the page prevent the subtree from being expanded.