### PR TITLE
Make connection_configurations accept both symbols and strings as keys

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -274,7 +274,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def delete_unused_connection_configurations(options)
-    chosen_endpoints   = options.map { |x| x.fetch_path(:endpoint, :role).try(:to_sym) }.compact.uniq
+    chosen_endpoints = options.map { |x| x.deep_symbolize_keys.fetch_path(:endpoint, :role).try(:to_sym) }.compact.uniq
     existing_endpoints = endpoints.pluck(:role).map(&:to_sym)
     # Delete endpoint that were not picked
     roles_for_deletion = existing_endpoints - chosen_endpoints
@@ -299,19 +299,20 @@ class ExtManagementSystem < ApplicationRecord
   # Takes a hash of connection data
   # hostname, port, and authentication
   # if no role is passed in assume is default role
-  def add_connection_configuration_by_role(options)
-    unless options[:endpoint].key?(:role)
-      options[:endpoint][:role] ||= "default"
+  def add_connection_configuration_by_role(connection)
+    connection.deep_symbolize_keys!
+    unless connection[:endpoint].key?(:role)
+      connection[:endpoint][:role] ||= "default"
     end
-    if options[:authentication].blank?
-      options.delete(:authentication)
+    if connection[:authentication].blank?
+      connection.delete(:authentication)
     else
-      unless options[:authentication].key?(:role)
-        options[:authentication][:role] ||= "default"
+      unless connection[:authentication].key?(:role)
+        connection[:authentication][:role] ||= "default"
       end
     end
 
-    build_connection(options)
+    build_connection(connection)
   end
 
   def connection_configuration_by_role(role = "default")

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -135,6 +135,44 @@ describe ExtManagementSystem do
     end
   end
 
+  context "with multiple endpoints using connection_configurations" do
+    let(:ems) do
+      FactoryGirl.build("ems_openstack",
+                        :hostname                  => "example.org",
+                        :connection_configurations => [{:endpoint => {:role     => "amqp",
+                                                                      :hostname => "amqp.example.org"}}])
+    end
+
+    it "will contain seperate ampq endpoint" do
+      expect(ems.default_endpoint.hostname).to eq "example.org"
+      expect(ems.connection_configuration_by_role("amqp").endpoint.hostname).to eq "amqp.example.org"
+    end
+
+    it "will contain multiple endpoints" do
+      expected_endpoints = ["example.org", "amqp.example.org"]
+      expect(ems.hostnames).to match_array(expected_endpoints)
+    end
+  end
+
+  context "with multiple endpoints using connection_configurations (string keys)" do
+    let(:ems) do
+      FactoryGirl.build("ems_openstack",
+                        "hostname"                  => "example.org",
+                        "connection_configurations" => [{"endpoint" => {"role"     => "amqp",
+                                                                        "hostname" => "amqp.example.org"}}])
+    end
+
+    it "will contain seperate ampq endpoint" do
+      expect(ems.default_endpoint.hostname).to eq "example.org"
+      expect(ems.connection_configuration_by_role("amqp").endpoint.hostname).to eq "amqp.example.org"
+    end
+
+    it "will contain multiple endpoints" do
+      expected_endpoints = ["example.org", "amqp.example.org"]
+      expect(ems.hostnames).to match_array(expected_endpoints)
+    end
+  end
+
   context "with two small envs" do
     before(:each) do
       @zone1 = FactoryGirl.create(:small_environment)


### PR DESCRIPTION
**Purpose**
The `connection_configurations` attribute for creating a new ExtManagementSystem accept only symbols as keys.
Allowing strings as keys makes this attribute more robust and easy the use. It also allow the use of this attribute with data structs that use string for keys (e.g. json from the api).

**Links**
https://github.com/ManageIQ/manageiq/pull/9648