### PR TITLE
Gitignore for pluggable providers setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .tags
 /data/
 /productization
+/providers
 /vmdb/
 BUILD
 ca/root


### PR DESCRIPTION
Gitignore for pluggable providers setup documented in
https://github.com/ManageIQ/guides/pull/136