### PR TITLE
Fix Regression in EMS Form validation

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -372,6 +372,7 @@ module Mixins
       end
 
       if ems.kind_of?(ManageIQ::Providers::ContainerManager)
+        params[:cred_type] = ems.default_authentication_type if params[:cred_type] == "default"
         ems.hostname = hostname
         hawkular_hostname = hostname if hawkular_hostname.blank?
 
@@ -442,9 +443,9 @@ module Mixins
         session[:oauth_response] = nil
       end
       if ems.kind_of?(ManageIQ::Providers::ContainerManager) &&
-         ems.supports_authentication?(:bearer) && params[:bearer_password]
-        creds[:hawkular] = {:auth_key => params[:bearer_password], :userid => "_"}
-        creds[:bearer] = {:auth_key => params[:bearer_password]}
+         ems.supports_authentication?(:bearer) && !params[:default_password].blank?
+        creds[:hawkular] = {:auth_key => params[:default_password], :userid => "_"}
+        creds[:bearer] = {:auth_key => params[:default_password]}
         ems.update_authentication(creds, :save => (mode != :validate))
       end
       creds

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -194,9 +194,9 @@ describe EmsContainerController do
           controller.instance_variable_set(:@_params, :name              => 'EMS 2',
                                                       :default_hostname  => '10.10.10.11',
                                                       :default_api_port  => '5000',
+                                                      :default_password  => 'valid-token',
                                                       :hawkular_hostname => '10.10.10.10',
                                                       :hawkular_api_port => '8443',
-                                                      :bearer_password   => 'valid-token',
                                                       :emstype           => @type)
           session[:edit] = assigns(:edit)
           controller.send(:set_ems_record_vars, @ems)


### PR DESCRIPTION
EMS Form validation can not create new ems container with bearer (default) authentication.

Issue:
https://github.com/ManageIQ/manageiq/issues/9768