### PR TITLE
Broken export of Policy that have no EventDefinition

### DIFF
--- a/app/models/miq_policy_content.rb
+++ b/app/models/miq_policy_content.rb
@@ -26,7 +26,7 @@ class MiqPolicyContent < ApplicationRecord
     h = attributes
     ["id", "created_on", "updated_on", "miq_policy_id", "miq_event_definition_id", "miq_action_id"].each { |k| h.delete(k) }
     h.delete_if { |_k, v| v.nil? }
-    h["MiqEventDefinition"]  = miq_event_definition.export_to_array.first["MiqEventDefinition"]
+    h["MiqEventDefinition"] = miq_event_definition.export_to_array.first["MiqEventDefinition"] if miq_event_definition
     h["MiqAction"] = miq_action.export_to_array.first["MiqAction"] if miq_action
     [self.class.to_s => h]
   end

--- a/spec/models/miq_policy_content_spec.rb
+++ b/spec/models/miq_policy_content_spec.rb
@@ -1,0 +1,8 @@
+describe MiqPolicyContent do
+  context 'Empty content' do
+    describe '#export_to_array' do
+      subject { FactoryGirl.create(:miq_policy_content).export_to_array }
+      it { is_expected.to match_array(['MiqPolicyContent'=>{}]) }
+    end
+  end
+end


### PR DESCRIPTION
Addressing UI failure on Control/Export/Policy -> Export action:
```
Error during export: undefined method `export_to_array' for nil:NilClass
```
![export-fail](https://cloud.githubusercontent.com/assets/6666052/16842941/9bf4e4c4-49df-11e6-87e7-52199d33fb25.jpg)

@miq-bot add_label control, bug
