### PR TITLE
Refactor API spec helper expect_result_resource_keys_to_be_like_klass

### DIFF
--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -106,7 +106,7 @@ describe ApiController do
       run_post(providers_url, sample_rhevm)
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       provider_id = response.parsed_body["results"].first["id"]
@@ -121,7 +121,7 @@ describe ApiController do
       run_post(providers_url, sample_openshift.merge("credentials" => [openshift_credentials]))
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
       expect_results_to_match_hash("results", [sample_openshift.except(*ENDPOINT_ATTRS)])
 
       provider_id = response.parsed_body["results"].first["id"]
@@ -139,7 +139,7 @@ describe ApiController do
       run_post(providers_url, gen_request(:create, sample_rhevm))
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       provider_id = response.parsed_body["results"].first["id"]
@@ -152,7 +152,7 @@ describe ApiController do
       run_post(providers_url, sample_vmware.merge("credentials" => default_credentials))
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
       expect_results_to_match_hash("results", [sample_vmware.except(*ENDPOINT_ATTRS)])
 
       provider_id = response.parsed_body["results"].first["id"]
@@ -168,7 +168,7 @@ describe ApiController do
       run_post(providers_url, sample_rhevm.merge("credentials" => compound_credentials))
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       provider_id = response.parsed_body["results"].first["id"]
@@ -186,7 +186,7 @@ describe ApiController do
       run_post(providers_url, gen_request(:create, [sample_vmware, sample_rhevm]))
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => all(a_hash_including("id" => kind_of(Integer))))
       expect_results_to_match_hash("results",
                                    [sample_vmware.except(*ENDPOINT_ATTRS), sample_rhevm.except(*ENDPOINT_ATTRS)])
 

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -106,8 +106,12 @@ describe ApiController do
       run_post(providers_url, sample_rhevm)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
-      expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
+      expected = {
+        "results" => [
+          a_hash_including({"id" => kind_of(Integer)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
 
       provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -121,8 +125,12 @@ describe ApiController do
       run_post(providers_url, sample_openshift.merge("credentials" => [openshift_credentials]))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
-      expect_results_to_match_hash("results", [sample_openshift.except(*ENDPOINT_ATTRS)])
+      expected = {
+        "results" => [
+          a_hash_including({"id" => kind_of(Integer)}.merge(sample_openshift.except(*ENDPOINT_ATTRS)))
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
 
       provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -139,8 +147,12 @@ describe ApiController do
       run_post(providers_url, gen_request(:create, sample_rhevm))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
-      expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
+      expected = {
+        "results" => [
+          a_hash_including({"id" => kind_of(Integer)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
 
       provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -152,8 +164,12 @@ describe ApiController do
       run_post(providers_url, sample_vmware.merge("credentials" => default_credentials))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
-      expect_results_to_match_hash("results", [sample_vmware.except(*ENDPOINT_ATTRS)])
+      expected = {
+        "results" => [
+          a_hash_including({"id" => kind_of(Integer)}.merge(sample_vmware.except(*ENDPOINT_ATTRS)))
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
 
       provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -168,8 +184,12 @@ describe ApiController do
       run_post(providers_url, sample_rhevm.merge("credentials" => compound_credentials))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
-      expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
+      expected = {
+        "results" => [
+          a_hash_including({"id" => kind_of(Integer)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
 
       provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -186,9 +206,13 @@ describe ApiController do
       run_post(providers_url, gen_request(:create, [sample_vmware, sample_rhevm]))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => all(a_hash_including("id" => kind_of(Integer))))
-      expect_results_to_match_hash("results",
-                                   [sample_vmware.except(*ENDPOINT_ATTRS), sample_rhevm.except(*ENDPOINT_ATTRS)])
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including({"id" => kind_of(Integer)}.merge(sample_vmware.except(*ENDPOINT_ATTRS))),
+          a_hash_including({"id" => kind_of(Integer)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+        )
+      }
+      expect(response.parsed_body).to include(expected)
 
       results = response.parsed_body["results"]
       p1_id, p2_id = results.first["id"], results.second["id"]

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -55,8 +55,15 @@ describe ApiController do
       run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
-      expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
+      expected = {
+        "results" => [
+          a_hash_including(
+            "id"   => kind_of(Integer),
+            "name" => "sample service catalog"
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
 
       sc_id = response.parsed_body["results"].first["id"]
 
@@ -69,8 +76,15 @@ describe ApiController do
       run_post(service_catalogs_url, "name" => "sample service catalog")
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
-      expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
+      expected = {
+        "results" => [
+          a_hash_including(
+            "id"   => kind_of(Integer),
+            "name" => "sample service catalog"
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
 
       sc_id = response.parsed_body["results"].first["id"]
 
@@ -83,8 +97,13 @@ describe ApiController do
       run_post(service_catalogs_url, gen_request(:add, [{"name" => "sc1"}, {"name" => "sc2"}]))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("results" => all(a_hash_including("id" => kind_of(Integer))))
-      expect_results_to_match_hash("results", [{"name" => "sc1"}, {"name" => "sc2"}])
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including("id" => kind_of(Integer), "name" => "sc1"),
+          a_hash_including("id" => kind_of(Integer), "name" => "sc2")
+        )
+      }
+      expect(response.parsed_body).to include(expected)
 
       results = response.parsed_body["results"]
       sc_id1, sc_id2 = results.first["id"], results.second["id"]

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -55,7 +55,7 @@ describe ApiController do
       run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
       sc_id = response.parsed_body["results"].first["id"]
@@ -69,7 +69,7 @@ describe ApiController do
       run_post(service_catalogs_url, "name" => "sample service catalog")
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => [a_hash_including("id" => kind_of(Integer))])
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
       sc_id = response.parsed_body["results"].first["id"]
@@ -83,7 +83,7 @@ describe ApiController do
       run_post(service_catalogs_url, gen_request(:add, [{"name" => "sc1"}, {"name" => "sc2"}]))
 
       expect(response).to have_http_status(:ok)
-      expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
+      expect(response.parsed_body).to include("results" => all(a_hash_including("id" => kind_of(Integer))))
       expect_results_to_match_hash("results", [{"name" => "sc1"}, {"name" => "sc2"}])
 
       results = response.parsed_body["results"]

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -238,8 +238,7 @@ module ApiSpecHelper
   end
 
   def expect_result_resource_keys_to_be_like_klass(collection, key, klass)
-    expect(response.parsed_body).to have_key(collection)
-    expect(response.parsed_body[collection].all? { |result| result[key].kind_of?(klass) }).to be_truthy
+    expect(response.parsed_body).to include(collection => all(a_hash_including(key => kind_of(klass))))
   end
 
   def expect_result_resources_to_include_keys(collection, keys)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -237,10 +237,6 @@ module ApiSpecHelper
     expect_results_to_match_hash("resources", result_hash)
   end
 
-  def expect_result_resource_keys_to_be_like_klass(collection, key, klass)
-    expect(response.parsed_body).to include(collection => all(a_hash_including(key => kind_of(klass))))
-  end
-
   def expect_result_resources_to_include_keys(collection, keys)
     expect(response.parsed_body).to have_key(collection)
     results = response.parsed_body[collection]


### PR DESCRIPTION
Purpose or Intent
-----------------
Another small refactoring of API specs to arrive at fewer total expectations, removing the `expect_result_resource_keys_to_be_like_klass` in favor of RSpec's composable matchers, which can be combined with other expectations on the response for better readability and feedback.

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 