### PR TITLE
rename supports_retirement? to supports_retire?

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -180,7 +180,7 @@ module ApplicationController::CiProcessing
     assert_privileges(params[:pressed])
     vms = find_checked_items
     if !%w(orchestration_template service).include?(request.parameters["controller"]) &&
-       VmOrTemplate.find(vms).any? { |vm| !vm.supports_retirement? }
+       VmOrTemplate.find(vms).any? { |vm| !vm.supports_retire? }
       add_flash(_("Set Retirement Date does not apply to selected %{model}") %
         {:model => ui_lookup(:table => "miq_template")}, :error)
       render_flash_and_scroll
@@ -1570,7 +1570,7 @@ module ApplicationController::CiProcessing
       vms = find_checked_items
       if method == 'retire_now' &&
          !%w(orchestration_template service).include?(request.parameters["controller"]) &&
-         VmOrTemplate.find(vms).any? { |vm| !vm.supports_retirement? }
+         VmOrTemplate.find(vms).any? { |vm| !vm.supports_retire? }
         add_flash(_("Retire does not apply to selected %{model}") %
           {:model => ui_lookup(:table => "miq_template")}, :error)
         render_flash_and_scroll

--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -19,11 +19,4 @@ module Vm::Operations::Lifecycle
     {:available => !(self.blank? || self.orphaned? || self.archived?), :message   => nil}
   end
 
-  def validate_retire
-    {:available => !(self.orphaned? || self.archived?), :message   => nil}
-  end
-
-  def validate_retire_now
-    {:available => !(self.orphaned? || self.archived?), :message   => nil}
-  end
 end

--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -2,10 +2,8 @@ module Vm::Operations::Lifecycle
   extend ActiveSupport::Concern
 
   included do
-    supports :retirement do
-      if orphaned? || archived?
-        unsupported_reason_add :retirement, "VM orphaned or archived already"
-      end
+    supports :retire do
+      unsupported_reason_add(:retire, "VM orphaned or archived already") if orphaned? || archived?
     end
   end
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -31,7 +31,7 @@ class VmOrTemplate < ApplicationRecord
 
   include AvailabilityMixin
 
-  supports_not :retirement
+  supports_not :retire
 
   has_many :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy,
            :class_name => "CustomAttribute"


### PR DESCRIPTION
this is more in line with the old version of validate_retire it also
follows the pattern where supports call and the method or action which is
inquired are named the same and named as a verb

also remove validate_retire, which is replaced by supports_retire


related PR https://github.com/ManageIQ/manageiq/pull/9272