### PR TITLE
Move CloudManager network relations to base class

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -8,7 +8,6 @@ class CloudTenant < ApplicationRecord
   has_many   :cloud_subnets
   has_many   :network_ports
   has_many   :network_routers
-  has_many   :shared_cloud_networks, -> { where :shared => true }, :through => :ext_management_system, :source => :cloud_networks
   has_many   :vms
   has_many   :vms_and_templates
   has_many   :miq_templates
@@ -29,5 +28,9 @@ class CloudTenant < ApplicationRecord
 
   def all_cloud_networks
     direct_cloud_networks + shared_cloud_networks
+  end
+
+  def shared_cloud_networks
+    try(:ext_management_system).try(:cloud_networks).try(:where, :shared => true) || []
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -21,35 +21,14 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
   has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy
 
-  has_one :network_manager,
-          :foreign_key => :parent_ems_id,
-          :class_name  => "ManageIQ::Providers::Azure::NetworkManager",
-          :autosave    => true,
-          :dependent   => :destroy
-
-  delegate :floating_ips,
-           :security_groups,
-           :cloud_networks,
-           :cloud_subnets,
-           :network_ports,
-           :network_routers,
-           :public_networks,
-           :private_networks,
-           :all_cloud_networks,
-           :to        => :network_manager,
-           :allow_nil => true
-
-  before_validation :ensure_managers
-
   supports :discovery
   supports :provisioning
   supports :regions
 
-  def ensure_managers
-    build_network_manager unless network_manager
-    network_manager.name            = "#{name} Network Manager"
-    network_manager.zone_id         = zone_id
-    network_manager.provider_region = provider_region
+  before_validation :ensure_managers
+
+  def ensure_network_manager
+    build_network_manager(:type => 'ManageIQ::Providers::Azure::NetworkManager') unless network_manager
   end
 
   def self.ems_type

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -23,23 +23,14 @@ module ManageIQ::Providers
     has_many :cloud_volume_snapshots,        :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_services,                :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_databases,               :foreign_key => :ems_id, :dependent => :destroy
     has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
-    # TODO(lsmola) NetworkManager, when network manager is integrated to all cloud providers, change below relations
-    # to delegations to network manager
-    has_many :floating_ips,    :foreign_key => :ems_id, :dependent => :destroy
-    has_many :security_groups, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :cloud_networks,  :foreign_key => :ems_id, :dependent => :destroy
-    has_many :cloud_subnets,   :foreign_key => :ems_id, :dependent => :destroy
-    has_many :network_ports,   :foreign_key => :ems_id, :dependent => :destroy
-    has_many :network_routers, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :cloud_services,  :foreign_key => :ems_id, :dependent => :destroy
 
     validates_presence_of :zone
 
+    include HasNetworkManagerMixin
     include HasManyOrchestrationStackMixin
-
-    alias_method :all_cloud_networks, :cloud_networks
 
     supports_not :discovery
 

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -16,34 +16,13 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
 
   include ManageIQ::Providers::Google::ManagerMixin
 
-  has_one :network_manager,
-          :foreign_key => :parent_ems_id,
-          :class_name  => "ManageIQ::Providers::Google::NetworkManager",
-          :autosave    => true,
-          :dependent   => :destroy
-
-  delegate :floating_ips,
-           :security_groups,
-           :cloud_networks,
-           :cloud_subnets,
-           :network_ports,
-           :network_routers,
-           :public_networks,
-           :private_networks,
-           :all_cloud_networks,
-           :to        => :network_manager,
-           :allow_nil => true
-
-  before_validation :ensure_managers
-
   supports :provisioning
   supports :regions
 
-  def ensure_managers
-    build_network_manager unless network_manager
-    network_manager.name            = "#{name} Network Manager"
-    network_manager.zone_id         = zone_id
-    network_manager.provider_region = provider_region
+  before_validation :ensure_managers
+
+  def ensure_network_manager
+    build_network_manager(:type => 'ManageIQ::Providers::Google::NetworkManager') unless network_manager
   end
 
   def self.ems_type

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager < EmsCloud
+class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :AuthKeyPair
   require_nested :AvailabilityZone
   require_nested :AvailabilityZoneNull
@@ -22,9 +22,14 @@ class ManageIQ::Providers::Openstack::CloudManager < EmsCloud
   require_nested :Vm
 
   include ManageIQ::Providers::Openstack::ManagerMixin
-  include HasManyCloudNetworksMixin
 
   supports :provisioning
+
+  before_validation :ensure_managers
+
+  def ensure_network_manager
+    build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager
+  end
 
   def self.ems_type
     @ems_type ||= "openstack".freeze

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -15,10 +15,15 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
 
   include ManageIQ::Providers::Openstack::ManagerMixin
   include HasManyOrchestrationStackMixin
-  include HasManyCloudNetworksMixin
+  include HasNetworkManagerMixin
 
   before_save :ensure_parent_provider
   before_destroy :destroy_parent_provider
+  before_validation :ensure_managers
+
+  def ensure_network_manager
+    build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager
+  end
 
   def cloud_tenants
     CloudTenant.where(:ems_id => provider.try(:cloud_ems).try(:collect, &:id).try(:uniq))

--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -1,12 +1,10 @@
-module HasManyCloudNetworksMixin
+module HasNetworkManagerMixin
   extend ActiveSupport::Concern
 
-  # TODO(lsmola) NetworkManager, change this once we have a full representation of the NetworkManager, now we are
-  # showing everything under CloudManager
   included do
     has_one :network_manager,
             :foreign_key => :parent_ems_id,
-            :class_name  => "ManageIQ::Providers::Openstack::NetworkManager",
+            :class_name  => "ManageIQ::Providers::NetworkManager",
             :autosave    => true,
             :dependent   => :destroy
 
@@ -22,14 +20,15 @@ module HasManyCloudNetworksMixin
              :to        => :network_manager,
              :allow_nil => true
 
-    before_validation :ensure_managers
+    alias_method :all_cloud_networks, :cloud_networks
 
     private
 
     def ensure_managers
-      build_network_manager unless network_manager
-      network_manager.name    = "#{name} Network Manager"
-      network_manager.zone_id = zone_id
+      ensure_network_manager
+      network_manager.name            = "#{name} Network Manager"
+      network_manager.zone_id         = zone_id
+      network_manager.provider_region = provider_region
     end
   end
 end

--- a/spec/models/cloud_tenant_spec.rb
+++ b/spec/models/cloud_tenant_spec.rb
@@ -3,9 +3,9 @@ describe CloudTenant do
     ems     = FactoryGirl.create(:ems_openstack)
     tenant1 = FactoryGirl.create(:cloud_tenant,  :ext_management_system => ems)
     tenant2 = FactoryGirl.create(:cloud_tenant,  :ext_management_system => ems)
-    net1    = FactoryGirl.create(:cloud_network, :ext_management_system => ems, :shared => true)
-    net2    = FactoryGirl.create(:cloud_network, :ext_management_system => ems, :cloud_tenant => tenant1)
-    _net3   = FactoryGirl.create(:cloud_network, :ext_management_system => ems, :cloud_tenant => tenant2)
+    net1    = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager, :shared => true)
+    net2    = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager, :cloud_tenant => tenant1)
+    _net3   = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager, :cloud_tenant => tenant2)
 
     expect(tenant1.all_cloud_networks).to match_array([net1, net2])
   end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -95,10 +95,10 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
     expect(@ems.flavors.size).to eq(0)
     expect(@ems.availability_zones.size).to eq(0)
-    expect(@ems.floating_ips.size).to eq(0)
+    expect(@ems.floating_ips).to eq(nil)
     expect(@ems.key_pairs.size).to eq(0)
-    expect(@ems.cloud_networks.size).to eq(0)
-    expect(@ems.security_groups.size).to eq(0)
+    expect(@ems.cloud_networks).to eq(nil)
+    expect(@ems.security_groups).to eq(nil)
     expect(@ems.vms_and_templates.size).to eq(5)
     expect(@ems.vms.size).to eq(2)
     expect(@ems.miq_templates.size).to eq(3)


### PR DESCRIPTION
Purpose or Intent
-----------------
Move CloudManager network relations to base class, all cloud managers have network model unified now, we can move the common behavior to a base class.

Steps for Testing/QA
--------------------
This is just a code cleanup, that should not affect functionality in any way.
