### PR TITLE
Migrate HostStorages ems_ref from reserved table

### DIFF
--- a/db/migrate/20160713141244_upgrade_host_storage_from_reserved.rb
+++ b/db/migrate/20160713141244_upgrade_host_storage_from_reserved.rb
@@ -1,0 +1,23 @@
+class UpgradeHostStorageFromReserved < ActiveRecord::Migration[5.0]
+  class HostStorage < ActiveRecord::Base
+    include ReservedMixin
+    include MigrationStubHelper
+  end
+
+  def up
+    say_with_time("Migrate data from reserved table to host_storages") do
+      HostStorage.includes(:reserved_rec).each do |hs|
+        hs.reserved_hash_migrate(:ems_ref)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrate data from host_storages to reserved table") do
+      HostStorage.includes(:reserved_rec).each do |hs|
+        hs.reserved_hash_set(:ems_ref, hs.ems_ref)
+        hs.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20160713141244_upgrade_host_storage_from_reserved_spec.rb
+++ b/spec/migrations/20160713141244_upgrade_host_storage_from_reserved_spec.rb
@@ -1,0 +1,48 @@
+require_migration
+
+describe UpgradeHostStorageFromReserved do
+  let(:reserve_stub)      { MigrationSpecStubs.reserved_stub }
+  let(:host_storage_stub) { migration_stub(:HostStorage) }
+
+  migration_context :up do
+    it "Migrates Reserves data to HostStorage" do
+      hs = host_storage_stub.create!
+      reserve_stub.create!(
+        :resource_type => "HostStorage",
+        :resource_id   => hs.id,
+        :reserved      => {
+          :ems_ref => "datastore-1"
+        }
+      )
+
+      migrate
+
+      hs.reload
+
+      expect(reserve_stub.count).to eq(0)
+      expect(hs.ems_ref).to eq("datastore-1")
+    end
+  end
+
+  migration_context :down do
+    it "Migrates ems_ref in HostStorage to Reserves table" do
+      host    = FactoryGirl.create(:host)
+      storage = FactoryGirl.create(:storage)
+
+      hs = host_storage_stub.create!(
+        :host_id    => host.id,
+        :storage_id => storage.id,
+        :ems_ref    => "datastore-1"
+      )
+
+      migrate
+
+      r = reserve_stub.first
+
+      expect(reserve_stub.count).to eq(1)
+      expect(r.resource_id).to   eq(hs.id)
+      expect(r.resource_type).to eq("HostStorage")
+      expect(r.reserved).to      eq(:ems_ref => "datastore-1")
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Migrate data that was added to the reserve table for the HostStorages model, specifically the ems_ref attribute.

This was added originally in https://github.com/ManageIQ/manageiq/pull/9670 to fix provisioning when a storage has different ems_refs.
The backport to darga is here https://github.com/ManageIQ/manageiq/pull/9688 and uses the Reserve table to avoid a db schema change.

/cc @lpichler migration currently fails with `GoodMigrations` due to `lib/reserved_mixin.rb` pulling in `app/models/reserve.rb`