### PR TITLE
Fix a typo in configuration script center toolbar.

### DIFF
--- a/app/helpers/application_helper/toolbar/x_configuration_scripts_center.rb
+++ b/app/helpers/application_helper/toolbar/x_configuration_scripts_center.rb
@@ -1,3 +1,3 @@
 class ApplicationHelper::Toolbar::XConfigurationScriptsCenter < ApplicationHelper::Toolbar::Basic
-  include ApplicationHelper::Toolbar::ConfigurationScript::PolicyMixin
+  include ApplicationHelper::Toolbar::ConfigurationScripts::PolicyMixin
 end


### PR DESCRIPTION
Wrong class name fixed.

Ping @mzazrivec, @lgalis 

------------
## Testing

```
devil - [~/Projects/manageiq] (fix_tb_conf_script)$ bundle exec rails c
** Using session_store: ActionDispatch::Session::MemCacheStore
DEPRECATION WARNING: You didn't set `secret_key_base`. Read the upgrade documentation to learn more about this new config option. (called from block in controller at /home/martin/.rvm/gems/ruby-2.2.2@cfme/bundler/gems/draper-a788c38eab4a/lib/draper/view_context/build_strategy.rb:43)
Loading development environment (Rails 5.0.0)
irb: warn: can't alias context from irb_context.
2.2.2 :001 > ApplicationHelper::Toolbar::ConfigurationScript::PolicyMixin
NameError: uninitialized constant ConfigurationScript::PolicyMixin
        from (irb):1
        from /home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/railties-5.0.0/lib/rails/commands/console.rb:65:in `start'
        from /home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/railties-5.0.0/lib/rails/commands/console_helper.rb:9:in `start'
        from /home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/railties-5.0.0/lib/rails/commands/commands_tasks.rb:78:in `console'
        from /home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/railties-5.0.0/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
        from /home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/railties-5.0.0/lib/rails/commands.rb:18:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
2.2.2 :002 > ApplicationHelper::Toolbar::ConfigurationScripts::PolicyMixin
 => ApplicationHelper::Toolbar::ConfigurationScripts::PolicyMixin 
```
