### PR TITLE
Load custom attribute columns from miq expression when report is generated

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1560,6 +1560,26 @@ class MiqExpression
     end
   end
 
+  def custom_attribute_columns(expression = nil)
+    return custom_attribute_columns(exp).uniq if expression.nil?
+
+    case expression
+    when Array
+      expression.flat_map { |x| custom_attribute_columns(x) }
+    when Hash
+      expression_values = expression.values
+
+      if expression.keys.first == "field"
+        field = Field.parse(expression_values.first)
+        field.custom_attribute_column? ? [field.column] : []
+      else
+        expression.keys.first.casecmp('find').zero? ? [] : custom_attribute_columns(expression_values)
+      end
+    else
+      []
+    end
+  end
+
   private
 
   def to_arel(exp, tz)

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -2,7 +2,7 @@ class MiqExpression::Field
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
 \.?(?<associations>[a-z_\.]+)*
--(?<column>[a-z]+(_[a-z]+)*)
+-(?<column>[a-z]+(_[[:alnum:]]+)*)
 /x
 
   ParseError = Class.new(StandardError)
@@ -36,6 +36,10 @@ class MiqExpression::Field
   def plural?
     return false if reflections.empty?
     [:has_many, :has_and_belongs_to_many].include?(reflections.last.macro)
+  end
+
+  def custom_attribute_column?
+    @column.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
   end
 
   def reflections

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -39,7 +39,7 @@ class MiqExpression::Field
   end
 
   def custom_attribute_column?
-    @column.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
+    column.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
   end
 
   def reflections

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -200,7 +200,8 @@ class MiqReport < ApplicationRecord
   def load_custom_attributes
     klass = db.safe_constantize
     return unless klass < CustomAttributeMixin
-    klass.load_custom_attributes_for(cols)
+    cols.concat(conditions.custom_attribute_columns) if conditions.present?
+    klass.load_custom_attributes_for(cols.uniq)
   end
 
   # this method adds :custom_attributes => {} to MiqReport#include


### PR DESCRIPTION
Purpose or Intent
-----------------
Custom virtual dynamic field for reporting have been introduced here https://github.com/ManageIQ/manageiq/pull/9451 
When we are using custom virtual dynamic fields in filters (MiqExpression) and these field are not listed in MiqReport#cols (selected fields for report) then it was causing error message when such report is generated for first time.

This fix is loading virtual custom fields from MiqExpression.  

Links
-----
> https://github.com/ManageIQ/manageiq/pull/9451 


cc @gtanzillo 
fyi @imtayadeway 


@miq-bot add_label reporting, bug
