### PR TITLE
Pull count out of Rbac.find_targets_with_rbac

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -408,7 +408,8 @@ module Rbac
       ids_clause = ["#{klass.table_name}.id IN (?)", target_ids] if klass.respond_to?(:table_name)
     else # targets is a scope, class, or AASM class (VimPerformanceDaily in particular)
       targets = to_class(targets)
-      targets = targets.all if targets < ActiveRecord::Base
+      # could just call all on everything, but that will display deprecation warnings
+      targets = targets.all if targets < ActiveRecord::Base || targets.kind_of?(ActsAsArModel)
 
       scope = apply_scope(targets, scope)
 
@@ -459,12 +460,7 @@ module Rbac
   end
 
   def self.method_with_scope(ar_scope, options)
-    # for the most part, it is just asking if it extends ActsAsArModel
-    if ar_scope.try(:instances_are_derived?)
-      ar_scope.all(options)
-    else
-      ar_scope.apply_legacy_finder_options(options)
-    end
+    ar_scope.apply_legacy_finder_options(options)
   end
 
   def self.apply_scope(klass, scope)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -213,10 +213,7 @@ module Rbac
       find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], ids_clause)
       _log.debug("New Find options: #{find_options.inspect}")
     end
-    targets     = method_with_scope(scope, find_options)
-    auth_count  = targets.except(:offset, :limit, :order).count(:all)
-
-    return targets, auth_count
+    method_with_scope(scope, find_options)
   end
 
   def self.get_belongsto_filter_object_ids(klass, filter)
@@ -268,7 +265,9 @@ module Rbac
     end
 
     if apply_rbac_to_class?(klass)
-      find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
+      targets = find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
+      auth_count  = targets.except(:offset, :limit, :order).count(:all)
+      return targets, auth_count
     elsif apply_rbac_to_associated_class?(klass)
       find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
     elsif apply_user_group_rbac_to_class?(klass, miq_group)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -271,15 +271,11 @@ module Rbac
       auth_count = targets.except(:offset, :limit, :order).count(:all)
       return targets, auth_count
     else
-      find_targets_without_rbac(scope, find_options)
+      targets = method_with_scope(scope, find_options)
+      auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count : targets.length
+
+      return targets, auth_count
     end
-  end
-
-  def self.find_targets_without_rbac(scope, find_options)
-    targets    = method_with_scope(scope, find_options)
-    auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count : targets.length
-
-    return targets, auth_count
   end
 
   def self.get_user_info(user, userid, miq_group, miq_group_id)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -255,22 +255,17 @@ module Rbac
 
     if apply_rbac_to_class?(klass)
       targets = find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
-      auth_count  = targets.except(:offset, :limit, :order).count(:all)
-      return targets, auth_count
     elsif apply_rbac_to_associated_class?(klass)
       targets = find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
-      auth_count  = targets.except(:offset, :limit, :order).count
-      return targets, auth_count
     elsif apply_user_group_rbac_to_class?(klass, miq_group)
       targets = find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user, miq_group)
-      auth_count = targets.except(:offset, :limit, :order).count(:all)
-      return targets, auth_count
     else
       targets = method_with_scope(scope, find_options)
-      auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count : targets.length
-
-      return targets, auth_count
     end
+
+    auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count(:all) : targets.length
+
+    return targets, auth_count
   end
 
   def self.get_user_info(user, userid, miq_group, miq_group_id)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -238,15 +238,12 @@ module Rbac
   def self.find_targets_with_user_group_rbac(scope, _rbac_filters, find_options, user, miq_group)
     klass = scope.respond_to?(:klass) ? scope.klass : scope
     if klass == User && user
-      cond = {:id => user.id}
+      scope = scope.where(:id => user.id)
     elsif klass == MiqGroup
-      cond = {:id => miq_group.id}
+      scope = scope.where(:id => miq_group.id)
     end
 
-    targets = klass.where(cond).where(find_options[:condition])
-                .includes(find_options[:include]).references(find_options[:include])
-                .group(find_options[:group]).order(find_options[:order])
-                .offset(find_options[:offset]).limit(find_options[:limit])
+    targets     = method_with_scope(scope, find_options)
     auth_count = targets.except(:offset, :limit, :order).count(:all)
 
     return targets, auth_count

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -237,10 +237,7 @@ module Rbac
       scope = scope.where(:id => miq_group.id)
     end
 
-    targets     = method_with_scope(scope, find_options)
-    auth_count = targets.except(:offset, :limit, :order).count(:all)
-
-    return targets, auth_count
+    method_with_scope(scope, find_options)
   end
 
   def self.find_options_for_tenant(scope, user, miq_group, find_options)
@@ -270,7 +267,9 @@ module Rbac
       auth_count  = targets.except(:offset, :limit, :order).count
       return targets, auth_count
     elsif apply_user_group_rbac_to_class?(klass, miq_group)
-      find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user, miq_group)
+      targets = find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user, miq_group)
+      auth_count = targets.except(:offset, :limit, :order).count(:all)
+      return targets, auth_count
     else
       find_targets_without_rbac(scope, find_options)
     end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -202,7 +202,7 @@ module Rbac
       _log.debug("New Find options: #{find_options.inspect}")
     end
     targets     = method_with_scope(scope, find_options)
-    auth_count  = scope.where(find_options[:conditions]).includes(find_options[:include]).references(find_options[:include]).count
+    auth_count  = targets.except(:offset, :limit, :order).count
 
     return targets, auth_count
   end
@@ -246,9 +246,10 @@ module Rbac
     targets = klass.where(cond).where(find_options[:condition])
                 .includes(find_options[:include]).references(find_options[:include])
                 .group(find_options[:group]).order(find_options[:order])
-                .offset(find_options[:offset]).limit(find_options[:limit]).to_a
+                .offset(find_options[:offset]).limit(find_options[:limit])
+    auth_count = targets.except(:offset, :limit, :order).count(:all)
 
-    [targets, targets.length, targets.length]
+    return targets, auth_count
   end
 
   def self.find_options_for_tenant(scope, user, miq_group, find_options)
@@ -282,7 +283,7 @@ module Rbac
 
   def self.find_targets_without_rbac(scope, find_options)
     targets    = method_with_scope(scope, find_options)
-    auth_count = find_options[:limit] ? scope.where(find_options[:conditions]).includes(find_options[:include]).references(find_options[:include]).count : targets.length
+    auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count : targets.length
 
     return targets, auth_count
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -193,13 +193,10 @@ module Rbac
     if filtered_ids
       reflection = scope.reflections[parent_class.name.underscore]
       if reflection
-        ids_clause = ["#{scope.table_name}.#{reflection.foreign_key} IN (?)", filtered_ids]
+        scope = scope.where("#{scope.table_name}.#{reflection.foreign_key} IN (?)", filtered_ids)
       else
-        ids_clause = ["#{scope.table_name}.resource_type = ? AND #{scope.table_name}.resource_id IN (?)", parent_class.name, filtered_ids]
+        scope = scope.where("#{scope.table_name}.resource_type = ? AND #{scope.table_name}.resource_id IN (?)", parent_class.name, filtered_ids)
       end
-
-      find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], ids_clause)
-      _log.debug("New Find options: #{find_options.inspect}")
     end
     method_with_scope(scope, find_options)
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -201,10 +201,7 @@ module Rbac
       find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], ids_clause)
       _log.debug("New Find options: #{find_options.inspect}")
     end
-    targets     = method_with_scope(scope, find_options)
-    auth_count  = targets.except(:offset, :limit, :order).count
-
-    return targets, auth_count
+    method_with_scope(scope, find_options)
   end
 
   def self.find_targets_filtered_by_ids(scope, find_options, filtered_ids)
@@ -269,7 +266,9 @@ module Rbac
       auth_count  = targets.except(:offset, :limit, :order).count(:all)
       return targets, auth_count
     elsif apply_rbac_to_associated_class?(klass)
-      find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
+      targets = find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
+      auth_count  = targets.except(:offset, :limit, :order).count
+      return targets, auth_count
     elsif apply_user_group_rbac_to_class?(klass, miq_group)
       find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user, miq_group)
     else

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -206,9 +206,7 @@ module Rbac
 
   def self.find_targets_filtered_by_ids(scope, find_options, filtered_ids)
     if filtered_ids
-      ids_clause  = ["#{scope.table_name}.id IN (?)", filtered_ids]
-      find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], ids_clause)
-      _log.debug("New Find options: #{find_options.inspect}")
+      scope = scope.where("#{scope.table_name}.id IN (?)", filtered_ids)
     end
     method_with_scope(scope, find_options)
   end

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -254,18 +254,14 @@ module Rbac
     end
 
     if apply_rbac_to_class?(klass)
-      targets = find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
+      find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
     elsif apply_rbac_to_associated_class?(klass)
-      targets = find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
+      find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
     elsif apply_user_group_rbac_to_class?(klass, miq_group)
-      targets = find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user, miq_group)
+      find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user, miq_group)
     else
-      targets = method_with_scope(scope, find_options)
+      method_with_scope(scope, find_options)
     end
-
-    auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count(:all) : targets.length
-
-    return targets, auth_count
   end
 
   def self.get_user_info(user, userid, miq_group, miq_group_id)
@@ -416,7 +412,8 @@ module Rbac
 
     _log.debug("Find options: #{find_options.inspect}")
 
-    targets, auth_count = find_targets_with_rbac(klass, scope, user_filters, find_options, user, miq_group)
+    targets = find_targets_with_rbac(klass, scope, user_filters, find_options, user, miq_group)
+    auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count(:all) : targets.length
 
     if search_filter && targets && (!exp_attrs || !exp_attrs[:supported_by_sql])
       rejects     = targets.reject { |obj| self.matches_search_filters?(obj, search_filter, tz) }

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1052,7 +1052,7 @@ describe Rbac do
     it "works with no filters" do
       all_vms
       result = Rbac.find_targets_with_direct_rbac(Vm, {}, {}, nil, nil)
-      expect_counts(result, all_vms, all_vms.size)
+      expect(result).to match_array(all_vms)
     end
 
     # most of the functionality of search is channeled through find_options. including filters
@@ -1060,7 +1060,7 @@ describe Rbac do
     it "applies find_options[:conditions, :include]" do
       all_vms
       result = Rbac.find_targets_with_direct_rbac(Vm, {}, host_filter_find_options, nil, nil)
-      expect_counts(result, vms_match, 2)
+      expect(result).to match_array(vms_match)
     end
   end
 


### PR DESCRIPTION
Theme
----

Rbac is currently used to query the database and apply user centric security filters.
The interface to Rbac has grown as we have increased our access pattern to the database.

The goal is change `Rbac` from a query engine, to a tool that only enhances a `where` clause of the query. This will allos us to move all the query logic (e.g.: `limit`, `order`, `group`) from our own custom interface to using the standard active record query interface. (e.g. `all.limit(5).order(:name).group(:type)` )

Overview
---------

AR|code
---|---
old|`find(:conditions => {}, :limit => 5)`
new|`.where({}).limit(5)`

Good news: We recently changed `ActsAsArModel` to support the new AR format.

This PR drops support for the old format from `method_with_scope`. So `find_options` no longer needs to hold the complete query.

`apply_legacy_finder_options` is a simple bridge from the old format to the new format. We will parameter by parameter stop putting the parameter into `find_options` and just call the method directly on the `scope`


Details
-----

Changed various rbac filters to work with a scope and call count on that.
The same logic was called in a number of ways, this just consolidated them.

Since these are all private methods, there should be no visible changes in the public API ( `search` and `filtered`). One test did need to change from calling private methods. It works both before and after the code changes.