### PR TITLE
Include backtrace in error response in tests

### DIFF
--- a/app/controllers/api_controller/error_handler.rb
+++ b/app/controllers/api_controller/error_handler.rb
@@ -31,6 +31,8 @@ class ApiController
         :message => message,
         :klass   => klass
       }
+      err[:backtrace] = backtrace if Rails.env.test?
+
       api_log_error("#{klass}: #{message}")
       # We don't want to return the stack trace, but only log it in case of an internal error
       api_log_error("\n\n#{backtrace}") if kind == :internal_server_error && !backtrace.empty?


### PR DESCRIPTION
I always add the backtrace to the error response when developing a new
feature or debugging to enhance feedback in request specs, which can be
a bit opaque. I'm proposing that we make this a default in the test
environment.

@miq-bot add-label test, api, enhancement
@miq-bot assign @abellotti 

@abellotti I'm OK with not adding this, just offering this for consideration