### PR TITLE
Fix auto-tagging to handle empty-value labels

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -77,14 +77,21 @@ class ContainerLabelTagMapping < ApplicationRecord
   private_class_method :create_specific_value_mapping
 
   def self.create_tag(name, value, category_tag)
-    entry_name = Classification.sanitize_name(value)
     category = category_tag.classification
     unless category
       category = Classification.create_category!(:description => "Kubernetes label '#{name}'",
                                                  :read_only   => true,
                                                  :tag         => category_tag)
     end
-    entry = category.add_entry(:name => entry_name, :description => value)
+
+    if value.empty?
+      entry_name = ':empty:' # ':' character won't occur in kubernetes values.
+      description = '<empty value>'
+    else
+      entry_name = Classification.sanitize_name(value)
+      description = value
+    end
+    entry = category.add_entry(:name => entry_name, :description => description)
     entry.save!
     entry.tag
   end

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -13,6 +13,9 @@ describe ContainerLabelTagMapping do
   let(:cat_classification) { FactoryGirl.create(:classification) }
   let(:cat_tag) { cat_classification.tag }
   let(:tag_under_cat) { cat_classification.add_entry(:name => 'value_1', :description => 'value-1').tag }
+  let(:empty_tag_under_cat) do
+    cat_classification.add_entry(:name => 'my_empty', :description => 'Custom description for empty value').tag
+  end
 
   # Each test here may populate the table differently.
   after :each do
@@ -55,7 +58,7 @@ describe ContainerLabelTagMapping do
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
       FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value-1', :tag => tag1)
       FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value-1', :tag => tag_under_cat)
-      # Force a tag to exist that we don't map to.
+      # Force a tag to exist that we don't map to (for testing .mappable_tags).
       tag2
     end
 
@@ -81,11 +84,25 @@ describe ContainerLabelTagMapping do
 
       expect(ContainerLabelTagMapping.mappable_tags).to contain_exactly(tag1, tag_under_cat, tags[0])
     end
+  end
 
-    it "does not crash with empty value" do
-      pending "fix"
+  context "given an empty label value" do
+    before do
       label(node, 'name', '')
+    end
+
+    it "any-value mapping does not crash" do
+      pending "fix"
+      FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
       ContainerLabelTagMapping.tags_for_entity(node)
+    end
+
+    it "honors specific mapping for the empty value" do
+      FactoryGirl.create(:container_label_tag_mapping, :label_value => '', :tag => empty_tag_under_cat)
+      expect(ContainerLabelTagMapping.tags_for_entity(node)).to contain_exactly(empty_tag_under_cat)
+      # same with both any-value and specific-value mappings
+      FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
+      expect(ContainerLabelTagMapping.tags_for_entity(node)).to contain_exactly(empty_tag_under_cat)
     end
   end
 

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -18,7 +18,7 @@ describe ContainerLabelTagMapping do
   after :each do
     ContainerLabelTagMapping.drop_cache
   end
-  # If the mapping was called from *elsewhere* the might already be a stale cache.
+  # If the mapping was called from *elsewhere* there might already be a stale cache.
   # TODO: This assumes all other tests only use an empty mapping.
   before :all do
     ContainerLabelTagMapping.drop_cache
@@ -80,6 +80,12 @@ describe ContainerLabelTagMapping do
       expect(ContainerLabelTagMapping.tags_for_entity(node)).to contain_exactly(tags[0])
 
       expect(ContainerLabelTagMapping.mappable_tags).to contain_exactly(tag1, tag_under_cat, tags[0])
+    end
+
+    it "does not crash with empty value" do
+      pending "fix"
+      label(node, 'name', '')
+      ContainerLabelTagMapping.tags_for_entity(node)
     end
   end
 

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -91,10 +91,11 @@ describe ContainerLabelTagMapping do
       label(node, 'name', '')
     end
 
-    it "any-value mapping does not crash" do
-      pending "fix"
+    it "any-value mapping generates a tag" do
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
-      ContainerLabelTagMapping.tags_for_entity(node)
+      tags = ContainerLabelTagMapping.tags_for_entity(node)
+      expect(tags.size).to eq(1)
+      expect(tags[0].classification.description).to eq('<empty value>')
     end
 
     it "honors specific mapping for the empty value" do


### PR DESCRIPTION
Fixes #9713 which was breaking refresh.
https://bugzilla.redhat.com/show_bug.cgi?id=1358257 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1358303 (darga)

Given any-value mapping `foo` -> "Foo" category,
`foo=` label will create "Foo : \<empty value>" tag.

![screenshot-localhost 3001 2016-07-25 19-25-47 empty value](https://cloud.githubusercontent.com/assets/273688/17108830/d9a8ab9a-529d-11e6-8a21-79047e0edeaf.png)

