### PR TITLE
Add memory usage to Availability C&U chart UI

### DIFF
--- a/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
@@ -26,6 +26,25 @@
     :columns: 
     - derived_vm_count_on
 
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - min_derived_memory_used
+  - max_derived_memory_used
+  - trend_max_derived_memory_used
+  - resource.derived_memory_used_high_over_time_period
+  - resource.derived_memory_used_low_over_time_period
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Chart-VMs-topday:Top Instances on this day
+  - Display-VMs-on:Instances that were running
+  :chart2: 
+    :type: Line
+    :title: Instances
+    :columns: 
+    - derived_vm_count_on
+
 - :title: Disk I/O (KBps)
   :type: Line
   :columns:

--- a/product/charts/layouts/daily_tag_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/daily_tag_charts/AvailabilityZone.yaml
@@ -13,6 +13,15 @@
   :max_value: 100.4
   :decimals: 1
 
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  :menu:
+  - Chart-Current-Hourly:Hourly on this day
+  - Chart-VMs-topday:Top Instances for <cat> on this day
+  - Display-VMs-bytag:Instances for <cat> that were running
+
 - :title: Disk I/O (KBps)
   :type: Line
   :columns:

--- a/product/charts/layouts/hourly_perf_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/hourly_perf_charts/AvailabilityZone.yaml
@@ -17,6 +17,20 @@
     :columns: 
     - derived_vm_count_on
 
+- :title: Memory(MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  :menu:
+  - Chart-Vms-tophour:Top Instances during this hour
+  - Chart-Current-Daily:Back to daily
+  - Display-VMs-on:Instances that were running
+  :chart2: 
+    :type: Line
+    :title: Instances
+    :columns: 
+    - derived_vm_count_on
+
 - :title: Disk I/O (KBps)
   :type: Line
   :columns:

--- a/product/charts/layouts/hourly_tag_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/hourly_tag_charts/AvailabilityZone.yaml
@@ -10,6 +10,15 @@
 #  - Timeline-Current-Hourly:Hourly events on this Availability Zone
   - Display-VMs-bytag:Instances for <cat> that were running
 
+- :title: Memory(MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  :menu:
+  - Chart-Vms-tophour:Top Instances for <cat> during this hour
+  - Chart-Current-Daily:Back to daily
+  - Display-VMs-bytag:Instances for <cat> that were running
+
 - :title: Disk I/O (KBps)
   :type: Line
   :columns:


### PR DESCRIPTION
Now that metric rollups for Availability Zones include memory usage
(BZ1345832), add memory usage to the C&U charts for Availability
Zones (includes both daily and hourly, filtered and unfiltered)

There is no BZ for this yet, but I've been told that one is forthcoming.