### PR TITLE
No indication of failed data gathering from Hawkular endpoint

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -1,5 +1,7 @@
 module EmsContainerHelper::TextualSummary
   include TextualMixins::TextualRefreshStatus
+  include TextualMixins::TextualAuthenticationsStatus
+  include TextualMixins::TextualMetricsStatus
   #
   # Groups
   #
@@ -19,26 +21,7 @@ module EmsContainerHelper::TextualSummary
   end
 
   def textual_group_status
-    textual_authentications + %i(refresh_status)
-  end
-
-  def textual_authentications
-    authentications = @ems.authentications
-    return [{:label => _("Default Authentication"), :title => t = _("None"), :value => t}] if authentications.blank?
-
-    authentications.order(:authtype).collect do |auth|
-      label =
-        case auth.authtype
-        when "default" then _("Default")
-        when "bearer" then _("Bearer")
-        when "hawkular" then _("Hawkular")
-        else; _("<Unknown>")
-        end
-
-      {:label => _("%{label} Authentication") % {:label => label},
-       :value => auth.status || _("None"),
-       :title => auth.status_details}
-    end
+    textual_authentications_status + %i(authentications_status metrics_status refresh_status)
   end
 
   def textual_group_component_statuses

--- a/app/helpers/textual_mixins/textual_authentications_status.rb
+++ b/app/helpers/textual_mixins/textual_authentications_status.rb
@@ -1,0 +1,43 @@
+module TextualMixins::TextualAuthenticationsStatus
+  def textual_time_ago(time)
+    if time
+      time_str = time_ago_in_words(time.in_time_zone(Time.zone)).titleize
+      _("%{time} Ago") % { :time => time_str }
+    else
+      _("Never")
+    end
+  end
+
+  def textual_authentication_value(status, updated_on, valid_str = _("Valid"))
+    return _("None") unless status
+    _("%{status} - %{time}") % { :status => status == "Valid" ? valid_str : status,
+                                 :time   => textual_time_ago(updated_on) }
+  end
+
+  def textual_authentication_title(status, updated_on, last_valid_on)
+    if status == "Valid"
+      _("Updated - %{time}") % { :time => textual_time_ago(updated_on) }
+    else
+      times = { :update_time => textual_time_ago(updated_on),
+                :valid_time  => textual_time_ago(last_valid_on) }
+      _("Updated - %{update_time}, Last valid connection - %{valid_time}") % times
+    end
+  end
+
+  def map_authentications(authentications)
+    authentications.map do |auth|
+      { :label => _("%{label} Authentication") % { :label => auth.authtype.to_s.titleize },
+        :value => textual_authentication_value(auth.status, auth.updated_on),
+        :title => textual_authentication_title(auth.status, auth.updated_on, auth.last_valid_on) }
+    end
+  end
+
+  def textual_authentications_status
+    authentications = @ems.authentications.order(:authtype).collect
+    return [{ :label => _("%{label} Authentication") % { :label => @ems.default_authentication_type.to_s.titleize },
+              :title => t = _("None"),
+              :value => t }] if authentications.blank?
+
+    map_authentications(authentications)
+  end
+end

--- a/app/helpers/textual_mixins/textual_metrics_status.rb
+++ b/app/helpers/textual_mixins/textual_metrics_status.rb
@@ -1,0 +1,19 @@
+module TextualMixins::TextualMetricsStatus
+  def textual_metrics_status
+    return {
+      :label => _("Last Metrics Collection"),
+      :title => _("None"),
+      :value => _("None")
+    } unless @ems.last_metrics_update_date
+
+    status        = (@ems.last_metrics_error || :valid).to_s.titleize
+    updated_on    = @ems.last_metrics_update_date
+    last_valid_on = @ems.last_metrics_success_date
+
+    {
+      :label => _("Last Metrics Collection"),
+      :value => textual_authentication_value(status, updated_on, _("Success")),
+      :title => textual_authentication_title(status, updated_on, last_valid_on)
+    }
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -69,6 +69,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     self.class.raw_connect(options[:hostname], options[:port], options)
   end
 
+  def authentications_to_validate
+    at = [:bearer]
+    at << :hawkular if has_authentication_type?(:hawkular)
+    at
+  end
+
   def verify_credentials(auth_type = nil, options = {})
     options = options.merge(:auth_type => auth_type)
     if options[:auth_type] == "hawkular"

--- a/db/migrate/20160808150745_add_metrics_status_to_ext_management_system.rb
+++ b/db/migrate/20160808150745_add_metrics_status_to_ext_management_system.rb
@@ -1,0 +1,7 @@
+class AddMetricsStatusToExtManagementSystem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ext_management_systems, :last_metrics_error, :text
+    add_column :ext_management_systems, :last_metrics_update_date, :timestamp
+    add_column :ext_management_systems, :last_metrics_success_date, :timestamp
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1177,6 +1177,9 @@ ext_management_systems:
 - project
 - parent_ems_id
 - subscription
+- last_metrics_error
+- last_metrics_update_date
+- last_metrics_success_date
 file_depots:
 - id
 - name


### PR DESCRIPTION
**Description**
When gathering hawkular metrics fails, user has no indication in the status ui page.

This PR updates the status of the Metrics Collection Status line each time metrics is collected.
It also display the last update date and time as an html title for each endpoint status, so users can know when the status was last checked.

**Screenshots**
![metrics_valid](https://cloud.githubusercontent.com/assets/2181522/17293840/7901f13a-57fb-11e6-9c25-f0920bb61328.png)

![metrics_invalid](https://cloud.githubusercontent.com/assets/2181522/17293842/7d8534c4-57fb-11e6-8636-79b988907816.png)

**Bugzzila**
https://bugzilla.redhat.com/show_bug.cgi?id=1344308
https://bugzilla.redhat.com/show_bug.cgi?id=1356130