### PR TITLE
Fix Ceilometer Events for Openstack 9

### DIFF
--- a/gems/pending/openstack/events/openstack_ceilometer_event_monitor.rb
+++ b/gems/pending/openstack/events/openstack_ceilometer_event_monitor.rb
@@ -70,7 +70,7 @@ class OpenstackCeilometerEventMonitor < OpenstackEventMonitor
   def query_options
     [{
       'field' => 'start_timestamp',
-      'op'    => 'gt',
+      'op'    => 'ge',
       'value' => latest_event_timestamp || ''
     }]
   end


### PR DESCRIPTION
Ceilometer Events query now uses 'ge' operator instead of 'gt'
because only 'eq', 'ge', 'le' operators are allowed in Ceilomemeter
API since Mitaka release - rhbz#1337961.

This change works on older Openstack versions with Ceilometer too.

https://bugzilla.redhat.com/show_bug.cgi?id=1337429