### PR TITLE
Remove Type / Template/VMs from VMs filters

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -1135,27 +1135,6 @@
     search_type: default
     db: ManageIQ::Providers::InfraManager::Vm
 - attributes:
-    name: default_Type / Template
-    description: Type / Template
-    filter: !ruby/object:MiqExpression
-      exp:
-        "=":
-          field: VmInfra-template
-          value: "true"
-    search_type: default
-    db: ManageIQ::Providers::InfraManager::Vm
-- attributes:
-    name: default_Type / VM
-    description: Type / VM
-    filter: !ruby/object:MiqExpression
-      exp:
-        not:
-          ENDS WITH:
-            field: VmInfra-location
-            value: .vmtx
-    search_type: default
-    db: ManageIQ::Providers::InfraManager::Vm
-- attributes:
     name: default_Status / Retired
     description: Status / Retired
     filter: !ruby/object:MiqExpression

--- a/db/migrate/20160713130940_remove_type_template_and_vms_filters_from_miq_search.rb
+++ b/db/migrate/20160713130940_remove_type_template_and_vms_filters_from_miq_search.rb
@@ -1,0 +1,33 @@
+class RemoveTypeTemplateAndVmsFiltersFromMiqSearch < ActiveRecord::Migration[5.0]
+  class MiqSearch < ActiveRecord::Base
+    serialize :filter
+  end
+
+  TEMPLATE_FITLER_EXPR = MiqExpression.new("=" => {"field" => "VmInfra-template", "value" => "true"})
+  TEMPLATE_TYPE_FILTER = {:name => "default_Type / Template", :description => "Type / Template",
+                          :filter => TEMPLATE_FITLER_EXPR, :search_type => "default",
+                          :db => "ManageIQ::Providers::InfraManager::Vm"}.freeze
+
+  VMS_FITLER_EXPR = MiqExpression.new("not" => {"ENDS WITH" => {"field" => "VmInfra-location", "value" => ".vmtx"}})
+  VMS_TYPE_FILTER = {:name => "default_Type / VM", :description => "Type / VM", :filter => VMS_FITLER_EXPR,
+                     :search_type => "default", :db => "ManageIQ::Providers::InfraManager::Vm"}.freeze
+
+  def up
+    say_with_time('Remove Type / Template and Type / VM from VMs filters') do
+      template_filter = TEMPLATE_TYPE_FILTER.dup
+      template_filter.except!(:filter, :search_type)
+      MiqSearch.where(template_filter).delete_all
+
+      vms_filter = VMS_TYPE_FILTER.dup
+      vms_filter.except!(:filter, :search_type)
+      MiqSearch.where(vms_filter).delete_all
+    end
+  end
+
+  def down
+    say_with_time('Add Type / Template and Type / VM to VMs filters') do
+      MiqSearch.create!(TEMPLATE_TYPE_FILTER)
+      MiqSearch.create!(VMS_TYPE_FILTER)
+    end
+  end
+end

--- a/spec/migrations/20160713130940_remove_type_template_and_vms_filters_from_miq_search_spec.rb
+++ b/spec/migrations/20160713130940_remove_type_template_and_vms_filters_from_miq_search_spec.rb
@@ -1,0 +1,40 @@
+require_migration
+
+describe RemoveTypeTemplateAndVmsFiltersFromMiqSearch do
+  let(:miq_search_stub) { migration_stub(:MiqSearch) }
+
+  migration_context :up do
+    it "removes Type Template/VMs filters from MiqSearch" do
+      filter_1 = miq_search_stub.create!(described_class::TEMPLATE_TYPE_FILTER)
+      filter_2 = miq_search_stub.create!(described_class::VMS_TYPE_FILTER)
+      filter_3 = miq_search_stub.create!(:name => 'Template/VMs test filter')
+
+      migrate
+
+      filter_1 = miq_search_stub.find_by(:id => filter_1.id)
+      filter_2 = miq_search_stub.find_by(:id => filter_2.id)
+      filter_3 = miq_search_stub.find_by(:id => filter_3.id)
+
+      expect(filter_1).to be_nil
+      expect(filter_2).to be_nil
+      expect(filter_3).to_not be_nil
+    end
+  end
+
+  migration_context :down do
+    it "adds Type Template/VMs filters to MiqSearch" do
+      migrate
+
+      temp_filter = described_class::TEMPLATE_TYPE_FILTER.dup
+      temp_filter.except!(:filter, :search_type)
+      filter_1 = miq_search_stub.where(temp_filter).first
+
+      vms_filter = described_class::VMS_TYPE_FILTER.dup
+      vms_filter.except!(:filter, :search_type)
+      filter_2 = miq_search_stub.where(vms_filter).first
+
+      expect(filter_1).to_not have_attributes(described_class::TEMPLATE_TYPE_FILTER)
+      expect(filter_2).to_not have_attributes(described_class::VMS_TYPE_FILTER)
+    end
+  end
+end


### PR DESCRIPTION
It is removed from tree view because it makes no sense.
VMs and Templates filters are separated from each other.

https://bugzilla.redhat.com/show_bug.cgi?id=1351210