### PR TITLE
Fix gen_time_attr_type_hash in ApiController

### DIFF
--- a/app/controllers/api_controller/initializer.rb
+++ b/app/controllers/api_controller/initializer.rb
@@ -70,7 +70,7 @@ class ApiController
       # Let's dynamically get the :date and :datetime attributes from the Classes we care about.
       #
       def gen_time_attr_type_hash
-        Api::Settings.collections.each_value do |cspec|
+        Api::Settings.collections.each do |_, cspec|
           next if cspec[:klass].blank?
           klass = cspec[:klass].constantize
           klass.columns_hash.collect  do |name, typeobj|

--- a/spec/requests/api/normalization_spec.rb
+++ b/spec/requests/api/normalization_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe "Normalization of objects API" do
+  it "represents datetimes in ISO8601 format" do
+    api_basic_authorize action_identifier(:hosts, :read, :resource_actions, :get)
+    host = FactoryGirl.create(:host)
+
+    run_get(hosts_url(host.id))
+
+    expect(response_hash).to include("created_on" => host.created_on.iso8601)
+  end
+end


### PR DESCRIPTION
When the API config was changed to be a `Config::Options`,
`Api::Settings.collections` stopped responding properly to `each_value`
- it now just returns `nil` and does not execute the block. Changing it
to `each` fixes the issue.

@miq-bot add-label bug, api
@miq-bot assign @abellotti 

/cc @isimluk 