### PR TITLE
Fix storage_accounts method for Azure metrics capture

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -59,10 +59,8 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
     ]
   end
 
-  def storage_accounts(connection)
-    @storage_accounts ||= with_metrics_services(connection) do |_metrics_conn, storage_conn|
-      storage_conn.list_all
-    end
+  def storage_accounts(storage_account_service)
+    @storage_accounts ||= storage_account_service.list_all
   end
 
   def perf_capture_data_azure(metrics_conn, storage_conn, start_time, end_time)


### PR DESCRIPTION
This is a fix for a mistake that was made in https://github.com/ManageIQ/manageiq/pull/9558. The argument passed to the method is already a StorageAccountService object, whereas I previously thought it was a configuration object.
