### PR TITLE
Use the released version of default_value_for

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 gem "color",                          "~>1.8"
-gem "default_value_for",              "~>3.0.2.alpha-miq.1", :git => "git://github.com/jrafanie/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
+gem "default_value_for",              "~>3.0.2"
 gem "draper",                         "~>2.1.0", :git => "git://github.com/janraasch/draper.git", :branch => "feature/rails5-compatibility" # https://github.com/drapergem/draper/pull/712
 gem "hamlit-rails",                   "~>0.1.0"
 gem "high_voltage",                   "~>2.4.0"


### PR DESCRIPTION
Now that https://github.com/FooBarWidget/default_value_for/pull/57 has been merged and released, we can use the released version rather than a git gem.

@jrafanie please review (not sure if this should be `:require => false`?)

@simaishi going from git-based to released shouldn't cause any issues with rpm updates right?