### PR TITLE
Correct mistake in warning in Policy Simulation

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -674,7 +674,10 @@ module VmCommon
     build_policy_tree(@polArr)
     @edit = session[:edit] if session[:edit]
     if @edit && @edit[:explorer]
-      render_flash(_("No policies were selected for Policy Simulation."), :error) if session[:policies].empty?
+      if session[:policies].empty?
+        render_flash(_("No policies were selected for Policy Simulation."), :error)
+        return
+      end
       @in_a_form = true
       replace_right_cell
     else


### PR DESCRIPTION
Incorrect condition that handles click on quadicon in Policy Simulation when no policy is selected.

Thanks @martinpovolny 

@miq-bot add_label bug, ui