### PR TITLE
Removed fieldsets from Dialog Editor

### DIFF
--- a/app/views/miq_ae_customization/_dialog_resources.html.haml
+++ b/app/views/miq_ae_customization/_dialog_resources.html.haml
@@ -1,25 +1,25 @@
 - parent_id ||= nil
 #form_widgets_div
-  %fieldset
-    %h3
-      = typ.capitalize
-    .row#modules
-      .col-md-4#col1
-        - objects = @edit[:new][:tabs]
-        - if parent_id
-          - ids = parent_id.split('_')
-          - case ids.length
-          - when 1
-            - objects = !@edit[:new][:tabs][ids.first.to_i].blank? ? @edit[:new][:tabs][ids.first.to_i][:groups] : nil
-          - when 2
-            - objects = !@edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i].blank? ? @edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i][:fields] : nil
-        - if objects.blank?
-          = _("No %s found.") % typ.pluralize.capitalize
-        - else
-          - objects.each_with_index do |obj, i|
-            - if obj[:label]
-              = render(:partial => 'dialog_resource',
-                :locals => {:obj => obj,
-                  :typ           => typ,
-                  :parent_id     => parent_id,
-                  :curr_pos      => i})
+  %hr
+  %h3
+    = typ.capitalize
+  .row#modules
+    .col-md-4#col1
+      - objects = @edit[:new][:tabs]
+      - if parent_id
+        - ids = parent_id.split('_')
+        - case ids.length
+        - when 1
+          - objects = !@edit[:new][:tabs][ids.first.to_i].blank? ? @edit[:new][:tabs][ids.first.to_i][:groups] : nil
+        - when 2
+          - objects = !@edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i].blank? ? @edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i][:fields] : nil
+      - if objects.blank?
+        = _("No %s found.") % typ.pluralize.capitalize
+      - else
+        - objects.each_with_index do |obj, i|
+          - if obj[:label]
+            = render(:partial => 'dialog_resource',
+              :locals => {:obj => obj,
+                :typ           => typ,
+                :parent_id     => parent_id,
+                :curr_pos      => i})


### PR DESCRIPTION
Purpose or Intent
-----------------
Remove unwanted `%fieldset`s from views

Before:
![screencapture-localhost-3000-miq_ae_customization-explorer-1468589969321](https://cloud.githubusercontent.com/assets/1187051/16876007/8e6e0498-4aa2-11e6-90ba-9e9bfbd2a065.png)

After:
![screencapture-localhost-3000-miq_ae_customization-explorer-1468589951201](https://cloud.githubusercontent.com/assets/1187051/16876012/91edd800-4aa2-11e6-961c-4371b5540e01.png)

@epwinchell please review

Links
-----
Parent issue: #8502


Steps for Testing/QA
--------------------
> [Optional] If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.

