### PR TITLE
Refactor/api result resources to have only keys helper

### DIFF
--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -323,9 +323,21 @@ describe ApiController do
 
       run_get vms_url, :expand => "resources", :attributes => "name,vendor"
 
-      expect_query_result(:vms, 1, 1)
-      expect(response.parsed_body).to include("resources" => all(match("id" => anything, "href" => anything, "name" => anything, "vendor" => anything)))
-      expect_result_resources_to_match_hash([{"name" => "aa", "id" => vm.id, "href" => vms_url(vm.id)}])
+      expected = {
+        "name"      => "vms",
+        "count"     => 1,
+        "subcount"  => 1,
+        "resources" => [
+          {
+            "id"     => vm.id,
+            "href"   => a_string_matching(vms_url(vm.id)),
+            "name"   => "aa",
+            "vendor" => anything
+          }
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
 
     it "skips requests of invalid attributes" do
@@ -375,8 +387,14 @@ describe ApiController do
 
       run_get vms_url
 
-      expect_query_result(:vms, 2, 2)
-      expect(response.parsed_body).to include("resources" => all(match("href" => anything)))
+      expected = {
+        "name"      => "vms",
+        "count"     => 2,
+        "subcount"  => 2,
+        "resources" => Array.new(2) { {"href" => anything} }
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
 
     it "supports expanding resources" do

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -324,7 +324,7 @@ describe ApiController do
       run_get vms_url, :expand => "resources", :attributes => "name,vendor"
 
       expect_query_result(:vms, 1, 1)
-      expect_result_resources_to_have_only_keys("resources", %w(id href name vendor))
+      expect(response.parsed_body).to include("resources" => all(match("id" => anything, "href" => anything, "name" => anything, "vendor" => anything)))
       expect_result_resources_to_match_hash([{"name" => "aa", "id" => vm.id, "href" => vms_url(vm.id)}])
     end
 
@@ -376,7 +376,7 @@ describe ApiController do
       run_get vms_url
 
       expect_query_result(:vms, 2, 2)
-      expect_result_resources_to_have_only_keys("resources", %w(href))
+      expect(response.parsed_body).to include("resources" => all(match("href" => anything)))
     end
 
     it "supports expanding resources" do

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -26,7 +26,7 @@ describe ApiController do
       run_get service_dialogs_url
 
       expect_query_result(:service_dialogs, Dialog.count, Dialog.count)
-      expect_result_resources_to_have_only_keys("resources", %w(href))
+      expect(response.parsed_body).to include("resources" => all(match("href" => anything)))
     end
 
     it "query with expanded resources to include content" do

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -25,8 +25,14 @@ describe ApiController do
       api_basic_authorize collection_action_identifier(:service_dialogs, :read, :get)
       run_get service_dialogs_url
 
-      expect_query_result(:service_dialogs, Dialog.count, Dialog.count)
-      expect(response.parsed_body).to include("resources" => all(match("href" => anything)))
+      expected = {
+        "name"      => "service_dialogs",
+        "count"     => Dialog.count,
+        "subcount"  => Dialog.count,
+        "resources" => Array.new(Dialog.count) { {"href" => anything} }
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
 
     it "query with expanded resources to include content" do

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -248,12 +248,6 @@ module ApiSpecHelper
     fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy, "resource missing: #{key}" }
   end
 
-  def expect_result_resources_to_have_only_keys(collection, keys)
-    key_list = fetch_value(keys)
-    expect(response.parsed_body).to include(collection => all(match(Hash[key_list.map { |k| [k, anything] }
-])))
-  end
-
   # Primary result construct methods
 
   def expect_empty_query_result(collection)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -249,9 +249,9 @@ module ApiSpecHelper
   end
 
   def expect_result_resources_to_have_only_keys(collection, keys)
-    key_list = fetch_value(keys).sort
-    expect(response.parsed_body).to have_key(collection)
-    expect(response.parsed_body[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
+    key_list = fetch_value(keys)
+    expect(response.parsed_body).to include(collection => all(match(Hash[key_list.map { |k| [k, anything] }
+])))
   end
 
   # Primary result construct methods


### PR DESCRIPTION
This removes this helper, which was only used in 3 places, in favor of consolidated expectations on the response which are more transparent in reflecting the structure of the response JSON. This PR favors readability over terseness, so there's a bit more :green_apple: to :red_circle: here.

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 