### PR TITLE
Fix HTML id for NetworkManager filters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,8 +25,16 @@ module ApplicationHelper
               :class => 'documentation-link', :target => '_blank')
     end
   end
+
+  def valid_html_id(id)
+    id = id.to_s.gsub("::", "__")
+    raise "HTML ID is not valid" if /[^\w_]/.match(id)
+    id
+  end
+
   # Create a collapsed panel based on a condition
   def miq_accordion_panel(title, condition, id, &block)
+    id = valid_html_id(id)
     content_tag(:div, :class => "panel panel-default") do
       out = content_tag(:div, :class => "panel-heading") do
         content_tag(:h4, :class => "panel-title") do


### PR DESCRIPTION
Fix HTML id for NetworkManager filters. HTML id can't contain
::, it should contain only \w or _.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1349477

Darga BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1353646