### PR TITLE
Replacing validate_evacuate method by supports :evacuate

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -551,7 +551,7 @@ module ApplicationController::CiProcessing
     recs = find_checked_items
     recs = [params[:id].to_i] if recs.blank?
     @record = find_by_id_filtered(VmOrTemplate, recs.first)
-    if @record.is_available?(:evacuate) && !@record.ext_management_system.nil?
+    if @record.supports_evacuate?
       if @explorer
         evacuate
         @refresh_partial = "vm_common/evacuate"
@@ -562,7 +562,7 @@ module ApplicationController::CiProcessing
       add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
         :instance => ui_lookup(:table => 'vm_cloud'),
         :name     => @record.name,
-        :details  => @record.is_available_now_error_message(:evacuate)}, :error)
+        :details  => @record.unsupported_reason(:evacuate)}, :error)
     end
   end
   alias instance_evacuate evacuatevms
@@ -577,7 +577,7 @@ module ApplicationController::CiProcessing
         :model => ui_lookup(:table => "vm_cloud"), :name => @record.name})
       @record = @sb[:action] = nil
     when "submit"
-      if @record.is_available?(:evacuate)
+      if @record.supports_evacuate?
         if params['auto_select_host'] == 'on'
           hostname = nil
         else
@@ -604,7 +604,7 @@ module ApplicationController::CiProcessing
         add_flash(_("Unable to evacuate %{instance} \"%{name}\": %{details}") % {
           :instance => ui_lookup(:table => 'vm_cloud'),
           :name     => @record.name,
-          :details  => @record.is_available_now_error_message(:evacuate)}, :error)
+          :details  => @record.unsupported_reason(:evacuate)}, :error)
       end
       params[:id] = @record.id.to_s # reset id in params for show
       @record = nil

--- a/app/helpers/application_helper/button/instance_evacuate.rb
+++ b/app/helpers/application_helper/button/instance_evacuate.rb
@@ -1,10 +1,10 @@
 class ApplicationHelper::Button::InstanceEvacuate < ApplicationHelper::Button::Basic
   def calculate_properties
     super
-    self[:title] = @record.is_available_now_error_message(:evacuate) if disabled?
+    self[:title] = @record.unsupported_reason(:evacuate) if disabled?
   end
 
   def disabled?
-    !@record.is_available?(:evacuate)
+    !@record.supports_evacuate?
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
@@ -7,6 +7,10 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
     end
 
     supports_not :migrate, :reason => _("Migrate operation is not supported.")
+
+    supports :evacuate do
+      unsupported_reason_add(:evacuate, unsupported_reason(:control)) unless supports_control?
+    end
   end
 
   def raw_live_migrate(options = {})
@@ -31,11 +35,5 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
     end
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "MIGRATING")
-  end
-
-  def validate_evacuate
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
-    {:available => true, :message => nil}
   end
 end

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -2,7 +2,8 @@ module VmOrTemplate::Operations::Relocation
   extend ActiveSupport::Concern
 
   included do
-    supports_not :live_migrate, :reason => _("Live Migrate VM Operation is not available for VM or Template.")
+    supports_not :live_migrate, :reason => _("Operation not supported.")
+    supports_not :evacuate, :reason => _("Operation not supported.")
   end
 
   def raw_live_migrate(_options = nil)
@@ -13,17 +14,12 @@ module VmOrTemplate::Operations::Relocation
     raw_live_migrate(options)
   end
 
-
   def raw_evacuate(_options = nil)
     raise NotImplementedError, _("raw_evacuate must be implemented in a subclass")
   end
 
   def evacuate(options = {})
     raw_evacuate(options)
-  end
-
-  def validate_evacuate
-    validate_unsupported("Evacuate VM Operation")
   end
 
   def raw_migrate(host, pool = nil, priority = "defaultPriority", state = nil)

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -57,8 +57,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
         expect(vm.power_state).to eq 'migrating'
       end
 
-      it "checks evacuation is_available?" do
-        expect(vm.is_available?(:evacuate)).to eq true
+      it "returns true for querying vm if the evacuate operation is supported" do
+        expect(vm.supports_evacuate?).to eq true
       end
     end
   end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -440,15 +440,15 @@ describe VmOrTemplate do
     end
   end
 
-  context "#is_available? for evacuate" do
-    it "returns false for vmware VM" do
+  context "#supports_evacuate?" do
+    it "returns false for querying vmware VM if it supports evacuate operation" do
       vm =  FactoryGirl.create(:vm_vmware)
-      expect(vm.is_available?(:evacuate)).to eq(false)
+      expect(vm.supports_evacuate?).to eq(false)
     end
 
-    it "returns false for SCVMM VM" do
+    it "returns false for querying SCVMM VM if it supports evacuate operation" do
       vm =  FactoryGirl.create(:vm_microsoft)
-      expect(vm.is_available?(:evacuate)).to eq(false)
+      expect(vm.supports_evacuate?).to eq(false)
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
This pull request intends to remove the usage of validate_evacuate method and replaces it by the new method supports_evacuate which is supported by SupportsFeatureMixin.

This is in continuation with PR: https://github.com/ManageIQ/manageiq/pull/9683

The original method validate_evacuate is kept as it is for backward compatibility of code, but the body of the function internally relies on supports_evacuate method.


Steps for Testing/QA
--------------------
Below are the outputs from relevant Rspec tests.

bundle exec rspec spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb

Randomized with seed 18019
.........................

Finished in 2.56 seconds (files took 5.79 seconds to load)
25 examples, 0 failures

Randomized with seed 18019

bundle exec rspec spec/models/vm_or_template_spec.rb

Randomized with seed 52558
..............................................................................

Finished in 6.32 seconds (files took 5.68 seconds to load)
78 examples, 0 failures

Randomized with seed 52558


