### PR TITLE
Display "Not Found" information message

### DIFF
--- a/app/views/miq_policy/_action_list.html.haml
+++ b/app/views/miq_policy/_action_list.html.haml
@@ -1,11 +1,10 @@
 #action_list_div
-  - if x_active_tree == :action_tree && @view
-    - if @view.table.data.empty?
-      - if @search_text.blank?
-        - msg = _('No Actions are defined.')
-      - else
-        - msg = _('No Actions are defined that match the entered search string')
-      = render :partial => 'layouts/info_msg', :locals => {:message => msg}
+  - if @view.table.data.empty?
+    - if @search_text.empty?
+      - msg = _("No Actions are defined")
     - else
-      #main_div
-        = render :partial => 'layouts/gtl', :locals  => {:action_url => "action_get_all", :button_div => 'policy_bar'}
+      - msg = _("No Actions are defined that match the entered search string '%s'") % @search_text
+    = render 'layouts/info_msg', :message => msg
+  - else
+    #main_div
+      = render :partial => 'layouts/gtl', :locals  => {:action_url => "action_get_all", :button_div => 'policy_bar'}

--- a/app/views/miq_policy/_alert_list.html.haml
+++ b/app/views/miq_policy/_alert_list.html.haml
@@ -1,11 +1,10 @@
 #alert_list_div
-  - if x_active_tree == :alert_tree && @view
-    - if @view.table.data.empty?
-      - if @search_text.blank?
-        - msg = _("No Alerts are defined.")
-      - else
-        - msg = _("No Alerts are defined that match the entered search string.")
-      = render :partial => 'layouts/info_msg', :locals => {:message => msg}
+  - if @view.table.data.empty?
+    - if @search_text.empty?
+      - msg = _("No Alerts are defined")
     - else
-      #main_div
-        = render :partial => 'layouts/gtl', :locals  => {:action_url => "alert_get_all", :button_div => 'policy_bar'}
+      - msg = _("No Alerts are defined that match the entered search string '%s'") % @search_text
+    = render 'layouts/info_msg', :message => msg
+  - else
+    #main_div
+      = render :partial => 'layouts/gtl', :locals  => {:action_url => "alert_get_all", :button_div => 'policy_bar'}

--- a/app/views/miq_policy/_event_list.html.haml
+++ b/app/views/miq_policy/_event_list.html.haml
@@ -1,12 +1,11 @@
 #event_list_div
   - if @events
-    = render :partial => "layouts/flash_msg"
     - if @events.empty?
-      .note
-        - if @search_text.blank?
-          = _("* No Events are defined")
-        - else
-          = _("* No Events are defined that match the entered search string")
+      - if @search_text.empty?
+        - msg = _("No Events are defined")
+      - else
+        - msg = _("No Events are defined that match the entered search string '%s'") % @search_text
+      = render 'layouts/info_msg', :message => msg
     - else
       %table.table.table-striped.table-bordered.table-hover
         %tbody


### PR DESCRIPTION

![action not found search result](https://cloud.githubusercontent.com/assets/552686/17033767/8a92cd2c-4f34-11e6-9b51-078c9ceff0ba.png)
![event not found search result](https://cloud.githubusercontent.com/assets/552686/17033775/930b6b94-4f34-11e6-82e8-5b0a40bd9d00.png)

Display user info message when a search fails for Alert, Action or Event in Control/Explorer pages

![alert not found search result](https://cloud.githubusercontent.com/assets/552686/16770766/f55b21e2-4802-11e6-881f-9b0ce47a27ba.png)
https://bugzilla.redhat.com/show_bug.cgi?id=1324400