### PR TITLE
Fix incorrect line terminators in user_suspend_vm_ok.yaml file.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_suspend_vm_ok.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_suspend_vm_ok.yaml
@@ -3,10 +3,10 @@ object_type: instance
 version: 1.0
 object:
   attributes:
-    display_name:
+    display_name: 
     name: USER_SUSPEND_VM_OK
-    inherits:
-    description:
+    inherits: 
+    description: 
   fields:
   - rel4:
       value: "/System/event_handlers/change_event_target_state?target=src_vm&param=suspended"


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix incorrect line terminators in user_suspend_vm_ok.yaml file which was introduced in #9736.

Links
-----
Fix #9797.