### PR TITLE
hide view toggle buttons in utilization and timelines views

### DIFF
--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -39,7 +39,7 @@ class ApplicationHelper::ToolbarChooser
       'compare_view_tb'
     elsif @lastaction == "drift"
       'drift_view_tb'
-    elsif %w(ems_container).include?(@layout)
+    elsif %w(ems_container).include?(@layout) && %(main dashboard topology).include?(@display)
       'dashboard_summary_toggle_view_tb'
     elsif !%w(all_tasks all_ui_tasks timeline diagnostics my_tasks my_ui_tasks miq_server usage).include?(@layout) &&
           (!@layout.starts_with?("miq_request")) && !@treesize_buttons &&


### PR DESCRIPTION
Before:
![screencapture-localhost-3000-ems_container-5-1468494508101](https://cloud.githubusercontent.com/assets/11256940/16837551/913cda2c-49cc-11e6-8c17-5fd42f689b8f.png)

After:
![screencapture-localhost-3000-ems_container-5-1468494398042](https://cloud.githubusercontent.com/assets/11256940/16837472/348476a0-49cc-11e6-9395-e90041629fd8.png)

@miq-bot add_label ui, providers/containers
cc @simon3z 