### PR TITLE
Replace page.redirect_to blocks with a helper method.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -652,10 +652,7 @@ class ApplicationController < ActionController::Base
       else
         redirect_to_action = lastaction
       end
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true
-      end
+      javascript_redirect :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true
     else
       redirect_to :action => lastaction, :id => params[:id], :escape => false
     end
@@ -1060,10 +1057,7 @@ class ApplicationController < ActionController::Base
       end
 
       format.js do
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => 'dashboard', :action => 'login', :timeout => timed_out
-        end
+        javascript_redirect :controller => 'dashboard', :action => 'login', :timeout => timed_out
       end
     end
   end
@@ -1102,10 +1096,7 @@ class ApplicationController < ActionController::Base
     pass = check_generic_rbac
     unless pass
       if request.xml_http_request?
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(:controller => 'dashboard', :action => 'auth_error')
-        end
+        javascript_redirect :controller => 'dashboard', :action => 'auth_error'
       else
         redirect_to(:controller => 'dashboard', :action => 'auth_error')
       end
@@ -1681,45 +1672,30 @@ class ApplicationController < ActionController::Base
   def render_or_redirect_partial(pfx)
     if @redirect_controller
       if ["#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-        render :update do |page|
-          page << javascript_prologue
-          if flash_errors?
+        if flash_errors?
+          render :update do |page|
+            page << javascript_prologue
             page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-          else
-            page.redirect_to :controller => @redirect_controller,
-                             :action     => @refresh_partial,
-                             :id         => @redirect_id,
-                             :prov_type  => @prov_type,
-                             :prov_id    => @prov_id
           end
+        else
+          javascript_redirect :controller => @redirect_controller,
+                              :action     => @refresh_partial,
+                              :id         => @redirect_id,
+                              :prov_type  => @prov_type,
+                              :prov_id    => @prov_id
         end
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
-        end
+        javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
       end
     else
       if params[:pressed] == "ems_cloud_edit" && params[:id]
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to edit_ems_cloud_path(params[:id])
-        end
+        javascript_redirect edit_ems_cloud_path(params[:id])
       elsif params[:pressed] == "ems_infra_edit" && params[:id]
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to edit_ems_infra_path(params[:id])
-        end
+        javascript_redirect edit_ems_infra_path(params[:id])
       elsif params[:pressed] == "ems_container_edit" && params[:id]
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to edit_ems_container_path(params[:id])
-        end
+        javascript_redirect edit_ems_container_path(params[:id])
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => @refresh_partial, :id => @redirect_id
-        end
+        javascript_redirect :action => @refresh_partial, :id => @redirect_id
       end
     end
   end

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -22,12 +22,12 @@ module ApplicationController::Automate
       end
     end
     c_tb = build_toolbar(center_toolbar_filename)
-    render :update do |page|
-      page << javascript_prologue
-      # IE7 doesn't redraw the tree until the screen is clicked, so redirect back to this method for a refresh
-      if is_browser_ie? && browser_info(:version) == "7"
-        page.redirect_to :action => 'resolve'
-      else
+    # IE7 doesn't redraw the tree until the screen is clicked, so redirect back to this method for a refresh
+    if is_browser_ie? && browser_info(:version) == "7"
+      javascript_redirect :action => 'resolve'
+    else
+      render :update do |page|
+        page << javascript_prologue
         page.replace("left_cell_bottom", :partial => "resolve_form_buttons")
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace_html("main_div", :partial => "results_tabs")
@@ -94,10 +94,7 @@ module ApplicationController::Automate
     end
 
     # workaround to get "Simulate button" work from customization explorer
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to :action => 'resolve', :controller => "miq_ae_tools", :simulate => "simulate", :escape => false
-    end
+    javascript_redirect :action => 'resolve', :controller => "miq_ae_tools", :simulate => "simulate", :escape => false
   end
   private :resolve_button_simulate
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -46,6 +46,8 @@ module ApplicationController::CiProcessing
     else
       if role_allows(:feature => "vm_ownership")
         javascript_redirect :controller => "#{rec_cls}", :action => 'ownership' # redirect to build the ownership screen
+      else
+        render :nothing
       end
     end
   end
@@ -664,6 +666,8 @@ module ApplicationController::CiProcessing
     else
       if role_allows(:feature => "vm_right_size")
         javascript_redirect :controller => "#{rec_cls}", :action => 'right_size', :id => recs[0], :escape => false # redirect to build the ownership screen
+      else
+        render :nothing
       end
     end
   end
@@ -1426,6 +1430,8 @@ module ApplicationController::CiProcessing
     else
       if role_allows(:feature => "vm_reconfigure")
         javascript_redirect :controller => "#{rec_cls}", :action => 'reconfigure', :req_id => @request_id, :rec_ids => @reconfigure_items, :escape => false # redirect to build the ownership screen
+      else
+        render :nothing
       end
     end
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -44,11 +44,8 @@ module ApplicationController::CiProcessing
       @edit[:explorer] = true
       ownership
     else
-      render :update do |page|
-        page << javascript_prologue
-        if role_allows(:feature => "vm_ownership")
-          page.redirect_to :controller => "#{rec_cls}", :action => 'ownership'              # redirect to build the ownership screen
-        end
+      if role_allows(:feature => "vm_ownership")
+        javascript_redirect :controller => "#{rec_cls}", :action => 'ownership' # redirect to build the ownership screen
       end
     end
   end
@@ -123,10 +120,7 @@ module ApplicationController::CiProcessing
         replace_right_cell
       else
         session[:flash_msgs] = @flash_array
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(previous_breadcrumb_url)
-        end
+        javascript_redirect previous_breadcrumb_url
       end
     when "save"
       opts = {}
@@ -164,10 +158,7 @@ module ApplicationController::CiProcessing
           replace_right_cell
         else
           session[:flash_msgs] = @flash_array
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to(previous_breadcrumb_url)
-          end
+          javascript_redirect previous_breadcrumb_url
         end
       end
     when "reset"
@@ -177,13 +168,10 @@ module ApplicationController::CiProcessing
         add_flash(_("All changes have been reset"), :warning)
         request.parameters[:controller] == "service" ? replace_right_cell("ownership") : replace_right_cell
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action        => 'ownership',
-                           :flash_msg     => _("All changes have been reset"),
-                           :flash_warning => true,
-                           :escape        => true
-        end
+        javascript_redirect :action        => 'ownership',
+                            :flash_msg     => _("All changes have been reset"),
+                            :flash_warning => true,
+                            :escape        => true
       end
     end
   end
@@ -226,10 +214,7 @@ module ApplicationController::CiProcessing
     else
       drop_breadcrumb(:name => _("Retire %{name}") % {:name => rec_cls.to_s.pluralize},
                       :url  => "/#{session[:controller]}/retire")
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :controller => rec_cls, :action => 'retire'      # redirect to build the retire screen
-      end
+      javascript_redirect :controller => rec_cls, :action => 'retire' # redirect to build the retire screen
     end
   end
   alias_method :instance_retire, :retirevms
@@ -300,10 +285,7 @@ module ApplicationController::CiProcessing
         replace_right_cell
       else
         session[:flash_msgs] = @flash_array.dup
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to previous_breadcrumb_url
-        end
+        javascript_redirect previous_breadcrumb_url
       end
       return
     end
@@ -367,10 +349,7 @@ module ApplicationController::CiProcessing
         resize
         @refresh_partial = "vm_common/resize"
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => 'vm', :action => 'resize', :rec_id => @record.id, :escape => false     # redirect to build the retire screen
-        end
+        javascript_redirect :controller => 'vm', :action => 'resize', :rec_id => @record.id, :escape => false # redirect to build the retire screen
       end
     else
       add_flash(_("Unable to reconfigure %{instance} \"%{name}\": %{details}") % {
@@ -423,10 +402,7 @@ module ApplicationController::CiProcessing
       replace_right_cell
     else
       session[:flash_msgs] = @flash_array.dup
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to previous_breadcrumb_url
-      end
+      javascript_redirect previous_breadcrumb_url
     end
     return
   end
@@ -455,10 +431,7 @@ module ApplicationController::CiProcessing
         live_migrate
         @refresh_partial = "vm_common/live_migrate"
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => 'vm', :action => 'live_migrate', :rec_id => @record.id, :escape => false
-        end
+        javascript_redirect :controller => 'vm', :action => 'live_migrate', :rec_id => @record.id, :escape => false
       end
     else
       add_flash(_("Unable to live migrate %{instance} \"%{name}\": %{details}") % {
@@ -553,10 +526,7 @@ module ApplicationController::CiProcessing
       replace_right_cell
     else
       session[:flash_msgs] = @flash_array.dup
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to previous_breadcrumb_url
-      end
+      javascript_redirect previous_breadcrumb_url
     end
     return
   end
@@ -584,10 +554,7 @@ module ApplicationController::CiProcessing
         evacuate
         @refresh_partial = "vm_common/evacuate"
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => 'vm', :action => 'evacuate', :rec_id => @record.id, :escape => false
-        end
+        javascript_redirect :controller => 'vm', :action => 'evacuate', :rec_id => @record.id, :escape => false
       end
     else
       add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
@@ -645,10 +612,7 @@ module ApplicationController::CiProcessing
       replace_right_cell
     else
       session[:flash_msgs] = @flash_array.dup
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to previous_breadcrumb_url
-      end
+      javascript_redirect previous_breadcrumb_url
     end
   end
 
@@ -698,11 +662,8 @@ module ApplicationController::CiProcessing
       right_size
       replace_right_cell if @orig_action == "x_history"
     else
-      render :update do |page|
-        page << javascript_prologue
-        if role_allows(:feature => "vm_right_size")
-          page.redirect_to :controller => "#{rec_cls}", :action => 'right_size', :id => recs[0], :escape => false           # redirect to build the ownership screen
-        end
+      if role_allows(:feature => "vm_right_size")
+        javascript_redirect :controller => "#{rec_cls}", :action => 'right_size', :id => recs[0], :escape => false # redirect to build the ownership screen
       end
     end
   end
@@ -739,10 +700,7 @@ module ApplicationController::CiProcessing
         replace_right_cell
       else
         session[:flash_msgs] = @flash_array
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(previous_breadcrumb_url)
-        end
+        javascript_redirect previous_breadcrumb_url
       end
     when "submit"
       options = {:src_ids => params[:objectIds]}
@@ -793,16 +751,10 @@ module ApplicationController::CiProcessing
       if VmReconfigureRequest.make_request(@request_id, options, current_user)
         flash = _("VM Reconfigure Request was saved")
         if role_allows(:feature => "miq_request_show_list", :any => true)
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to :controller => 'miq_request', :action => 'show_list', :flash_msg => flash
-          end
+          javascript_redirect :controller => 'miq_request', :action => 'show_list', :flash_msg => flash
         else
           url = previous_breadcrumb_url.split('/')
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to :controller => url[1], :action => url[2], :flash_msg => flash
-          end
+          javascript_redirect :controller => url[1], :action => url[2], :flash_msg => flash
         end
       else
         # TODO - is request ever nil? ??
@@ -844,7 +796,6 @@ module ApplicationController::CiProcessing
     @redirect_id = obj[0] if obj.length == 1      # not redirecting to an id if multi host are selected for credential edit
 
     if !["ScanItemSet", "Condition", "Schedule", "MiqAeInstance"].include?(db)
-      #       page.redirect_to :controller=>params[:rec], :action=>link   # redirect to build the compare screen
       @refresh_partial = "edit"
       @refresh_partial = "edit_set" if params[:db] == "policyprofile"
     else
@@ -1473,11 +1424,8 @@ module ApplicationController::CiProcessing
       session[:changed] = true  # need to enable submit button when screen loads
       @refresh_partial = "vm_common/reconfigure"
     else
-      render :update do |page|
-        page << javascript_prologue
-        if role_allows(:feature => "vm_reconfigure")
-          page.redirect_to :controller => "#{rec_cls}", :action => 'reconfigure', :req_id => @request_id, :rec_ids => @reconfigure_items, :escape => false         # redirect to build the ownership screen
-        end
+      if role_allows(:feature => "vm_reconfigure")
+        javascript_redirect :controller => "#{rec_cls}", :action => 'reconfigure', :req_id => @request_id, :rec_ids => @reconfigure_items, :escape => false # redirect to build the ownership screen
       end
     end
   end
@@ -1945,10 +1893,7 @@ module ApplicationController::CiProcessing
         policy_sim
         @refresh_partial = "layouts/policy_sim"
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => 'vm', :action => 'policy_sim'   # redirect to build the policy simulation screen
-        end
+        javascript_redirect :controller => 'vm', :action => 'policy_sim' # redirect to build the policy simulation screen
       end
     end
   end

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -899,10 +899,7 @@ module ApplicationController::Compare
       if @explorer
         compare_miq(@sb[:compare_db])
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'compare_miq'    # redirect to build the compare screen
-        end
+        javascript_redirect :action => 'compare_miq' # redirect to build the compare screen
       end
     end
   end
@@ -947,10 +944,7 @@ module ApplicationController::Compare
       if @explorer
         drift
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => controller_name, :action => 'drift', :id => @drift_obj.id
-        end
+        javascript_redirect :controller => controller_name, :action => 'drift', :id => @drift_obj.id
       end
     end
   end

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -8,12 +8,9 @@ module ApplicationController::DialogRunner
       add_flash(flash)
       replace_right_cell
     else
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action    => 'show',
-                         :id        => session[:edit][:target_id],
-                         :flash_msg => flash  # redirect to miq_request show_list screen
-      end
+      javascript_redirect :action    => 'show',
+                          :id        => session[:edit][:target_id],
+                          :flash_msg => flash # redirect to miq_request show_list screen
     end
   end
 
@@ -49,26 +46,18 @@ module ApplicationController::DialogRunner
             @in_a_form = false
             if session[:edit][:explorer]
               add_flash(flash)
-              # redirect to miq_request show_list screen
-              render :update do |page|
-                page << javascript_prologue
-                page.redirect_to :controller => 'miq_request',
-                                 :action     => 'show_list',
-                                 :flash_msg  => flash
-              end
+              javascript_redirect :controller => 'miq_request',
+                                  :action     => 'show_list',
+                                  :flash_msg  => flash
             else
               model = ("#{controller_name.camelize}Controller").constantize.model
-              render :update do |page|
-                page << javascript_prologue
+              javascript_redirect(
                 if restful_routed?(model)
-                  page.redirect_to polymorphic_path(model.where(:id => session[:edit][:target_id]).first,
-                                                    :flash_msg => flash)
+                  polymorphic_path(model.where(:id => session[:edit][:target_id]).first, :flash_msg => flash)
                 else
-                  page.redirect_to :action    => 'show',
-                                   :id        => session[:edit][:target_id],
-                                   :flash_msg => flash
+                  {:action => 'show', :id => session[:edit][:target_id], :flash_msg => flash}
                 end
-              end
+              )
             end
           else
             dialog_cancel_form(flash)
@@ -82,10 +71,7 @@ module ApplicationController::DialogRunner
         add_flash(flash, :warning)
         replace_right_cell("dialog_provision")
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'dialog_load', :flash_msg => flash, :flash_warning => true, :escape => false  # redirect to miq_request show_list screen
-        end
+        javascript_redirect :action => 'dialog_load', :flash_msg => flash, :flash_warning => true, :escape => false # redirect to miq_request show_list screen
       end
     else
       return unless load_edit("dialog_edit__#{params[:id]}", "replace_cell__explorer")
@@ -181,10 +167,7 @@ module ApplicationController::DialogRunner
     if @edit[:explorer]
       replace_right_cell("dialog_provision")
     else
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'dialog_load'
-      end
+      javascript_redirect :action => 'dialog_load'
     end
   end
 

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -504,10 +504,7 @@ module ApplicationController::Filter
           if @quick_search_active
             quick_search_show
           else
-            render :update do |page|
-              page << javascript_prologue
-              page.redirect_to :action => 'show_list' # Redirect to build the list screen
-            end
+            javascript_redirect :action => 'show_list' # Redirect to build the list screen
           end
         end
         format.html do
@@ -744,10 +741,7 @@ module ApplicationController::Filter
         self.x_node = "root"                                      # Position on root node
         replace_right_cell
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'show_list'                 # redirect to build the list screen
-        end
+        javascript_redirect :action => 'show_list' # redirect to build the list screen
       end
       return
 
@@ -952,10 +946,7 @@ module ApplicationController::Filter
     if @edit[:in_explorer]
       replace_right_cell
     else
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(:action => 'show_list')
-      end
+      javascript_redirect :action => 'show_list'
     end
   end
   private :quick_search_apply_click

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -79,15 +79,12 @@ module ApplicationController::MiqRequestMethods
         @sb[:action] = nil
         replace_right_cell
       else
-        render :update do |page|
-          page << javascript_prologue
-          if @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
-            page.redirect_to :action => "show_list", :controller => "vm"
-          else
-            # had to get id from breadcrumbs url, because there is no params[:id] when cancel is pressed on copy Request screen.
-            url = @breadcrumbs.last[:url].split('/')
-            page.redirect_to :controller => url[1], :action => url[2], :id => url[3]
-          end
+        if @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
+          javascript_redirect :action => "show_list", :controller => "vm"
+        else
+          # had to get id from breadcrumbs url, because there is no params[:id] when cancel is pressed on copy Request screen.
+          url = @breadcrumbs.last[:url].split('/')
+          javascript_redirect :controller => url[1], :action => url[2], :id => url[3]
         end
       end
     elsif params[:button] == "continue"       # Template chosen, start vm provisioning
@@ -117,14 +114,10 @@ module ApplicationController::MiqRequestMethods
           @sb[:action] = "pre_prov"
           replace_right_cell
         else
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to :controller     => @redirect_controller,
-                             :action         => "prov_edit",
-                             :src_vm_id      => @src_vm_id,
-                             :org_controller => "vm"
-            page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-          end
+          javascript_redirect :controller     => @redirect_controller,
+                              :action         => "prov_edit",
+                              :src_vm_id      => @src_vm_id,
+                              :org_controller => "vm"
         end
       end
     elsif params[:sort_choice]
@@ -576,13 +569,10 @@ module ApplicationController::MiqRequestMethods
       @sb[:action] = nil
       replace_right_cell
     else
-      render :update do |page|
-        page << javascript_prologue
-        if @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
-          page.redirect_to :action => "show_list", :controller => "vm"
-        else
-          page.redirect_to @breadcrumbs.last[:url]
-        end
+      if @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
+        javascript_redirect :action => "show_list", :controller => "vm"
+      else
+        javascript_redirect @breadcrumbs.last[:url]
       end
     end
   end
@@ -606,13 +596,10 @@ module ApplicationController::MiqRequestMethods
       @explorer = @edit[:explorer] ? @edit[:explorer] : false
       @sb[:action] = @edit = session[:edit] =  nil                                                # Clear out session[:edit]
       if role_allows(:feature => "miq_request_show_list", :any => true)
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => 'miq_request',
-                           :action     => 'show_list',
-                           :flash_msg  => flash,
-                           :typ        => typ
-        end
+        javascript_redirect :controller => 'miq_request',
+                            :action     => 'show_list',
+                            :flash_msg  => flash,
+                            :typ        => typ
       else
         add_flash(flash)
         prov_request_cancel_submit_response

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -259,13 +259,10 @@ module ApplicationController::Performance
 
     if cmd == "Display" && model == "Current" && typ == "Top"                   # Display the CI selected from a Top chart
       return unless perf_menu_record_valid(data_row["resource_type"], data_row["resource_id"], data_row["resource_name"])
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(:controller => data_row["resource_type"].underscore,
-                         :action     => "show",
-                         :id         => data_row["resource_id"],
-                         :escape     => false)
-      end
+      javascript_redirect :controller => data_row["resource_type"].underscore,
+                          :action     => "show",
+                          :id         => data_row["resource_id"],
+                          :escape     => false
       return
 
     elsif cmd == "Display" && typ == "bytag"  # Display selected resources from a tag chart
@@ -281,15 +278,12 @@ module ApplicationController::Performance
              else
                _("%{model} (%{tag} running %{time})") % {:tag => bc_tag, :model => bc_model, :time => dt}
              end
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(:controller    => model.downcase.singularize,
-                           :action        => "show_list",
-                           :menu_click    => params[:menu_click],
-                           :sb_controller => request.parameters["controller"],
-                           :bc            => bc,
-                           :escape        => false)
-        end
+        javascript_redirect :controller    => model.downcase.singularize,
+                            :action        => "show_list",
+                            :menu_click    => params[:menu_click],
+                            :sb_controller => request.parameters["controller"],
+                            :bc            => bc,
+                            :escape        => false
         return
       end
 
@@ -300,15 +294,12 @@ module ApplicationController::Performance
         msg = _("No %{model} were %{state} %{time}") % {:model => model, :state => state, :time => dt}
       else
         bc = request.parameters["controller"] == "storage" ? "#{bc_model} #{dt}" : "#{bc_model} #{state} #{dt}"
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(:controller    => model.downcase.singularize,
-                           :action        => "show_list",
-                           :menu_click    => params[:menu_click],
-                           :sb_controller => request.parameters["controller"],
-                           :bc            => bc,
-                           :escape        => false)
-        end
+        javascript_redirect :controller    => model.downcase.singularize,
+                            :action        => "show_list",
+                            :menu_click    => params[:menu_click],
+                            :sb_controller => request.parameters["controller"],
+                            :bc            => bc,
+                            :escape        => false
         return
       end
 
@@ -340,15 +331,12 @@ module ApplicationController::Performance
           @_params[:refresh] = "n"
           show_timeline
         else
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to(:id         => @perf_record.id,
-                             :action     => "show",
-                             :display    => "timeline",
-                             :controller => model_to_controller(@perf_record),
-                             :refresh    => "n",
-                             :escape     => false)
-          end
+          javascript_redirect :id         => @perf_record.id,
+                              :action     => "show",
+                              :display    => "timeline",
+                              :controller => model_to_controller(@perf_record),
+                              :refresh    => "n",
+                              :escape     => false
         end
         return
       end
@@ -380,21 +368,18 @@ module ApplicationController::Performance
           @_params[:refresh] = "n"
           show_timeline
         else
-          render :update do |page|
-            page << javascript_prologue
-            if data_row["resource_type"] == "VmOrTemplate"
-              tree_node_id = TreeBuilder.build_node_id(@record.class.base_model, @record.id)
-              session[:exp_parms] = {:display => "timeline", :refresh => "n", :id => tree_node_id}
-              page.redirect_to(:controller => data_row["resource_type"].underscore.downcase.singularize,
-                               :action     => "explorer")
-            else
-              page.redirect_to(:controller => data_row["resource_type"].underscore.downcase.singularize,
-                               :action     => "show",
-                               :display    => "timeline",
-                               :id         => data_row["resource_id"],
-                               :refresh    => "n",
-                               :escape     => false)
-            end
+          if data_row["resource_type"] == "VmOrTemplate"
+            tree_node_id = TreeBuilder.build_node_id(@record.class.base_model, @record.id)
+            session[:exp_parms] = {:display => "timeline", :refresh => "n", :id => tree_node_id}
+            javascript_redirect :controller => data_row["resource_type"].underscore.downcase.singularize,
+                                :action     => "explorer"
+          else
+            javascript_redirect :controller => data_row["resource_type"].underscore.downcase.singularize,
+                                :action     => "show",
+                                :display    => "timeline",
+                                :id         => data_row["resource_id"],
+                                :refresh    => "n",
+                                :escape     => false
           end
         end
         return
@@ -489,22 +474,19 @@ module ApplicationController::Performance
       session[:sandboxes][cont][:perf_options] ||= {}
       session[:sandboxes][cont][:perf_options].merge!(new_opts)
 
-      render :update do |page|
-        page << javascript_prologue
-        if data_row["resource_type"] == "VmOrTemplate"
-          prefix = TreeBuilder.get_prefix_for_model(@record.class.base_model)
-          tree_node_id = "#{prefix}-#{@record.id}"  # Build the tree node id
-          session[:exp_parms] = {:display => "performance", :refresh => "n", :id => tree_node_id}
-          page.redirect_to(:controller => data_row["resource_type"].underscore.downcase.singularize,
-                           :action     => "explorer")
-        else
-          page.redirect_to(:controller => data_row["resource_type"].underscore.downcase.singularize,
-                           :action     => "show",
-                           :id         => data_row["resource_id"],
-                           :display    => "performance",
-                           :refresh    => "n",
-                           :escape     => false)
-        end
+      if data_row["resource_type"] == "VmOrTemplate"
+        prefix = TreeBuilder.get_prefix_for_model(@record.class.base_model)
+        tree_node_id = "#{prefix}-#{@record.id}"  # Build the tree node id
+        session[:exp_parms] = {:display => "performance", :refresh => "n", :id => tree_node_id}
+        javascript_redirect :controller => data_row["resource_type"].underscore.downcase.singularize,
+                            :action     => "explorer"
+      else
+        javascript_redirect :controller => data_row["resource_type"].underscore.downcase.singularize,
+                            :action     => "show",
+                            :id         => data_row["resource_id"],
+                            :display    => "performance",
+                            :refresh    => "n",
+                            :escape     => false
       end
       return
 
@@ -517,14 +499,11 @@ module ApplicationController::Performance
       if top_ids.blank?
         msg = "No #{bc_tag} #{bc_model} were running #{dt}"
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(:id          => @perf_record.id,
-                           :action      => "perf_top_chart",
-                           :menu_choice => params[:menu_click],
-                           :bc          => "#{@perf_record.name} top #{bc_model} (#{bc_tag} #{dt})",
-                           :escape      => false)
-        end
+        javascript_redirect :id          => @perf_record.id,
+                            :action      => "perf_top_chart",
+                            :menu_choice => params[:menu_click],
+                            :bc          => "#{@perf_record.name} top #{bc_model} (#{bc_tag} #{dt})",
+                            :escape      => false
         return
       end
 
@@ -536,14 +515,11 @@ module ApplicationController::Performance
       if top_ids.blank?
         msg = _("No %{model} were running %{time}") % {:model => model, :time => dt}
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(:id          => @perf_record.id,
-                           :action      => "perf_top_chart",
-                           :menu_choice => params[:menu_click],
-                           :bc          => "#{@perf_record.name} top #{bc_model} (#{dt})",
-                           :escape      => false)
-        end
+        javascript_redirect :id          => @perf_record.id,
+                            :action      => "perf_top_chart",
+                            :menu_choice => params[:menu_click],
+                            :bc          => "#{@perf_record.name} top #{bc_model} (#{dt})",
+                            :escape      => false
         return
       end
 

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -186,10 +186,7 @@ module ApplicationController::PolicySupport
       protect
       @refresh_partial = "layouts/protect"
     else
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'protect'   # redirect to build policy screen
-      end
+      javascript_redirect :action => 'protect' # redirect to build policy screen
     end
   end
   %w(image instance vm miq_template container_image ems_container).each do |old_name|

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -187,10 +187,7 @@ module ApplicationController::Tags
     else
       @edit = nil                               # clean out the saved info
       session[:flash_msgs] = @flash_array.dup   # Put msg in session for next transaction to display
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(previous_breadcrumb_url)
-      end
+      javascript_redirect previous_breadcrumb_url
     end
   end
 
@@ -207,10 +204,7 @@ module ApplicationController::Tags
     else
       @edit = nil
       session[:flash_msgs] = @flash_array.dup   # Put msg in session for next transaction to display
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(previous_breadcrumb_url)
-      end
+      javascript_redirect previous_breadcrumb_url
     end
   end
 
@@ -382,13 +376,10 @@ module ApplicationController::Tags
     @tagging = session[:tag_db] = db        # Remember the DB
     get_tag_items
     drop_breadcrumb(:name => _("Tag Assignment"), :url => "/#{session[:controller]}/tagging_edit")
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to :action => 'tagging_edit',
-                       :id     => params[:id],
-                       :db     => db,
-                       :escape => false
-    end
+    javascript_redirect :action => 'tagging_edit',
+                         :id     => params[:id],
+                         :db     => db,
+                         :escape => false
   end
 
   # Getting my company tags and my tags to display on summary screen

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -29,20 +29,13 @@ class AuthKeyPairCloudController < ApplicationController
     new if params[:pressed] == 'auth_key_pair_cloud_new'
 
     if !@flash_array.nil? && params[:pressed] == "auth_key_pair_cloud_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        # redirect to build the retire screen
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif params[:pressed] == "auth_key_pair_cloud_new"
       if @flash_array
         show_list
         replace_gtl_main_div
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => "new"
-        end
+        javascript_redirect :action => "new"
       end
     elsif @refresh_div == "main_div" && @lastaction == "show_list"
       replace_gtl_main_div
@@ -104,13 +97,9 @@ class AuthKeyPairCloudController < ApplicationController
 
     case params[:button]
     when "cancel"
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action    => 'show_list',
-                         :flash_msg => _("Add of new %{model} was cancelled by the user") % {
-                           :model => ui_lookup(:table => 'auth_key_pair_cloud')
-                         }
-      end
+      javascript_redirect :action    => 'show_list',
+                          :flash_msg => _("Add of new %{model} was cancelled by the user") %
+                          {:model => ui_lookup(:table => 'auth_key_pair_cloud')}
     when "save"
       ext_management_system = find_by_id_filtered(ManageIQ::Providers::CloudManager, options[:ems_id])
       kls = kls.class_by_ems(ext_management_system)
@@ -129,10 +118,7 @@ class AuthKeyPairCloudController < ApplicationController
         @breadcrumbs.pop if @breadcrumbs
         session[:edit] = nil
         session[:flash_msgs] = @flash_array.dup if @flash_array
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => "show_list"
-        end
+        javascript_redirect :action => "show_list"
       else
         @in_a_form = true
         add_flash(kls.is_available_now_error_message(:create_key_pair, ext_management_system, kls))

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -55,10 +55,7 @@ class CloudTenantController < ApplicationController
 
   def render_button_partial(pfx)
     if @flash_array && params[:pressed] == "#{@table_name}_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -47,10 +47,7 @@ class CloudVolumeController < ApplicationController
       replace_gtl_main_div
     elsif params[:pressed] == "cloud_volume_attach"
       checked_volume_id = get_checked_volume_id(params)
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "attach", :id => checked_volume_id
-      end
+      javascript_redirect :action => "attach", :id => checked_volume_id
     elsif params[:pressed] == "cloud_volume_detach"
       checked_volume_id = get_checked_volume_id(params)
       @volume = find_by_id_filtered(CloudVolume, checked_volume_id)
@@ -61,22 +58,13 @@ class CloudVolumeController < ApplicationController
           :instances   => ui_lookup(:tables => 'vm_cloud')}, :error)
         render_flash
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => "detach", :id => checked_volume_id
-        end
+        javascript_redirect :action => "detach", :id => checked_volume_id
       end
     elsif params[:pressed] == "cloud_volume_edit"
       checked_volume_id = get_checked_volume_id(params)
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "edit", :id => checked_volume_id
-      end
+      javascript_redirect :action => "edit", :id => checked_volume_id
     elsif params[:pressed] == "cloud_volume_new"
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "new"
-      end
+      javascript_redirect :action => "new"
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)
@@ -178,13 +166,10 @@ class CloudVolumeController < ApplicationController
   def cancel_action(message)
     session[:edit] = nil
     @breadcrumbs.pop if @breadcrumbs
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to :action    => @lastaction,
-                       :id        => @volume.id,
-                       :display   => session[:cloud_volume_display],
-                       :flash_msg => message
-    end
+    javascript_redirect :action    => @lastaction,
+                        :id        => @volume.id,
+                        :display   => session[:cloud_volume_display],
+                        :flash_msg => message
   end
 
   def attach_volume
@@ -220,10 +205,7 @@ class CloudVolumeController < ApplicationController
       @breadcrumbs.pop if @breadcrumbs
       session[:edit] = nil
       session[:flash_msgs] = @flash_array.dup if @flash_array
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "show", :id => @volume.id.to_s
-      end
+      javascript_redirect :action => "show", :id => @volume.id.to_s
     end
   end
 
@@ -261,10 +243,7 @@ class CloudVolumeController < ApplicationController
       @breadcrumbs.pop if @breadcrumbs
       session[:edit] = nil
       session[:flash_msgs] = @flash_array.dup if @flash_array
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "show", :id => @volume.id.to_s
-      end
+      javascript_redirect :action => "show", :id => @volume.id.to_s
     end
   end
 
@@ -284,12 +263,8 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_new")
     case params[:button]
     when "cancel"
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(:action => 'show_list', :flash_msg => _("Add of new %{model} was cancelled by the user") % {
-          :model => ui_lookup(:table => 'cloud_volume')
-        })
-      end
+      javascript_redirect :action => 'show_list',
+                          :flash_msg => _("Add of new %{model} was cancelled by the user") % {:model => ui_lookup(:table => 'cloud_volume')}
 
     when "add"
       @volume = CloudVolume.new
@@ -310,10 +285,7 @@ class CloudVolumeController < ApplicationController
         end
         @breadcrumbs.pop if @breadcrumbs
         session[:flash_msgs] = @flash_array.dup if @flash_array
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => "show_list"
-        end
+        javascript_redirect :action => "show_list"
       else
         @in_a_form = true
         add_flash(_(action_details), :error) unless action_details.nil?
@@ -388,10 +360,7 @@ class CloudVolumeController < ApplicationController
       @breadcrumbs.pop if @breadcrumbs
       session[:edit] = nil
       session[:flash_msgs] = @flash_array.dup if @flash_array
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "show", :id => @volume.id
-      end
+      javascript_redirect :action => "show", :id => @volume.id
 
     when "validate"
       @in_a_form = true

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -57,10 +57,7 @@ class ConfigurationController < ApplicationController
     end
 
     if params[:pressed].ends_with?("_edit", "_copy")
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => @refresh_partial, :id => @redirect_id
-      end
+      javascript_redirect :action => @refresh_partial, :id => @redirect_id
     else
       c_tb = build_toolbar(center_toolbar_filename)
       render :update do |page|
@@ -437,10 +434,7 @@ class ConfigurationController < ApplicationController
     when "cancel"
       add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => "TimeProfile")})
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'change_tab', :typ => "timeprofiles", :tab => 4
-      end
+      javascript_redirect :action => 'change_tab', :typ => "timeprofiles", :tab => 4
     when "add"
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
         add_flash(_("Description is required"), :error)
@@ -475,10 +469,7 @@ class ConfigurationController < ApplicationController
         AuditEvent.success(build_created_audit(@timeprofile, @edit))
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "TimeProfile"), :name => @timeprofile.description})
         session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'change_tab', :typ => "timeprofiles", :tab => 4
-        end
+        javascript_redirect :action => 'change_tab', :typ => "timeprofiles", :tab => 4
       end
     end
   end
@@ -490,10 +481,7 @@ class ConfigurationController < ApplicationController
       add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "TimeProfile"), :name => @timeprofile.description})
       params[:id] = @timeprofile.id.to_s
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'change_tab', :typ => "timeprofiles", :tab => 4, :id => @timeprofile.id.to_s
-      end
+      javascript_redirect :action => 'change_tab', :typ => "timeprofiles", :tab => 4, :id => @timeprofile.id.to_s
     elsif params[:button] == "reset"
       @edit[:new] = copy_hash(@edit[:current])
       params[:id] = @timeprofile.id
@@ -502,10 +490,7 @@ class ConfigurationController < ApplicationController
       drop_breadcrumb(:name => _("Edit '%{description}'") % {:description => @timeprofile.description},
                       :url  => "/configuration/timeprofile_edit")
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'timeprofile_edit', :id => @timeprofile.id.to_s
-      end
+      javascript_redirect :action => 'timeprofile_edit', :id => @timeprofile.id.to_s
     elsif params[:button] == "save"
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
         add_flash(_("Description is required"), :error)
@@ -544,10 +529,7 @@ class ConfigurationController < ApplicationController
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "TimeProfile"),
                                                          :name  => @timeprofile.description})
         session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'change_tab', :typ => "timeprofiles", :tab => 4, :id => @timeprofile.id.to_s
-        end
+        javascript_redirect :action => 'change_tab', :typ => "timeprofiles", :tab => 4, :id => @timeprofile.id.to_s
       end
     end
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -217,10 +217,7 @@ class DashboardController < ApplicationController
     ws.destroy unless ws.nil?
     ws = create_user_dashboard(@sb[:active_db_id])
     @sb[:dashboards] = nil  # Reset dashboards hash so it gets recreated
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to :action => 'show'
-    end
+    javascript_redirect :action => 'show'
   end
 
   # Toggle dashboard item size
@@ -302,10 +299,7 @@ class DashboardController < ApplicationController
       w = MiqWidget.find_by_id(w)
       ws.remove_member(w) if w
       save_user_dashboards
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show'
-      end
+      javascript_redirect :action => 'show'
     else
       head :ok
     end
@@ -329,10 +323,7 @@ class DashboardController < ApplicationController
       if ws.add_member(w).present?
         save_user_dashboards
         w.create_initial_content_for_user(session[:userid])
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'show'
-        end
+        javascript_redirect :action => 'show'
       else
         render_flash(_("The widget \"%{widget_name}\" is already part of the edited dashboard") %
          {:widget_name => w.name}, :error)
@@ -371,26 +362,23 @@ class DashboardController < ApplicationController
 
   # AJAX login retry method
   def login_retry
-    render :update do |page|
-      page << javascript_prologue
-      #     if MiqServer.my_server(true).logon_status == :starting
-      logon_details = MiqServer.my_server(true).logon_status_details
-      if logon_details[:status] == :starting
+    #     if MiqServer.my_server(true).logon_status == :starting
+    logon_details = MiqServer.my_server(true).logon_status_details
+    if logon_details[:status] == :starting
+      render :update do |page|
+        page << javascript_prologue
         @login_message = logon_details[:message] if logon_details[:message]
         page.replace("login_message_div", :partial => "login_message")
         page << "setTimeout(\"#{remote_function(:url => {:action => 'login_retry'})}\", 10000);"
-      else
-        page.redirect_to :action => 'login'
       end
+    else
+      javascript_redirect :action => 'login'
     end
   end
 
   # Initiate a SAML Login from the main login page
   def initiate_saml_login
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to(saml_protected_page)
-    end
+    javascript_redirect saml_protected_page
   end
 
   # Login support for SAML - GET /saml_login
@@ -465,15 +453,12 @@ class DashboardController < ApplicationController
     }
 
     if params[:user_name].blank? && params[:user_password].blank? &&
-       request.headers["X-Remote-User"].blank? &&
-       get_vmdb_config[:authentication][:mode] == "httpd" &&
-       get_vmdb_config[:authentication][:sso_enabled] &&
-       params[:action] == "authenticate"
+      request.headers["X-Remote-User"].blank? &&
+      get_vmdb_config[:authentication][:mode] == "httpd" &&
+      get_vmdb_config[:authentication][:sso_enabled] &&
+      params[:action] == "authenticate"
 
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(root_path)
-      end
+      javascript_redirect root_path
       return
     end
 
@@ -606,10 +591,7 @@ class DashboardController < ApplicationController
     session_init(db_user)
     session[:group_changed] = true
     url = start_url_for_user(nil) || url_for(:controller => params[:controller], :action => 'show')
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to(url)
-    end
+    javascript_redirect url
   end
 
   # Put out error msg if user's role is not authorized for an action

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -203,10 +203,7 @@ class EmsClusterController < ApplicationController
     end
 
     if !@flash_array.nil? && params[:pressed] == "ems_cluster_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -159,10 +159,7 @@ module EmsCommon
       if !@flash_array && valid_record?(add_ems) && add_ems.save
         AuditEvent.success(build_created_audit(add_ems, @edit))
         session[:edit] = nil  # Clear the edit object from the session object
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'show_list', :flash_msg => _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:tables => @table_name), :name => add_ems.name}
-        end
+        javascript_redirect :action => 'show_list', :flash_msg => _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:tables => @table_name), :name => add_ems.name}
       else
         @in_a_form = true
         unless @flash_array
@@ -254,12 +251,9 @@ module EmsCommon
   def update_button_cancel
     session[:edit] = nil  # clean out the saved info
     _model = model
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to(:action => @lastaction, :id => @ems.id, :display => session[:ems_display],
-                       :flash_msg => _("Edit of %{model} \"%{name}\" was cancelled by the user") %
-                       {:model => ui_lookup(:model => _model.to_s), :name => @ems.name})
-    end
+    javascript_redirect :action => @lastaction, :id => @ems.id, :display => session[:ems_display],
+                        :flash_msg => _("Edit of %{model} \"%{name}\" was cancelled by the user") %
+                        {:model => ui_lookup(:model => _model.to_s), :name => @ems.name}
   end
   private :update_button_cancel
 
@@ -277,10 +271,7 @@ module EmsCommon
               {:model => ui_lookup(:model => model.to_s), :name => update_ems.name}
       AuditEvent.success(build_saved_audit(update_ems, @edit))
       session[:edit] = nil  # clean out the saved info
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show', :id => @ems.id.to_s, :flash_msg => flash
-      end
+      javascript_redirect :action => 'show', :id => @ems.id.to_s, :flash_msg => flash
       return
     else
       @edit[:errors].each { |msg| add_flash(msg, :error) }
@@ -304,10 +295,7 @@ module EmsCommon
     @in_a_form = true
     set_verify_status
     session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to :action => 'edit', :id => @ems.id.to_s
-    end
+    javascript_redirect :action => 'edit', :id => @ems.id.to_s
   end
   private :update_button_reset
 
@@ -411,10 +399,7 @@ module EmsCommon
         tl_build_timeline                       # Create the timeline report
         drop_breadcrumb(:name => _("Timelines"), :url => show_link(@record, :refresh => "n", :display => "timeline"))
         session[:tl_record_id] = @record.id
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to  polymorphic_path(@record, :display => 'timeline')
-        end
+        javascript_redirect polymorphic_path(@record, :display => 'timeline')
         return
       end
       if params[:pressed] == "#{@table_name}_perf"
@@ -423,17 +408,11 @@ module EmsCommon
         drop_breadcrumb(:name => _("%{name} Capacity & Utilization") % {:name => @record.name},
                         :url  => show_link(@record, :refresh => "n", :display => "performance"))
         perf_gen_init_options # Intialize options, charts are generated async
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to polymorphic_path(@record, :display => "performance")
-        end
+        javascript_redirect polymorphic_path(@record, :display => "performance")
         return
       end
       if params[:pressed] == "refresh_server_summary"
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to  :back
-        end
+        javascript_redirect :back
         return
       end
       if params[:pressed] == "ems_cloud_recheck_auth_status" ||
@@ -460,10 +439,7 @@ module EmsCommon
     end
 
     if !@flash_array.nil? && params[:pressed] == "#{@table_name}_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -27,10 +27,7 @@ class MiqPolicyController < ApplicationController
       if @lastaction != "fetch_yaml"
         add_flash(_("Export cancelled by user"))
       end
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "explorer"
-      end
+      javascript_redirect :action => "explorer"
     when "export"
       if params[:choices_chosen]
         @sb[:new][:choices_chosen] = params[:choices_chosen]
@@ -58,10 +55,7 @@ class MiqPolicyController < ApplicationController
             filename = "Alerts"
           end
           session[:export_data] = MiqPolicy.export_to_yaml(@sb[:new][:choices_chosen], db)
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to :action => 'fetch_yaml', :fname => filename, :escape => false
-          end
+          javascript_redirect :action => 'fetch_yaml', :fname => filename, :escape => false
         rescue StandardError => bang
           add_flash(_("Error during export: %{error_message}") % {:error_message => bang.message}, :error)
           render :update do |page|
@@ -203,10 +197,7 @@ class MiqPolicyController < ApplicationController
     elsif params[:commit] == "cancel"
       miq_policy_import_service.cancel_import(@import_file_upload_id)
 
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'export', :flash_msg => _("Import cancelled by user")
-      end
+      javascript_redirect :action => 'export', :flash_msg => _("Import cancelled by user")
 
     # init import
     else
@@ -231,7 +222,6 @@ class MiqPolicyController < ApplicationController
     render :update do |page|
       page << javascript_prologue
       if prev_dbtype != @sb[:dbtype]    # If any export db type has changed
-        # page.redirect_to :action=>"export", :dbtype=>params[:dbtype], :typ=>"export"
         page.replace_html("profile_export_div", :partial => "export")
       end
     end

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -45,10 +45,7 @@ module MiqPolicyController::Rsop
     elsif params[:button] == "reset"
       @sb[:rsop] = {}     # Reset all RSOP stored values
       session[:changed] = session[:rsop_tree] = nil
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'rsop'
-      end
+      javascript_redirect :action => 'rsop'
     else  # No params, first time in
       @breadcrumbs = []
       @accords = [{:name => "rsop", :title => "Options", :container => "rsop_options_div"}]

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -26,34 +26,22 @@ class MiqRequestController < ApplicationController
     end
     return if params[:pressed] == "miq_request_edit" && @refresh_partial == "reconfigure"
     if !@flash_array.nil? && params[:pressed] == "miq_request_delete"
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif ["miq_request_copy", "miq_request_edit"].include?(params[:pressed])
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :controller     => @redirect_controller,
-                         :action         => @refresh_partial,
-                         :id             => @redirect_id,
-                         :prov_type      => @prov_type,
-                         :req_id         => @req_id,
-                         :org_controller => @org_controller,
-                         :prov_id        => @prov_id
-      end
+      javascript_redirect :controller     => @redirect_controller,
+                          :action         => @refresh_partial,
+                          :id             => @redirect_id,
+                          :prov_type      => @prov_type,
+                          :req_id         => @req_id,
+                          :org_controller => @org_controller,
+                          :prov_id        => @prov_id
     elsif params[:pressed].ends_with?("_edit")
       if @refresh_partial == "show_list"
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action      => @refresh_partial,
-                           :flash_msg   => _("Default Requests can not be edited"),
-                           :flash_error => true
-        end
+        javascript_redirect :action      => @refresh_partial,
+                            :flash_msg   => _("Default Requests can not be edited"),
+                            :flash_error => true
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => @refresh_partial, :id => @redirect_id
-        end
+        javascript_redirect :action => @refresh_partial, :id => @redirect_id
       end
     elsif params[:pressed] == "miq_request_reload"
       if @display == "main" && params[:id].present?
@@ -202,10 +190,7 @@ class MiqRequestController < ApplicationController
       end
       session[:flash_msgs] = @flash_array.dup
       @edit = nil
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => @lastaction, :id => session[:edit][:request].id
-      end
+      javascript_redirect :action => @lastaction, :id => session[:edit][:request].id
     elsif params[:button] == "submit"
       return unless load_edit("stamp_edit__#{params[:id]}", "show")
       stamp_request = MiqRequest.find(@edit[:request].id)         # Get the current request record
@@ -218,10 +203,7 @@ class MiqRequestController < ApplicationController
       add_flash(_("Request \"%{name}\" was %{task}") % {:name => stamp_request.description, :task => (session[:edit] && session[:edit][:stamp_typ]) == "approve" ? "approved" : "denied"})
       session[:flash_msgs] = @flash_array.dup                     # Put msg in session for next transaction to display
       @edit = nil
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => "show_list"
-      end
+      javascript_redirect :action => "show_list"
     else  # First time in, set up @edit hash
       identify_request
       @edit = {}

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -22,16 +22,13 @@ module Mixins
                   {:model => ui_lookup(:model => model_name),
                    :name  => update_ems.name}
       ems_path = ems_path(update_ems, :flash_msg => flash_msg)
-      render :update do |page|
-        page << javascript_prologue
-        if @lastaction == "show"
-          page.redirect_to ems_path
-        else
-          page.redirect_to(:action    => @lastaction,
-                           :id        => update_ems.id,
-                           :display   => session[:ems_display],
-                           :flash_msg => flash_msg)
-        end
+      if @lastaction == "show"
+        javascript_redirect ems_path
+      else
+        javascript_redirect :action    => @lastaction,
+                            :id        => update_ems.id,
+                            :display   => session[:ems_display],
+                            :flash_msg => flash_msg
       end
     end
 
@@ -46,10 +43,7 @@ module Mixins
         construct_edit_for_audit(update_ems)
         AuditEvent.success(build_saved_audit(update_ems, @edit))
         ems_path = ems_path(update_ems, :flash_msg => flash)
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to ems_path
-        end
+        javascript_redirect ems_path
       else
         update_ems.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -96,11 +90,8 @@ module Mixins
         AuditEvent.success(build_created_audit(ems, @edit))
         flash_msg = _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:tables => @table_name),
                                                            :name  => ems.name}
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action    => 'show_list',
-                           :flash_msg => flash_msg
-        end
+        javascript_redirect :action    => 'show_list',
+                            :flash_msg => flash_msg
       else
         @in_a_form = true
         ems.errors.each do |field, msg|
@@ -123,13 +114,10 @@ module Mixins
 
     def create_ems_button_cancel
       model_name = model.to_s
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(:action    => @lastaction,
-                         :display   => session[:ems_display],
-                         :flash_msg => _("Add of %{model} was cancelled by the user") %
-                             {:model => ui_lookup(:model => model_name)})
-      end
+      javascript_redirect :action    => @lastaction,
+                          :display   => session[:ems_display],
+                          :flash_msg => _("Add of %{model} was cancelled by the user") %
+                          {:model => ui_lookup(:model => model_name)}
     end
 
     def ems_form_fields

--- a/app/controllers/ontap_file_share_controller.rb
+++ b/app/controllers/ontap_file_share_controller.rb
@@ -49,12 +49,12 @@ class OntapFileShareController < CimInstanceController
     return unless request.parameters[:controller] == "ontap_file_share"
     @sb[:sfs_id] = params[:id]
     @record = OntapFileShare.find(params[:id])
-    render :update do |page|
-      page << javascript_prologue
-      area = request.parameters["controller"]
-      if role_allows(:feature => "#{area}_tag")
-        page.redirect_to :action => 'create_ds'
-      else
+    area = request.parameters["controller"]
+    if role_allows(:feature => "#{area}_tag")
+      javascript_redirect :action => 'create_ds'
+    else
+      render :update do |page|
+        page << javascript_prologue
         add_flash(_("The user is not authorized for this task or item."), :error)
         page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
       end
@@ -82,10 +82,7 @@ class OntapFileShareController < CimInstanceController
       add_flash(_("%{model} \"%{name}\": %{task} successfully initiated") % {:model => ui_lookup(:model => "OntapFileShare"), :name => sfs.name, :task => "Create Datastore"})
       @edit = nil # clean out the saved info
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(previous_breadcrumb_url)
-      end
+      javascript_redirect previous_breadcrumb_url
     else
       sfs.errors.each do |field, msg|
         add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -102,10 +99,7 @@ class OntapFileShareController < CimInstanceController
     add_flash(_("Create Datastore was cancelled by the user"))
     @edit = nil # clean out the saved info
     session[:flash_msgs] = @flash_array.dup                   # Put msgs in session for next transaction
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to(previous_breadcrumb_url)
-    end
+    javascript_redirect previous_breadcrumb_url
   end
 
   # Set form vars for create_ds

--- a/app/controllers/ontap_storage_system_controller.rb
+++ b/app/controllers/ontap_storage_system_controller.rb
@@ -54,12 +54,12 @@ class OntapStorageSystemController < CimInstanceController
     return unless request.parameters[:controller] == "ontap_storage_system"
     @sb[:ccs_id] = params[:id]
     @record = OntapStorageSystem.find(params[:id])
-    render :update do |page|
-      page << javascript_prologue
-      area = request.parameters["controller"]
-      if role_allows(:feature => "#{area}_tag")
-        page.redirect_to :action => 'create_ld'
-      else
+    area = request.parameters["controller"]
+    if role_allows(:feature => "#{area}_tag")
+      javascript_redirect :action => 'create_ld'
+    else
+      render :update do |page|
+        page << javascript_prologue
         add_flash(_("The user is not authorized for this task or item."), :error)
         page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
       end
@@ -89,10 +89,7 @@ class OntapStorageSystemController < CimInstanceController
                   {:model => ui_lookup(:model => "OntapStorageSystem"), :name => ccs.name})
       @edit = nil # clean out the saved info
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(previous_breadcrumb_url)
-      end
+      javascript_redirect previous_breadcrumb_url
     else
       ccs.errors.each do |field, msg|
         add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -109,10 +106,7 @@ class OntapStorageSystemController < CimInstanceController
     add_flash(_("Create Logical Disk was cancelled by the user"))
     @edit = nil # clean out the saved info
     session[:flash_msgs] = @flash_array.dup                   # Put msgs in session for next transaction
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to(previous_breadcrumb_url)
-    end
+    javascript_redirect previous_breadcrumb_url
   end
 
   # Set form vars for create_ld

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -481,10 +481,7 @@ module OpsController::Settings::Common
         if @sb[:active_tab] == "settings_server"
           replace_right_cell(@nodetype, [:diagnostics, :settings])
         elsif @sb[:active_tab] == "settings_custom_logos"
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to :action => 'explorer', :flash_msg => @flash_array[0][:message], :flash_error => @flash_array[0][:level] == :error, :escape => false  # redirect to build the server screen
-          end
+          javascript_redirect :action => 'explorer', :flash_msg => @flash_array[0][:message], :flash_error => @flash_array[0][:level] == :error, :escape => false # redirect to build the server screen
           return
         else
           replace_right_cell(@nodetype)

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -3,13 +3,10 @@ module OpsController::Settings::Tags
 
   # AJAX routine for user selected
   def category_select
-    render :update do |page|
-      page << javascript_prologue
-      if params[:id] == "new"
-        page.redirect_to :action => 'category_new'    # redirect to new
-      else
-        page.redirect_to :action => 'category_edit', :id => params[:id], :field => params[:field]   # redirect to edit
-      end
+    if params[:id] == "new"
+      javascript_redirect :action => 'category_new' # redirect to new
+    else
+      javascript_redirect :action => 'category_edit', :id => params[:id], :field => params[:field] # redirect to edit
     end
   end
 

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -131,10 +131,7 @@ class OrchestrationStackController < ApplicationController
     end
 
     if !@flash_array.nil? && params[:pressed] == "orchestration_stack_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)
@@ -248,23 +245,17 @@ class OrchestrationStackController < ApplicationController
       else
         flash_message = _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => 'OrchestrationTemplate'),
                                                                :name  => ot.name}
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(:controller    => 'catalog',
-                           :action        => 'ot_show',
-                           :id            => ot.id,
-                           :flash_message => flash_message)
-        end
+        javascript_redirect :controller    => 'catalog',
+                            :action        => 'ot_show',
+                            :id            => ot.id,
+                            :flash_message => flash_message
       end
     end
   end
 
   def orchestration_templates_view
     template = find_by_id_filtered(OrchestrationStack, params[:id]).orchestration_template
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to(:controller => 'catalog', :action => 'ot_show', :id => template.id)
-    end
+    javascript_redirect :controller => 'catalog', :action => 'ot_show', :id => template.id
   end
 
   def get_session_data

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -114,14 +114,11 @@ class ProviderForemanController < ApplicationController
     end
 
     if ConfiguredSystem.common_configuration_profiles_for_selected_configured_systems(provisioning_ids)
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :controller     => "miq_request",
-                         :action         => "prov_edit",
-                         :prov_id        => provisioning_ids,
-                         :org_controller => "configured_system",
-                         :escape         => false
-      end
+      javascript_redirect :controller     => "miq_request",
+                          :action         => "prov_edit",
+                          :prov_id        => provisioning_ids,
+                          :org_controller => "configured_system",
+                          :escape         => false
     else
       add_flash(_("No common configuration profiles available for the selected configured %s") % n_('system', 'systems', provisioning_ids.size), :error)
       replace_right_cell

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -156,10 +156,7 @@ class ResourcePoolController < ApplicationController
     end
 
     if !@flash_array.nil? && params[:pressed] == "resource_pool_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif ["#{pfx}_miq_request_new", "#{pfx}_migrate", "#{pfx}_clone",
            "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -187,10 +187,7 @@ class StorageController < ApplicationController
     end
 
     if !@flash_array.nil? && params[:pressed] == "storage_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)
@@ -256,24 +253,6 @@ class StorageController < ApplicationController
     @items_per_page = @settings[:perpage][@gtl_type.to_sym]   # Get the per page setting for this gtl type
     @storage_pages, @storages = paginate(:storages, :per_page => @items_per_page, :order => @col_names[get_sort_col] + " " + @sortdir)
   end
-
-  # # Tag selected Storage Locations
-  # def tagstorage
-  #   storages = Array.new
-  #   storages = find_checked_items
-  #   if storages.length < 1
-  #     add_flash("One or more Storage Locations must be selected for tagging", :error)
-  #     @refresh_div = "flash_msg_div"
-  #     @refresh_partial = "layouts/flash_msg"
-  #   else
-  #     session[:tag_items] = storages  # Set the array of tag items
-  #     session[:tag_db] = Storage      # Remember the DB
-  #     session[:assigned_filters] = assigned_filters
-  #      render :update do |page|
-  #       page.redirect_to :controller => 'storage', :action => 'tagging'   # redirect to build the tagging screen
-  #     end
-  #   end
-  # end
 
   def accordion_select
     @lastaction = "explorer"

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -30,21 +30,12 @@ class StorageManagerController < ApplicationController
     end
 
     if !@flash_array.nil? && params[:pressed] == "storage_manager_delete" && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
     elsif params[:pressed].ends_with?("_edit")
       if @redirect_controller
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
-        end
+        javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => @refresh_partial, :id => @redirect_id
-        end
+        javascript_redirect :action => @refresh_partial, :id => @redirect_id
       end
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
@@ -79,11 +70,8 @@ class StorageManagerController < ApplicationController
     get_form_vars
     case params[:button]
     when "cancel"
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => _("Add of new %{model} was cancelled by the user") %
-          {:model => ui_lookup(:table => "StorageManager")}
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => _("Add of new %{model} was cancelled by the user") %
+                          {:model => ui_lookup(:table => "StorageManager")}
     when "add"
       if @edit[:new][:sm_type].nil?
         add_flash(_("Type is required"), :error)
@@ -104,10 +92,7 @@ class StorageManagerController < ApplicationController
       if !@flash_array && valid_record?(add_sm) && add_sm.save
         AuditEvent.success(build_created_audit(add_sm, @edit))
         session[:edit] = nil  # Clear the edit object from the session object
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'show_list', :flash_msg => _("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "StorageManager"), :name => add_sm.name}
-        end
+        javascript_redirect :action => 'show_list', :flash_msg => _("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "StorageManager"), :name => add_sm.name}
       else
         @in_a_form = true
         unless @flash_array
@@ -191,10 +176,7 @@ class StorageManagerController < ApplicationController
     when "cancel"
       session[:edit] = nil  # clean out the saved info
       flash = _("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "StorageManager"), :name => @sm.name}
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => @lastaction, :id => @sm.id, :display => session[:sm_display], :flash_msg => flash
-      end
+      javascript_redirect :action => @lastaction, :id => @sm.id, :display => session[:sm_display], :flash_msg => flash
     when "save"
       update_sm = find_by_id_filtered(StorageManager, params[:id])
       set_record_vars(update_sm)
@@ -202,10 +184,7 @@ class StorageManagerController < ApplicationController
         # update_sm.reload
         AuditEvent.success(build_saved_audit(update_sm, @edit))
         session[:edit] = nil  # clean out the saved info
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'show', :id => @sm.id.to_s, :flash_msg => _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "StorageManager"), :name => update_sm.name}
-        end
+        javascript_redirect :action => 'show', :id => @sm.id.to_s, :flash_msg => _("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "StorageManager"), :name => update_sm.name}
         return
       else
         @edit[:errors].each { |msg| add_flash(msg, :error) }
@@ -228,10 +207,7 @@ class StorageManagerController < ApplicationController
       @in_a_form = true
       set_verify_status
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'edit', :id => @sm.id.to_s
-      end
+      javascript_redirect :action => 'edit', :id => @sm.id.to_s
     when "validate"
       verify_sm = find_by_id_filtered(StorageManager, params[:id])
       set_record_vars(verify_sm, :validate)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -36,21 +36,12 @@ module VmCommon
     @vm = @record = identify_record(params[:id], VmOrTemplate) unless @lastaction == "show_list"
 
     if !@flash_array.nil? && @single_delete
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to :action => 'show_list', :flash_msg => @flash_array[0][:message]  # redirect to build the retire screen
-      end
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message] # redirect to build the retire screen
     elsif params[:pressed].ends_with?("_edit")
       if @redirect_controller
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id, :org_controller => @org_controller
-        end
+        javascript_redirect :controller => @redirect_controller, :action => @refresh_partial, :id => @redirect_id, :org_controller => @org_controller
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => @refresh_partial, :id => @redirect_id
-        end
+        javascript_redirect :action => @refresh_partial, :id => @redirect_id
       end
     else
       if @refresh_div == "main_div" && @lastaction == "show_list"
@@ -485,10 +476,7 @@ module VmCommon
     base = params[:id].split('-')
     session[:base_vm] = "_h-#{base[1]}"
     @display = "vmtree_info"
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to :action => "show", :id => base[1], :vm_tree => "vmtree_info"
-    end
+    javascript_redirect :action => "show", :id => base[1], :vm_tree => "vmtree_info"
   end
 
   def snap_pressed
@@ -876,10 +864,7 @@ module VmCommon
     @rightsize = true
     @in_a_form = true
     if params[:button] == "back"
-      render :update do |page|
-        page << javascript_prologue
-        page.redirect_to(previous_breadcrumb_url)
-      end
+      javascript_prologue( previous_breadcrumb_url)
     end
     if !@explorer && params[:button] != "back"
       drop_breadcrumb(:name => _("Right Size VM '%{name}''") % {:name => @record.name}, :url => "/vm/right_size")
@@ -942,10 +927,7 @@ module VmCommon
         @sb[:action] = nil
         replace_right_cell
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'show', :id => @record.id, :flash_msg => msg
-        end
+        javascript_redirect :action => 'show', :id => @record.id, :flash_msg => msg
       end
     when "save"
       svr = @edit[:new][:server] && @edit[:new][:server] != "" ? MiqServer.find(@edit[:new][:server]) : nil
@@ -957,10 +939,7 @@ module VmCommon
         @sb[:action] = nil
         replace_right_cell
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'show', :id => @record.id, :flash_msg => msg
-        end
+        javascript_redirect :action => 'show', :id => @record.id, :flash_msg => msg
       end
     when "reset"
       @in_a_form = true
@@ -970,10 +949,7 @@ module VmCommon
         add_flash(_("All changes have been reset"), :warning)
         replace_right_cell
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to :action => 'evm_relationship', :id => @record.id, :flash_msg => _("All changes have been reset"), :flash_warning => true, :escape => true
-        end
+        javascript_redirect :action => 'evm_relationship', :id => @record.id, :flash_msg => _("All changes have been reset"), :flash_warning => true, :escape => true
       end
     end
   end
@@ -1105,10 +1081,7 @@ module VmCommon
       else
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "Vm"), :name => @record.name})
         session[:flash_msgs] = @flash_array.dup
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(previous_breadcrumb_url)
-        end
+        javascript_redirect previous_breadcrumb_url
       end
     when "save"
       if @edit[:new][:parent] != -1 && @edit[:new][:kids].invert.include?(@edit[:new][:parent]) # Check if parent is a kid, if selected
@@ -1152,10 +1125,7 @@ module VmCommon
           replace_right_cell
         else
           session[:flash_msgs] = @flash_array.dup
-          render :update do |page|
-            page << javascript_prologue
-            page.redirect_to(previous_breadcrumb_url)
-          end
+          javascript_redirect previous_breadcrumb_url
         end
       end
     when "reset"
@@ -1168,10 +1138,7 @@ module VmCommon
       if @edit[:explorer]
         replace_right_cell
       else
-        render :update do |page|
-          page << javascript_prologue
-          page.redirect_to(:action => "edit", :controller => "vm", :id => params[:id])
-        end
+        javascript_redirect :action => "edit", :controller => "vm", :id => params[:id]
       end
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1044,6 +1044,13 @@ module ApplicationHelper
     true
   end
 
+  def javascript_redirect(args)
+    render :update do |page|
+      page << javascript_prologue
+      page.redirect_to args
+    end
+  end
+
   def record_no_longer_exists?(what, model = nil)
     return false unless what.nil?
     add_flash(@bang || model.present? ?


### PR DESCRIPTION
Replace page.redirect_to with a helper method
-----------------

Doing this to:
 1. cleanup code
 2. make is easier in the future to change this to non-RJS

Steps for Testing/QA
--------------------
Several redirect using this code can be found e.g. in editing an infra provider.