### PR TITLE
Network menu tabs needs to be all plural

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -150,9 +150,9 @@ module Menu
           Menu::Item.new('ems_network',      N_('Providers'),       'ems_network',      {:feature => 'ems_network_show_list'},    '/ems_network'),
           Menu::Item.new('cloud_network',    N_('Networks'),        'cloud_network',    {:feature => 'cloud_network_show_list'},  '/cloud_network'),
           Menu::Item.new('cloud_subnet',     N_('Subnets'),         'cloud_subnet',     {:feature => 'cloud_subnet_show_list'},   '/cloud_subnet'),
-          Menu::Item.new('network_router',   N_('Network Router'),  'network_router',   {:feature => 'network_router_show_list'}, '/network_router'),
+          Menu::Item.new('network_router',   N_('Network Routers'), 'network_router',   {:feature => 'network_router_show_list'}, '/network_router'),
           Menu::Item.new('security_group',   N_('Security Groups'), 'security_group',   {:feature => 'security_group_show_list'}, '/security_group'),
-          Menu::Item.new('floating_ip',      N_('Floating IP'),     'floating_ip',      {:feature => 'floating_ip_show_list'},    '/floating_ip'),
+          Menu::Item.new('floating_ip',      N_('Floating IPs'),    'floating_ip',      {:feature => 'floating_ip_show_list'},    '/floating_ip'),
           Menu::Item.new('network_port',     N_('Network Ports'),   'network_port',     {:feature => 'network_port_show_list'},   '/network_port'),
           Menu::Item.new('network_topology', N_('Topology'),        'network_topology', {:feature => 'network_topology'},         '/network_topology'),
         ])


### PR DESCRIPTION
Network menu tabs needs to be all plural

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1356025