### PR TITLE
Server/Roles trees conversion to user TreeBuilder.

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -429,9 +429,9 @@ function miqOnDblClickNoBaseExpand(node, _event) {
 
 // OnClick handler for Server Roles Tree
 function miqOnClickServerRoles(id) {
-  var typ = id.split('_')[0]; // Break apart the node ids
+  var typ = id.split('-')[0]; // Break apart the node ids
   switch (typ) {
-    case 'server':
+    case 'svr':
     case 'role':
     case 'asr':
       miqJqueryRequest(ManageIQ.dynatree.clickUrl + '?id=' + id, {beforeSend: true, complete: true});

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -194,7 +194,7 @@ module ApplicationController::Explorer
   end
 
   def x_build_node_id(object, options = {})
-    TreeNodeBuilder.build_id(object, nil, options)
+    TreeNodeBuilder.build_id(object, nil, options, @sb)
   end
 
   # Add the children of a node that is being expanded (autoloaded), called by generic tree_autoload method

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -194,7 +194,7 @@ module ApplicationController::Explorer
   end
 
   def x_build_node_id(object, options = {})
-    TreeNodeBuilder.build_id(object, nil, options, @sb)
+    TreeNodeBuilder.build_id(object, nil, options)
   end
 
   # Add the children of a node that is being expanded (autoloaded), called by generic tree_autoload method

--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -78,12 +78,14 @@ module Sandbox
     configuration_manager_providers_tree
     rbac_tree
     reports_tree
+    roles_by_server_tree
     roles_tree
     rsop_tree
     sa_tree
     sandt_tree
     savedreports_tree
     schedules_tree
+    servers_by_role_tree
     settings_tree
     snapshot_tree
     stcat_tree

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -296,7 +296,11 @@ class TreeBuilder
   end
 
   def x_build_single_node(object, pid, options)
-    node_builder.build(object, pid, options, @sb)
+    sandbox_variables = {
+      :parent_kls  => @sb[:parent_kls],
+      :parent_name => @sb[:parent_name],
+    }
+    node_builder.build(object, pid, options, sandbox_variables)
   end
 
   # Called with object, tree node parent id, tree options

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -71,6 +71,8 @@ class TreeBuilder
     # OPS explorer trees
     when :diagnostics           then TreeBuilderOpsDiagnostics
     when :rbac                  then TreeBuilderOpsRbac
+    when :servers_by_role       then TreeBuilderServersByRole
+    when :roles_by_server       then TreeBuilderRolesByServer
     when :settings              then TreeBuilderOpsSettings
     when :vmdb                  then TreeBuilderOpsVmdb
 
@@ -294,7 +296,7 @@ class TreeBuilder
   end
 
   def x_build_single_node(object, pid, options)
-    node_builder.build(object, pid, options)
+    node_builder.build(object, pid, options, @sb)
   end
 
   # Called with object, tree node parent id, tree options
@@ -355,6 +357,7 @@ class TreeBuilder
     "aen" => "MiqAeNamespace",
     "al"  => "MiqAlert",
     "ap"  => "MiqAlertSet",
+    "asr" => "AssignedServerRole",
     "az"  => "AvailabilityZone",
     "azu" => "OrchestrationTemplateAzure",
     "at"  => "ManageIQ::Providers::AnsibleTower::ConfigurationManager",
@@ -412,6 +415,7 @@ class TreeBuilder
     "sl"  => "MiqScsiLun",
     "sg"  => "MiqScsiTarget",
     "sis" => "ScanItemSet",
+    "role" => "ServerRole",
     "st"  => "ServiceTemplate",
     "stc" => "ServiceTemplateCatalog",
     "sr"  => "ServiceResource",

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -296,11 +296,9 @@ class TreeBuilder
   end
 
   def x_build_single_node(object, pid, options)
-    sandbox_variables = {
-      :parent_kls  => @sb[:parent_kls],
-      :parent_name => @sb[:parent_name],
-    }
-    node_builder.build(object, pid, options, sandbox_variables)
+    options[:parent_kls]  = @sb[:parent_kls] if @sb[:parent_kls]
+    options[:parent_name] = @sb[:parent_name] if @sb[:parent_name]
+    node_builder.build(object, pid, options)
   end
 
   # Called with object, tree node parent id, tree options

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -33,24 +33,20 @@ class TreeBuilderRolesByServer < TreeBuilder
   end
 
   def x_get_tree_miq_servers
-    objects = []
-    @root.miq_servers.sort_by { |s| s.name.to_s }.each do |s|
+    @root.miq_servers.sort_by { |s| s.name.to_s }.each_with_object([]) do |server, objects|
       unless @sb[:diag_selected_id] # Set default selected record vars
-        @sb[:diag_selected_model] = s.class.to_s
-        @sb[:diag_selected_id] = s.id
+        @sb[:diag_selected_model] = server.class.to_s
+        @sb[:diag_selected_id] = server.id
       end
-      objects.push(s)
+      objects.push(server)
     end
-    objects
   end
 
   def x_get_tree_miq_server_kids(parent, _count_only)
-    objects = []
-    parent.assigned_server_roles.sort_by { |asr| asr.server_role.description }.each do |asr|
+    parent.assigned_server_roles.sort_by { |asr| asr.server_role.description }.each_with_object([]) do |asr, objects|
       next if parent.kind_of?(MiqRegion) && !asr.server_role.regional_role? # Only regional roles under Region
       next if asr.server_role.name == "database_owner"
       objects.push(asr)
     end
-    objects
   end
 end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -44,10 +44,10 @@ class TreeBuilderRolesByServer < TreeBuilder
     objects
   end
 
-  def x_get_tree_miq_server_kids(parent, count_only)
+  def x_get_tree_miq_server_kids(parent, _count_only)
     objects = []
     parent.assigned_server_roles.sort_by { |asr| asr.server_role.description }.each do |asr|
-      next if parent.kind_of?(MiqRegion) && !asr.server_role.regional_role?  # Only regional roles under Region
+      next if parent.kind_of?(MiqRegion) && !asr.server_role.regional_role? # Only regional roles under Region
       next if asr.server_role.name == "database_owner"
       objects.push(asr)
     end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -1,0 +1,56 @@
+class TreeBuilderRolesByServer < TreeBuilder
+  has_kids_for MiqServer, [:x_get_tree_miq_server_kids]
+
+  def initialize(name, type, sandbox, build = true, parent = nil)
+    @root = parent
+    super(name, type, sandbox, build)
+  end
+
+  private
+
+  def tree_init_options(_tree_name)
+    {
+      :add_root => false,
+      :expand   => true,
+      :lazy     => false,
+      :open_all => true
+    }
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:autoload  => false,
+                  :click_url => "/ops/diagnostics_tree_select/",
+                  :onclick   => "miqOnClickServerRoles")
+  end
+
+  def root_options
+    []
+  end
+
+  def x_get_tree_roots(count_only = false, _options)
+    count_only_or_objects(count_only, x_get_tree_miq_servers)
+  end
+
+  def x_get_tree_miq_servers
+    objects = []
+    @root.miq_servers.sort_by { |s| s.name.to_s }.each do |s|
+      unless @sb[:diag_selected_id] # Set default selected record vars
+        @sb[:diag_selected_model] = s.class.to_s
+        @sb[:diag_selected_id] = s.id
+      end
+      objects.push(s)
+    end
+    objects
+  end
+
+  def x_get_tree_miq_server_kids(parent, count_only)
+    objects = []
+    parent.assigned_server_roles.sort_by { |asr| asr.server_role.description }.each do |asr|
+      next if parent.kind_of?(MiqRegion) && !asr.server_role.regional_role?  # Only regional roles under Region
+      next if asr.server_role.name == "database_owner"
+      objects.push(asr)
+    end
+    objects
+  end
+end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -28,8 +28,8 @@ class TreeBuilderRolesByServer < TreeBuilder
     []
   end
 
-  def x_get_tree_roots(count_only = false, _options)
-    count_only_or_objects(count_only, x_get_tree_miq_servers)
+  def x_get_tree_roots(_count_only, _options)
+    x_get_tree_miq_servers
   end
 
   def x_get_tree_miq_servers

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -35,9 +35,9 @@ class TreeBuilderServersByRole < TreeBuilder
   def x_get_tree_server_roles
     objects = []
     ServerRole.all.sort_by(&:description).each do |r|
-      next if @root.kind_of?(MiqRegion) && !r.regional_role?  # Only regional roles under Region
+      next if @root.kind_of?(MiqRegion) && !r.regional_role? # Only regional roles under Region
       next unless (@root.kind_of?(Zone) && r.miq_servers.any? { |s| s.my_zone == @root.name }) ||
-        (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
+                  (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
       next if r.name == "database_owner"
       unless @sb[:diag_selected_id] # Set default selected record vars
         @sb[:diag_selected_model] = r.class.to_s

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -1,0 +1,59 @@
+class TreeBuilderServersByRole < TreeBuilder
+  has_kids_for ServerRole, [:x_get_tree_server_role_kids]
+
+  def initialize(name, type, sandbox, build = true, parent = nil)
+    @root = parent
+    super(name, type, sandbox, build)
+  end
+
+  private
+
+  def tree_init_options(_tree_name)
+    {
+      :add_root => false,
+      :expand   => true,
+      :lazy     => false,
+      :open_all => true
+    }
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:autoload  => false,
+                  :click_url => "/ops/diagnostics_tree_select/",
+                  :onclick   => "miqOnClickServerRoles")
+  end
+
+  def root_options
+    []
+  end
+
+  def x_get_tree_roots(count_only = false, _options)
+    count_only_or_objects(count_only, x_get_tree_server_roles)
+  end
+
+  def x_get_tree_server_roles
+    objects = []
+    ServerRole.all.sort_by(&:description).each do |r|
+      next if @root.kind_of?(MiqRegion) && !r.regional_role?  # Only regional roles under Region
+      next unless (@root.kind_of?(Zone) && r.miq_servers.any? { |s| s.my_zone == @root.name }) ||
+        (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
+      next if r.name == "database_owner"
+      unless @sb[:diag_selected_id] # Set default selected record vars
+        @sb[:diag_selected_model] = r.class.to_s
+        @sb[:diag_selected_id] = r.id
+      end
+      objects.push(r)
+    end
+    objects
+  end
+
+  def x_get_tree_server_role_kids(parent, count_only)
+    kids = count_only ? 0 : []
+    parent.assigned_server_roles.sort_by { |asr| asr.miq_server.name }.each do |asr|
+      next if parent.kind_of?(Zone) && asr.miq_server.my_zone != parent.name
+      kids.push(asr)
+    end
+    kids
+  end
+end

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -33,8 +33,7 @@ class TreeBuilderServersByRole < TreeBuilder
   end
 
   def x_get_tree_server_roles
-    objects = []
-    ServerRole.all.sort_by(&:description).each do |r|
+    ServerRole.all.sort_by(&:description).each_with_object([]) do |r, objects|
       next if @root.kind_of?(MiqRegion) && !r.regional_role? # Only regional roles under Region
       next unless (@root.kind_of?(Zone) && r.miq_servers.any? { |s| s.my_zone == @root.name }) ||
                   (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
@@ -45,15 +44,12 @@ class TreeBuilderServersByRole < TreeBuilder
       end
       objects.push(r)
     end
-    objects
   end
 
   def x_get_tree_server_role_kids(parent, count_only)
-    kids = count_only ? 0 : []
-    parent.assigned_server_roles.sort_by { |asr| asr.miq_server.name }.each do |asr|
+    parent.assigned_server_roles.sort_by { |asr| asr.miq_server.name }.each_with_object([]) do |asr, kids|
       next if parent.kind_of?(Zone) && asr.miq_server.my_zone != parent.name
       kids.push(asr)
     end
-    kids
   end
 end

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -28,8 +28,8 @@ class TreeBuilderServersByRole < TreeBuilder
     []
   end
 
-  def x_get_tree_roots(count_only = false, _options)
-    count_only_or_objects(count_only, x_get_tree_server_roles)
+  def x_get_tree_roots(_count_only, _options)
+    x_get_tree_server_roles
   end
 
   def x_get_tree_server_roles
@@ -46,7 +46,7 @@ class TreeBuilderServersByRole < TreeBuilder
     end
   end
 
-  def x_get_tree_server_role_kids(parent, count_only)
+  def x_get_tree_server_role_kids(parent, _count_only)
     parent.assigned_server_roles.sort_by { |asr| asr.miq_server.name }.each_with_object([]) do |asr, kids|
       next if parent.kind_of?(Zone) && asr.miq_server.my_zone != parent.name
       kids.push(asr)

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -47,9 +47,8 @@ class TreeBuilderServersByRole < TreeBuilder
   end
 
   def x_get_tree_server_role_kids(parent, _count_only)
-    parent.assigned_server_roles.sort_by { |asr| asr.miq_server.name }.each_with_object([]) do |asr, kids|
-      next if parent.kind_of?(Zone) && asr.miq_server.my_zone != parent.name
-      kids.push(asr)
+    parent.assigned_server_roles.sort_by { |asr| asr.miq_server.name }.select do |asr|
+      !parent.kind_of?(Zone) || asr.miq_server.my_zone == parent.name
     end
   end
 end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -474,43 +474,40 @@ class TreeNodeBuilder
 
     if object.master_supported?
       priority = case object.priority
-      when 1
-        "primary, "
-      when 2
-        "secondary, "
-      else
-        ""
-      end
+                 when 1
+                   "primary, "
+                 when 2
+                   "secondary, "
+                 else
+                   ""
+                 end
     end
     if object.active? && object.miq_server.started?
       @node[:icon] = ActionController::Base.helpers.image_path("100/on.png")
       @node[:title] += _(" (%{priority}active, PID=%{number})") % {:priority => priority, :number => object.miq_server.pid}
-    else
-      if object.miq_server.started?
+    elsif object.miq_server.started?
         @node[:icon] = ActionController::Base.helpers.image_path("100/suspended.png")
         @node[:title] += _(" (%{priority}available, PID=%{number})") % {:priority => priority,
                                                                         :number   => object.miq_server.pid}
-      else
-        @node[:icon] = ActionController::Base.helpers.image_path("100/off.png")
-        @node[:title] += _(" (%{priority}unavailable)") % {:priority => priority}
-      end
+    else
+      @node[:icon] = ActionController::Base.helpers.image_path("100/off.png")
+      @node[:title] += _(" (%{priority}unavailable)") % {:priority => priority}
     end
+
     if object.server_role.regional_role?
       @node[:addClass] = "cfme-opacity-node"
     end
     @node
   end
 
-
   def server_role_node(object)
     status = "stopped"
-    object.assigned_server_roles.where(:active => true).each do |asr|            # Go thru all active assigned server roles
-      if asr.miq_server.started?        # Find a started server
-        if @sb[:parent_kls] == "MiqRegion" || # it's in the region
-          (@sb[:parent_kls] == "Zone" && asr.miq_server.my_zone == @sb[:parent_name]) # it's in the zone
-          status = "active"
-          break
-        end
+    object.assigned_server_roles.where(:active => true).each do |asr| # Go thru all active assigned server roles
+      next unless asr.miq_server.started? # Find a started server
+      if @sb[:parent_kls] == "MiqRegion" || # it's in the region
+         (@sb[:parent_kls] == "Zone" && asr.miq_server.my_zone == @sb[:parent_name]) # it's in the zone
+        status = "active"
+        break
       end
     end
     @node = {

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -477,9 +477,9 @@ class TreeNodeBuilder
     if object.master_supported?
       priority = case object.priority
                  when 1
-                   "primary, "
+                   _("primary, ")
                  when 2
-                   "secondary, "
+                   _("secondary, ")
                  else
                    ""
                  end
@@ -520,7 +520,7 @@ class TreeNodeBuilder
       :icon   => ActionController::Base.helpers.image_path("100/role-#{object.name}.png"),
       :expand => true
     }
-    @node
     tooltip(_("Role: %{description} (%{status})") % {:description => object.description, :status => status})
+    @node
   end
 end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -24,18 +24,18 @@ class TreeNodeBuilder
   #   :open_nodes -- Tree node ids of currently open nodes
   #   FIXME: fill in missing docs
   #
-  def self.build(object, parent_id, options, sandbox)
-    builder = new(object, parent_id, options, sandbox)
+  def self.build(object, parent_id, options)
+    builder = new(object, parent_id, options)
     builder.build
   end
 
-  def self.build_id(object, parent_id, options, sandbox)
-    builder = new(object, parent_id, options, sandbox)
+  def self.build_id(object, parent_id, options)
+    builder = new(object, parent_id, options)
     builder.build_id
   end
 
-  def initialize(object, parent_id, options, sandbox)
-    @object, @parent_id, @options, @sb = object, parent_id, options, sandbox
+  def initialize(object, parent_id, options)
+    @object, @parent_id, @options = object, parent_id, options
   end
 
   attr_reader :object, :parent_id, :options
@@ -498,7 +498,7 @@ class TreeNodeBuilder
       end
       @node[:addClass] = "cfme-red-node" if object.priority == 1
     end
-    if @sb[:parent_kls] == "Zone" && object.server_role.regional_role?
+    if @options[:parent_kls] == "Zone" && object.server_role.regional_role?
       @node[:addClass] = "cfme-opacity-node"
     end
     @node
@@ -508,8 +508,8 @@ class TreeNodeBuilder
     status = "stopped"
     object.assigned_server_roles.where(:active => true).each do |asr| # Go thru all active assigned server roles
       next unless asr.miq_server.started? # Find a started server
-      if @sb[:parent_kls] == "MiqRegion" || # it's in the region
-         (@sb[:parent_kls] == "Zone" && asr.miq_server.my_zone == @sb[:parent_name]) # it's in the zone
+      if @options[:parent_kls] == "MiqRegion" || # it's in the region
+         (@options[:parent_kls] == "Zone" && asr.miq_server.my_zone == @options[:parent_name]) # it's in the zone
         status = "active"
         break
       end

--- a/app/views/ops/_zone_tree.html.haml
+++ b/app/views/ops/_zone_tree.html.haml
@@ -6,19 +6,7 @@
     - else
       = _("Status of Roles for Servers in %{kind} %{description}") % params
 
-  - treebox = "#{session[:tree_name]}box"
-  %div{:id => treebox}
-
-  = render(:partial => "layouts/dynatree", :locals => |
-    {:tree_id     => treebox,                         |
-    :tree_name    => session[:tree_name],             |
-    :tree_state   => true,                            |
-    :json_tree    => @server_tree,                    |
-    :click_url    => "/ops/diagnostics_tree_select/", |
-    :onclick      => "miqOnClickServerRoles",         |
-    :highlighting => true,                            |
-    :exp_tree     => true})                           |
-
+  = render(:partial => 'shared/tree', :locals => {:tree => @server_tree, :name => @server_tree.name.to_s})
   = format(_("* Primary Server Roles shown as %{bold} text."), :bold => content_tag(:b, _("bold"))).html_safe
   - if @selected_server.kind_of?(Zone)
     = format(_("Region based nodes shown as %{dimmed} text."), :dimmed => content_tag(:span, _("dimmed"), :class => 'dimmed')).html_safe

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -167,12 +167,28 @@ describe OpsController do
     describe '#delete_server' do
       context "server does exist" do
         it 'deletes server and refreshes screen' do
+          server = FactoryGirl.create(:miq_server, :zone => @zone)
           sb_hash = {
             :trees            => {:diagnostics_tree => {:active_node => "z-#{@zone.id}"}},
             :active_tree      => :diagnostics_tree,
             :diag_selected_id => @miq_server_to_delete.id,
             :active_tab       => "diagnostics_roles_servers"
           }
+          @server_role = FactoryGirl.create(
+            :server_role,
+            :name              => "smartproxy",
+            :description       => "SmartProxy",
+            :max_concurrent    => 1,
+            :external_failover => false,
+            :role_scope        => "zone"
+          )
+          @assigned_server_role = FactoryGirl.create(
+            :assigned_server_role,
+            :miq_server_id  => server.id,
+            :server_role_id => @server_role.id,
+            :active         => true,
+            :priority       => 1
+          )
           controller.instance_variable_set(:@sb, sb_hash)
           controller.instance_variable_set(:@_params, :pressed => "zone_delete_server")
           expect(controller).to receive :render
@@ -182,7 +198,7 @@ describe OpsController do
           flash_array = assigns(:flash_array)
 
           diag_selected_id = controller.instance_variable_get(:@sb)[:diag_selected_id]
-          expect(diag_selected_id).to eq(nil)
+          expect(diag_selected_id).not_to eq(@miq_server_to_delete.id)
           expect(flash_array.size).to eq 1
           expect(flash_array.first[:message]).to match(/Server .*: Delete successful/)
         end

--- a/spec/presenters/tree_builder_node_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_node_datacenter_spec.rb
@@ -2,44 +2,44 @@ describe TreeNodeBuilder do
   context '#tooltip' do
     it 'returns correct tooltip for ResourcePool node' do
       object = FactoryGirl.build(:resource_pool)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
       expect(node[:tooltip]).to eq("Resource Pool: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Host node' do
       object = FactoryGirl.build(:host)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
       expect(node[:tooltip]).to eq("Host / Node: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for VM node' do
       object = FactoryGirl.build(:vm)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
       expect(node[:tooltip]).to eq("VM: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Cluster node' do
       object = FactoryGirl.build(:ems_cluster)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
       expect(node[:tooltip]).to eq("Cluster / Deployment Role: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Datacenter node' do
       object = FactoryGirl.build(:datacenter)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
       expect(node[:tooltip]).to eq("Datacenter: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Folder node' do
       object = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
       expect(node[:tooltip]).to eq("Folder: #{node[:title]} (Click to view)")
     end
   end
   context 'icon' do
     it 'is blue folder when type is :vat' do
       object = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilderDatacenter.build(object, nil, :type => :vat)
+      node = TreeNodeBuilderDatacenter.build(object, nil, {:type => :vat}, {})
       expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/#{"blue_folder.png"}"))
     end
     it 'is normal folder when type is not :vat' do
       object = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
       expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/#{"folder.png"}"))
     end
   end

--- a/spec/presenters/tree_builder_node_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_node_datacenter_spec.rb
@@ -2,44 +2,44 @@ describe TreeNodeBuilder do
   context '#tooltip' do
     it 'returns correct tooltip for ResourcePool node' do
       object = FactoryGirl.build(:resource_pool)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {})
       expect(node[:tooltip]).to eq("Resource Pool: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Host node' do
       object = FactoryGirl.build(:host)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {})
       expect(node[:tooltip]).to eq("Host / Node: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for VM node' do
       object = FactoryGirl.build(:vm)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {})
       expect(node[:tooltip]).to eq("VM: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Cluster node' do
       object = FactoryGirl.build(:ems_cluster)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {})
       expect(node[:tooltip]).to eq("Cluster / Deployment Role: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Datacenter node' do
       object = FactoryGirl.build(:datacenter)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {})
       expect(node[:tooltip]).to eq("Datacenter: #{node[:title]} (Click to view)")
     end
     it 'returns correct tooltip for Folder node' do
       object = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {})
       expect(node[:tooltip]).to eq("Folder: #{node[:title]} (Click to view)")
     end
   end
   context 'icon' do
     it 'is blue folder when type is :vat' do
       object = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {:type => :vat}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {:type => :vat})
       expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/#{"blue_folder.png"}"))
     end
     it 'is normal folder when type is not :vat' do
       object = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilderDatacenter.build(object, nil, {}, {})
+      node = TreeNodeBuilderDatacenter.build(object, nil, {})
       expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/#{"folder.png"}"))
     end
   end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -1,0 +1,76 @@
+describe TreeBuilderRolesByServer do
+  context 'TreeBuilderRolesByServer' do
+    before do
+      MiqRegion.seed
+      @miq_server = EvmSpecHelper.local_miq_server
+      @server_role = FactoryGirl.create(
+        :server_role,
+        :name              => "smartproxy",
+        :description       => "SmartProxy",
+        :max_concurrent    => 1,
+        :external_failover => false,
+        :role_scope        => "zone"
+      )
+
+      @assigned_server_role1 = FactoryGirl.create(
+        :assigned_server_role,
+        :miq_server_id  => @miq_server.id,
+        :server_role_id => @server_role.id,
+        :active         => true,
+        :priority       => 1
+      )
+
+      @assigned_server_role2 = FactoryGirl.create(
+        :assigned_server_role,
+        :miq_server_id  => @miq_server.id,
+        :server_role_id => @server_role.id,
+        :active         => true,
+        :priority       => 2
+      )
+      @sb = {:active_tree => :diagnostics_tree}
+      parent = MiqRegion.my_region
+      @sb[:selected_server_id] = parent.id
+      @sb[:selected_typ] = "miq_region"
+      @server_tree = TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, parent)
+    end
+
+
+    it "is not lazy" do
+      tree_options = @server_tree.send(:tree_init_options, :roles_by_server)
+      expect(tree_options[:lazy]).to eq(false)
+    end
+
+    it 'has no root' do
+      tree_options = @server_tree.send(:tree_init_options, :roles_by_server)
+      root = @server_tree.send(:root_options)
+      expect(tree_options[:add_root]).to eq(false)
+      expect(root).to eq([])
+    end
+
+    it 'returns server nodes as root kids' do
+      server_nodes = @server_tree.send(:x_get_tree_roots, false)
+      expect(server_nodes).to eq([@miq_server])
+    end
+
+    it 'returns Roles by Servers' do
+      nodes = [{:key      => "svr-#{MiqRegion.compress_id(@miq_server.id)}",
+                :title    => "<b class='dynatree-title'>Server: #{@miq_server.name} [#{@miq_server.id}] (current)</b>",
+                :icon     => ActionController::Base.helpers.image_path('100/miq_server.png'),
+                :expand   => true,
+                :tooltip  => "Server: #{@miq_server.name} [#{@miq_server.id}] (current)",
+                :children => [{:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role1.id)}",
+                               :addClass => "dynatree-title",
+                               :title    => "Role: SmartProxy (primary, active, PID=)",
+                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                               },
+                              {:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role2.id)}",
+                               :addClass => "dynatree-title",
+                               :title    => "Role: SmartProxy (secondary, active, PID=)",
+                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                              },
+                ],
+               }]
+      expect(@server_tree.locals_for_render[:json_tree]).to eq(nodes.to_json)
+    end
+  end
+end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -72,8 +72,6 @@ describe TreeBuilderRolesByServer do
                               },
                 ],
                }]
-      p "XXXX #{@server_tree.locals_for_render[:json_tree].inspect}"
-      p "XXXX #{nodes.to_json.inspect}"
       expect(@server_tree.locals_for_render[:json_tree]).to eq(nodes.to_json)
     end
   end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -34,7 +34,6 @@ describe TreeBuilderRolesByServer do
       @server_tree = TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, parent)
     end
 
-
     it "is not lazy" do
       tree_options = @server_tree.send(:tree_init_options, :roles_by_server)
       expect(tree_options[:lazy]).to eq(false)
@@ -48,7 +47,7 @@ describe TreeBuilderRolesByServer do
     end
 
     it 'returns server nodes as root kids' do
-      server_nodes = @server_tree.send(:x_get_tree_roots, false)
+      server_nodes = @server_tree.send(:x_get_tree_roots, false, {})
       expect(server_nodes).to eq([@miq_server])
     end
 

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -54,22 +54,26 @@ describe TreeBuilderRolesByServer do
 
     it 'returns Roles by Servers' do
       nodes = [{:key      => "svr-#{MiqRegion.compress_id(@miq_server.id)}",
-                :title    => "<b class='dynatree-title'>Server: #{@miq_server.name} [#{@miq_server.id}] (current)</b>",
+                :title    => "<b class='dynatree-title'>Server: #{@miq_server.name} [#{@miq_server.id}] (current) (started)</b>",
                 :icon     => ActionController::Base.helpers.image_path('100/miq_server.png'),
                 :expand   => true,
-                :tooltip  => "Server: #{@miq_server.name} [#{@miq_server.id}] (current)",
+                :tooltip  => "Server: #{@miq_server.name} [#{@miq_server.id}] (current) (started)",
                 :children => [{:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role1.id)}",
                                :addClass => "dynatree-title",
                                :title    => "Role: SmartProxy (primary, active, PID=)",
-                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                               :icon     => ActionController::Base.helpers.image_path('100/on.png'),
+                               :expand   => true,
                                },
                               {:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role2.id)}",
                                :addClass => "dynatree-title",
                                :title    => "Role: SmartProxy (secondary, active, PID=)",
-                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                               :icon     => ActionController::Base.helpers.image_path('100/on.png'),
+                               :expand   => true,
                               },
                 ],
                }]
+      p "XXXX #{@server_tree.locals_for_render[:json_tree].inspect}"
+      p "XXXX #{nodes.to_json.inspect}"
       expect(@server_tree.locals_for_render[:json_tree]).to eq(nodes.to_json)
     end
   end

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -18,7 +18,7 @@ describe TreeBuilderServersByRole do
         :assigned_server_role,
         :miq_server_id  => @miq_server.id,
         :server_role_id => @server_role.id,
-        :active         => true,
+        :active         => false,
         :priority       => 1
       )
 
@@ -61,14 +61,16 @@ describe TreeBuilderServersByRole do
                 :expand   => true,
                 :tooltip  => "Role: SmartProxy (stopped)",
                 :children => [{:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role1.id)}",
-                               :addClass => "dynatree-title",
-                               :title    => "Server: smartproxy [#{@assigned_server_role1.id}] (primary, active, PID=)",
-                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                               :addClass => "cfme-red-node",
+                               :title    => "Server: smartproxy [#{@assigned_server_role1.id}] (primary, available, PID=)",
+                               :icon     => ActionController::Base.helpers.image_path('100/suspended.png'),
+                               :expand   => true,
                               },
                               {:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role2.id)}",
                                :addClass => "dynatree-title",
                                :title    => "Server: smartproxy [#{@assigned_server_role2.id}] (secondary, active, PID=)",
-                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                               :icon     => ActionController::Base.helpers.image_path('100/on.png'),
+                               :expand   => true,
                               },
                 ],
                }]

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -1,0 +1,78 @@
+describe TreeBuilderServersByRole do
+  context 'TreeBuilderServersByRole' do
+    before do
+      MiqRegion.seed
+      zone = FactoryGirl.create(:zone)
+      @miq_server = FactoryGirl.create(:miq_server, :zone => zone)
+      allow(MiqServer).to receive(:my_zone).and_return(zone)
+      @server_role = FactoryGirl.create(
+        :server_role,
+        :name              => "smartproxy",
+        :description       => "SmartProxy",
+        :max_concurrent    => 1,
+        :external_failover => false,
+        :role_scope        => "zone"
+      )
+
+      @assigned_server_role1 = FactoryGirl.create(
+        :assigned_server_role,
+        :miq_server_id  => @miq_server.id,
+        :server_role_id => @server_role.id,
+        :active         => true,
+        :priority       => 1
+      )
+
+      @assigned_server_role2 = FactoryGirl.create(
+        :assigned_server_role,
+        :miq_server_id  => @miq_server.id,
+        :server_role_id => @server_role.id,
+        :active         => true,
+        :priority       => 2
+      )
+      @sb = {:active_tree => :diagnostics_tree}
+      parent = zone
+      @sb[:selected_server_id] = parent.id
+      @sb[:selected_typ] = "miq_region"
+      @server_tree = TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, parent)
+    end
+
+
+    it "is not lazy" do
+      tree_options = @server_tree.send(:tree_init_options, :servers_by_role)
+      expect(tree_options[:lazy]).to eq(false)
+    end
+
+    it 'has no root' do
+      tree_options = @server_tree.send(:tree_init_options, :servers_by_role)
+      root = @server_tree.send(:root_options)
+      expect(tree_options[:add_root]).to eq(false)
+      expect(root).to eq([])
+    end
+
+    it 'returns server nodes as root kids' do
+      server_nodes = @server_tree.send(:x_get_tree_roots, false)
+      expect(server_nodes).to eq([@server_role])
+    end
+
+    it 'returns Servers by Roles' do
+      nodes = [{:key      => "role-#{MiqRegion.compress_id(@server_role.id)}",
+                :title    => "Role: SmartProxy (stopped)",
+                :icon     => ActionController::Base.helpers.image_path('100/role-smartproxy.png'),
+                :expand   => true,
+                :tooltip  => "Role: SmartProxy (stopped)",
+                :children => [{:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role1.id)}",
+                               :addClass => "dynatree-title",
+                               :title    => "Server: smartproxy [#{@assigned_server_role1.id}] (primary, active, PID=)",
+                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                              },
+                              {:key      => "asr-#{MiqRegion.compress_id(@assigned_server_role2.id)}",
+                               :addClass => "dynatree-title",
+                               :title    => "Server: smartproxy [#{@assigned_server_role2.id}] (secondary, active, PID=)",
+                               :icon     => ActionController::Base.helpers.image_path('100/on.png')
+                              },
+                ],
+               }]
+      expect(@server_tree.locals_for_render[:json_tree]).to eq(nodes.to_json)
+    end
+  end
+end

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -36,7 +36,6 @@ describe TreeBuilderServersByRole do
       @server_tree = TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, parent)
     end
 
-
     it "is not lazy" do
       tree_options = @server_tree.send(:tree_init_options, :servers_by_role)
       expect(tree_options[:lazy]).to eq(false)
@@ -50,7 +49,7 @@ describe TreeBuilderServersByRole do
     end
 
     it 'returns server nodes as root kids' do
-      server_nodes = @server_tree.send(:x_get_tree_roots, false)
+      server_nodes = @server_tree.send(:x_get_tree_roots, false, {})
       expect(server_nodes).to eq([@server_role])
     end
 

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -2,19 +2,19 @@ describe TreeNodeBuilder do
   context '.build' do
     it 'ExtManagementSystem node' do
       mgmt_system = FactoryGirl.build(:ems_redhat)
-      node = TreeNodeBuilder.build(mgmt_system, nil, {})
+      node = TreeNodeBuilder.build(mgmt_system, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'AvailabilityZone node' do
       zone = FactoryGirl.build(:availability_zone_amazon)
-      node = TreeNodeBuilder.build(zone, nil, {})
+      node = TreeNodeBuilder.build(zone, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'ChargebackRate node' do
       rate = FactoryGirl.create(:chargeback_rate)
-      node = TreeNodeBuilder.build(rate, nil, {})
+      node = TreeNodeBuilder.build(rate, nil, {}, {})
       expect(node).not_to be_nil
     end
 
@@ -23,55 +23,55 @@ describe TreeNodeBuilder do
                                  :applies_to_class => 'bleugh',
                                  :applies_to_id    => nil,
                                 )
-      node = TreeNodeBuilder.build(button, nil, {})
+      node = TreeNodeBuilder.build(button, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'CustomButtonSet node' do
       button_set = FactoryGirl.build(:custom_button_set)
-      node = TreeNodeBuilder.build(button_set, nil, {})
+      node = TreeNodeBuilder.build(button_set, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'CustomizationTemplate node' do
       template = FactoryGirl.build(:customization_template)
-      node = TreeNodeBuilder.build(template, nil, {})
+      node = TreeNodeBuilder.build(template, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'Dialog node' do
       dialog = FactoryGirl.build(:dialog, :label => 'How much wood would a woodchuck chuck if a woodchuck would chuck wood?')
-      node = TreeNodeBuilder.build(dialog, nil, {})
+      node = TreeNodeBuilder.build(dialog, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'DialogTab node' do
       tab = FactoryGirl.create(:dialog_tab, :label => '<script>alert("Hacked!");</script>')
-      node = TreeNodeBuilder.build(tab, nil, {})
+      node = TreeNodeBuilder.build(tab, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'DialogGroup node' do
       group = FactoryGirl.create(:dialog_group, :label => '&nbsp;foobar&gt;')
-      node = TreeNodeBuilder.build(group, nil, {})
+      node = TreeNodeBuilder.build(group, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'DialogField node' do
       field = FactoryGirl.build(:dialog_field, :name => 'random field name', :label => 'foo')
-      node = TreeNodeBuilder.build(field, nil, {})
+      node = TreeNodeBuilder.build(field, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'EmsFolder node' do
       folder = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilder.build(folder, nil, {})
+      node = TreeNodeBuilder.build(folder, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'valid EmsCluster node' do
       cluster = FactoryGirl.create(:ems_cluster, :name => "My Cluster")
-      node = TreeNodeBuilder.build(cluster, nil, {})
+      node = TreeNodeBuilder.build(cluster, nil, {}, {})
       expect(node).not_to be_nil
 
       expect(node[:key]).to eq("c-#{MiqRegion.compress_id(cluster.id)}")
@@ -82,7 +82,7 @@ describe TreeNodeBuilder do
 
     it 'valid Host Node' do
       host = FactoryGirl.create(:host, :name => "My Host")
-      node = TreeNodeBuilder.build(host, nil, {})
+      node = TreeNodeBuilder.build(host, nil, {}, {})
 
       expect(node[:key]).to eq("h-#{MiqRegion.compress_id(host.id)}")
       expect(node[:title]).to eq(host.name)
@@ -93,62 +93,62 @@ describe TreeNodeBuilder do
     it 'IsoDatastore node' do
       mgmt_system = FactoryGirl.build(:ems_redhat)
       datastore = FactoryGirl.build(:iso_datastore, :ext_management_system => mgmt_system)
-      node = TreeNodeBuilder.build(datastore, nil, {})
+      node = TreeNodeBuilder.build(datastore, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'IsoImage node' do
       image = FactoryGirl.create(:iso_image, :name => 'foo')
-      node = TreeNodeBuilder.build(image, nil, {})
+      node = TreeNodeBuilder.build(image, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'ResourcePool node' do
       pool = FactoryGirl.build(:resource_pool)
-      node = TreeNodeBuilder.build(pool, nil, {})
+      node = TreeNodeBuilder.build(pool, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'Vm node' do
       vm = FactoryGirl.build(:vm_amazon)
-      node = TreeNodeBuilder.build(vm, nil, {})
+      node = TreeNodeBuilder.build(vm, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'Vm node with /' do
       vm = FactoryGirl.create(:vm_amazon, :name => 'foo / bar')
-      node = TreeNodeBuilder.build(vm, 'foo', {})
+      node = TreeNodeBuilder.build(vm, 'foo', {}, {})
       expect(node[:title]).to eq('foo / bar')
     end
 
     it 'Vm node with %2f' do
       vm = FactoryGirl.create(:vm_amazon, :name => 'foo %2f bar')
-      node = TreeNodeBuilder.build(vm, nil, {})
+      node = TreeNodeBuilder.build(vm, nil, {}, {})
       expect(node[:title]).to eq('foo / bar')
     end
 
     it 'Vm node with tooltip' do
       vm = FactoryGirl.create(:vm_amazon, :name => 'name')
-      node = TreeNodeBuilder.build(vm, nil, {})
+      node = TreeNodeBuilder.build(vm, nil, {}, {})
       expect(node[:tooltip]).to eq(_("VM: %{name} (Click to view)") % {:name => vm.name})
     end
 
     it 'EmsFolder tooltip with %2f' do
       ems_folder = FactoryGirl.create(:ems_folder, :name => 'foo %2f bar')
-      node = TreeNodeBuilder.build(ems_folder, nil, {})
+      node = TreeNodeBuilder.build(ems_folder, nil, {}, {})
       expect(node[:tooltip]).to eq('Folder: foo / bar')
     end
 
     it 'MiqAeClass node' do
       namespace = FactoryGirl.build(:miq_ae_namespace)
       aclass = FactoryGirl.build(:miq_ae_class, :namespace_id => namespace.id)
-      node = TreeNodeBuilder.build(aclass, nil, {})
+      node = TreeNodeBuilder.build(aclass, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAeInstance node' do
       instance = FactoryGirl.build(:miq_ae_instance)
-      node = TreeNodeBuilder.build(instance, nil, {})
+      node = TreeNodeBuilder.build(instance, nil, {}, {})
       expect(node).not_to be_nil
     end
 
@@ -156,25 +156,25 @@ describe TreeNodeBuilder do
       login_as FactoryGirl.create(:user_with_group)
 
       namespace = FactoryGirl.build(:miq_ae_namespace)
-      node = TreeNodeBuilder.build(namespace, nil, {})
+      node = TreeNodeBuilder.build(namespace, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAlertSet node' do
       set = FactoryGirl.build(:miq_alert_set)
-      node = TreeNodeBuilder.build(set, nil, {})
+      node = TreeNodeBuilder.build(set, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqReport node' do
       report = FactoryGirl.build(:miq_report)
-      node = TreeNodeBuilder.build(report, nil, {})
+      node = TreeNodeBuilder.build(report, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqReportResult node' do
       report_result = FactoryGirl.create(:miq_report_result)
-      node = TreeNodeBuilder.build(report_result, nil, {})
+      node = TreeNodeBuilder.build(report_result, nil, {}, {})
       expect(node).not_to be_nil
       expect(node[:icon]).to eq(ActionController::Base.helpers.image_path('100/report_result.png'))
     end
@@ -184,97 +184,97 @@ describe TreeNodeBuilder do
       server = FactoryGirl.build(:miq_server, :zone => zone)
       allow(MiqServer).to receive(:my_server).and_return(server)
       schedule = FactoryGirl.build(:miq_schedule)
-      node = TreeNodeBuilder.build(schedule, nil, {})
+      node = TreeNodeBuilder.build(schedule, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqServer node' do
       zone   = FactoryGirl.build(:zone)
       server = FactoryGirl.build(:miq_server, :zone => zone)
-      node = TreeNodeBuilder.build(server, nil, {})
+      node = TreeNodeBuilder.build(server, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqTemplate node' do
       template = FactoryGirl.build(:miq_template, :name => "template", :location => "abc/abc.vmtx", :template => true, :vendor => "vmware")
-      node = TreeNodeBuilder.build(template, nil, {})
+      node = TreeNodeBuilder.build(template, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAlert node' do
       alert = FactoryGirl.build(:miq_alert)
-      node = TreeNodeBuilder.build(alert, nil, {})
+      node = TreeNodeBuilder.build(alert, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAction node' do
       action = FactoryGirl.build(:miq_action, :name => "raise_automation_event")
-      node = TreeNodeBuilder.build(action, nil, :tree => :action_tree)
+      node = TreeNodeBuilder.build(action, nil, {:tree => :action_tree}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqEventDefinition node' do
       event = FactoryGirl.build(:miq_event_definition)
-      node = TreeNodeBuilder.build(event, nil, {})
+      node = TreeNodeBuilder.build(event, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqGroup node' do
       group = FactoryGirl.build(:miq_group)
-      node = TreeNodeBuilder.build(group, nil, {})
+      node = TreeNodeBuilder.build(group, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqPolicy node' do
       policy = FactoryGirl.create(:miq_policy, :towhat => 'Vm', :active => true, :mode => 'control')
-      node = TreeNodeBuilder.build(policy, nil, {})
+      node = TreeNodeBuilder.build(policy, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqPolicySet node' do
       policy_set = FactoryGirl.build(:miq_policy_set, :name => 'Just a set')
-      node = TreeNodeBuilder.build(policy_set, nil, {})
+      node = TreeNodeBuilder.build(policy_set, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqUserRole node' do
       role = FactoryGirl.build(:miq_user_role)
-      node = TreeNodeBuilder.build(role, nil, {})
+      node = TreeNodeBuilder.build(role, nil, {}, {})
       expect(node).not_to be_nil
     end
     it 'PxeImage node' do
       image = FactoryGirl.build(:pxe_image)
-      node = TreeNodeBuilder.build(image, nil, {})
+      node = TreeNodeBuilder.build(image, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'WindowsImage node' do
       image = FactoryGirl.build(:windows_image)
-      node = TreeNodeBuilder.build(image, nil, {})
+      node = TreeNodeBuilder.build(image, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'PxeImageType node' do
       image_type = FactoryGirl.create(:pxe_image_type, :name => 'foo')
-      node = TreeNodeBuilder.build(image_type, nil, {})
+      node = TreeNodeBuilder.build(image_type, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'PxeServer node' do
       server = FactoryGirl.build(:pxe_server)
-      node = TreeNodeBuilder.build(server, nil, {})
+      node = TreeNodeBuilder.build(server, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'Service node' do
       service = FactoryGirl.create(:service)
-      node = TreeNodeBuilder.build(service, nil, {})
+      node = TreeNodeBuilder.build(service, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'ServiceResource node' do
       resource = FactoryGirl.create(:service_resource)
-      node = TreeNodeBuilder.build(resource, nil, {})
+      node = TreeNodeBuilder.build(resource, nil, {}, {})
       expect(node).not_to be_nil
     end
 
@@ -282,7 +282,7 @@ describe TreeNodeBuilder do
       template = FactoryGirl.build(:service_template,
         :name   => 'test template',
         :tenant => FactoryGirl.create(:tenant))
-      node = TreeNodeBuilder.build(template, nil, {})
+      node = TreeNodeBuilder.build(template, nil, {}, {})
       expect(node).not_to be_nil
     end
 
@@ -290,79 +290,79 @@ describe TreeNodeBuilder do
       catalog = FactoryGirl.build(:service_template_catalog,
         :name   => 'test template catalog',
         :tenant => FactoryGirl.create(:tenant))
-      node = TreeNodeBuilder.build(catalog, nil, {})
+      node = TreeNodeBuilder.build(catalog, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'Storage node' do
       storage = FactoryGirl.build(:storage)
-      node = TreeNodeBuilder.build(storage, nil, {})
+      node = TreeNodeBuilder.build(storage, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'User node' do
       user = FactoryGirl.build(:user)
-      node = TreeNodeBuilder.build(user, nil, {})
+      node = TreeNodeBuilder.build(user, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqDialog node' do
       dialog = FactoryGirl.build(:miq_dialog)
-      node = TreeNodeBuilder.build(dialog, nil, {})
+      node = TreeNodeBuilder.build(dialog, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqRegion node' do
       region = FactoryGirl.build(:miq_region, :description => 'Elbonia')
-      node = TreeNodeBuilder.build(region, nil, {})
+      node = TreeNodeBuilder.build(region, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqWidget node' do
       widget = FactoryGirl.build(:miq_widget)
-      node = TreeNodeBuilder.build(widget, nil, {})
+      node = TreeNodeBuilder.build(widget, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqWidgetSet node' do
       widget_set = FactoryGirl.build(:miq_widget_set, :name => 'foo')
-      node = TreeNodeBuilder.build(widget_set, nil, {})
+      node = TreeNodeBuilder.build(widget_set, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'VmdbTableEvm node' do
       table = FactoryGirl.build(:vmdb_table_evm, :name => 'a table')
-      node = TreeNodeBuilder.build(table, nil, {})
+      node = TreeNodeBuilder.build(table, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'VmdbIndex node' do
       index = FactoryGirl.create(:vmdb_index, :name => 'foo')
-      node = TreeNodeBuilder.build(index, nil, {})
+      node = TreeNodeBuilder.build(index, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it 'Zone node' do
       zone = FactoryGirl.build(:zone, :name => 'foo')
-      node = TreeNodeBuilder.build(zone, nil, {})
+      node = TreeNodeBuilder.build(zone, nil, {}, {})
       expect(node).not_to be_nil
     end
 
     it "expand attribute of node should be set to true when open_all is true and expand is nil in options" do
       tenant = FactoryGirl.build(:tenant)
-      node = TreeNodeBuilder.build(tenant, "root", :expand => nil, :open_all => true)
+      node = TreeNodeBuilder.build(tenant, "root", {:expand => nil, :open_all => true}, {})
       expect(node[:expand]).to eq(true)
     end
 
     it "expand attribute of node should be set to nil when open_all is true and expand is set to false in options" do
       tenant = FactoryGirl.build(:tenant)
-      node = TreeNodeBuilder.build(tenant, "root", :expand => false, :open_all => true)
+      node = TreeNodeBuilder.build(tenant, "root", {:expand => false, :open_all => true}, {})
       expect(node[:expand]).to eq(nil)
     end
 
     it "expand attribute of node should be set to true when open_all and expand are true in options" do
       tenant = FactoryGirl.build(:tenant)
-      node = TreeNodeBuilder.build(tenant, "root", :expand => true, :open_all => true)
+      node = TreeNodeBuilder.build(tenant, "root", {:expand => true, :open_all => true}, {})
       expect(node[:expand]).to eq(true)
     end
 
@@ -370,7 +370,7 @@ describe TreeNodeBuilder do
       mgmt_system = FactoryGirl.build(:ems_redhat)
       mgmt_system.name = nil
       mgmt_system.id = 'e-1000'
-      node = TreeNodeBuilder.build(mgmt_system, nil, {})
+      node = TreeNodeBuilder.build(mgmt_system, nil, {}, {})
       expect(node).not_to be_nil
     end
   end
@@ -383,7 +383,7 @@ describe TreeNodeBuilder do
       domain = FactoryGirl.create(:miq_ae_domain,
                                   :name    => "test1",
                                   :enabled => false)
-      node = TreeNodeBuilder.build(domain, nil, {})
+      node = TreeNodeBuilder.build(domain, nil, {}, {})
       expect(node[:title]).to eq('test1 (Disabled)')
     end
 
@@ -401,7 +401,7 @@ describe TreeNodeBuilder do
 
     it "should return node text with no suffix when Domain is not Locked or Disabled" do
       domain = FactoryGirl.create(:miq_ae_domain, :name => "test1")
-      node = TreeNodeBuilder.build(domain, nil, {})
+      node = TreeNodeBuilder.build(domain, nil, {}, {})
       expect(node[:title]).to eq('test1')
     end
   end

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -375,6 +375,47 @@ describe TreeNodeBuilder do
     end
   end
 
+  context "Nodes for Server By Roles/Roles By Servers trees" do
+    before(:each) do
+      @miq_server = EvmSpecHelper.local_miq_server
+      @server_role = FactoryGirl.create(
+        :server_role,
+        :name              => "smartproxy",
+        :description       => "SmartProxy",
+        :max_concurrent    => 1,
+        :external_failover => false,
+        :role_scope        => "zone"
+      )
+
+      @priority = AssignedServerRole::DEFAULT_PRIORITY
+      @assigned_server_role = FactoryGirl.create(
+        :assigned_server_role,
+        :miq_server_id  => @miq_server.id,
+        :server_role_id => @server_role.id,
+        :active         => true,
+        :priority       => 1
+      )
+    end
+
+    it 'Node for ServerRole' do
+      node = TreeNodeBuilder.build(@server_role, nil, {}, {})
+      expect(node[:key]).to eq("role-#{MiqRegion.compress_id(@server_role.id)}")
+      expect(node[:title]).to eq("Role: SmartProxy (stopped)")
+    end
+
+    it 'Node for AssignedServerRole' do
+      node = TreeNodeBuilder.build(@assigned_server_role, nil, {}, {})
+      expect(node[:key]).to eq("asr-#{MiqRegion.compress_id(@assigned_server_role.id)}")
+      expect(node[:title]).to eq("Role: SmartProxy (primary, active, PID=)")
+    end
+
+    it 'Node for MiqServer' do
+      node = TreeNodeBuilder.build(@miq_server, nil, {}, {})
+      expect(node[:key]).to eq("svr-#{MiqRegion.compress_id(@miq_server.id)}")
+      expect(node[:title]).to eq("Server: #{@miq_server.name} [#{@miq_server.id}]")
+    end
+  end
+
   context "#node_with_display_name" do
     before do
       login_as FactoryGirl.create(:user_with_group)

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -430,13 +430,13 @@ describe TreeNodeBuilder do
 
     it "should return node text with Locked in the text for Locked domain" do
       domain = FactoryGirl.create(:miq_ae_system_domain_enabled, :name => "test1")
-      node = TreeNodeBuilder.build(domain, nil, {})
+      node = TreeNodeBuilder.build(domain, nil, {}, {})
       expect(node[:title]).to eq('test1 (Locked)')
     end
 
     it "should return node text with Locked & Disabled in the text for Locked & Disabled domain" do
       domain = FactoryGirl.create(:miq_ae_system_domain, :name => "test1")
-      node = TreeNodeBuilder.build(domain, nil, {})
+      node = TreeNodeBuilder.build(domain, nil, {}, {})
       expect(node[:title]).to eq('test1 (Locked & Disabled)')
     end
 

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -2,19 +2,19 @@ describe TreeNodeBuilder do
   context '.build' do
     it 'ExtManagementSystem node' do
       mgmt_system = FactoryGirl.build(:ems_redhat)
-      node = TreeNodeBuilder.build(mgmt_system, nil, {}, {})
+      node = TreeNodeBuilder.build(mgmt_system, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'AvailabilityZone node' do
       zone = FactoryGirl.build(:availability_zone_amazon)
-      node = TreeNodeBuilder.build(zone, nil, {}, {})
+      node = TreeNodeBuilder.build(zone, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'ChargebackRate node' do
       rate = FactoryGirl.create(:chargeback_rate)
-      node = TreeNodeBuilder.build(rate, nil, {}, {})
+      node = TreeNodeBuilder.build(rate, nil, {})
       expect(node).not_to be_nil
     end
 
@@ -23,55 +23,55 @@ describe TreeNodeBuilder do
                                  :applies_to_class => 'bleugh',
                                  :applies_to_id    => nil,
                                 )
-      node = TreeNodeBuilder.build(button, nil, {}, {})
+      node = TreeNodeBuilder.build(button, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'CustomButtonSet node' do
       button_set = FactoryGirl.build(:custom_button_set)
-      node = TreeNodeBuilder.build(button_set, nil, {}, {})
+      node = TreeNodeBuilder.build(button_set, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'CustomizationTemplate node' do
       template = FactoryGirl.build(:customization_template)
-      node = TreeNodeBuilder.build(template, nil, {}, {})
+      node = TreeNodeBuilder.build(template, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'Dialog node' do
       dialog = FactoryGirl.build(:dialog, :label => 'How much wood would a woodchuck chuck if a woodchuck would chuck wood?')
-      node = TreeNodeBuilder.build(dialog, nil, {}, {})
+      node = TreeNodeBuilder.build(dialog, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'DialogTab node' do
       tab = FactoryGirl.create(:dialog_tab, :label => '<script>alert("Hacked!");</script>')
-      node = TreeNodeBuilder.build(tab, nil, {}, {})
+      node = TreeNodeBuilder.build(tab, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'DialogGroup node' do
       group = FactoryGirl.create(:dialog_group, :label => '&nbsp;foobar&gt;')
-      node = TreeNodeBuilder.build(group, nil, {}, {})
+      node = TreeNodeBuilder.build(group, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'DialogField node' do
       field = FactoryGirl.build(:dialog_field, :name => 'random field name', :label => 'foo')
-      node = TreeNodeBuilder.build(field, nil, {}, {})
+      node = TreeNodeBuilder.build(field, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'EmsFolder node' do
       folder = FactoryGirl.build(:ems_folder)
-      node = TreeNodeBuilder.build(folder, nil, {}, {})
+      node = TreeNodeBuilder.build(folder, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'valid EmsCluster node' do
       cluster = FactoryGirl.create(:ems_cluster, :name => "My Cluster")
-      node = TreeNodeBuilder.build(cluster, nil, {}, {})
+      node = TreeNodeBuilder.build(cluster, nil, {})
       expect(node).not_to be_nil
 
       expect(node[:key]).to eq("c-#{MiqRegion.compress_id(cluster.id)}")
@@ -82,7 +82,7 @@ describe TreeNodeBuilder do
 
     it 'valid Host Node' do
       host = FactoryGirl.create(:host, :name => "My Host")
-      node = TreeNodeBuilder.build(host, nil, {}, {})
+      node = TreeNodeBuilder.build(host, nil, {})
 
       expect(node[:key]).to eq("h-#{MiqRegion.compress_id(host.id)}")
       expect(node[:title]).to eq(host.name)
@@ -93,62 +93,62 @@ describe TreeNodeBuilder do
     it 'IsoDatastore node' do
       mgmt_system = FactoryGirl.build(:ems_redhat)
       datastore = FactoryGirl.build(:iso_datastore, :ext_management_system => mgmt_system)
-      node = TreeNodeBuilder.build(datastore, nil, {}, {})
+      node = TreeNodeBuilder.build(datastore, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'IsoImage node' do
       image = FactoryGirl.create(:iso_image, :name => 'foo')
-      node = TreeNodeBuilder.build(image, nil, {}, {})
+      node = TreeNodeBuilder.build(image, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'ResourcePool node' do
       pool = FactoryGirl.build(:resource_pool)
-      node = TreeNodeBuilder.build(pool, nil, {}, {})
+      node = TreeNodeBuilder.build(pool, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'Vm node' do
       vm = FactoryGirl.build(:vm_amazon)
-      node = TreeNodeBuilder.build(vm, nil, {}, {})
+      node = TreeNodeBuilder.build(vm, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'Vm node with /' do
       vm = FactoryGirl.create(:vm_amazon, :name => 'foo / bar')
-      node = TreeNodeBuilder.build(vm, 'foo', {}, {})
+      node = TreeNodeBuilder.build(vm, 'foo', {})
       expect(node[:title]).to eq('foo / bar')
     end
 
     it 'Vm node with %2f' do
       vm = FactoryGirl.create(:vm_amazon, :name => 'foo %2f bar')
-      node = TreeNodeBuilder.build(vm, nil, {}, {})
+      node = TreeNodeBuilder.build(vm, nil, {})
       expect(node[:title]).to eq('foo / bar')
     end
 
     it 'Vm node with tooltip' do
       vm = FactoryGirl.create(:vm_amazon, :name => 'name')
-      node = TreeNodeBuilder.build(vm, nil, {}, {})
+      node = TreeNodeBuilder.build(vm, nil, {})
       expect(node[:tooltip]).to eq(_("VM: %{name} (Click to view)") % {:name => vm.name})
     end
 
     it 'EmsFolder tooltip with %2f' do
       ems_folder = FactoryGirl.create(:ems_folder, :name => 'foo %2f bar')
-      node = TreeNodeBuilder.build(ems_folder, nil, {}, {})
+      node = TreeNodeBuilder.build(ems_folder, nil, {})
       expect(node[:tooltip]).to eq('Folder: foo / bar')
     end
 
     it 'MiqAeClass node' do
       namespace = FactoryGirl.build(:miq_ae_namespace)
       aclass = FactoryGirl.build(:miq_ae_class, :namespace_id => namespace.id)
-      node = TreeNodeBuilder.build(aclass, nil, {}, {})
+      node = TreeNodeBuilder.build(aclass, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAeInstance node' do
       instance = FactoryGirl.build(:miq_ae_instance)
-      node = TreeNodeBuilder.build(instance, nil, {}, {})
+      node = TreeNodeBuilder.build(instance, nil, {})
       expect(node).not_to be_nil
     end
 
@@ -156,25 +156,25 @@ describe TreeNodeBuilder do
       login_as FactoryGirl.create(:user_with_group)
 
       namespace = FactoryGirl.build(:miq_ae_namespace)
-      node = TreeNodeBuilder.build(namespace, nil, {}, {})
+      node = TreeNodeBuilder.build(namespace, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAlertSet node' do
       set = FactoryGirl.build(:miq_alert_set)
-      node = TreeNodeBuilder.build(set, nil, {}, {})
+      node = TreeNodeBuilder.build(set, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqReport node' do
       report = FactoryGirl.build(:miq_report)
-      node = TreeNodeBuilder.build(report, nil, {}, {})
+      node = TreeNodeBuilder.build(report, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqReportResult node' do
       report_result = FactoryGirl.create(:miq_report_result)
-      node = TreeNodeBuilder.build(report_result, nil, {}, {})
+      node = TreeNodeBuilder.build(report_result, nil, {})
       expect(node).not_to be_nil
       expect(node[:icon]).to eq(ActionController::Base.helpers.image_path('100/report_result.png'))
     end
@@ -184,97 +184,97 @@ describe TreeNodeBuilder do
       server = FactoryGirl.build(:miq_server, :zone => zone)
       allow(MiqServer).to receive(:my_server).and_return(server)
       schedule = FactoryGirl.build(:miq_schedule)
-      node = TreeNodeBuilder.build(schedule, nil, {}, {})
+      node = TreeNodeBuilder.build(schedule, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqServer node' do
       zone   = FactoryGirl.build(:zone)
       server = FactoryGirl.build(:miq_server, :zone => zone)
-      node = TreeNodeBuilder.build(server, nil, {}, {})
+      node = TreeNodeBuilder.build(server, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqTemplate node' do
       template = FactoryGirl.build(:miq_template, :name => "template", :location => "abc/abc.vmtx", :template => true, :vendor => "vmware")
-      node = TreeNodeBuilder.build(template, nil, {}, {})
+      node = TreeNodeBuilder.build(template, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAlert node' do
       alert = FactoryGirl.build(:miq_alert)
-      node = TreeNodeBuilder.build(alert, nil, {}, {})
+      node = TreeNodeBuilder.build(alert, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqAction node' do
       action = FactoryGirl.build(:miq_action, :name => "raise_automation_event")
-      node = TreeNodeBuilder.build(action, nil, {:tree => :action_tree}, {})
+      node = TreeNodeBuilder.build(action, nil, {:tree => :action_tree})
       expect(node).not_to be_nil
     end
 
     it 'MiqEventDefinition node' do
       event = FactoryGirl.build(:miq_event_definition)
-      node = TreeNodeBuilder.build(event, nil, {}, {})
+      node = TreeNodeBuilder.build(event, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqGroup node' do
       group = FactoryGirl.build(:miq_group)
-      node = TreeNodeBuilder.build(group, nil, {}, {})
+      node = TreeNodeBuilder.build(group, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqPolicy node' do
       policy = FactoryGirl.create(:miq_policy, :towhat => 'Vm', :active => true, :mode => 'control')
-      node = TreeNodeBuilder.build(policy, nil, {}, {})
+      node = TreeNodeBuilder.build(policy, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqPolicySet node' do
       policy_set = FactoryGirl.build(:miq_policy_set, :name => 'Just a set')
-      node = TreeNodeBuilder.build(policy_set, nil, {}, {})
+      node = TreeNodeBuilder.build(policy_set, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqUserRole node' do
       role = FactoryGirl.build(:miq_user_role)
-      node = TreeNodeBuilder.build(role, nil, {}, {})
+      node = TreeNodeBuilder.build(role, nil, {})
       expect(node).not_to be_nil
     end
     it 'PxeImage node' do
       image = FactoryGirl.build(:pxe_image)
-      node = TreeNodeBuilder.build(image, nil, {}, {})
+      node = TreeNodeBuilder.build(image, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'WindowsImage node' do
       image = FactoryGirl.build(:windows_image)
-      node = TreeNodeBuilder.build(image, nil, {}, {})
+      node = TreeNodeBuilder.build(image, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'PxeImageType node' do
       image_type = FactoryGirl.create(:pxe_image_type, :name => 'foo')
-      node = TreeNodeBuilder.build(image_type, nil, {}, {})
+      node = TreeNodeBuilder.build(image_type, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'PxeServer node' do
       server = FactoryGirl.build(:pxe_server)
-      node = TreeNodeBuilder.build(server, nil, {}, {})
+      node = TreeNodeBuilder.build(server, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'Service node' do
       service = FactoryGirl.create(:service)
-      node = TreeNodeBuilder.build(service, nil, {}, {})
+      node = TreeNodeBuilder.build(service, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'ServiceResource node' do
       resource = FactoryGirl.create(:service_resource)
-      node = TreeNodeBuilder.build(resource, nil, {}, {})
+      node = TreeNodeBuilder.build(resource, nil, {})
       expect(node).not_to be_nil
     end
 
@@ -282,7 +282,7 @@ describe TreeNodeBuilder do
       template = FactoryGirl.build(:service_template,
         :name   => 'test template',
         :tenant => FactoryGirl.create(:tenant))
-      node = TreeNodeBuilder.build(template, nil, {}, {})
+      node = TreeNodeBuilder.build(template, nil, {})
       expect(node).not_to be_nil
     end
 
@@ -290,79 +290,79 @@ describe TreeNodeBuilder do
       catalog = FactoryGirl.build(:service_template_catalog,
         :name   => 'test template catalog',
         :tenant => FactoryGirl.create(:tenant))
-      node = TreeNodeBuilder.build(catalog, nil, {}, {})
+      node = TreeNodeBuilder.build(catalog, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'Storage node' do
       storage = FactoryGirl.build(:storage)
-      node = TreeNodeBuilder.build(storage, nil, {}, {})
+      node = TreeNodeBuilder.build(storage, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'User node' do
       user = FactoryGirl.build(:user)
-      node = TreeNodeBuilder.build(user, nil, {}, {})
+      node = TreeNodeBuilder.build(user, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqDialog node' do
       dialog = FactoryGirl.build(:miq_dialog)
-      node = TreeNodeBuilder.build(dialog, nil, {}, {})
+      node = TreeNodeBuilder.build(dialog, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqRegion node' do
       region = FactoryGirl.build(:miq_region, :description => 'Elbonia')
-      node = TreeNodeBuilder.build(region, nil, {}, {})
+      node = TreeNodeBuilder.build(region, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqWidget node' do
       widget = FactoryGirl.build(:miq_widget)
-      node = TreeNodeBuilder.build(widget, nil, {}, {})
+      node = TreeNodeBuilder.build(widget, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'MiqWidgetSet node' do
       widget_set = FactoryGirl.build(:miq_widget_set, :name => 'foo')
-      node = TreeNodeBuilder.build(widget_set, nil, {}, {})
+      node = TreeNodeBuilder.build(widget_set, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'VmdbTableEvm node' do
       table = FactoryGirl.build(:vmdb_table_evm, :name => 'a table')
-      node = TreeNodeBuilder.build(table, nil, {}, {})
+      node = TreeNodeBuilder.build(table, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'VmdbIndex node' do
       index = FactoryGirl.create(:vmdb_index, :name => 'foo')
-      node = TreeNodeBuilder.build(index, nil, {}, {})
+      node = TreeNodeBuilder.build(index, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'Zone node' do
       zone = FactoryGirl.build(:zone, :name => 'foo')
-      node = TreeNodeBuilder.build(zone, nil, {}, {})
+      node = TreeNodeBuilder.build(zone, nil, {})
       expect(node).not_to be_nil
     end
 
     it "expand attribute of node should be set to true when open_all is true and expand is nil in options" do
       tenant = FactoryGirl.build(:tenant)
-      node = TreeNodeBuilder.build(tenant, "root", {:expand => nil, :open_all => true}, {})
+      node = TreeNodeBuilder.build(tenant, "root", {:expand => nil, :open_all => true})
       expect(node[:expand]).to eq(true)
     end
 
     it "expand attribute of node should be set to nil when open_all is true and expand is set to false in options" do
       tenant = FactoryGirl.build(:tenant)
-      node = TreeNodeBuilder.build(tenant, "root", {:expand => false, :open_all => true}, {})
+      node = TreeNodeBuilder.build(tenant, "root", {:expand => false, :open_all => true})
       expect(node[:expand]).to eq(nil)
     end
 
     it "expand attribute of node should be set to true when open_all and expand are true in options" do
       tenant = FactoryGirl.build(:tenant)
-      node = TreeNodeBuilder.build(tenant, "root", {:expand => true, :open_all => true}, {})
+      node = TreeNodeBuilder.build(tenant, "root", {:expand => true, :open_all => true})
       expect(node[:expand]).to eq(true)
     end
 
@@ -370,7 +370,7 @@ describe TreeNodeBuilder do
       mgmt_system = FactoryGirl.build(:ems_redhat)
       mgmt_system.name = nil
       mgmt_system.id = 'e-1000'
-      node = TreeNodeBuilder.build(mgmt_system, nil, {}, {})
+      node = TreeNodeBuilder.build(mgmt_system, nil, {})
       expect(node).not_to be_nil
     end
   end
@@ -398,19 +398,19 @@ describe TreeNodeBuilder do
     end
 
     it 'Node for ServerRole' do
-      node = TreeNodeBuilder.build(@server_role, nil, {}, {})
+      node = TreeNodeBuilder.build(@server_role, nil, {})
       expect(node[:key]).to eq("role-#{MiqRegion.compress_id(@server_role.id)}")
       expect(node[:title]).to eq("Role: SmartProxy (stopped)")
     end
 
     it 'Node for AssignedServerRole' do
-      node = TreeNodeBuilder.build(@assigned_server_role, nil, {}, {})
+      node = TreeNodeBuilder.build(@assigned_server_role, nil, {})
       expect(node[:key]).to eq("asr-#{MiqRegion.compress_id(@assigned_server_role.id)}")
       expect(node[:title]).to eq("Role: SmartProxy (primary, active, PID=)")
     end
 
     it 'Node for MiqServer' do
-      node = TreeNodeBuilder.build(@miq_server, nil, {}, {})
+      node = TreeNodeBuilder.build(@miq_server, nil, {})
       expect(node[:key]).to eq("svr-#{MiqRegion.compress_id(@miq_server.id)}")
       expect(node[:title]).to eq("Server: #{@miq_server.name} [#{@miq_server.id}]")
     end
@@ -424,25 +424,25 @@ describe TreeNodeBuilder do
       domain = FactoryGirl.create(:miq_ae_domain,
                                   :name    => "test1",
                                   :enabled => false)
-      node = TreeNodeBuilder.build(domain, nil, {}, {})
+      node = TreeNodeBuilder.build(domain, nil, {})
       expect(node[:title]).to eq('test1 (Disabled)')
     end
 
     it "should return node text with Locked in the text for Locked domain" do
       domain = FactoryGirl.create(:miq_ae_system_domain_enabled, :name => "test1")
-      node = TreeNodeBuilder.build(domain, nil, {}, {})
+      node = TreeNodeBuilder.build(domain, nil, {})
       expect(node[:title]).to eq('test1 (Locked)')
     end
 
     it "should return node text with Locked & Disabled in the text for Locked & Disabled domain" do
       domain = FactoryGirl.create(:miq_ae_system_domain, :name => "test1")
-      node = TreeNodeBuilder.build(domain, nil, {}, {})
+      node = TreeNodeBuilder.build(domain, nil, {})
       expect(node[:title]).to eq('test1 (Locked & Disabled)')
     end
 
     it "should return node text with no suffix when Domain is not Locked or Disabled" do
       domain = FactoryGirl.create(:miq_ae_domain, :name => "test1")
-      node = TreeNodeBuilder.build(domain, nil, {}, {})
+      node = TreeNodeBuilder.build(domain, nil, {})
       expect(node[:title]).to eq('test1')
     end
   end


### PR DESCRIPTION
- Server By Roles and Roles By Servers trees in OPS/Diagnostics(Zone and Region nodes) conversion to use TreeBuilder class.
- Had to pass in sandbox to TreeNodeBuilder class to get correct node titles to appear on the trees and also needed it for other node calculations.
- Adjusted any existing broken spec tests to work changes in the commit. Updated delete_server diagnostics_spec test to add another server to be able to build and return tree nodes successfully after one of the server nodes is deleted.

affected tree screenshots:
![zone_tree1](https://cloud.githubusercontent.com/assets/3450808/16820406/e2c2739c-491e-11e6-8cb5-103d9da9b6bd.png)

![zone_tree2](https://cloud.githubusercontent.com/assets/3450808/16820410/e6be5060-491e-11e6-97c1-4ed6cfc21336.png)

![region_tree1](https://cloud.githubusercontent.com/assets/3450808/16820414/ea089424-491e-11e6-9f48-2bec8c4a3a09.png)

![region_tree2](https://cloud.githubusercontent.com/assets/3450808/16820424/ee0a4bee-491e-11e6-8c31-04ccab53d3d3.png)


