### PR TITLE
Combine duplicated stack resources

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -100,10 +100,8 @@ module ManageIQ::Providers
         resources = @tds.list_deployment_operations(name, group)
         # relying on deployment operations to collect resources; but each resource may appear multiple times
         # consolidate multiple appearances into only one
-        pos = -1
         resources.reject! do |resource|
-          pos += 1
-          resource.properties.try(:target_resource).nil? || resource_already_collected?(resources, resource, pos)
+          resource.properties.try(:target_resource).nil? || resource_already_collected?(resources, resource)
         end
 
         process_collection(resources, :orchestration_stack_resources) do |resource|
@@ -111,9 +109,9 @@ module ManageIQ::Providers
         end
       end
 
-      def resource_already_collected?(all, resource, position)
-        all.each_with_index do |old_resource, index|
-          return false if index == position
+      def resource_already_collected?(all, resource)
+        all.each do |old_resource|
+          return false if old_resource.equal?(resource)
           old_id = old_resource.properties.target_resource.id
           search_id = resource.properties.target_resource.id
           if old_id == search_id

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -89,7 +89,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :orchestration_stack           => 10,
       :orchestration_stack_parameter => 138,
       :orchestration_stack_output    => 7,
-      :orchestration_stack_resource  => 42,
+      :orchestration_stack_resource  => 54,
       :security_group                => 8,
       :network_port                  => 10,
       :cloud_network                 => 6,


### PR DESCRIPTION
Purpose or Intent
-----------------
Fixes #8522
Previous implementation assumed the `Array#reject!` removes elements after the iteration but it actually removes elements immediately in Ruby 2.2. The assumption is correct for Ruby 2.3. This explains the spec failure reported in #8522.

Although the code works in Ruby 2.3, it is necessary to have a fix for 2.2. The actual fix is simpler and does not depends on the iteration index thus works in both 2.2 and 2.3.

Links
-----
https://github.com/ruby/spec/issues/175
https://bugs.ruby-lang.org/issues/10714