### PR TITLE
Aggregate failures for API specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,7 @@ RSpec.configure do |config|
   config.include ApiSpecHelper,     :rest_api => true
   config.include AuthRequestHelper, :type => :request
   config.define_derived_metadata(:file_path => /spec\/requests\/api/) do |metadata|
+    metadata[:aggregate_failures] = true
     metadata[:rest_api] = true
   end
 


### PR DESCRIPTION
API/request specs are expensive, so it makes sense to aggregate
expectations around a single response. Unfortunately this usually means
that the error feedback is as helpful as "expected 200, got 500". RSpec
3.3 introduced failure aggregation, which this revision turns on for all
API specs, so every failing test should produce some helpful
feedback. This doesn't seem to work where we are putting expectations on
things other than the response (or just any two things). But for a one
line change, I think this adds a significant improvement. Here's a
sample output:

```
Failures:

  1) tenants API can list all the tenants
     Got 1 failure and 1 other error:

     1.1) Failure/Error: expect(response_hash).to have_key(collection)
            expected #has_key?("resources") to return true, got false
          # ./spec/support/api_spec_helper.rb:194:in `expect_result_resources_to_include_hrefs'
          # ./spec/requests/api/tenants_spec.rb:11:in `block (2 levels) in <top (required)>'

     1.2) Failure/Error: expect(response_hash[collection].size).to eq(href_list.size)

          NoMethodError:
            undefined method `size' for nil:NilClass
          # ./spec/support/api_spec_helper.rb:196:in `expect_result_resources_to_include_hrefs'
          # ./spec/requests/api/tenants_spec.rb:11:in `block (2 levels) in <top (required)>'

  2) tenants API can show a single tenant
     Got 2 failures:

     2.1) Failure/Error: expect(result).to include(attr_hash)

            expected {"error" => {"kind" => "internal_server_error", "message" => "boom", "klass" => "RuntimeError"}} to include {"href" => (a string matching "/api/tenants/17289"), "id" => 17289, "name" => "Test Tenant", "description" => "Tenant for this test"}
            Diff:
            @@ -1,5 +1,2 @@
            -"description" => "Tenant for this test",
            -"href" => (a string matching "/api/tenants/17289"),
            -"id" => 17289,
            -"name" => "Test Tenant",
            +"error" => {"kind"=>"internal_server_error", "message"=>"boom", "klass"=>"RuntimeError"},

          # ./spec/support/api_spec_helper.rb:234:in `expect_result_to_match_hash'
          # ./spec/requests/api/tenants_spec.rb:34:in `block (2 levels) in <top (required)>'

     2.2) Failure/Error: expect(response).to have_http_status(:ok)
            expected the response to have status code :ok (200) but it was :internal_server_error (500)
          # ./spec/requests/api/tenants_spec.rb:41:in `block (2 levels) in <top (required)>'

  3) tenants API without an appropriate role will not update multiple tenants with POST
     Failure/Error: expect(response).to have_http_status(:forbidden)
       expected the response to have status code :forbidden (403) but it was :internal_server_error (500)
     # ./spec/requests/api/tenants_spec.rb:251:in `block (3 levels) in <top (required)>'

  4) tenants API without an appropriate role will not delete a tenant with DELETE
     Failure/Error: expect(response).to have_http_status(:forbidden)
       expected the response to have status code :forbidden (403) but it was :internal_server_error (500)
     # ./spec/requests/api/tenants_spec.rb:269:in `block (3 levels) in <top (required)>'

  5) tenants API without an appropriate role will not update multiple tenants with POST
     Failure/Error: expect(response).to have_http_status(:forbidden)
       expected the response to have status code :forbidden (403) but it was :internal_server_error (500)
     # ./spec/requests/api/tenants_spec.rb:284:in `block (3 levels) in <top (required)>'

  6) tenants API without an appropriate role will not delete a tenant with POST
     Failure/Error: expect(response).to have_http_status(:forbidden)
       expected the response to have status code :forbidden (403) but it was :internal_server_error (500)
     # ./spec/requests/api/tenants_spec.rb:261:in `block (3 levels) in <top (required)>'

  7) tenants API without an appropriate role will not update a tenant with POST
     Failure/Error: expect(response).to have_http_status(:forbidden)
       expected the response to have status code :forbidden (403) but it was :internal_server_error (500)
     # ./spec/requests/api/tenants_spec.rb:208:in `block (3 levels) in <top (required)>'

  8) tenants API without an appropriate role will not create a tenant
     Failure/Error: expect(response).to have_http_status(:forbidden)
       expected the response to have status code :forbidden (403) but it was :internal_server_error (500)
     # ./spec/requests/api/tenants_spec.rb:193:in `block (3 levels) in <top (required)>'

  9) tenants API without an appropriate role will not update a tenant with PUT
     Failure/Error: expect(response).to have_http_status(:forbidden)
       expected the response to have status code :forbidden (403) but it was :internal_server_error (500)
     # ./spec/requests/api/tenants_spec.rb:226:in `block (3 levels) in <top (required)>'

  10) tenants API with an appropriate role can update multiple tenants with POST
      Got 2 failures and 1 other error:

      10.1) Failure/Error: expect(response).to have_http_status(:ok)
              expected the response to have status code :ok (200) but it was :internal_server_error (500)
            # ./spec/requests/api/tenants_spec.rb:143:in `block (3 levels) in <top (required)>'

      10.2) Failure/Error: expect(response_hash).to have_key(collection)
              expected #has_key?("results") to return true, got false
            # ./spec/support/api_spec_helper.rb:238:in `expect_results_to_match_hash'
            # ./spec/requests/api/tenants_spec.rb:144:in `block (3 levels) in <top (required)>'

      10.3) Failure/Error:
              fetch_value(result_hash).zip(response_hash[collection]) do |expected, actual|
                expect_result_to_match_hash(actual, expected)
              end

            TypeError:
              wrong argument type NilClass (must respond to :each)
            # ./spec/support/api_spec_helper.rb:239:in `zip'
            # ./spec/support/api_spec_helper.rb:239:in `expect_results_to_match_hash'
            # ./spec/requests/api/tenants_spec.rb:144:in `block (3 levels) in <top (required)>'

```

@miq-bot add-label test, api
@miq-bot assign @abellotti 