### PR TITLE
Add subnet_names to network_port list

### DIFF
--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -31,6 +31,7 @@ class NetworkPort < ApplicationRecord
   virtual_column :ipaddresses, :type => :string_set, :uses => [:cloud_subnet_network_ports, :floating_ips]
   virtual_column :fixed_ip_addresses, :type => :string_set, :uses => :cloud_subnet_network_ports
   virtual_column :floating_ip_addresses, :type => :string_set, :uses => :floating_ips
+  virtual_column :cloud_subnets_names, :type => :string_set, :uses => :floating_ips
 
   def floating_ip_addresses
     @floating_ip_addresses ||= floating_ips.collect(&:address).compact.uniq
@@ -42,6 +43,10 @@ class NetworkPort < ApplicationRecord
 
   def ipaddresses
     @ipaddresses ||= (fixed_ip_addresses || []) + (floating_ip_addresses || [])
+  end
+
+  def cloud_subnets_names
+    @cloud_subnets_names ||= cloud_subnets.collect(&:name).compact.uniq
   end
 
   # Define all getters and setters for extra_attributes related virtual columns

--- a/product/views/NetworkPort.yaml
+++ b/product/views/NetworkPort.yaml
@@ -22,6 +22,7 @@ cols:
 - name
 - mac_address
 - ipaddresses
+- cloud_subnets_names
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -42,6 +43,7 @@ col_order:
 - name
 - mac_address
 - ipaddresses
+- cloud_subnets_names
 #- device.name
 - ext_management_system.name
 
@@ -50,6 +52,7 @@ headers:
 - Name
 - Mac Address
 - IP Addresses
+- Subnets
 #- Instance name
 - Network Provider
 


### PR DESCRIPTION
Add subnet_names to network_port list, allowing us to quickly
see where are the ports plugged.