### PR TITLE
Upgrade docker image to postgres95

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,10 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
                    nodejs                  \
                    openssl-devel           \
                    patch                   \
-                   rh-postgresql94-postgresql-server \
-                   rh-postgresql94-postgresql-devel  \
-                   rh-postgresql94-postgresql-pglogical-output \
-                   rh-postgresql94-postgresql-pglogical \
+                   rh-postgresql95-postgresql-server \
+                   rh-postgresql95-postgresql-devel  \
+                   rh-postgresql95-postgresql-pglogical-output \
+                   rh-postgresql95-postgresql-pglogical \
                    readline-devel          \
                    sqlite-devel            \
                    sysvinit-tools          \
@@ -61,7 +61,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     yum clean all
 
 # Add persistent data volume for postgres
-VOLUME [ "/var/opt/rh/rh-postgresql94/lib/pgsql/data" ]
+VOLUME [ "/var/opt/rh/rh-postgresql95/lib/pgsql/data" ]
 
 # Download chruby and chruby-install, install, setup environment, clean all
 RUN curl -sL https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz | tar xz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,13 @@ ENV APP_ROOT /var/www/miq/vmdb
 ENV APPLIANCE_ROOT /opt/manageiq/manageiq-appliance
 ENV SSUI_ROOT /opt/manageiq/manageiq-ui-self_service
 
-# Fetch postgresql 9.4 COPR and pglogical repos
-RUN curl -sSLko /etc/yum.repos.d/rhscl-rh-postgresql94-epel-7.repo \
-      https://copr-fe.cloud.fedoraproject.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo && \
-    curl -sSLko /etc/yum.repos.d/ncarboni-pglogical-SCL-epel-7.repo \
+# Fetch pglogical repo
+RUN curl -sSLko /etc/yum.repos.d/ncarboni-pglogical-SCL-epel-7.repo \
       https://copr.fedorainfracloud.org/coprs/ncarboni/pglogical-SCL/repo/epel-7/ncarboni-pglogical-SCL-epel-7.repo
 
 ## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum -y install centos-release-scl-rh && \
     yum -y install --setopt=tsflags=nodocs \
                    bison                   \
                    bzip2                   \


### PR DESCRIPTION
Upgrade the package list and volume path in the Docker file to be compatible with PostgreSQL 9.5

This change is really a port of two PRs on the manageiq-appliance-build repo

ManageIQ/manageiq-appliance-build#137 - which changes the repo we pull postgres packages from (the old one didn't have 9.5)
ManageIQ/manageiq-appliance-build#140 - which updates the package names and paths.

@bdunne please review