### PR TITLE
Add CRUD support for VMware vCloud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ gem "savon",                          "~>2.2.0",   :require => false  # Automate
 gem "snmp",                           "~>1.2.0",   :require => false
 gem "uglifier",                       "~>2.7.1",   :require => false
 gem "sshkey",                         "~>1.8.0",   :require => false
+gem "fog-vcloud-director",            "~>0.1.1",   :require => false
 
 
 ### Start of gems excluded from the appliances.

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -1,0 +1,87 @@
+class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudManager
+  def self.ems_type
+    @ems_type ||= "vmware_cloud".freeze
+  end
+
+  def self.description
+    @description ||= "VMware vCloud".freeze
+  end
+
+  def self.default_blacklisted_event_names
+    []
+  end
+
+  def self.hostname_required?
+    true
+  end
+
+  def supports_port?
+    true
+  end
+
+  def supported_auth_types
+    %w(default)
+  end
+
+  def supports_authentication?(authtype)
+    supported_auth_types.include?(authtype.to_s)
+  end
+
+  #
+  # Connections
+  #
+
+  def self.raw_connect(server, port, username, password)
+    require 'fog/vcloud_director'
+
+    params = {
+      :vcloud_director_username      => username,
+      :vcloud_director_password      => password,
+      :vcloud_director_host          => server,
+      :vcloud_director_show_progress => false,
+      :port                          => port,
+      :connection_options            => {
+        :ssl_verify_peer => false # for development
+      }
+    }
+
+    Fog::Compute::VcloudDirector.new(params)
+  end
+
+  def connect(options = {})
+    raise "no credentials defined" if missing_credentials?(options[:auth_type])
+
+    server   = options[:ip] || address
+    port     = options[:port] || self.port
+    username = options[:user] || authentication_userid(options[:auth_type])
+    password = options[:pass] || authentication_password(options[:auth_type])
+
+    self.class.raw_connect(server, port, username, password)
+  end
+
+  def translate_exception(err)
+    case err
+    when Fog::Compute::VcloudDirector::Unauthorized
+      MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
+    else
+      MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
+    end
+  end
+
+  def verify_credentials(auth_type = nil, options = {})
+    raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
+
+    begin
+      with_provider_connection(options.merge(:auth_type => auth_type)) do |vcd|
+        vcd.organizations.all
+      end
+    rescue => err
+      miq_exception = translate_exception(err)
+
+      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+      raise miq_exception
+    end
+
+    true
+  end
+end

--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -32,3 +32,4 @@
 - ems-type:rhevm
 - ems-type:scvmm
 - ems-type:vmwarews
+- ems-type:vmware_cloud

--- a/config/secrets.yml.sample
+++ b/config/secrets.yml.sample
@@ -9,6 +9,11 @@ development:
     client_secret: yyyyy
     tenant_id: zzzzz
 
+  vmware_cloud:
+    host: xxxxx
+    userid: yyyyy
+    password: zzzzz
+
 test:
   azure:
     client_id: xxxxx
@@ -19,3 +24,8 @@ test:
     client_id: xxxxx
     client_secret: yyyyy
     tenant_id: zzzzz
+
+  vmware_cloud:
+    host: xxxxx
+    userid: yyyyy
+    password: zzzzz

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Vmware_CloudManager < MiqAeServiceManageIQ_Providers_CloudManager
+  end
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -123,6 +123,12 @@ FactoryGirl.define do
     end
   end
 
+  factory :ems_vmware_cloud,
+          :aliases => ["manageiq/providers/vmware/cloud_manager"],
+          :class   => "ManageIQ::Providers::Vmware::CloudManager",
+          :parent  => :ems_cloud do
+  end
+
   # Leaf classes for ems_cloud
 
   factory :ems_amazon,

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -39,6 +39,7 @@ describe ExtManagementSystem do
       "rhevm"                       => "Red Hat Enterprise Virtualization Manager",
       "scvmm"                       => "Microsoft System Center VMM",
       "vmwarews"                    => "VMware vCenter",
+      "vmware_cloud"                => "VMware vCloud",
     }
   end
 

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -3,7 +3,8 @@ describe EmsCloud do
     expected_types = [ManageIQ::Providers::Amazon::CloudManager,
                       ManageIQ::Providers::Azure::CloudManager,
                       ManageIQ::Providers::Openstack::CloudManager,
-                      ManageIQ::Providers::Google::CloudManager].collect(&:ems_type)
+                      ManageIQ::Providers::Google::CloudManager,
+                      ManageIQ::Providers::Vmware::CloudManager].collect(&:ems_type)
     expect(described_class.types).to match_array(expected_types)
   end
 
@@ -11,7 +12,8 @@ describe EmsCloud do
     expected_subclasses = [ManageIQ::Providers::Amazon::CloudManager,
                            ManageIQ::Providers::Azure::CloudManager,
                            ManageIQ::Providers::Openstack::CloudManager,
-                           ManageIQ::Providers::Google::CloudManager]
+                           ManageIQ::Providers::Google::CloudManager,
+                           ManageIQ::Providers::Vmware::CloudManager]
     expect(described_class.supported_subclasses).to match_array(expected_subclasses)
   end
 
@@ -19,7 +21,8 @@ describe EmsCloud do
     expected_types = [ManageIQ::Providers::Amazon::CloudManager,
                       ManageIQ::Providers::Azure::CloudManager,
                       ManageIQ::Providers::Openstack::CloudManager,
-                      ManageIQ::Providers::Google::CloudManager].collect(&:ems_type)
+                      ManageIQ::Providers::Google::CloudManager,
+                      ManageIQ::Providers::Vmware::CloudManager].collect(&:ems_type)
     expect(described_class.supported_types).to match_array(expected_types)
   end
 end

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -1,0 +1,58 @@
+describe ManageIQ::Providers::Vmware::CloudManager do
+  before(:context) do
+    @host = Rails.application.secrets.vmware_cloud.try(:[], 'host') || 'vmwarecloudhost'
+    host_uri = URI.parse("https://#{@host}")
+
+    @hostname = host_uri.host
+    @port = host_uri.port == 443 ? nil : host_uri.port
+
+    @userid = Rails.application.secrets.vmware_cloud.try(:[], 'userid') || 'VMWARE_CLOUD_USERID'
+    @password = Rails.application.secrets.vmware_cloud.try(:[], 'password') || 'VMWARE_CLOUD_PASSWORD'
+
+    VCR.configure do |c|
+      # workaround for escaping host in spec/spec_helper.rb
+      c.before_playback do |interaction|
+        interaction.filter!(CGI.escape(@host), @host)
+        interaction.filter!(CGI.escape('VMWARE_CLOUD_HOST'), 'vmwarecloudhost')
+      end
+
+      c.filter_sensitive_data('VMWARE_CLOUD_AUTHORIZATION') { Base64.encode64("#{@userid}:#{@password}").chomp }
+      c.filter_sensitive_data('VMWARE_CLOUD_INVALIDAUTHORIZATION') { Base64.encode64("#{@userid}:invalid").chomp }
+    end
+  end
+
+  before(:example) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryGirl.create(
+      :ems_vmware_cloud,
+      :zone     => zone,
+      :hostname => @hostname,
+      :port     => @port
+    )
+  end
+
+  it ".ems_type" do
+    expect(described_class.ems_type).to eq('vmware_cloud')
+  end
+
+  it ".description" do
+    expect(described_class.description).to eq('VMware vCloud')
+  end
+
+  it "will verify credentials" do
+    VCR.use_cassette("#{described_class.name.underscore}_valid_credentials") do
+      @ems.update_authentication(:default => {:userid => @userid, :password => @password})
+
+      expect(@ems.verify_credentials).to eq(true)
+    end
+  end
+
+  it "will fail to verify invalid credentials" do
+    VCR.use_cassette("#{described_class.name.underscore}_invalid_credentials") do
+      @ems.update_authentication(:default => {:userid => @userid, :password => 'invalid'})
+
+      expect { @ems.verify_credentials }.to raise_error(
+        MiqException::MiqInvalidCredentialsError, 'Login failed due to a bad username or password.')
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager_invalid_credentials.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager_invalid_credentials.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://VMWARE_CLOUD_HOST/api/sessions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      Authorization:
+      - Basic VMWARE_CLOUD_INVALIDAUTHORIZATION
+  response:
+    status:
+      code: 401
+      message: ''
+    headers:
+      Date:
+      - Fri, 15 Jul 2016 11:15:51 GMT
+      Www-Authenticate:
+      - BASIC realm="vCloud"
+      X-Vmware-Vcloud-Request-Id:
+      - 02602cb7-f8e4-46e1-a34f-070d08210b57
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 15 Jul 2016 11:15:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager_valid_credentials.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager_valid_credentials.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://VMWARE_CLOUD_HOST/api/sessions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      Authorization:
+      - Basic VMWARE_CLOUD_AUTHORIZATION
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/vnd.vmware.vcloud.session+xml;version=5.1
+      Date:
+      - Fri, 15 Jul 2016 11:15:50 GMT, Fri, 15 Jul 2016 11:15:51 GMT
+      Set-Cookie:
+      - vcloud-token=5d96f19a28ed42c4a1ec2fdb2718adef; Secure; Path=/
+      X-Vcloud-Authorization:
+      - 5d96f19a28ed42c4a1ec2fdb2718adef
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '185'
+      X-Vmware-Vcloud-Request-Id:
+      - c76da6fa-e862-4e58-bc55-3d155cc24c34
+      Content-Length:
+      - '1205'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Session xmlns="http://www.vmware.com/vcloud/v1.5" org="xlab" user="admin" href="https://VMWARE_CLOUD_HOST/api/session" type="application/vnd.vmware.vcloud.session+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://91.223.115.135/api/v1.5/schema/master.xsd">
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/" type="application/vnd.vmware.vcloud.orgList+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/session"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/admin/" type="application/vnd.vmware.admin.vcloud+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/7a9d63a6-b3ee-474e-884d-9a184beb95d3" name="xlab" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/query" type="application/vnd.vmware.vcloud.query.queryList+xml"/>
+            <Link rel="entityResolver" href="https://VMWARE_CLOUD_HOST/api/entity/" type="application/vnd.vmware.vcloud.entity+xml"/>
+            <Link rel="down:extensibility" href="https://VMWARE_CLOUD_HOST/api/extensibility" type="application/vnd.vmware.vcloud.apiextensibility+xml"/>
+        </Session>
+    http_version: 
+  recorded_at: Fri, 15 Jul 2016 11:15:51 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/org
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5d96f19a28ed42c4a1ec2fdb2718adef
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/vnd.vmware.vcloud.orglist+xml;version=5.1
+      Date:
+      - Fri, 15 Jul 2016 11:15:51 GMT, Fri, 15 Jul 2016 11:15:51 GMT
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '9'
+      X-Vmware-Vcloud-Request-Id:
+      - 1c3bf23b-04d0-4c62-acf3-5c136ff64ca9
+      Content-Length:
+      - '491'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <OrgList xmlns="http://www.vmware.com/vcloud/v1.5" href="https://VMWARE_CLOUD_HOST/api/org/" type="application/vnd.vmware.vcloud.orgList+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://91.223.115.135/api/v1.5/schema/master.xsd">
+            <Org href="https://VMWARE_CLOUD_HOST/api/org/7a9d63a6-b3ee-474e-884d-9a184beb95d3" name="xlab" type="application/vnd.vmware.vcloud.org+xml"/>
+        </OrgList>
+    http_version: 
+  recorded_at: Fri, 15 Jul 2016 11:15:51 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Purpose or Intent
-----------------
Add CRUD support for VMware vCloud cloud provider as discussed with @sergio-ocon and @agrare. This is the first pull request in the series.

* forked `fog` and created `fog-vcloud-director` gem (could not add fog as a dependency)
* basic cloud provider structure

Links
-----
* https://github.com/xlab-si/fog-vcloud-director

Steps for Testing/QA
--------------------
/