### PR TITLE
Add event USER_SUSPEND_VM_OK to refresh VM and update its power state.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_suspend_vm_ok.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_suspend_vm_ok.yaml
@@ -3,12 +3,14 @@ object_type: instance
 version: 1.0
 object:
   attributes:
-    display_name: 
-    name: VmSuspendedEvent
-    inherits: 
-    description: 
+    display_name:
+    name: USER_SUSPEND_VM_OK
+    inherits:
+    description:
   fields:
   - rel4:
       value: "/System/event_handlers/change_event_target_state?target=src_vm&param=suspended"
   - rel5:
       value: "/System/event_handlers/event_action_refresh?target=src_vm"
+  - rel6:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_suspend&param="


### PR DESCRIPTION
Purpose or Intent
-----------------
Add event USER_SUSPEND_VM_OK to Automate so VM's power state can be updated and raise vm_suspend event for policy after being suspended.

Also add refresh action to VmSuspendedEvent which is the same kind of suspend event for VMware.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1343684