### PR TITLE
Fix broken reports screen behavior

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -227,7 +227,7 @@ module ReportController::Schedules
       @schedule = nil
       @edit = session[:edit] = nil  # clean out the saved info
       @in_a_form = false
-      @sb[:active_accord] = :schedules
+
       replace_right_cell
     when "save", "add"
       id = params[:id] ? params[:id] : "new"
@@ -249,11 +249,11 @@ module ReportController::Schedules
         # ensure we land in the right accordion with the right tree and
         # with the listing opened even when entering 'add' from the reports
         # menu
-        @sb[:active_tree]   = :schedules_tree
-        @sb[:active_accord] = :schedules
-        # FIXME: change to x_active_node after 5.2
-        @sb[:trees][@sb[:active_tree]][:active_node] = 'root'
+
+        self.x_active_tree   = "schedules_tree"
+        self.x_active_accord = "schedules"
         self.x_node = "msc-#{to_cid(schedule.id)}"
+        @_params[:accord] = "schedules"
         replace_right_cell(:replace_trees => [:schedules])
       else
         schedule.errors.each do |field, msg|


### PR DESCRIPTION
If from a report a user clicks "Add a new schedule" and cancels the form, the right cell will be blank until the "Reports" node on the tree is clicked.

**Before** 
![screen shot 2016-07-12 at 12 53 16 pm](https://cloud.githubusercontent.com/assets/39493/16781460/499fe3be-4830-11e6-90aa-1482ca015a1c.png)

**After**
![screen shot 2016-07-12 at 12 51 45 pm](https://cloud.githubusercontent.com/assets/39493/16781468/52bbb41e-4830-11e6-8e05-8e7748ff797d.png)

Also after submitting the form, the accordion is not updated correctly:

**Before**
![screen shot 2016-07-12 at 12 54 02 pm](https://cloud.githubusercontent.com/assets/39493/16781517/8468a53a-4830-11e6-8c7a-0cf81c925826.png)

**After**
![screen shot 2016-07-12 at 12 52 23 pm](https://cloud.githubusercontent.com/assets/39493/16781526/8db9658e-4830-11e6-8c86-3d942bde21fa.png)


Fixes #9608  
-- and --  
https://bugzilla.redhat.com/show_bug.cgi?id=1353363