### PR TITLE
[DARGA] template typo factory fix

### DIFF
--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     raw_power_state "running"
   end
 
-  factory :template, :class => "Template", :parent => :vm_or_template do
+  factory :template, :class => "MiqTemplate", :parent => :vm_or_template do
     sequence(:name) { |n| "template_#{seq_padded_for_sorting(n)}" }
     template        true
     raw_power_state "never"


### PR DESCRIPTION
taken from #8339 - **TARGET: DARGA**

This fixes a typo in `factories/vm_or_template.rb`