### PR TITLE
Retrieve VMware Storage Profile Inventory

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -58,6 +58,7 @@ module EmsRefresh::SaveInventoryInfra
       :vms,
       :folders,
       :resource_pools,
+      :storage_profiles,
       :customization_specs,
       :orchestration_templates,
       :orchestration_stacks
@@ -282,6 +283,10 @@ module EmsRefresh::SaveInventoryInfra
 
     save_inventory_multi(ems.resource_pools, hashes, deletes, [:uid_ems], nil, :ems_children)
     store_ids_for_new_records(ems.resource_pools, hashes, :uid_ems)
+  end
+
+  def save_storage_profiles_inventory(ems, hashes, _target = nil)
+    save_inventory_multi(ems.storage_profiles, hashes, :use_association, [:ems_ref])
   end
 
   def save_customization_specs_inventory(ems, hashes, _target = nil)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -79,8 +79,9 @@ module ManageIQ::Providers
 
         profile_inv.each do |uid, profile|
           new_result = {
-            :ems_ref => uid,
-            :name    => profile.name
+            :ems_ref      => uid,
+            :name         => profile.name,
+            :profile_type => profile.profileCategory
           }
 
           result << new_result

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -13,6 +13,7 @@ module ManageIQ::Providers
 
         result[:storages], uids[:storages] = storage_inv_to_hashes(inv[:storage])
         result[:clusters], uids[:clusters] = cluster_inv_to_hashes(inv[:cluster])
+        result[:storage_profiles], uids[:storage_profiles] = storage_profile_inv_to_hashes(inv[:storage_profile])
 
         result[:hosts], uids[:hosts], uids[:clusters_by_host], uids[:lans], uids[:switches], uids[:guest_devices], uids[:scsi_luns] = host_inv_to_hashes(inv[:host], inv, uids[:storages], uids[:clusters])
         result[:vms], uids[:vms] = vm_inv_to_hashes(inv[:vm], inv[:storage], uids[:storages], uids[:hosts], uids[:clusters_by_host], uids[:lans])
@@ -69,6 +70,23 @@ module ManageIQ::Providers
           result_uids[mor] = new_result
           result_uids[:storage_id][uid] = new_result
         end
+        return result, result_uids
+      end
+
+      def self.storage_profile_inv_to_hashes(profile_inv)
+        result = []
+        result_uids = {}
+
+        profile_inv.each do |uid, profile|
+          new_result = {
+            :ems_ref => uid,
+            :name    => profile.name
+          }
+
+          result << new_result
+          result_uids[uid] = new_result
+        end unless profile_inv.nil?
+
         return result, result_uids
       end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -77,6 +77,7 @@ module ManageIQ::Providers
       VC_ACCESSORS = [
         [:dataStoresByMor,              :storage],
         [:storagePodsByMor,             :storage_pod],
+        [:pbmProfilesByUid,             :storage_profile],
         [:dvPortgroupsByMor,            :dvportgroup],
         [:dvSwitchesByMor,              :dvswitch],
         [:hostSystemsByMor,             :host],

--- a/gems/pending/VMwareWebService/MiqPbmInventory.rb
+++ b/gems/pending/VMwareWebService/MiqPbmInventory.rb
@@ -14,7 +14,7 @@ module MiqPbmInventory
     end
   end
 
-  def pbmProfilesByUid
+  def pbmProfilesByUid(_selspec = nil)
     profiles = {}
     return profiles if @pbm_svc.nil?
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Retrieve a list of VMware Storage Profiles from `MiqPbmInventory` using the `pbmProfilesByUid` method.

Links
-----
* https://www.vmware.com/support/developer/vc-sdk/spbm-sdk/

Depends on: https://github.com/ManageIQ/manageiq/pull/9604