### PR TITLE
Fix division by 0 error in reconfigure VM

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
@@ -24,9 +24,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
   end
 
   def build_config_spec(task_options)
-    {"numCoresPerSocket" => task_options[:cores_per_socket].to_i,
-      "memoryMB"         => task_options[:vm_memory].to_i,
-      "numCPUs"          => task_options[:number_of_cpus].to_i
+    {
+      "numCoresPerSocket" => (task_options[:cores_per_socket].to_i if task_options[:cores_per_socket]),
+      "memoryMB"          => (task_options[:vm_memory].to_i if task_options[:vm_memory]),
+      "numCPUs"           => (task_options[:number_of_cpus].to_i if task_options[:number_of_cpus])
     }
   end
 end


### PR DESCRIPTION
The logic of reconfigure vm relies on the existence of
values for vm reconfiguration properties. If a property
wasn't provided by the user, the value shouldn't be considered as '0'.

http://bugzilla.redhat.com/1352509