### PR TITLE
Make connection_configuration respect the default authentication type

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -320,7 +320,8 @@ class ExtManagementSystem < ApplicationRecord
     endpoint = endpoints.detect { |e| e.role == role }
 
     if endpoint
-      auth = authentications.detect { |a| a.authtype == endpoint.role }
+      authtype = endpoint.role == "default" ? default_authentication_type.to_s : endpoint.role
+      auth = authentications.detect { |a| a.authtype == authtype }
 
       options = {:endpoint => endpoint, :authentication => auth}
       OpenStruct.new(options)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -194,6 +194,20 @@ describe ExtManagementSystem do
     end
   end
 
+  context "with multiple endpoints using default authtype" do
+    let(:ems) do
+      FactoryGirl.build(:ems_openshift,
+                        :connection_configurations => [{:endpoint       => {:role     => "default",
+                                                                            :hostname => "openshift.example.org"},
+                                                        :authentication => {:role     => "bearer",
+                                                                            :auth_key => "SomeSecret"}}])
+    end
+
+    it "will contain the bearer authentication as default" do
+      expect(ems.connection_configuration_by_role("default").authentication.authtype).to eq("bearer")
+    end
+  end
+
   context "with two small envs" do
     before(:each) do
       @zone1 = FactoryGirl.create(:small_environment)


### PR DESCRIPTION
**Purpose**
When using `connection_configurations` on `ems_container` default authentication is `nil`, because the `connection_configuration_by_role` method does not respect the authentication default type.

**Issue**
https://github.com/ManageIQ/manageiq/issues/9742