### PR TITLE
[DARGA] Update the default values for the upgrade repo names

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -32,7 +32,7 @@ class MiqDatabase < ApplicationRecord
   end
 
   def self.registration_default_value_for_update_repo_name
-    "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+    "cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
   end
 
   def update_repo_names

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -7,7 +7,7 @@ describe MiqDatabase do
         db = MiqDatabase.seed
         expect(db.csrf_secret_token_encrypted).to be_encrypted
         expect(db.session_secret_token_encrypted).to be_encrypted
-        expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
+        expect(db.update_repo_name).to eq("cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         expect(db.registration_type).to eq("sm_hosted")
         expect(db.registration_server).to eq("subscription.rhn.redhat.com")
       end
@@ -23,7 +23,7 @@ describe MiqDatabase do
           db = MiqDatabase.seed
           expect(db.csrf_secret_token_encrypted).to be_encrypted
           expect(db.session_secret_token_encrypted).to be_encrypted
-          expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
+          expect(db.update_repo_name).to eq("cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         end
 
         it "will not change existing values" do


### PR DESCRIPTION
This PR is a cherry-pick of just one commit of https://github.com/ManageIQ/manageiq/pull/9526 which will avoid backporting the migration that was included in the original PR.

https://bugzilla.redhat.com/show_bug.cgi?id=1351669