### PR TITLE
Remove the validation for detecting spaces in service account for GCE provider 

### DIFF
--- a/app/views/layouts/angular/_auth_service_account_angular.html.haml
+++ b/app/views/layouts/angular/_auth_service_account_angular.html.haml
@@ -14,7 +14,6 @@
                                "ng-model"                => "#{ng_model}.service_account",
                                "prefix"                  => prefix,
                                "ng-trim"                 => false,
-                               "detect_spaces"           => "",
                                "reset-validation-status" => "#{prefix}_auth_status"}
         %span.help-block{"ng-show" => "angularForm.service_account.$error.required"}
           = _("Required")


### PR DESCRIPTION
Remove the directive for detecting spaces in the `service account` input text field.

Fixes https://github.com/ManageIQ/manageiq/issues/9783