### PR TITLE
Enhancement to /api/users for settings

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -89,7 +89,7 @@ class ApiController
     def user_settings
       {
         :locale => I18n.locale.to_s.sub('-', '_'),
-      }
+      }.merge(@auth_user_obj.settings)
     end
 
     def userid_to_userobj(userid)

--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -69,7 +69,7 @@ class ApiController
     def edit_resource(type, id, data)
       klass = collection_class(type)
       resource = resource_search(id, type, klass)
-      resource.update_attributes(data.except(*ID_ATTRS))
+      resource.update_attributes!(data.except(*ID_ATTRS))
       resource
     end
 

--- a/app/controllers/api_controller/users.rb
+++ b/app/controllers/api_controller/users.rb
@@ -1,12 +1,15 @@
 class ApiController
-  INVALID_USER_ATTRS = %w(id href current_group_id)
+  INVALID_USER_ATTRS = %w(id href current_group_id settings).freeze # Cannot update other people's settings
+  INVALID_SELF_USER_ATTRS = %w(id href current_group_id).freeze
 
   module Users
     def update_users
       aname = @req.action
       if aname == "edit" && !api_user_role_allows?(aname) && update_target_is_api_user?
-        if json_body_resource.try(:keys) != %w(password)
-          raise BadRequestError, "Cannot update non-password attributes of the authenticated user resource"
+        editable_attrs = %w(password email settings)
+        if (Array(json_body_resource.try(:keys)) - editable_attrs).present?
+          raise BadRequestError,
+                "Cannot update attributes other than #{editable_attrs.join(', ')} for the authenticated user"
         end
         render_normal_update :users, update_collection(:users, @req.c_id)
       else
@@ -18,6 +21,7 @@ class ApiController
       validate_user_create_data(data)
       parse_set_group(data)
       raise BadRequestError, "Must specify a valid group for creating a user" unless data["miq_groups"]
+      parse_set_settings(data)
       user = collection_class(:users).create(data)
       if user.invalid?
         raise BadRequestError, "Failed to add a new user - #{user.errors.full_messages.join(', ')}"
@@ -26,8 +30,9 @@ class ApiController
     end
 
     def edit_resource_users(type, id, data)
-      validate_user_data(data)
+      (id == @auth_user_obj.id) ? validate_self_user_data(data) : validate_user_data(data)
       parse_set_group(data)
+      parse_set_settings(data, resource_search(id, type, collection_class(type)))
       edit_resource(type, id, data)
     end
 
@@ -48,9 +53,22 @@ class ApiController
       data.merge!("miq_groups" => Array(group)) if group
     end
 
+    def parse_set_settings(data, user = nil)
+      settings = data.delete("settings")
+      if settings.present?
+        current_settings = user.nil? ? {} : user.settings
+        data.merge!("settings" => Hash(current_settings).deep_merge(settings.deep_symbolize_keys))
+      end
+    end
+
     def validate_user_data(data = {})
       bad_attrs = data.keys.select { |k| INVALID_USER_ATTRS.include?(k) }.compact.join(", ")
       raise BadRequestError, "Invalid attribute(s) #{bad_attrs} specified for a user" if bad_attrs.present?
+    end
+
+    def validate_self_user_data(data = {})
+      bad_attrs = data.keys.select { |k| INVALID_SELF_USER_ATTRS.include?(k) }.compact.join(", ")
+      raise BadRequestError, "Invalid attribute(s) #{bad_attrs} specified for the current user" if bad_attrs.present?
     end
 
     def validate_user_create_data(data)

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe "API entrypoint" do
     expect(%w(en en_US)).to include(response_hash['settings']['locale'])
   end
 
+  it "returns users's settings" do
+    api_basic_authorize
+
+    test_settings = {:cartoons => {:saturday => {:tom_jerry => 'n', :bugs_bunny => 'y'}}}
+    @user.update_attributes!(:settings => test_settings)
+
+    run_get entrypoint_url
+
+    expect(response_hash['settings']).to a_hash_including(test_settings.deep_stringify_keys)
+  end
+
   it "collection query is sorted" do
     api_basic_authorize
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "can change the user's own email" do
+      api_basic_authorize action_identifier(:users, :edit)
+
+      expect do
+        run_post users_url(@user.id), gen_request(:edit, :email => "tom@cartoons.com")
+      end.to change { @user.reload.email }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can change the user's own settings" do
+      api_basic_authorize action_identifier(:users, :edit)
+
+      expect do
+        run_post users_url(@user.id), gen_request(:edit, :settings => {:cartoon => {:tom_jerry => 'y'}})
+      end.to change { @user.reload.settings }
+
+      expect(response).to have_http_status(:ok)
+    end
+
     it "will not allow the changing of attributes other than the password, email or settings" do
       api_basic_authorize
 
@@ -76,6 +96,17 @@ RSpec.describe "users API" do
       expect do
         run_post users_url(user.id), gen_request(:edit, :password => "new_password")
       end.not_to change { user.reload.password_digest }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "cannot change another user's settings" do
+      api_basic_authorize
+      user = FactoryGirl.create(:user, :settings => {:locale => "en"})
+
+      expect do
+        run_post users_url(user.id), gen_request(:edit, :settings => {:locale => "ja"})
+      end.not_to change { user.reload.settings }
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:ok)
     end
 
-    it "will not allow the changing of attributes other than the password" do
+    it "will not allow the changing of attributes other than the password, email or settings" do
       api_basic_authorize
 
       expect do
-        run_post users_url(@user.id), gen_request(:edit, :email => "new.email@example.com")
-      end.not_to change { @user.reload.email }
+        run_post users_url(@user.id), gen_request(:edit, :name => "updated_name")
+      end.not_to change { @user.reload.name }
 
       expect(response).to have_http_status(:bad_request)
     end


### PR DESCRIPTION
Purpose or Intent
-----------------

- Users can update their own email and settings in addition to password
- Make sure we cannot edit other people's settings
- Update to /api entry to include all user's settings in the settings element.
- Added tests