### PR TITLE
Extract class API::Initializer

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -140,8 +140,6 @@ class ApiController < ApplicationController
     @collection_config ||= CollectionConfig.new
   end
 
-  delegate :user_token_service, :to => self
-
   def initialize
     @module          = base_config[:module]
     @name            = base_config[:name]

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,3 +1,8 @@
+#
+# Initializing REST API environment, called once @ startup
+#
+Api::Initializer.new.go
+
 class ApiController < ApplicationController
   skip_before_action :get_global_session_data
   skip_after_action :set_global_session_data
@@ -135,11 +140,6 @@ class ApiController < ApplicationController
     @prefix          = "/#{@module}"
     @api_config      = VMDB::Config.new("vmdb").config[@module.to_sym] || {}
   end
-
-  #
-  # Initializing REST API environment, called once @ startup
-  #
-  include_concern 'Initializer'
 
   before_action :parse_api_request, :log_api_request, :validate_api_request
   after_action :log_api_response

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -102,19 +102,6 @@ class ApiController < ApplicationController
   TAG_NAMESPACE = "/managed"
 
   #
-  # Custom normalization on these attribute types.
-  # Converted to normalized_attributes hash at init, much faster access.
-  #
-  ATTR_TYPES = {
-    :time      => %w(expires_on),
-    :url       => %w(href),
-    :resource  => %w(image_href),
-    :encrypted => %w(password) |
-                  ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
-                  ::Vmdb::Settings::PASSWORD_FIELDS.map(&:to_s)
-  }
-
-  #
   # Attributes used for identification
   #
   ID_ATTRS = %w(href id)

--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -6,7 +6,7 @@ class ApiController
 
     def show_auth
       requester_type = fetch_and_validate_requester_type
-      auth_token = user_token_service.generate_token(@auth_user, requester_type)
+      auth_token = Api.user_token_service.generate_token(@auth_user, requester_type)
       res = {
         :auth_token => auth_token,
         :token_ttl  => api_token_mgr.token_get_info(@module, auth_token, :token_ttl),
@@ -115,7 +115,7 @@ class ApiController
 
     def fetch_and_validate_requester_type
       requester_type = params['requester_type']
-      user_token_service.validate_requester_type(requester_type)
+      Api.user_token_service.validate_requester_type(requester_type)
       requester_type
     rescue => err
       raise BadRequestError, err.to_s
@@ -159,7 +159,7 @@ class ApiController
     end
 
     def api_token_mgr
-      user_token_service.token_mgr
+      Api.user_token_service.token_mgr
     end
   end
 end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -3,56 +3,7 @@ class ApiController
     extend ActiveSupport::Concern
 
     included do
-      init_env
-      gen_attr_type_hash
-    end
-
-    module ClassMethods
-      private
-
-      def log_kv(key, val, pref = "")
-        $api_log.info("#{pref}  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
-      end
-
-      #
-      # Initializing REST API environment, called once @ startup
-      #
-      def init_env
-        $api_log.info("Initializing Environment for #{Api::Settings.base[:name]}")
-        log_config
-      end
-
-      def log_config
-        $api_log.info("")
-        $api_log.info("Static Configuration")
-        Api::Settings.base.each { |key, val| log_kv(key, val) }
-
-        $api_log.info("")
-        $api_log.info("Dynamic Configuration")
-        Api.user_token_service.api_config.each { |key, val| log_kv(key, val) }
-      end
-
-      #
-      # Let's create our attribute type hashes.
-      # Accessed as normalized_attributes[<name>], much faster than array include?
-      #
-      def gen_attr_type_hash
-        ATTR_TYPES.each { |type, attrs| attrs.each { |a| Api.normalized_attributes[type][a] = true } }
-        gen_time_attr_type_hash
-      end
-
-      #
-      # Let's dynamically get the :date and :datetime attributes from the Classes we care about.
-      #
-      def gen_time_attr_type_hash
-        Api::Settings.collections.each do |_, cspec|
-          next if cspec[:klass].blank?
-          klass = cspec[:klass].constantize
-          klass.columns_hash.collect  do |name, typeobj|
-            Api.normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
-          end
-        end
-      end
+      Api::Initializer.new.go
     end
   end
 end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -8,20 +8,6 @@ class ApiController
     end
 
     module ClassMethods
-      #
-      # Let's fetch encrypted attribute names of objects being rendered if not already done
-      #
-      def fetch_encrypted_attribute_names(klass)
-        return [] unless klass.respond_to?(:encrypted_columns)
-        encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
-          Api.normalized_attributes[:encrypted][attr] = true
-        end
-      end
-
-      def encrypted_objects_checked
-        @encrypted_objects_checked ||= {}
-      end
-
       private
 
       def log_kv(key, val, pref = "")

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -19,10 +19,6 @@ class ApiController
         end
       end
 
-      def user_token_service
-        @user_token_service ||= ApiUserTokenService.new(Api::Settings, :log_init => true)
-      end
-
       private
 
       def log_kv(key, val, pref = "")
@@ -44,7 +40,7 @@ class ApiController
 
         $api_log.info("")
         $api_log.info("Dynamic Configuration")
-        user_token_service.api_config.each { |key, val| log_kv(key, val) }
+        Api.user_token_service.api_config.each { |key, val| log_kv(key, val) }
       end
 
       #

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -1,9 +1,0 @@
-class ApiController
-  module Initializer
-    extend ActiveSupport::Concern
-
-    included do
-      Api::Initializer.new.go
-    end
-  end
-end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -12,11 +12,14 @@ class ApiController
       # Let's fetch encrypted attribute names of objects being rendered if not already done
       #
       def fetch_encrypted_attribute_names(klass)
-        @encrypted_objects_checked ||= {}
         return [] unless klass.respond_to?(:encrypted_columns)
-        @encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
+        encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
           Api.normalized_attributes[:encrypted][attr] = true
         end
+      end
+
+      def encrypted_objects_checked
+        @encrypted_objects_checked ||= {}
       end
 
       private

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -20,7 +20,7 @@ class ApiController
       end
 
       def user_token_service
-        @api_user_token_service
+        @user_token_service ||= ApiUserTokenService.new(Api::Settings, :log_init => true)
       end
 
       private
@@ -34,7 +34,6 @@ class ApiController
       #
       def init_env
         $api_log.info("Initializing Environment for #{Api::Settings.base[:name]}")
-        @api_user_token_service ||= ApiUserTokenService.new(Api::Settings, :log_init => true)
         log_config
       end
 

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -15,16 +15,12 @@ class ApiController
         @encrypted_objects_checked ||= {}
         return [] unless klass.respond_to?(:encrypted_columns)
         @encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
-          normalized_attributes[:encrypted][attr] = true
+          Api.normalized_attributes[:encrypted][attr] = true
         end
       end
 
       def user_token_service
         @api_user_token_service
-      end
-
-      def normalized_attributes
-        @normalized_attributes ||= {:time => {}, :url => {}, :resource => {}, :encrypted => {}}
       end
 
       private
@@ -57,7 +53,7 @@ class ApiController
       # Accessed as normalized_attributes[<name>], much faster than array include?
       #
       def gen_attr_type_hash
-        ATTR_TYPES.each { |type, attrs| attrs.each { |a| normalized_attributes[type][a] = true } }
+        ATTR_TYPES.each { |type, attrs| attrs.each { |a| Api.normalized_attributes[type][a] = true } }
         gen_time_attr_type_hash
       end
 
@@ -69,7 +65,7 @@ class ApiController
           next if cspec[:klass].blank?
           klass = cspec[:klass].constantize
           klass.columns_hash.collect  do |name, typeobj|
-            normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
+            Api.normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
           end
         end
       end

--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -8,7 +8,7 @@ class ApiController
     # virtual subcollections is added.
 
     def normalize_hash(type, obj, opts = {})
-      ApiController.fetch_encrypted_attribute_names(obj.class)
+      Api.fetch_encrypted_attribute_names(obj.class)
       attrs = normalize_select_attributes(obj, opts)
       result = {}
 
@@ -36,7 +36,7 @@ class ApiController
     end
 
     def normalize_virtual_hash(vtype, obj, options)
-      ApiController.fetch_encrypted_attribute_names(obj.class)
+      Api.fetch_encrypted_attribute_names(obj.class)
       attrs = (obj.respond_to?(:attributes) ? obj.attributes.keys : obj.keys)
       attrs.each_with_object({}) do |k, res|
         value = normalize_virtual(vtype, k, obj[k], options)

--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -49,13 +49,13 @@ class ApiController
     #
     def normalize_attr_byname(attr, value)
       return if value.nil?
-      if self.class.normalized_attributes[:time].key?(attr.to_s)
+      if Api.normalized_attributes[:time].key?(attr.to_s)
         normalize_time(value)
-      elsif self.class.normalized_attributes[:url].key?(attr.to_s)
+      elsif Api.normalized_attributes[:url].key?(attr.to_s)
         normalize_url(value)
-      elsif self.class.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?("password")
+      elsif Api.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?("password")
         normalize_encrypted
-      elsif self.class.normalized_attributes[:resource].key?(attr.to_s)
+      elsif Api.normalized_attributes[:resource].key?(attr.to_s)
         normalize_resource(value)
       else
         value

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -2,4 +2,8 @@ module Api
   def self.normalized_attributes
     @normalized_attributes ||= {:time => {}, :url => {}, :resource => {}, :encrypted => {}}
   end
+
+  def self.user_token_service
+    @user_token_service ||= ApiUserTokenService.new(Api::Settings, :log_init => true)
+  end
 end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -6,4 +6,15 @@ module Api
   def self.user_token_service
     @user_token_service ||= ApiUserTokenService.new(Api::Settings, :log_init => true)
   end
+
+  def self.fetch_encrypted_attribute_names(klass)
+    return [] unless klass.respond_to?(:encrypted_columns)
+    encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
+      Api.normalized_attributes[:encrypted][attr] = true
+    end
+  end
+
+  def self.encrypted_objects_checked
+    @encrypted_objects_checked ||= {}
+  end
 end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,0 +1,5 @@
+module Api
+  def self.normalized_attributes
+    @normalized_attributes ||= {:time => {}, :url => {}, :resource => {}, :encrypted => {}}
+  end
+end

--- a/lib/api/initializer.rb
+++ b/lib/api/initializer.rb
@@ -1,18 +1,5 @@
 module Api
   class Initializer
-    #
-    # Custom normalization on these attribute types.
-    # Converted to normalized_attributes hash at init, much faster access.
-    #
-    ATTR_TYPES = {
-      :time      => %w(expires_on),
-      :url       => %w(href),
-      :resource  => %w(image_href),
-      :encrypted => %w(password) |
-                    ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
-                    ::Vmdb::Settings::PASSWORD_FIELDS.map(&:to_s)
-    }
-
     def go
       init_env
       gen_attr_type_hash
@@ -45,7 +32,7 @@ module Api
     # Accessed as normalized_attributes[<name>], much faster than array include?
     #
     def gen_attr_type_hash
-      ATTR_TYPES.each { |type, attrs| attrs.each { |a| Api.normalized_attributes[type][a] = true } }
+      attr_types.each { |type, attrs| attrs.each { |a| Api.normalized_attributes[type][a] = true } }
       gen_time_attr_type_hash
     end
 
@@ -60,6 +47,23 @@ module Api
           Api.normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
         end
       end
+    end
+
+    private
+
+    #
+    # Custom normalization on these attribute types.
+    # Converted to normalized_attributes hash at init, much faster access.
+    #
+    def attr_types
+      @attr_types ||= {
+        :time      => %w(expires_on),
+        :url       => %w(href),
+        :resource  => %w(image_href),
+        :encrypted => %w(password) |
+                      ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
+                      ::Vmdb::Settings::PASSWORD_FIELDS.map(&:to_s)
+      }
     end
   end
 end

--- a/lib/api/initializer.rb
+++ b/lib/api/initializer.rb
@@ -1,0 +1,65 @@
+module Api
+  class Initializer
+    #
+    # Custom normalization on these attribute types.
+    # Converted to normalized_attributes hash at init, much faster access.
+    #
+    ATTR_TYPES = {
+      :time      => %w(expires_on),
+      :url       => %w(href),
+      :resource  => %w(image_href),
+      :encrypted => %w(password) |
+                    ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
+                    ::Vmdb::Settings::PASSWORD_FIELDS.map(&:to_s)
+    }
+
+    def go
+      init_env
+      gen_attr_type_hash
+    end
+
+    def log_kv(key, val, pref = "")
+      $api_log.info("#{pref}  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
+    end
+
+    #
+    # Initializing REST API environment, called once @ startup
+    #
+    def init_env
+      $api_log.info("Initializing Environment for #{Api::Settings.base[:name]}")
+      log_config
+    end
+
+    def log_config
+      $api_log.info("")
+      $api_log.info("Static Configuration")
+      Api::Settings.base.each { |key, val| log_kv(key, val) }
+
+      $api_log.info("")
+      $api_log.info("Dynamic Configuration")
+      Api.user_token_service.api_config.each { |key, val| log_kv(key, val) }
+    end
+
+    #
+    # Let's create our attribute type hashes.
+    # Accessed as normalized_attributes[<name>], much faster than array include?
+    #
+    def gen_attr_type_hash
+      ATTR_TYPES.each { |type, attrs| attrs.each { |a| Api.normalized_attributes[type][a] = true } }
+      gen_time_attr_type_hash
+    end
+
+    #
+    # Let's dynamically get the :date and :datetime attributes from the Classes we care about.
+    #
+    def gen_time_attr_type_hash
+      Api::Settings.collections.each do |_, cspec|
+        next if cspec[:klass].blank?
+        klass = cspec[:klass].constantize
+        klass.columns_hash.collect do |name, typeobj|
+          Api.normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
The stuff we do in the initializer module under the Api controller currently doesn't play well with an object oriented model - the data isn't shared down into subclasses. Rather than try to maintain them as class variables (where they would be), I've opted to break out the initializer from the controller instead. The benefits:

* the data it generates is encapsulated and can be accessed from anywhere.
* this makes room for the Api to be more flexible about when it initializes, which is fairly expensive

@jrafanie I think this will address part of the issue we saw last week where we wanted to defer loading of `ATTR_TYPES`, which accounted for the most of the performance regression when running `rake routes`. It is still loaded with `ApiController` as it stands but this could be deferred to some arbitrary point up to and including the first request made.

This is a fairly big PR - I'm happy to break it up into smaller ones if it's easier to review. The essential part (moving the data out of the Api controller) is currently blocking me from making objected oriented Api controllers.

Steps for Testing/QA
--------------------
The tests should be sufficient, and/or sending some requests to the server in development

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 
