### PR TITLE
Remove duplicated 'prefix' key

### DIFF
--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -58,7 +58,6 @@
                             "clear-field-set-focus"   => "",
                             "verifypasswd"            => "",
                             "checkchange"             => "",
-                            "prefix"                  => "#{prefix}",
                             "reset-validation-status" => "#{prefix}_auth_status"}
         %span.help-block{"ng-show" => "angularForm.#{prefix}_password.$error.required"}
           = _("Required")
@@ -83,7 +82,6 @@
                             "clear-field-set-focus"   => "no-focus",
                             "verifypasswd"            => "",
                             "checkchange"             => "",
-                            "prefix"                  => "#{prefix}",
                             "reset-validation-status" => "#{prefix}_auth_status"}
         %div{"ng-show" => "showVerify('#{prefix}_userid')"}
           %span.help-block{"ng-show" => "angularForm.#{prefix}_verify.$error.required"}


### PR DESCRIPTION
Removes a key that's already specified in the lines above it; it causes many, many warnings in test output.

@miq-bot add_labels technical debt
@miq-bot assign @AparnaKarve