### PR TITLE
Remove N+1 queries from NetworkManager list pages

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -10,14 +10,12 @@ class CloudNetwork < ApplicationRecord
   belongs_to :cloud_tenant
   belongs_to :orchestration_stack
 
-  has_many   :cloud_subnets, :dependent => :destroy
-  has_many   :network_ports, :through => :cloud_subnets
-  has_many   :floating_ips,  :dependent => :destroy
-
-  # TODO(lsmola) Defaulting CloudNetwork for Private network behaviour, otherwise I am unable to model
-  # vm.public_networks. Not specifying it here causes missing method, ans specifying CloudNetwork::Private
-  # causes filtering networks by Private, while I want to filter Public.
-  include CloudNetworkPrivateMixin
+  has_many :cloud_subnets, :dependent => :destroy
+  has_many :network_routers, -> { distinct }, :through => :cloud_subnets
+  has_many :public_networks, -> { distinct }, :through => :cloud_subnets
+  has_many :network_ports, :through => :cloud_subnets
+  has_many :floating_ips,  :dependent => :destroy
+  has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
   # TODO(lsmola) figure out what this means, like security groups used by VMs in the network? It's not being
   # refreshed, so we can probably delete this association
@@ -40,7 +38,7 @@ class CloudNetwork < ApplicationRecord
     end
   end
 
-  virtual_total :total_vms, :vms
+  virtual_total :total_vms, :vms, :uses => :vms
 
   private
 

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -19,6 +19,8 @@ class CloudSubnet < ApplicationRecord
   has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
   has_many :cloud_subnets, :foreign_key => :parent_cloud_subnet_id
 
+  has_one :public_network, :through => :network_router, :source => :cloud_network
+
   # Use for virtual columns, mainly for modeling array and hash types, we get from the API
   serialize :extra_attributes
   serialize :dns_nameservers
@@ -44,7 +46,7 @@ class CloudSubnet < ApplicationRecord
   end
   virtual_column :dns_nameservers_show, :type => :string, :uses => :dns_nameservers
 
-  virtual_total :total_vms, :vms
+  virtual_total :total_vms, :vms, :uses => :vms
 
   private
 

--- a/app/models/manageiq/providers/azure/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/azure/network_manager/security_group.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Azure::NetworkManager::SecurityGroup < ::SecurityGroup
-  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 end

--- a/app/models/manageiq/providers/google/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/google/network_manager/security_group.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Google::NetworkManager::SecurityGroup < ::SecurityGroup
-  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 end

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network/private.rb
@@ -1,8 +1,2 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
-  include CloudNetworkPrivateMixin
-
-  has_many :cloud_subnets, :class_name  => "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet",
-                           :foreign_key => :cloud_network_id, :dependent => :destroy
-  has_many :network_routers, -> { distinct }, :through => :cloud_subnets
-  has_many :public_networks, -> { distinct }, :through => :cloud_subnets
 end

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubnet
-  belongs_to :network_router, :class_name => "ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter"
-
-  has_one :public_network, :through => :network_router, :source => :cloud_network
 end

--- a/app/models/manageiq/providers/openstack/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_port.rb
@@ -1,7 +1,2 @@
 class ManageIQ::Providers::Openstack::NetworkManager::NetworkPort < ::NetworkPort
-  has_many :cloud_subnets, :through    => :cloud_subnet_network_ports,
-                           :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet"
-  has_many :network_routers, :through    => :cloud_subnets,
-                             :class_name => "ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter"
-  has_many :public_networks, :through => :cloud_subnets
 end

--- a/app/models/manageiq/providers/openstack/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_router.rb
@@ -1,8 +1,2 @@
 class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkRouter
-  belongs_to :cloud_network
-  alias public_network cloud_network
-
-  has_many :floating_ips, :through => :cloud_network
-  has_many :cloud_networks, :through => :cloud_subnets
-  alias private_networks cloud_networks
 end

--- a/app/models/manageiq/providers/openstack/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/security_group.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::SecurityGroup
-  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 end

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -17,6 +17,7 @@ class NetworkPort < ApplicationRecord
   has_many :cloud_subnet_network_ports
   has_many :cloud_subnets, :through => :cloud_subnet_network_ports
   has_many :network_routers, -> { distinct }, :through => :cloud_subnets
+  has_many :public_networks, :through => :cloud_subnets
 
   # Use for virtual columns, mainly for modeling array and hash types, we get from the API
   serialize :extra_attributes

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -15,6 +15,12 @@ class NetworkRouter < ApplicationRecord
   has_many :network_ports, :through => :cloud_subnets
   has_many :vms, :through => :cloud_subnets
 
+  has_many :floating_ips, :through => :cloud_network
+  has_many :cloud_networks, :through => :cloud_subnets
+
+  alias private_networks cloud_networks
+  alias public_network cloud_network
+
   # Use for virtual columns, mainly for modeling array and hash types, we get from the API
   serialize :extra_attributes
 

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -13,10 +13,12 @@ class SecurityGroup < ApplicationRecord
   belongs_to :network_group
   has_many   :firewall_rules, :as => :resource, :dependent => :destroy
 
-  has_and_belongs_to_many :vms
-  has_and_belongs_to_many :network_ports
+  has_many :network_port_security_groups
+  has_many :network_ports, :through => :network_port_security_groups
+  # TODO(lsmola) we should be able to remove table security_groups_vms, if it's unused now. Can't be backported
+  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
-  virtual_total :total_vms, :vms, :arel => nil
+  virtual_total :total_vms, :vms, :uses => :vms
 
   def self.non_cloud_network
     where(:cloud_network_id => nil)

--- a/spec/models/security_group_spec.rb
+++ b/spec/models/security_group_spec.rb
@@ -13,7 +13,13 @@ describe SecurityGroup do
   describe "#total_vms" do
     it "counts vms" do
       sg = FactoryGirl.create(:security_group)
-      2.times { sg.vms.create(FactoryGirl.attributes_for(:vm)) }
+
+      2.times do
+        vm = FactoryGirl.create(:vm_amazon)
+        FactoryGirl.create(:network_port_openstack,
+                           :device          => vm,
+                           :security_groups => [sg])
+      end
       expect(sg.reload.total_vms).to eq(2)
     end
 


### PR DESCRIPTION
Purpose or Intent
-----------------

N+1 was caused by STI inheritance of relations, for virtual
methods to work correctly, we need to hold the relations on a base
classes.

Steps for Testing/QA
--------------------

Turn on logging of SQL queries, you should not see any list page generating N+1 queries.
