### PR TITLE
Prevent failure if param ':timeout' is not supplied.

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -149,7 +149,7 @@ module ManageIQ::Providers
     end
 
     def suspend_middleware_server(ems_ref, params)
-      timeout = params.fetch ':timeout' || 0
+      timeout = params[':timeout'] || 0
       run_generic_operation(:Suspend, ems_ref, :timeout => timeout)
     end
 


### PR DESCRIPTION
Fix an issue where `params.fetch` would bail out if the key is not in `params`.

Private travis run is green https://travis-ci.org/pilhuhn/manageiq/builds/144445125

@miq-bot add_label bug, providers/hawkular
@miq-bot assign abonas
Fixes #9772 