### PR TITLE
Add href to explain schema validation spec in error message

### DIFF
--- a/spec/replication/util/schema_structure_spec.rb
+++ b/spec/replication/util/schema_structure_spec.rb
@@ -4,8 +4,8 @@ describe "database schema" do
 
     expect(ret).to be_nil, <<-EOS.gsub!(/^ +/, "")
       #{Rails.configuration.database_configuration[Rails.env]["database"]} is not structured as expected.
-
       #{ret}
+      Refer to http://talk.manageiq.org/t/new-schema-specs-for-new-replication/1404 for detail
     EOS
   end
 end


### PR DESCRIPTION
Adding db migration will break test due to the spec introduced in #8380.  Need some pointers that help developer jump to the solution quicker.

The original error message is like the following,
```
  1) database schema is structured as expected                                                                                                                                                  [132/1979]
     Failure/Error:
           expect(ret).to be_nil, <<-EOS.gsub!(/^ +/, "")
             #{Rails.configuration.database_configuration[Rails.env]["database"]} is not structured as expected.

             #{ret}
           EOS

       vmdb_test is not structured as expected.

       Schema validation failed for host localhost:

       Current schema tables do not match expected

       Additional tables in current schema: ["storage_profile_storages", "storage_profiles"]
       Missing tables in current schema: []
     # ./spec/replication/util/schema_structure_spec.rb:5:in `block (2 levels) in <top (required)>'
```

This PR will add a line pointing to the talk page as shown below

```
  1) database schema is structured as expected
     Failure/Error:
       expect(ret).to be_nil, <<-EOS.gsub!(/^ +/, "")
         #{Rails.configuration.database_configuration[Rails.env]["database"]} is not structured as expected.
         #{ret}
         Refer to http://talk.manageiq.org/t/new-schema-specs-for-new-replication/1404
       EOS

       vmdb_test is not structured as expected.
       Schema validation failed for host localhost:

       Current schema tables do not match expected

       Additional tables in current schema: ["storage_profile_storages", "storage_profiles"]
       Missing tables in current schema: []

       Refer to http://talk.manageiq.org/t/new-schema-specs-for-new-replication/1404
     # ./spec/replication/util/schema_structure_spec.rb:5:in `block (2 levels) in <top (required)>'
```

Note the second to last line,
```
       Refer to http://talk.manageiq.org/t/new-schema-specs-for-new-replication/1404
```