### PR TITLE
cap&u - skip alert status if timer is taking too long / timing out.

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -13,7 +13,7 @@ module Metric::Capture
   end
 
   def self.historical_days
-    (VMDB::Config.new("vmdb").config.fetch_path(:performance, :history, :initial_capture_days) || 7).to_i
+    (Settings.performance.history.initial_capture_days || 7).to_i
   end
 
   def self.historical_start_time
@@ -21,7 +21,7 @@ module Metric::Capture
   end
 
   def self.concurrent_requests(interval_name)
-    requests = VMDB::Config.new("vmdb").config.fetch_path(:performance, :concurrent_requests, interval_name.to_sym)
+    requests = Settings.performance.concurrent_requests[interval_name]
     requests ||= interval_name == 'realtime' ? 20 : 1
     requests = 20 if requests < 20 && interval_name == 'realtime'
     requests
@@ -78,7 +78,7 @@ module Metric::Capture
   def self.capture_threshold(target)
     key, default = MiqAlert.target_needs_realtime_capture?(target) ? [:capture_threshold_with_alerts, 1] : [:capture_threshold, 10]
 
-    value = VMDB::Config.new("vmdb").config.fetch_path(:performance, key, target.class.base_model.to_s.underscore.to_sym) || default
+    value = Settings.performance[key][target.class.base_model.to_s.underscore.to_sym] || default
     value = if value.kind_of?(Fixnum) # Default unit is minutes
               value.minutes.ago.utc
             else

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -32,7 +32,7 @@ module Metric::Capture
     minutes_ago(Settings.performance.capture_threshold[target_key] || 10)
   end
 
-  def self.realtime_capture_threshold(target)
+  def self.alert_capture_threshold(target)
     target_key = target.class.base_model.to_s.underscore.to_sym
     minutes_ago(Settings.performance.capture_threshold_with_alerts[target_key] || 1)
   end
@@ -82,11 +82,11 @@ module Metric::Capture
   # if it has not been run, or it was a very long time ago, just run it
   # if it has been run very recently (even too recently for realtime) then skip it
   # otherwise, it needs to be run if it is realtime, but not if it is standard threshold
-  # assumes realtime <= standard capture threshold
+  # assumes alert capture threshold <= standard capture threshold
   def self.perf_capture_now?(target)
     return true  if target.last_perf_capture_on.nil?
     return true  if target.last_perf_capture_on < standard_capture_threshold(target)
-    return false if target.last_perf_capture_on >= realtime_capture_threshold(target)
+    return false if target.last_perf_capture_on >= alert_capture_threshold(target)
     MiqAlert.target_needs_realtime_capture?(target)
   end
 

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -79,19 +79,18 @@ module Metric::Capture
     MiqQueue.put(item)
   end
 
+  # if it has not been run, or it was a very long time ago, just run it
+  # if it has been run very recently (even too recently for realtime) then skip it
+  # otherwise, it needs to be run if it is realtime, but not if it is standard threshold
+  # assumes realtime <= standard capture threshold
   def self.perf_capture_now?(target)
-    target.last_perf_capture_on.nil? || (target.last_perf_capture_on < capture_threshold(target))
+    return true  if target.last_perf_capture_on.nil?
+    return true  if target.last_perf_capture_on < standard_capture_threshold(target)
+    return false if target.last_perf_capture_on >= realtime_capture_threshold(target)
+    MiqAlert.target_needs_realtime_capture?(target)
   end
 
   private
-
-  def self.capture_threshold(target)
-    if MiqAlert.target_needs_realtime_capture?(target)
-      realtime_capture_threshold(target)
-    else
-      standard_capture_threshold(target)
-    end
-  end
 
   #
   # Capture entry points

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -10,7 +10,7 @@ describe Metric::Capture do
                      :capture_threshold_with_alerts => {:vm => capture_rt, :host => capture_rt}
                     }
                   }
-      stub_server_configuration(settings)
+      stub_settings(settings)
     end
 
     it "realtime vm uses capture_threshold_with_alerts minutes ago" do

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -1,63 +1,52 @@
 describe Metric::Capture do
-  shared_examples "captures a threshold" do |capture_fixnum, capture|
-    let(:threshold_default) { 10 }
-    let(:capture_rt) { 2 }
-    let(:time) { Time.utc(2013, 4, 22, 8, 31) }
+  describe ".alert_capture_threshold" do
+    let(:target) { FactoryGirl.build(:host_vmware) }
 
-    before do
-      settings =  {:performance =>
-                    {:capture_threshold             => {:vm => capture,    :host => capture},
-                     :capture_threshold_with_alerts => {:vm => capture_rt, :host => capture_rt}
-                    }
-                  }
-      stub_settings(settings)
-    end
-
-    it "knows realtime vm capture value" do
-      target = FactoryGirl.build(:vm_vmware)
-      Timecop.freeze(time) do
-        expect(described_class.realtime_capture_threshold(target)).to eq capture_rt.minutes.ago.utc
+    it "parses fixed num" do
+      stub_performance_settings(:capture_threshold_with_alerts => {:host => 4})
+      Timecop.freeze(Time.now.utc) do
+        expect(described_class.alert_capture_threshold(target)).to eq 4.minutes.ago.utc
       end
     end
 
-    it "knows realtime host capture value" do
-      target = FactoryGirl.build(:host_vmware)
-      Timecop.freeze(time) do
-        expect(described_class.realtime_capture_threshold(target)).to eq capture_rt.minutes.ago.utc
+    it "parses string" do
+      stub_performance_settings(:capture_threshold_with_alerts => {:host => "4.minutes"})
+      Timecop.freeze(Time.now.utc) do
+        expect(described_class.alert_capture_threshold(target)).to eq 4.minutes.ago.utc
       end
     end
 
-    it "knows non-realtime vm capture_threshold" do
-      target = FactoryGirl.build(:vm_vmware)
-
-      Timecop.freeze(time) do
-        result = threshold_default.minutes.ago.utc
-        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
-        expect(described_class.standard_capture_threshold(target)).to eq result
-      end
-    end
-
-    it "non-realtime host uses capture_threshold minutes ago" do
-      target = FactoryGirl.build(:host_vmware)
-
-      Timecop.freeze(time) do
-        result = threshold_default.minutes.ago.utc
-        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
-        expect(described_class.standard_capture_threshold(target)).to eq result
+    it "produces default with class not found" do
+      stub_performance_settings(:capture_threshold_with_alerts => {:vm => "4.minutes"})
+      Timecop.freeze(Time.now.utc) do
+        expect(described_class.alert_capture_threshold(target)).to eq 1.minute.ago.utc
       end
     end
   end
 
-  context ".capture_threshold with Fixnum" do
-    include_examples "captures a threshold", 20, 20
-  end
+  describe ".standard_capture_threshold" do
+    let(:host) { FactoryGirl.build(:host_vmware) }
 
-  context ".capture_threshold with String" do
-    include_examples "captures a threshold", 50, "50.minutes"
-  end
+    it "parses fixed num" do
+      stub_performance_settings(:capture_threshold => {:host => 4})
+      Timecop.freeze(Time.now.utc) do
+        expect(described_class.standard_capture_threshold(host)).to eq 4.minutes.ago.utc
+      end
+    end
 
-  context ".capture_threshold handles nil" do
-    include_examples "captures a threshold", nil, nil
+    it "parses string" do
+      stub_performance_settings(:capture_threshold => {:host => "4.minutes"})
+      Timecop.freeze(Time.now.utc) do
+        expect(described_class.standard_capture_threshold(host)).to eq 4.minutes.ago.utc
+      end
+    end
+
+    it "produces default with class not found" do
+      stub_performance_settings(:capture_threshold => {:vm => "4.minutes"})
+      Timecop.freeze(Time.now.utc) do
+        expect(described_class.standard_capture_threshold(host)).to eq 10.minutes.ago.utc
+      end
+    end
   end
 
   context ".perf_capture_health_check" do
@@ -79,67 +68,69 @@ describe Metric::Capture do
   end
 
   describe ".perf_capture_now?" do
-    let(:target) { FactoryGirl.build(:host_vmware) }
-
     before do
-      stub_settings(
-        :performance => {
-          :capture_threshold_with_alerts => {:host => 2},
-          :capture_threshold             => {:host => 10},
-        }
+      stub_performance_settings(
+        :capture_threshold_with_alerts => {:host => 2},
+        :capture_threshold             => {}
       )
     end
 
-    context "realtime host" do
-      before { enable_realtime(true) }
+    let(:target) { FactoryGirl.build(:host_vmware) }
 
-      it "always runs a host not run yet" do
+    context "with a host with alerts" do
+      before do
+        allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(true)
+      end
+
+      it "captures if the target has never been captured" do
         target.last_perf_capture_on = nil
         expect(described_class.perf_capture_now?(target)).to eq(true)
       end
 
-      it "detects too short" do
+      it "does not capture if the target has been captured very recenlty" do
         target.last_perf_capture_on = 1.minute.ago
         expect(described_class.perf_capture_now?(target)).to eq(false)
       end
 
-      it "detects realtime" do
+      it "captures if the target has been captured recently (but after realtime minimum)" do
         target.last_perf_capture_on = 5.minutes.ago
         expect(described_class.perf_capture_now?(target)).to eq(true)
       end
 
-      it "detects too long" do
+      it "captures if the target hasn't been captured in a long while" do
         target.last_perf_capture_on = 15.minutes.ago
         expect(described_class.perf_capture_now?(target)).to eq(true)
       end
     end
 
-    context "standard host" do
-      before { enable_realtime(false) }
+    context "with an alertless host" do
+      before do
+        allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(false)
+      end
 
-      it "always runs a host not run yet" do
+      it "captures if the target has never been captured" do
         target.last_perf_capture_on = nil
         expect(described_class.perf_capture_now?(target)).to eq(true)
       end
 
-      it "detects too short" do
+      it "does not captures if the target has been captured very recently" do
         target.last_perf_capture_on = 1.minute.ago
         expect(described_class.perf_capture_now?(target)).to eq(false)
       end
 
-      it "detects realtime" do
+      it "does not captures if the target has been captured recently (but after realtime minimum)" do
         target.last_perf_capture_on = 5.minutes.ago
         expect(described_class.perf_capture_now?(target)).to eq(false)
       end
 
-      it "detects too long" do
+      it "captures if the target hasn't been captured in a long while" do
         target.last_perf_capture_on = 15.minutes.ago
         expect(described_class.perf_capture_now?(target)).to eq(true)
       end
     end
+  end
 
-    def enable_realtime(value)
-      allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(value)
-    end
+  def stub_performance_settings(hash)
+    stub_settings(:performance => hash)
   end
 end

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -46,46 +46,6 @@ describe Metric::Capture do
         expect(described_class.standard_capture_threshold(target)).to eq result
       end
     end
-
-    it "realtime vm uses capture_threshold_with_alerts minutes ago" do
-      target = FactoryGirl.build(:vm_vmware)
-      allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(true)
-
-      Timecop.freeze(time) do
-        expect(described_class.capture_threshold(target)).to eq capture_rt.minutes.ago.utc
-      end
-    end
-
-    it "realtime host uses capture_threshold_with_alerts minutes ago" do
-      target = FactoryGirl.build(:host_vmware)
-      allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(true)
-
-      Timecop.freeze(time) do
-        expect(described_class.capture_threshold(target)).to eq capture_rt.minutes.ago.utc
-      end
-    end
-
-    it "non-realtime vm uses capture_threshold minutes ago" do
-      target = FactoryGirl.build(:vm_vmware)
-      allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(false)
-
-      Timecop.freeze(time) do
-        result = threshold_default.minutes.ago.utc
-        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
-        expect(described_class.capture_threshold(target)).to eq result
-      end
-    end
-
-    it "non-realtime host uses capture_threshold minutes ago" do
-      target = FactoryGirl.build(:host_vmware)
-      allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(false)
-
-      Timecop.freeze(time) do
-        result = threshold_default.minutes.ago.utc
-        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
-        expect(described_class.capture_threshold(target)).to eq result
-      end
-    end
   end
 
   context ".capture_threshold with Fixnum" do

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -13,6 +13,40 @@ describe Metric::Capture do
       stub_settings(settings)
     end
 
+    it "knows realtime vm capture value" do
+      target = FactoryGirl.build(:vm_vmware)
+      Timecop.freeze(time) do
+        expect(described_class.realtime_capture_threshold(target)).to eq capture_rt.minutes.ago.utc
+      end
+    end
+
+    it "knows realtime host capture value" do
+      target = FactoryGirl.build(:host_vmware)
+      Timecop.freeze(time) do
+        expect(described_class.realtime_capture_threshold(target)).to eq capture_rt.minutes.ago.utc
+      end
+    end
+
+    it "knows non-realtime vm capture_threshold" do
+      target = FactoryGirl.build(:vm_vmware)
+
+      Timecop.freeze(time) do
+        result = threshold_default.minutes.ago.utc
+        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
+        expect(described_class.standard_capture_threshold(target)).to eq result
+      end
+    end
+
+    it "non-realtime host uses capture_threshold minutes ago" do
+      target = FactoryGirl.build(:host_vmware)
+
+      Timecop.freeze(time) do
+        result = threshold_default.minutes.ago.utc
+        result = capture_fixnum.minutes.ago.utc unless capture_fixnum.nil?
+        expect(described_class.standard_capture_threshold(target)).to eq result
+      end
+    end
+
     it "realtime vm uses capture_threshold_with_alerts minutes ago" do
       target = FactoryGirl.build(:vm_vmware)
       allow(MiqAlert).to receive(:target_needs_realtime_capture?).with(target).and_return(true)

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -59,7 +59,7 @@ describe Metric do
 
       context "executing perf_capture_timer" do
         before(:each) do
-          stub_server_configuration(:performance => {:history => {:initial_capture_days => 7}})
+          stub_settings(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
 
@@ -401,7 +401,7 @@ describe Metric do
 
       context "executing perf_capture_now?" do
         before(:each) do
-          stub_server_configuration(:performance => {:capture_threshold => {:vm => 10}, :capture_threshold_with_alerts => {:vm => 2}})
+          stub_settings(:performance => {:capture_threshold => {:vm => 10}, :capture_threshold_with_alerts => {:vm => 2}})
         end
 
         it "without alerts assigned" do
@@ -1129,7 +1129,7 @@ describe Metric do
 
       context "executing perf_capture_timer" do
         before(:each) do
-          stub_server_configuration(:performance => {:history => {:initial_capture_days => 7}})
+          stub_settings(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
 


### PR DESCRIPTION
High Level
-----

The slowest part of cap&u timer is determining if a resource has an alert assigned and should be captured more frequently (aka run in "realtime").

So if it has been a long time since capturing a resource, why determine if it has been assigned an alert or not? It will need to be captured regardless. So try and determine capture eligibility quickly before even checking if an alert has been assigned.

Same goes for when the resource has been captured very recently. It isn't going to run regardless, so just skip it and don't even ask if the resource has an alert.

Nice side effect: If the `perf_capture_timer` times out, the resource will not have run recently, and the next time running will short circuiting the slow logic, and ensuring that it will at least be run at the non-realtime frequency.

The downside of this change is it will be harder to performance test cap&u timer since this change eagerly throw out recently run captures. This case is the most common case when performance tuning.

**NOTES:**

1. This is not a behavior change. Captures will run at the same frequency as before.
2. The alert determination logic will typically run the same number of times as before.
3. This mostly effects the situation where `perf_capture_timer` is sporadically run or if the process times out. Then the alert determination logic is skipped, and the resources are captured.
4. This builds upon #9477 but is potentially less intrusive for older branches
5. Once #9611 is merged, the numbers will not be as impressive.


Algorithm changes
----

**before**

1. Determine if a resource has an alert assigned.
2. Choose how frequently to capture this resource based upon if the resource has an alert assigned.
3. Trigger capturing this resource if it has has gone too long since the last run

**after**

1. Determine if the resource needs to be captured regardless of whether it has an alert assigned.
2. Determine if this resource wouldn't be captured regardless of whether it has an alert assigned.
3. If the previous questions are inconclusive, then determine if the resource has an alert assigned and go from there.

Step 3 should be the most commonly run. But there is a chance that it is not run. And if we start getting timeouts, step 3 will be run less frequently, and the longer capture takes to run, step 3 will be run less frequently.

Stats
---

In normal execution, the queries should be the same. In the case that it has been a while since running performance captures, or it has happened very frequently, the numbers change drastically:

10,000 Vms.

|        ms |    bytes |  objects |     queries | query (ms) |     rows ||
|       ---:|      ---:|      ---:|        ---:|      ---:|      ---:| ---
|  124,705.2 | 231,768,156* | 144,651,595 |   24,123 |  47,026.9 | 2,754,091 |`before`
|  40,578.9 | 242,065,307* | 30,674,875 |     21,784 | 14,803.7 |   11,488 |`after`

\* Memory usage for before does not reflect 71,040,436 freed objects.
\* Memory usage for after does not reflect 13,936,786 freed objects. 
