### PR TITLE
Do not put Zone ActiveRecord on Queue when scheduling C&U coordinator

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -45,9 +45,10 @@ module Metric::Capture
     _log.info "Queueing performance capture...Complete"
   end
 
-  def self.perf_capture_gap(start_time, end_time, zone = nil)
+  def self.perf_capture_gap(start_time, end_time, zone_id = nil)
     _log.info "Queueing performance capture for range: [#{start_time} - #{end_time}]..."
 
+    zone = Zone.find(zone_id) if zone_id
     targets = Metric::Targets.capture_targets(zone, :exclude_storages => true)
     targets.each { |target| target.perf_capture_queue('historical', :start_time => start_time, :end_time => end_time, :zone => zone) }
 
@@ -60,7 +61,7 @@ module Metric::Capture
       :method_name => "perf_capture_gap",
       :role        => "ems_metrics_coordinator",
       :priority    => MiqQueue::HIGH_PRIORITY,
-      :args        => [start_time, end_time, zone]
+      :args        => [start_time, end_time, zone.try(:id)]
     }
     item[:zone] = zone.name if zone
 

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -62,9 +62,7 @@ module Metric::Capture
       :priority    => MiqQueue::HIGH_PRIORITY,
       :args        => [start_time, end_time, zone]
     }
-
-    zone = Zone.find(zone) if zone.kind_of?(Integer)
-    item[:zone] = zone.name if zone.kind_of?(Zone)
+    item[:zone] = zone.name if zone
 
     MiqQueue.put(item)
   end


### PR DESCRIPTION
![crash_cu_gap_zone](https://cloud.githubusercontent.com/assets/6666052/16869961/9dfd824e-4a7f-11e6-8370-da90b740e443.jpg)

Since #8963, we want not to put ActiveRecords on Queue. 

@miq-bot add_label core, bug
@miq-bot assign @kbrock 