### PR TITLE
Update rest-client dependency to 2.0.0.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -42,7 +42,7 @@ gem "ovirt",                   "~>0.11.0",          :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rbvmomi",                 "~>1.8.0",           :require => false
-gem "rest-client",             "=2.0.0.rc1",        :require => false
+gem "rest-client",             "~>2.0.0",           :require => false
 gem "rubyzip",                 "~>1.2.0",           :require => false
 gem "zip-zip",                 "~>0.3.0",           :require => false
 gem "rufus-lru",               "~>1.0.3",           :require => false


### PR DESCRIPTION
This PR updates the rest-client dependency to 2.0.0 (just released July 2, 2016) from the RC release.

