### PR TITLE
Refactor/expect hash to have keys

### DIFF
--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -115,8 +115,9 @@ describe ApiController do
       run_get entrypoint_url, :attributes => "authorization"
 
       expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(ENTRYPOINT_KEYS + %w(authorization))
-      expect(response_hash).to include("authorization" => {"product_features" => anything})
+      expected = {"authorization" => hash_including("product_features")}
+      ENTRYPOINT_KEYS.each { |k| expected[k] = anything }
+      expect(response_hash).to include(expected)
     end
   end
 

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -116,7 +116,7 @@ describe ApiController do
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS + %w(authorization))
-      expect_hash_to_have_keys(response_hash["authorization"], %w(product_features))
+      expect(response_hash).to include("authorization" => {"product_features" => anything})
     end
   end
 

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -187,15 +187,18 @@ describe ApiController do
 
       run_get services_url(svc2.id), :attributes => "custom_actions"
 
-      expect_result_to_have_keys(%w(custom_actions))
-      custom_actions = response_hash["custom_actions"]
-      expect_hash_to_have_only_keys(custom_actions, %w(buttons button_groups))
-      expect(custom_actions["buttons"].size).to eq(1)
-      button = response_hash["custom_actions"]["buttons"].first
-      expect(response_hash).to include("custom_actions" => hash_including("buttons" => [hash_including("id", "resource_action")]))
-      ra = button["resource_action"]
-      expect(response_hash).to include("custom_actions" => hash_including("buttons" => [hash_including("resource_action" => hash_including("id", "dialog_id"))]))
-      expect_result_to_match_hash(ra, "id" => ra2.id, "dialog_id" => ra2.dialog_id)
+      expected = {
+        "custom_actions" => {
+          "button_groups" => anything,
+          "buttons"       => [
+            hash_including(
+              "id"              => anything,
+              "resource_action" => hash_including("id" => ra2.id, "dialog_id" => ra2.dialog_id)
+            )
+          ]
+        }
+      }
+      expect(response_hash).to include(expected)
     end
   end
 end

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -192,9 +192,9 @@ describe ApiController do
       expect_hash_to_have_only_keys(custom_actions, %w(buttons button_groups))
       expect(custom_actions["buttons"].size).to eq(1)
       button = response_hash["custom_actions"]["buttons"].first
-      expect_hash_to_have_keys(button, %w(id resource_action))
+      expect(response_hash).to include("custom_actions" => hash_including("buttons" => [hash_including("id", "resource_action")]))
       ra = button["resource_action"]
-      expect_hash_to_have_keys(ra, %w(id dialog_id))
+      expect(response_hash).to include("custom_actions" => hash_including("buttons" => [hash_including("resource_action" => hash_including("id", "dialog_id"))]))
       expect_result_to_match_hash(ra, "id" => ra2.id, "dialog_id" => ra2.dialog_id)
     end
   end

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -457,8 +457,8 @@ describe ApiController do
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
 
       expect_single_action_result(:success => true, :message => /refreshing dialog fields/i)
-      expect_hash_to_have_keys(response_hash, %w(success href service_template_id service_template_href result))
-      expect_hash_to_have_keys(response_hash["result"], %w(text1))
+      expect(response_hash).to include("success", "href", "service_template_id", "service_template_href", "result")
+      expect(response_hash).to include("result" => hash_including("text1"))
     end
   end
 end

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -456,9 +456,16 @@ describe ApiController do
 
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
 
-      expect_single_action_result(:success => true, :message => /refreshing dialog fields/i)
-      expect(response_hash).to include("success", "href", "service_template_id", "service_template_href", "result")
-      expect(response_hash).to include("result" => hash_including("text1"))
+      expected = {
+        "success"               => true,
+        "message"               => a_string_matching(/refreshing dialog fields/i),
+        "href"                  => anything,
+        "service_template_id"   => anything,
+        "service_template_href" => anything,
+        "result"                => hash_including("text1")
+      }
+      expect(response_hash).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -210,11 +210,7 @@ module ApiSpecHelper
   end
 
   def expect_result_to_have_keys(keys)
-    expect_hash_to_have_keys(response_hash, keys)
-  end
-
-  def expect_hash_to_have_keys(hash, keys)
-    fetch_value(keys).each { |key| expect(hash).to have_key(key) }
+    expect(response_hash).to include(*keys)
   end
 
   def expect_result_to_have_only_keys(keys)


### PR DESCRIPTION
Just a small refactoring to aid readibility/test feedback for specs that used `expect_hash_to_have_keys`, favoring RSpec's more flexible `include` matcher

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 
