### PR TITLE
Enforce single arg in expect_single_resource_query

### DIFF
--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -18,7 +18,7 @@ describe ApiController do
 
       run_get entrypoint_url
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
     end
 
@@ -67,7 +67,7 @@ describe ApiController do
 
       run_get entrypoint_url, :headers => {"miq_group" => group1.description}
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
     end
 
     it "test basic authentication with a secondary group" do
@@ -75,7 +75,7 @@ describe ApiController do
 
       run_get entrypoint_url, :headers => {"miq_group" => group2.description}
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -93,7 +93,7 @@ describe ApiController do
 
       run_get entrypoint_url, :headers => {"miq_group" => group2.description}
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
       expect_result_to_match_hash(
         response_hash["identity"],
@@ -114,7 +114,7 @@ describe ApiController do
 
       run_get entrypoint_url, :attributes => "authorization"
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS + %w(authorization))
       expect_hash_to_have_keys(response_hash["authorization"], %w(product_features))
     end
@@ -126,7 +126,7 @@ describe ApiController do
 
       run_get auth_url
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
     end
 
@@ -141,14 +141,14 @@ describe ApiController do
 
       run_get auth_url
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token))
 
       auth_token = response_hash["auth_token"]
 
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
     end
 
@@ -157,7 +157,7 @@ describe ApiController do
 
       run_get auth_url
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
 
       auth_token = response_hash["auth_token"]
@@ -170,7 +170,7 @@ describe ApiController do
       expect_any_instance_of(TokenManager).to receive(:reset_token).with("api", auth_token)
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
     end
 
@@ -180,7 +180,7 @@ describe ApiController do
       api_token_ttl = VMDB::Config.new("vmdb").config[:api][:token_ttl].to_i_with_method
       run_get auth_url
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
       expect(response_hash["token_ttl"]).to eq(api_token_ttl)
     end
@@ -199,7 +199,7 @@ describe ApiController do
       ui_token_ttl = VMDB::Config.new("vmdb").config[:session][:timeout].to_i_with_method
       run_get auth_url, :requester_type => "ui"
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
       expect(response_hash["token_ttl"]).to eq(ui_token_ttl)
     end

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "API entrypoint" do
 
     run_get entrypoint_url
 
-    expect_single_resource_query
+    expect(response).to have_http_status(:ok)
     expect_result_to_have_keys(%w(settings))
     expect(response_hash['settings']).to be_kind_of(Hash)
   end

--- a/spec/requests/api/versioning_spec.rb
+++ b/spec/requests/api/versioning_spec.rb
@@ -8,7 +8,7 @@ describe ApiController do
 
       run_get entrypoint_url
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(name description version versions collections))
     end
 
@@ -18,7 +18,7 @@ describe ApiController do
       # Let's get the versions
       run_get entrypoint_url
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(versions))
 
       versions = response_hash["versions"]
@@ -35,7 +35,7 @@ describe ApiController do
       # Let's try to access that version API URL
       run_get "#{entrypoint_url}/#{ident}"
 
-      expect_single_resource_query
+      expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(name description version versions collections))
     end
 

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -276,7 +276,7 @@ module ApiSpecHelper
     expect(response_hash["count"]).to eq(fetch_value(count)) if count.present?
   end
 
-  def expect_single_resource_query(attr_hash = {})
+  def expect_single_resource_query(attr_hash)
     expect(response).to have_http_status(:ok)
     expect_result_to_match_hash(response_hash, fetch_value(attr_hash))
   end


### PR DESCRIPTION
Prefer have_http_status where we're using this method only to check the
status code of the response.

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 