### PR TITLE
Skip unreachable middleware providers when reporting.

### DIFF
--- a/app/models/middleware_performance.rb
+++ b/app/models/middleware_performance.rb
@@ -19,7 +19,12 @@ class MiddlewarePerformance < ActsAsArModel
     results = []
 
     model_class.find_each do |ms|
-      raw_stats = fetch_raw_stats(ms, start_time, end_time, interval)
+      begin
+        raw_stats = fetch_raw_stats(ms, start_time, end_time, interval)
+      rescue ::Hawkular::BaseClient::HawkularConnectionException => exception
+        $log.error(exception)
+        next
+      end
       if raw_stats.values[0]
         parse_raw_stats_columns raw_stats
         raw_stats.each { |timestamp, stats| results.push(parse_row(ms, timestamp, interval, stats)) }


### PR DESCRIPTION
This will skip any MiddlewareServer that is unreachable. 

I'm thinking on adding to the hawkular-client-ruby an exception when there is connection issues Instead of rescuing all the connection related exceptions here... @abonas  WDYT?

Fixes #9773

@miq-bot add_label providers/hawkular
@miq-bot add_label wip