### PR TITLE
Check the host's CPU limit only when VM has a host.

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
   end
 
   def max_total_vcpus
-    [host.hardware.cpu_total_cores, max_total_vcpus_by_version].min
+    host ? [host.hardware.cpu_total_cores, max_total_vcpus_by_version].min : max_total_vcpus_by_version
   end
 
   def max_total_vcpus_by_version

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -53,6 +53,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
     it "big host logical cpus" do
       expect(subject).to eq(8)
     end
+
+    it 'when no host' do
+      vm.update_attributes(:host_id => nil)
+      expect(subject).to eq(vm.max_total_vcpus_by_version)
+    end
   end
 
   context "#build_config_spec" do


### PR DESCRIPTION
Purpose or Intent
-----------------
A VM's host may be nil if the VM is not running and is not assigned to run on a particular host.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1350965