### PR TITLE
Refactor/fetch encrypted attribute names in API

### DIFF
--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -16,8 +16,9 @@ class ApiController
         return [] unless obj.class.respond_to?(:encrypted_columns)
         klass = obj.class.name
         return unless @encrypted_objects_checked[klass].nil?
-        @encrypted_objects_checked[klass] = obj.class.encrypted_columns
-        @encrypted_objects_checked[klass].each { |attr| normalized_attributes[:encrypted][attr] = true }
+        @encrypted_objects_checked[klass] = obj.class.encrypted_columns.each do |attr|
+          normalized_attributes[:encrypted][attr] = true
+        end
       end
 
       def user_token_service

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -11,10 +11,10 @@ class ApiController
       #
       # Let's fetch encrypted attribute names of objects being rendered if not already done
       #
-      def fetch_encrypted_attribute_names(obj)
+      def fetch_encrypted_attribute_names(klass)
         @encrypted_objects_checked ||= {}
-        return [] unless obj.class.respond_to?(:encrypted_columns)
-        @encrypted_objects_checked[obj.class.name] ||= obj.class.encrypted_columns.each do |attr|
+        return [] unless klass.respond_to?(:encrypted_columns)
+        @encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
           normalized_attributes[:encrypted][attr] = true
         end
       end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -14,8 +14,7 @@ class ApiController
       def fetch_encrypted_attribute_names(obj)
         @encrypted_objects_checked ||= {}
         return [] unless obj.class.respond_to?(:encrypted_columns)
-        klass = obj.class.name
-        @encrypted_objects_checked[klass] ||= obj.class.encrypted_columns.each do |attr|
+        @encrypted_objects_checked[obj.class.name] ||= obj.class.encrypted_columns.each do |attr|
           normalized_attributes[:encrypted][attr] = true
         end
       end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -15,7 +15,7 @@ class ApiController
         @encrypted_objects_checked ||= {}
         klass = obj.class.name
         return unless @encrypted_objects_checked[klass].nil?
-        @encrypted_objects_checked[klass] = object_encrypted_attributes(obj)
+        @encrypted_objects_checked[klass] = obj.class.respond_to?(:encrypted_columns) ? obj.class.encrypted_columns : []
         @encrypted_objects_checked[klass].each { |attr| normalized_attributes[:encrypted][attr] = true }
       end
 
@@ -72,10 +72,6 @@ class ApiController
             normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
           end
         end
-      end
-
-      def object_encrypted_attributes(obj)
-        obj.class.respond_to?(:encrypted_columns) ? obj.class.encrypted_columns : []
       end
     end
   end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -15,8 +15,7 @@ class ApiController
         @encrypted_objects_checked ||= {}
         return [] unless obj.class.respond_to?(:encrypted_columns)
         klass = obj.class.name
-        return unless @encrypted_objects_checked[klass].nil?
-        @encrypted_objects_checked[klass] = obj.class.encrypted_columns.each do |attr|
+        @encrypted_objects_checked[klass] ||= obj.class.encrypted_columns.each do |attr|
           normalized_attributes[:encrypted][attr] = true
         end
       end

--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -13,9 +13,10 @@ class ApiController
       #
       def fetch_encrypted_attribute_names(obj)
         @encrypted_objects_checked ||= {}
+        return [] unless obj.class.respond_to?(:encrypted_columns)
         klass = obj.class.name
         return unless @encrypted_objects_checked[klass].nil?
-        @encrypted_objects_checked[klass] = obj.class.respond_to?(:encrypted_columns) ? obj.class.encrypted_columns : []
+        @encrypted_objects_checked[klass] = obj.class.encrypted_columns
         @encrypted_objects_checked[klass].each { |attr| normalized_attributes[:encrypted][attr] = true }
       end
 

--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -8,7 +8,7 @@ class ApiController
     # virtual subcollections is added.
 
     def normalize_hash(type, obj, opts = {})
-      ApiController.fetch_encrypted_attribute_names(obj)
+      ApiController.fetch_encrypted_attribute_names(obj.class)
       attrs = normalize_select_attributes(obj, opts)
       result = {}
 
@@ -36,7 +36,7 @@ class ApiController
     end
 
     def normalize_virtual_hash(vtype, obj, options)
-      ApiController.fetch_encrypted_attribute_names(obj)
+      ApiController.fetch_encrypted_attribute_names(obj.class)
       attrs = (obj.respond_to?(:attributes) ? obj.attributes.keys : obj.keys)
       attrs.each_with_object({}) do |k, res|
         value = normalize_virtual(vtype, k, obj[k], options)


### PR DESCRIPTION
Purpose or Intent
-----------------
I originally incorporated this refactoring (or similar) into https://github.com/ManageIQ/manageiq/pull/9738 which I think muddled the intention of that PR a bit. I'm pulling it out into this PR for clarity.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti  