### PR TITLE
Use response.parsed_body in API request specs

### DIFF
--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -96,7 +96,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
       expect_result_to_match_hash(
-        response_hash["identity"],
+        response.parsed_body["identity"],
         "userid"     => @user.userid,
         "name"       => @user.name,
         "user_href"  => "/api/users/#{@user.id}",
@@ -106,7 +106,7 @@ describe ApiController do
         "role_href"  => "/api/roles/#{group2.miq_user_role.id}",
         "tenant"     => @group.tenant.name
       )
-      expect(response_hash["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
+      expect(response.parsed_body["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
     end
 
     it "querying user's authorization" do
@@ -117,7 +117,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expected = {"authorization" => hash_including("product_features")}
       ENTRYPOINT_KEYS.each { |k| expected[k] = anything }
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
   end
 
@@ -145,7 +145,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token))
 
-      auth_token = response_hash["auth_token"]
+      auth_token = response.parsed_body["auth_token"]
 
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
@@ -161,8 +161,8 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
 
-      auth_token = response_hash["auth_token"]
-      token_expires_on = response_hash["expires_on"]
+      auth_token = response.parsed_body["auth_token"]
+      token_expires_on = response.parsed_body["expires_on"]
 
       tm = TokenManager.new("api")
       token_info = tm.token_get_info("api", auth_token)
@@ -183,7 +183,7 @@ describe ApiController do
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(response_hash["token_ttl"]).to eq(api_token_ttl)
+      expect(response.parsed_body["token_ttl"]).to eq(api_token_ttl)
     end
 
     it "gets a token based identifier with an invalid requester_type" do
@@ -202,7 +202,7 @@ describe ApiController do
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(response_hash["token_ttl"]).to eq(ui_token_ttl)
+      expect(response.parsed_body["token_ttl"]).to eq(ui_token_ttl)
     end
 
     it "forgets the current token when asked to" do
@@ -210,7 +210,7 @@ describe ApiController do
 
       run_get auth_url
 
-      auth_token = response_hash["auth_token"]
+      auth_token = response.parsed_body["auth_token"]
 
       expect_any_instance_of(TokenManager).to receive(:invalidate_token).with("api", auth_token)
       run_delete auth_url, "auth_token" => auth_token

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -35,7 +35,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response_hash["results"].first["id"]
+      task_id = response.parsed_body["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -48,7 +48,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response_hash["results"].first["id"]
+      task_id = response.parsed_body["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -61,7 +61,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = response_hash["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = response.parsed_body["results"].collect { |r| r["id"] }
       expect(AutomationRequest.exists?(task_id1)).to be_truthy
       expect(AutomationRequest.exists?(task_id2)).to be_truthy
     end

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "categories API" do
 
     run_get categories_url(category.id)
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "description" => category.description,
       "href"        => categories_url(category.id),
       "id"          => category.id
@@ -86,7 +86,7 @@ RSpec.describe "categories API" do
       run_post categories_url, options
 
       expect_result_to_match_hash(
-        response_hash["results"].first,
+        response.parsed_body["results"].first,
         "read_only"    => true,
         "show"         => true,
         "single_value" => true
@@ -97,7 +97,7 @@ RSpec.describe "categories API" do
       api_basic_authorize collection_action_identifier(:categories, :create)
 
       run_post categories_url, :name => "test", :description => "Test"
-      category = Category.find(response_hash["results"].first["id"])
+      category = Category.find(response.parsed_body["results"].first["id"])
 
       expect(category.tag.name).to eq("/managed/test")
     end

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "chargebacks API" do
     expect_result_resources_to_include_hrefs(
       "resources", [chargebacks_url(chargeback_rate.id)]
     )
-    expect_result_to_match_hash(response_hash, "count" => 1)
+    expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
   end
 
@@ -19,7 +19,7 @@ RSpec.describe "chargebacks API" do
     run_get chargebacks_url(chargeback_rate.id)
 
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "description" => chargeback_rate.description,
       "guid"        => chargeback_rate.guid,
       "id"          => chargeback_rate.id,
@@ -60,7 +60,7 @@ RSpec.describe "chargebacks API" do
     run_get "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}"
 
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "chargeback_rate_id" => chargeback_rate.id,
       "href"               => "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}",
       "id"                 => chargeback_rate_detail.id,
@@ -78,7 +78,7 @@ RSpec.describe "chargebacks API" do
     expect_result_resources_to_include_hrefs(
       "resources", ["/api/currencies/#{currency.id}"]
     )
-    expect_result_to_match_hash(response_hash, "count" => 1)
+    expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
   end
 
@@ -89,7 +89,7 @@ RSpec.describe "chargebacks API" do
     run_get "/api/currencies/#{currency.id}"
 
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "name" => currency.name,
       "id"   => currency.id,
       "href" => "/api/currencies/#{currency.id}"
@@ -106,7 +106,7 @@ RSpec.describe "chargebacks API" do
     expect_result_resources_to_include_hrefs(
       "resources", ["/api/measures/#{measure.id}"]
     )
-    expect_result_to_match_hash(response_hash, "count" => 1)
+    expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
   end
 
@@ -117,7 +117,7 @@ RSpec.describe "chargebacks API" do
     run_get "/api/measures/#{measure.id}"
 
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "name" => measure.name,
       "id"   => measure.id,
       "href" => "/api/measures/#{measure.id}",
@@ -134,9 +134,9 @@ RSpec.describe "chargebacks API" do
                  :description => "chargeback_0",
                  :rate_type   => "Storage"
       end.to change(ChargebackRate, :count).by(1)
-      expect_result_to_match_hash(response_hash["results"].first, "description" => "chargeback_0",
-                                                                  "rate_type"   => "Storage",
-                                                                  "default"     => false)
+      expect_result_to_match_hash(response.parsed_body["results"].first, "description" => "chargeback_0",
+                                                                         "rate_type"   => "Storage",
+                                                                         "default"     => false)
       expect(response).to have_http_status(:ok)
     end
 
@@ -156,7 +156,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:chargebacks, :edit)
       run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
 
-      expect(response_hash["description"]).to eq("chargeback_1")
+      expect(response.parsed_body["description"]).to eq("chargeback_1")
       expect(response).to have_http_status(:ok)
       expect(chargeback_rate.reload.description).to eq("chargeback_1")
     end
@@ -169,7 +169,7 @@ RSpec.describe "chargebacks API" do
                                                        :path   => "description",
                                                        :value  => "chargeback_1"}]
 
-      expect(response_hash["description"]).to eq("chargeback_1")
+      expect(response.parsed_body["description"]).to eq("chargeback_1")
       expect(response).to have_http_status(:ok)
       expect(chargeback_rate.reload.description).to eq("chargeback_1")
     end
@@ -208,7 +208,7 @@ RSpec.describe "chargebacks API" do
                  :source             => "used",
                  :enabled            => true
       end.to change(ChargebackRateDetail, :count).by(1)
-      expect_result_to_match_hash(response_hash["results"].first, "description" => "rate_0", "enabled" => true)
+      expect_result_to_match_hash(response.parsed_body["results"].first, "description" => "rate_0", "enabled" => true)
       expect(response).to have_http_status(:ok)
     end
 
@@ -235,7 +235,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :edit)
       run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_1")
 
-      expect(response_hash["description"]).to eq("rate_1")
+      expect(response.parsed_body["description"]).to eq("rate_1")
       expect(response).to have_http_status(:ok)
       expect(chargeback_rate_detail.reload.description).to eq("rate_1")
     end
@@ -251,7 +251,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :edit)
       run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "description", :value => "rate_1"}]
 
-      expect(response_hash["description"]).to eq("rate_1")
+      expect(response.parsed_body["description"]).to eq("rate_1")
       expect(response).to have_http_status(:ok)
       expect(chargeback_rate_detail.reload.description).to eq("rate_1")
     end

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -4,7 +4,7 @@ describe ApiController do
     api_basic_authorize collection_action_identifier(:container_deployments, :read, :get)
     run_get container_deployments_url + "/container_deployment_data"
     expect(response).to have_http_status(:ok)
-    expect_hash_to_have_only_keys(response_hash["data"], %w(providers provision))
+    expect_hash_to_have_only_keys(response.parsed_body["data"], %w(providers provision))
   end
 
   it "creates container deployment with POST" do

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -60,7 +60,7 @@ describe ApiController do
 
   def expect_result_to_have_custom_actions_hash
     expect_result_to_have_keys(%w(custom_actions))
-    custom_actions = response_hash["custom_actions"]
+    custom_actions = response.parsed_body["custom_actions"]
     expect_hash_to_have_only_keys(custom_actions, %w(buttons button_groups))
     expect(custom_actions["buttons"].size).to eq(1)
     expect(custom_actions["button_groups"].size).to eq(1)
@@ -75,7 +75,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response_hash["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
     end
   end
 
@@ -91,7 +91,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response_hash["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
     end
 
     it "supports the custom_actions attribute" do
@@ -111,7 +111,7 @@ describe ApiController do
       run_get services_url(svc1.id), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
-      expect(response_hash["custom_action_buttons"].size).to eq(3)
+      expect(response.parsed_body["custom_action_buttons"].size).to eq(3)
     end
   end
 
@@ -127,7 +127,7 @@ describe ApiController do
       run_get service_templates_url(template1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      action_specs = response_hash["actions"]
+      action_specs = response.parsed_body["actions"]
       expect(action_specs.size).to eq(1)
       expect(action_specs.first["name"]).to eq("edit")
     end
@@ -147,7 +147,7 @@ describe ApiController do
       run_get service_templates_url(template1.id), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
-      expect(response_hash["custom_action_buttons"].size).to eq(3)
+      expect(response.parsed_body["custom_action_buttons"].size).to eq(3)
     end
   end
 
@@ -198,7 +198,7 @@ describe ApiController do
           ]
         }
       }
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
   end
 end

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "API entrypoint" do
 
     expect(response).to have_http_status(:ok)
     expect_result_to_have_keys(%w(settings))
-    expect(response_hash['settings']).to be_kind_of(Hash)
+    expect(response.parsed_body['settings']).to be_kind_of(Hash)
   end
 
   it "returns a locale" do
@@ -14,7 +14,7 @@ RSpec.describe "API entrypoint" do
 
     run_get entrypoint_url
 
-    expect(%w(en en_US)).to include(response_hash['settings']['locale'])
+    expect(%w(en en_US)).to include(response.parsed_body['settings']['locale'])
   end
 
   it "collection query is sorted" do
@@ -22,7 +22,7 @@ RSpec.describe "API entrypoint" do
 
     run_get entrypoint_url
 
-    collection_names = response_hash['collections'].map { |c| c['name'] }
+    collection_names = response.parsed_body['collections'].map { |c| c['name'] }
     expect(collection_names).to eq(collection_names.sort)
   end
 end

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -70,7 +70,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = response_hash["results"].first["id"]
+      group_id = response.parsed_body["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -82,7 +82,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = response_hash["results"].first["id"]
+      group_id = response.parsed_body["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -97,7 +97,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      result = response_hash["results"].first
+      result = response.parsed_body["results"].first
       created_group = MiqGroup.find_by_id(result["id"])
 
       expect(created_group).to be_present
@@ -122,7 +122,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = response_hash["results"][0]["id"]
+      group_id = response.parsed_body["results"][0]["id"]
       expected_group = MiqGroup.find_by(:id => group_id)
       expect(expected_group).to be_present
       expect(expected_group.description).to eq(sample_group["description"])
@@ -138,7 +138,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = response_hash["results"]
+      results = response.parsed_body["results"]
       group1_id = results.first["id"]
       group2_id = results.second["id"]
       expect(MiqGroup.exists?(group1_id)).to be_truthy

--- a/spec/requests/api/normalization_spec.rb
+++ b/spec/requests/api/normalization_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe "Normalization of objects API" do
 
     run_get(hosts_url(host.id))
 
-    expect(response_hash).to include("created_on" => host.created_on.iso8601)
+    expect(response.parsed_body).to include("created_on" => host.created_on.iso8601)
   end
 end

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -24,9 +24,9 @@ describe ApiController do
   end
 
   def expect_result_to_include_picture_href(source_id)
-    expect_result_to_match_hash(response_hash, "id" => source_id)
+    expect_result_to_match_hash(response.parsed_body, "id" => source_id)
     expect_result_to_have_keys(%w(id href picture))
-    expect_result_to_match_hash(response_hash["picture"],
+    expect_result_to_match_hash(response.parsed_body["picture"],
                                 "id"          => picture.id,
                                 "resource_id" => template.id,
                                 "image_href"  => /^http:.*#{picture.image_href}$/)

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -109,7 +109,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = response_hash["results"].first["id"]
+      provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       endpoint = ExtManagementSystem.find(provider_id).default_endpoint
       expect_result_to_match_hash(endpoint.attributes, sample_rhevm.slice(*ENDPOINT_ATTRS))
@@ -124,7 +124,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_openshift.except(*ENDPOINT_ATTRS)])
 
-      provider_id = response_hash["results"].first["id"]
+      provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       ems = ExtManagementSystem.find(provider_id)
       expect(ems.authentications.size).to eq(1)
@@ -142,7 +142,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = response_hash["results"].first["id"]
+      provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
     end
 
@@ -155,7 +155,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_vmware.except(*ENDPOINT_ATTRS)])
 
-      provider_id = response_hash["results"].first["id"]
+      provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid).to eq(default_credentials["userid"])
@@ -171,7 +171,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      provider_id = response_hash["results"].first["id"]
+      provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid(:default)).to eq(default_credentials["userid"])
@@ -190,7 +190,7 @@ describe ApiController do
       expect_results_to_match_hash("results",
                                    [sample_vmware.except(*ENDPOINT_ATTRS), sample_rhevm.except(*ENDPOINT_ATTRS)])
 
-      results = response_hash["results"]
+      results = response.parsed_body["results"]
       p1_id, p2_id = results.first["id"], results.second["id"]
       expect(ExtManagementSystem.exists?(p1_id)).to be_truthy
       expect(ExtManagementSystem.exists?(p2_id)).to be_truthy
@@ -233,7 +233,7 @@ describe ApiController do
 
       run_post(providers_url(provider.id), gen_request(:edit, "name" => "updated provider", "port" => "8080"))
 
-      response_keys = response_hash.keys
+      response_keys = response.parsed_body.keys
       expect(response_keys).to include("tenant_id")
       expect(response_keys).not_to include("total_vms")
     end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -61,7 +61,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response_hash["results"].first["id"]
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -75,7 +75,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response_hash["results"].first["id"]
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -89,7 +89,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = response_hash["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = response.parsed_body["results"].collect { |r| r["id"] }
       expect(MiqProvisionRequest.exists?(task_id1)).to be_truthy
       expect(MiqProvisionRequest.exists?(task_id2)).to be_truthy
     end
@@ -171,7 +171,7 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      expect(response_hash["results"].first).to a_hash_including(
+      expect(response.parsed_body["results"].first).to a_hash_including(
         "options" => a_hash_including(
           "placement_auto"              => [false, 0],
           "placement_availability_zone" => [az.id, az.name],
@@ -182,7 +182,7 @@ describe ApiController do
         )
       )
 
-      task_id = response_hash["results"].first["id"]
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -203,14 +203,14 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      expect(response_hash["results"].first).to a_hash_including(
+      expect(response.parsed_body["results"].first).to a_hash_including(
         "options" => a_hash_including(
           "placement_auto"              => [true, 1],
           "placement_availability_zone" => [nil, nil]
         )
       )
 
-      task_id = response_hash["results"].first["id"]
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -232,14 +232,14 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      expect(response_hash["results"].first).to a_hash_including(
+      expect(response.parsed_body["results"].first).to a_hash_including(
         "options" => a_hash_including(
           "placement_auto"              => [true, 1],
           "placement_availability_zone" => [nil, nil]
         )
       )
 
-      task_id = response_hash["results"].first["id"]
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
   end

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -24,7 +24,7 @@ describe ApiController do
       run_get vms_url
 
       expect_query_result(:vms, 3, 3)
-      expect(response_hash).to include("resources" => all(match("href" => a_string_matching(vm_href_pattern))))
+      expect(response.parsed_body).to include("resources" => all(match("href" => a_string_matching(vm_href_pattern))))
     end
 
     it "returns seperate ids and href when expanded" do
@@ -39,7 +39,7 @@ describe ApiController do
                                             "id"   => a_kind_of(Integer),
                                             "guid" => anything))
       }
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
 
     it "always return ids and href when asking for specific attributes" do
@@ -119,9 +119,9 @@ describe ApiController do
       run_get(providers_url(provider.id), :attributes => "authentications")
 
       expect(response).to have_http_status(:ok)
-      expect_result_to_match_hash(response_hash, "name" => "sample")
+      expect_result_to_match_hash(response.parsed_body, "name" => "sample")
       expect_result_to_have_keys(%w(authentications))
-      authentication = response_hash["authentications"].first
+      authentication = response.parsed_body["authentications"].first
       expect(authentication["userid"]).to eq("admin")
       expect(authentication.key?("password")).to be_falsey
     end
@@ -142,8 +142,8 @@ describe ApiController do
       run_get provision_requests_url(request.id)
 
       expect(response).to have_http_status(:ok)
-      expect_result_to_match_hash(response_hash, "description" => "sample provision")
-      provision_attrs = response_hash.fetch_path("options", "attrs")
+      expect_result_to_match_hash(response.parsed_body, "description" => "sample provision")
+      provision_attrs = response.parsed_body.fetch_path("options", "attrs")
       expect(provision_attrs).to_not be_nil
       expect(provision_attrs["userid"]).to eq("admin")
       expect(provision_attrs.key?(password_field)).to be_falsey

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -406,7 +406,7 @@ describe ApiController do
       run_get vms_url(vm1.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to_not have_key("actions")
+      expect(response.parsed_body).to_not have_key("actions")
     end
 
     it "returns actions if authorized" do
@@ -425,7 +425,7 @@ describe ApiController do
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
-      actions = response_hash["actions"]
+      actions = response.parsed_body["actions"]
       expect(actions.size).to eq(1)
       expect(actions.first["name"]).to eq("suspend")
     end
@@ -439,7 +439,7 @@ describe ApiController do
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
-      expect(response_hash["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
     end
 
     it "returns actions if asked for with physical attributes" do

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "reports API" do
         reports_url(report_2.id)
       ]
     )
-    expect_result_to_match_hash(response_hash, "count" => 2, "name" => "reports")
+    expect_result_to_match_hash(response.parsed_body, "count" => 2, "name" => "reports")
     expect(response).to have_http_status(:ok)
   end
 
@@ -24,7 +24,7 @@ RSpec.describe "reports API" do
     run_get reports_url(report.id)
 
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "href"  => reports_url(report.id),
       "id"    => report.id,
       "name"  => report.name,
@@ -46,7 +46,7 @@ RSpec.describe "reports API" do
         "#{reports_url(report.id)}/results/#{report_result.to_param}"
       ]
     )
-    expect(response_hash["resources"]).not_to be_any { |resource| resource.key?("result_set") }
+    expect(response.parsed_body["resources"]).not_to be_any { |resource| resource.key?("result_set") }
     expect(response).to have_http_status(:ok)
   end
 
@@ -63,7 +63,7 @@ RSpec.describe "reports API" do
     api_basic_authorize
     run_get "#{reports_url(report.id)}/results/#{report_result.to_param}"
 
-    expect_result_to_match_hash(response_hash, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
+    expect_result_to_match_hash(response.parsed_body, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
     expect(response).to have_http_status(:ok)
   end
 
@@ -96,7 +96,7 @@ RSpec.describe "reports API" do
     api_basic_authorize action_identifier(:results, :read, :resource_actions, :get)
     run_get results_url(report_result.id)
 
-    expect_result_to_match_hash(response_hash, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
+    expect_result_to_match_hash(response.parsed_body, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
     expect(response).to have_http_status(:ok)
   end
 
@@ -136,7 +136,7 @@ RSpec.describe "reports API" do
     run_get "/api/reports/#{report.id}/schedules/#{schedule.id}"
 
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "href" => "/api/reports/#{report.id}/schedules/#{schedule.id}",
       "id"   => schedule.id,
       "name" => 'unit_test'
@@ -151,7 +151,7 @@ RSpec.describe "reports API" do
     api_basic_authorize
     run_get "#{reports_url(report.id)}/results/#{report_result.id}"
 
-    expect_result_to_match_hash(response_hash, "result_set" => [])
+    expect_result_to_match_hash(response.parsed_body, "result_set" => [])
     expect(response).to have_http_status(:ok)
   end
 
@@ -209,7 +209,7 @@ RSpec.describe "reports API" do
         run_post reports_url, gen_request(:import, :report => serialized_report, :options => options)
       end.to change(MiqReport, :count).by(1)
       expect_result_to_match_hash(
-        response_hash["results"].first["result"],
+        response.parsed_body["results"].first["result"],
         "name"      => "Test Report",
         "title"     => "Test Report",
         "rpt_group" => "Custom",
@@ -219,7 +219,7 @@ RSpec.describe "reports API" do
         "col_order" => %w(foo bar baz),
       )
       expect_result_to_match_hash(
-        response_hash["results"].first,
+        response.parsed_body["results"].first,
         "message" => "Imported Report: [Test Report]",
         "success" => true
       )

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Requests API" do
       run_get requests_url
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include("name" => "requests", "count" => 1, "subcount" => 0)
+      expect(response.parsed_body).to include("name" => "requests", "count" => 1, "subcount" => 0)
     end
 
     it "does not show another user's request" do
@@ -40,7 +40,7 @@ RSpec.describe "Requests API" do
         )
       }
       expect(response).to have_http_status(:not_found)
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
 
     it "a user can list their own requests" do
@@ -53,7 +53,7 @@ RSpec.describe "Requests API" do
       run_get requests_url
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include("name" => "requests", "count" => 1, "subcount" => 1)
+      expect(response.parsed_body).to include("name" => "requests", "count" => 1, "subcount" => 1)
     end
 
     it "a user can show their own request" do
@@ -66,7 +66,7 @@ RSpec.describe "Requests API" do
       run_get requests_url(service_request.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include("id"   => service_request.id,
+      expect(response.parsed_body).to include("id"   => service_request.id,
                                        "href" => a_string_matching(service_requests_url(service_request.id)))
     end
 
@@ -94,7 +94,7 @@ RSpec.describe "Requests API" do
         )
       }
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
 
     it "an admin can see another user's request" do
@@ -113,7 +113,7 @@ RSpec.describe "Requests API" do
         "href" => a_string_matching(service_requests_url(service_request.id))
       }
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
   end
 end

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -65,10 +65,10 @@ describe ApiController do
     run_get role_url, :expand => "features"
     expect(response).to have_http_status(:ok)
 
-    expect(response_hash).to have_key("name")
-    expect(response_hash["name"]).to eq(role.name)
-    expect(response_hash).to have_key("features")
-    expect(response_hash["features"].size).to eq(fetch_value(role.miq_product_features.count))
+    expect(response.parsed_body).to have_key("name")
+    expect(response.parsed_body["name"]).to eq(role.name)
+    expect(response.parsed_body).to have_key("features")
+    expect(response.parsed_body["features"].size).to eq(fetch_value(role.miq_product_features.count))
 
     expect_result_resources_to_include_data("features", attr.to_s => klass.pluck(attr))
   end
@@ -107,7 +107,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = response_hash["results"].first["id"]
+      role_id = response.parsed_body["results"].first["id"]
 
       run_get "#{roles_url}/#{role_id}/", :expand => "features"
 
@@ -127,7 +127,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = response_hash["results"].first["id"]
+      role_id = response.parsed_body["results"].first["id"]
       expect(MiqUserRole.exists?(role_id)).to be_truthy
       role = MiqUserRole.find(role_id)
       sample_role1['features'].each do |feature|
@@ -143,7 +143,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = response_hash["results"]
+      results = response.parsed_body["results"]
       r1_id = results.first["id"]
       r2_id = results.second["id"]
       expect(MiqUserRole.exists?(r1_id)).to be_truthy

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -58,7 +58,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
-      sc_id = response_hash["results"].first["id"]
+      sc_id = response.parsed_body["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -72,7 +72,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sample service catalog"}])
 
-      sc_id = response_hash["results"].first["id"]
+      sc_id = response.parsed_body["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -86,7 +86,7 @@ describe ApiController do
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
       expect_results_to_match_hash("results", [{"name" => "sc1"}, {"name" => "sc2"}])
 
-      results = response_hash["results"]
+      results = response.parsed_body["results"]
       sc_id1, sc_id2 = results.first["id"], results.second["id"]
       expect(ServiceTemplateCatalog.find(sc_id1)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id2)).to be_truthy
@@ -109,7 +109,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"name" => "sc", "description" => "sc description"}])
 
-      sc_id = response_hash["results"].first["id"]
+      sc_id = response.parsed_body["results"].first["id"]
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id).service_templates.pluck(:id)).to match_array([st1.id, st2.id])
@@ -330,7 +330,7 @@ describe ApiController do
       run_get sc_templates_url(sc.id, st1.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to_not include_actions("order")
+      expect(response.parsed_body).to_not include_actions("order")
     end
 
     it "returns order action for orderable service templates" do
@@ -343,7 +343,7 @@ describe ApiController do
       run_get sc_templates_url(sc.id, st1.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include_actions("order")
+      expect(response.parsed_body).to include_actions("order")
     end
 
     it "rejects order requests without appropriate role" do
@@ -464,7 +464,7 @@ describe ApiController do
         "service_template_href" => anything,
         "result"                => hash_including("text1")
       }
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -127,7 +127,7 @@ describe ApiController do
 
       run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
 
-      expect(response_hash).to include(
+      expect(response.parsed_body).to include(
         "success" => true,
         "message" => a_string_matching(/refreshing dialog fields/i),
         "href"    => a_string_matching(service_dialogs_url(dialog1.id)),

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "service orders API" do
       "resources" => [{"href" => a_string_matching(service_orders_url(shopping_cart_for_user.id))}]
     }
     expect(response).to have_http_status(:ok)
-    expect(response_hash).to include(expected)
+    expect(response.parsed_body).to include(expected)
   end
 
   it "can create a service order" do
@@ -51,7 +51,7 @@ RSpec.describe "service orders API" do
 
     run_post(service_orders_url, :name => "shopping cart")
 
-    expect(response_hash).to include("results" => [a_hash_including("state" => ServiceOrder::STATE_CART)])
+    expect(response.parsed_body).to include("results" => [a_hash_including("state" => ServiceOrder::STATE_CART)])
   end
 
   specify "a service order cannot be created in the 'ordered' state" do
@@ -62,7 +62,8 @@ RSpec.describe "service orders API" do
     end.not_to change(ServiceOrder, :count)
 
     expect(response).to have_http_status(:bad_request)
-    expect(response_hash).to include("error" => a_hash_including("message" => /can't create an ordered service order/i))
+    expected = {"error" => a_hash_including("message" => /can't create an ordered service order/i)}
+    expect(response.parsed_body).to include(expected)
   end
 
   it "can read a service order" do
@@ -71,7 +72,7 @@ RSpec.describe "service orders API" do
 
     run_get service_orders_url(service_order.id)
 
-    expect_result_to_match_hash(response_hash, "name" => service_order.name, "state" => service_order.state)
+    expect_result_to_match_hash(response.parsed_body, "name" => service_order.name, "state" => service_order.state)
     expect(response).to have_http_status(:ok)
   end
 
@@ -82,7 +83,7 @@ RSpec.describe "service orders API" do
     run_get service_orders_url("cart")
 
     expect(response).to have_http_status(:ok)
-    expect(response_hash).to include("id"   => shopping_cart.id,
+    expect(response.parsed_body).to include("id"   => shopping_cart.id,
                                      "href" => a_string_matching(service_orders_url(shopping_cart.id)))
   end
 
@@ -92,7 +93,7 @@ RSpec.describe "service orders API" do
     run_get service_orders_url("cart")
 
     expect(response).to have_http_status(:not_found)
-    expect(response_hash).to include("error" => a_hash_including("kind"    => "not_found",
+    expect(response.parsed_body).to include("error" => a_hash_including("kind"    => "not_found",
                                                                  "message" => /Couldn't find ServiceOrder/))
   end
 
@@ -102,7 +103,7 @@ RSpec.describe "service orders API" do
 
     run_post service_orders_url(service_order.id), :action => "edit", :resource => {:name => "new name"}
 
-    expect_result_to_match_hash(response_hash, "name" => "new name")
+    expect_result_to_match_hash(response.parsed_body, "name" => "new name")
     expect(response).to have_http_status(:ok)
   end
 
@@ -164,7 +165,7 @@ RSpec.describe "service orders API" do
 
         expected_href = a_string_matching("#{url}/#{service_request.id}")
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include("count"     => 1,
+        expect(response.parsed_body).to include("count"     => 1,
                                          "name"      => "service_requests",
                                          "resources" => [a_hash_including("href" => expected_href)],
                                          "subcount"  => 1)
@@ -179,7 +180,7 @@ RSpec.describe "service orders API" do
         run_get url
 
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include("id" => service_request.id, "href" => a_string_matching(url))
+        expect(response.parsed_body).to include("id" => service_request.id, "href" => a_string_matching(url))
       end
 
       it "can add a service request to a shopping cart" do
@@ -222,7 +223,7 @@ RSpec.describe "service orders API" do
           ]
         }
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
       end
 
       it "can add muliple service requests to a shopping cart by href" do
@@ -281,7 +282,7 @@ RSpec.describe "service orders API" do
           )
         }
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
       end
 
       it "can remove a service request from a shopping cart" do
@@ -298,7 +299,7 @@ RSpec.describe "service orders API" do
           "service_request_id"   => service_request.id
         }
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
         expect(shopping_cart.reload.miq_requests).not_to include(service_request)
       end
 
@@ -337,7 +338,7 @@ RSpec.describe "service orders API" do
           )
         }
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
         expect(shopping_cart.reload.miq_requests).not_to include(service_request_1, service_request_2)
       end
 
@@ -376,7 +377,7 @@ RSpec.describe "service orders API" do
           )
         }
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
         expect(shopping_cart.reload.miq_requests).not_to include(service_request_1, service_request_2)
       end
 
@@ -396,7 +397,7 @@ RSpec.describe "service orders API" do
           "id"   => shopping_cart.id
         }
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
         expect(shopping_cart.reload.miq_requests).to be_empty
       end
 
@@ -415,7 +416,7 @@ RSpec.describe "service orders API" do
           )
         }
         expect(response).to have_http_status(:bad_request)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
       end
 
       it "can checkout a shopping cart" do
@@ -433,7 +434,7 @@ RSpec.describe "service orders API" do
           "state" => ServiceOrder::STATE_ORDERED
         }
         expect(response).to have_http_status(:ok)
-        expect(response_hash).to include(expected)
+        expect(response.parsed_body).to include(expected)
         expect(shopping_cart.reload.state).to eq(ServiceOrder::STATE_ORDERED)
       end
     end

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -27,7 +27,7 @@ describe ApiController do
 
   def expect_result_to_have_provision_dialog
     expect_result_to_have_keys(%w(id href provision_dialog))
-    provision_dialog = response_hash["provision_dialog"]
+    provision_dialog = response.parsed_body["provision_dialog"]
     expect(provision_dialog).to be_kind_of(Hash)
     expect(provision_dialog).to have_key("label")
     expect(provision_dialog).to have_key("dialog_tabs")
@@ -37,7 +37,7 @@ describe ApiController do
   def expect_result_to_have_user_email(email)
     expect(response).to have_http_status(:ok)
     expect_result_to_have_keys(%w(id href user))
-    expect(response_hash["user"]["email"]).to eq(email)
+    expect(response.parsed_body["user"]["email"]).to eq(email)
   end
 
   describe "Service Requests query" do
@@ -166,7 +166,7 @@ describe ApiController do
       run_get service_requests_url
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include("name" => "service_requests", "count" => 1, "subcount" => 0)
+      expect(response.parsed_body).to include("name" => "service_requests", "count" => 1, "subcount" => 0)
     end
 
     it "does not show another user's request" do
@@ -185,7 +185,7 @@ describe ApiController do
         )
       }
       expect(response).to have_http_status(:not_found)
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
 
     it "a user can list their own requests" do
@@ -198,7 +198,7 @@ describe ApiController do
       run_get service_requests_url
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include("name" => "service_requests", "count" => 1, "subcount" => 1)
+      expect(response.parsed_body).to include("name" => "service_requests", "count" => 1, "subcount" => 1)
     end
 
     it "a user can show their own request" do
@@ -211,7 +211,7 @@ describe ApiController do
       run_get service_requests_url(service_request.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include("id"   => service_request.id,
+      expect(response.parsed_body).to include("id"   => service_request.id,
                                        "href" => a_string_matching(service_requests_url(service_request.id)))
     end
 
@@ -239,7 +239,7 @@ describe ApiController do
         )
       }
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
 
     it "an admin can see another user's request" do
@@ -258,7 +258,7 @@ describe ApiController do
         "href" => a_string_matching(service_requests_url(service_request.id))
       }
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to include(expected)
+      expect(response.parsed_body).to include(expected)
     end
   end
 end

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -49,7 +49,8 @@ describe ApiController do
       run_get service_templates_url(template.id), :attributes => "picture"
 
       expect_result_to_have_keys(%w(id href picture))
-      expect_result_to_match_hash(response_hash, "id" => template.id, "href" => service_templates_url(template.id))
+      expected = {"id" => template.id, "href" => service_templates_url(template.id)}
+      expect_result_to_match_hash(response.parsed_body, expected)
     end
 
     it "allows queries of the related picture and image_href" do
@@ -58,7 +59,7 @@ describe ApiController do
       run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
 
       expect_result_to_have_keys(%w(id href picture))
-      expect_result_to_match_hash(response_hash["picture"],
+      expect_result_to_match_hash(response.parsed_body["picture"],
                                   "id"          => picture.id,
                                   "resource_id" => template.id,
                                   "image_href"  => /^http:.*#{picture.image_href}$/)

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -230,7 +230,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to declare_actions("retire")
+      expect(response.parsed_body).to declare_actions("retire")
     end
 
     it "returns reconfigure action for reconfigurable services" do
@@ -245,7 +245,7 @@ describe ApiController do
       run_get services_url(svc1.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response_hash).to declare_actions("retire", "reconfigure")
+      expect(response.parsed_body).to declare_actions("retire", "reconfigure")
     end
 
     it "accepts action when service is reconfigurable" do

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -28,7 +28,7 @@ describe ApiController do
       category = api_settings.first
       run_get settings_url(category)
 
-      expect(response_hash[category]).to eq(Settings[category].to_hash.stringify_keys)
+      expect(response.parsed_body[category]).to eq(Settings[category].to_hash.stringify_keys)
     end
 
     it "rejects query for an invalid setting category " do

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -47,7 +47,7 @@ describe ApiController do
 
         expect { run_post tags_url, options }.to change(Tag, :count).by(1)
 
-        tag = Tag.find(response_hash["results"].first["id"])
+        tag = Tag.find(response.parsed_body["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -62,7 +62,7 @@ describe ApiController do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:id => category.id}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(response_hash["results"].first["id"])
+        tag = Tag.find(response.parsed_body["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -77,7 +77,7 @@ describe ApiController do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:name => category.name}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(response_hash["results"].first["id"])
+        tag = Tag.find(response.parsed_body["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -91,7 +91,7 @@ describe ApiController do
         expect do
           run_post "#{categories_url(category.id)}/tags", :name => "test_tag", :description => "Test Tag"
         end.to change(Tag, :count).by(1)
-        tag = Tag.find(response_hash["results"].first["id"])
+        tag = Tag.find(response.parsed_body["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -115,7 +115,7 @@ describe ApiController do
         expect do
           run_post tags_url(tag.id), gen_request(:edit, :name => "new_name")
         end.to change { classification.reload.tag.name }.to("#{category.tag.name}/new_name")
-        expect(response_hash["name"]).to eq("#{category.tag.name}/new_name")
+        expect(response.parsed_body["name"]).to eq("#{category.tag.name}/new_name")
         expect(response).to have_http_status(:ok)
       end
 
@@ -188,7 +188,7 @@ describe ApiController do
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect_result_to_match_hash(
-          response_hash,
+          response.parsed_body,
           "results" => [
             {"success" => true, "message" => "tags id: #{tag1.id} deleting"},
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}
@@ -212,7 +212,7 @@ describe ApiController do
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect_result_to_match_hash(
-          response_hash,
+          response.parsed_body,
           "results" => [
             {"success" => true, "message" => "tags id: #{tag1.id} deleting"},
             {"success" => true, "message" => "tags id: #{tag2.id} deleting"}

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -29,7 +29,7 @@ describe "tenant quotas API" do
       run_get "/api/tenants/#{tenant.id}/quotas/#{quota.id}"
 
       expect_result_to_match_hash(
-        response_hash,
+        response.parsed_body,
         "href"      => "/api/tenants/#{tenant.id}/quotas/#{quota.id}",
         "id"        => quota.id,
         "tenant_id" => tenant.id,

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "tenants API" do
     run_get tenants_url(tenant.id)
 
     expect_result_to_match_hash(
-      response_hash,
+      response.parsed_body,
       "href"        => tenants_url(tenant.id),
       "id"          => tenant.id,
       "name"        => "Test Tenant",
@@ -112,7 +112,7 @@ RSpec.describe "tenants API" do
         api_basic_authorize action_identifier(:tenants, :read, :resource_actions, :get)
         run_get tenants_url(root_tenant.id)
 
-        expect_result_to_match_hash(response_hash,
+        expect_result_to_match_hash(response.parsed_body,
                                     "href" => tenants_url(root_tenant.id),
                                     "id"   => root_tenant.id,
                                     "name" => config_attributes[:company],

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = response_hash["results"].first["id"]
+      user_id = response.parsed_body["results"].first["id"]
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -134,7 +134,7 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = response_hash["results"].first["id"]
+      user_id = response.parsed_body["results"].first["id"]
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -146,7 +146,7 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      results = response_hash["results"]
+      results = response.parsed_body["results"]
       user1_hash, user2_hash = results.first, results.second
       expect(User.exists?(user1_hash["id"])).to be_truthy
       expect(User.exists?(user2_hash["id"])).to be_truthy

--- a/spec/requests/api/versioning_spec.rb
+++ b/spec/requests/api/versioning_spec.rb
@@ -21,7 +21,7 @@ describe ApiController do
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(versions))
 
-      versions = response_hash["versions"]
+      versions = response.parsed_body["versions"]
 
       # Let's get the first version identifier
       expect(versions).to_not be_nil

--- a/spec/requests/api/virtual_templates_spec.rb
+++ b/spec/requests/api/virtual_templates_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Virtual Template API' do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys('results', expected_attributes)
 
-      id = response_hash['results'].first['id']
+      id = response.parsed_body['results'].first['id']
       expect(MiqTemplate.exists?(id)).to be_truthy
     end
 
@@ -100,7 +100,7 @@ RSpec.describe 'Virtual Template API' do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys('results', expected_attributes)
 
-      id = response_hash['results'].first['id']
+      id = response.parsed_body['results'].first['id']
       expect(MiqTemplate.exists?(id)).to be_truthy
     end
 
@@ -253,7 +253,7 @@ RSpec.describe 'Virtual Template API' do
       run_post(request_url, request)
 
       expect(response).to have_http_status(:ok)
-      task_id = response_hash['id']
+      task_id = response.parsed_body['id']
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -17,7 +17,7 @@ module ApiSpecHelper
   }
 
   def response_hash
-    JSON.parse(response.body)
+    response.parsed_body
   end
 
   def update_headers(headers)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -16,10 +16,6 @@ module ApiSpecHelper
     "Accept"       => "application/json"
   }
 
-  def response_hash
-    response.parsed_body
-  end
-
   def update_headers(headers)
     HEADER_ALIASES.keys.each do |k|
       if headers.key?(k)
@@ -177,44 +173,44 @@ module ApiSpecHelper
   # Rest API Expects
 
   def expect_bad_request(error_message)
-    expect(response_hash).to include_error_with_message(error_message)
+    expect(response.parsed_body).to include_error_with_message(error_message)
     expect(response).to have_http_status(:bad_request)
   end
 
   def expect_result_resources_to_include_data(collection, data)
-    expect(response_hash).to have_key(collection)
+    expect(response.parsed_body).to have_key(collection)
     fetch_value(data).each do |key, value|
       value_list = fetch_value(value)
-      expect(response_hash[collection].size).to eq(value_list.size)
-      expect(response_hash[collection].collect { |r| r[key] }).to match_array(value_list)
+      expect(response.parsed_body[collection].size).to eq(value_list.size)
+      expect(response.parsed_body[collection].collect { |r| r[key] }).to match_array(value_list)
     end
   end
 
   def expect_result_resources_to_include_hrefs(collection, hrefs)
-    expect(response_hash).to have_key(collection)
+    expect(response.parsed_body).to have_key(collection)
     href_list = fetch_value(hrefs)
-    expect(response_hash[collection].size).to eq(href_list.size)
+    expect(response.parsed_body[collection].size).to eq(href_list.size)
     href_list.each do |href|
-      expect(resources_include_suffix?(response_hash[collection], "href", href)).to be_truthy
+      expect(resources_include_suffix?(response.parsed_body[collection], "href", href)).to be_truthy
     end
   end
 
   def expect_result_resources_to_match_key_data(collection, key, values)
     value_list = fetch_value(values)
-    expect(response_hash).to have_key(collection)
-    expect(response_hash[collection].size).to eq(value_list.size)
-    value_list.zip(response_hash[collection]) do |value, hash|
+    expect(response.parsed_body).to have_key(collection)
+    expect(response.parsed_body[collection].size).to eq(value_list.size)
+    value_list.zip(response.parsed_body[collection]) do |value, hash|
       expect(hash).to have_key(key)
       expect(hash[key]).to match(value)
     end
   end
 
   def expect_result_to_have_keys(keys)
-    expect(response_hash).to include(*keys)
+    expect(response.parsed_body).to include(*keys)
   end
 
   def expect_result_to_have_only_keys(keys)
-    expect_hash_to_have_only_keys(response_hash, keys)
+    expect_hash_to_have_only_keys(response.parsed_body, keys)
   end
 
   def expect_hash_to_have_only_keys(hash, keys)
@@ -231,8 +227,8 @@ module ApiSpecHelper
   end
 
   def expect_results_to_match_hash(collection, result_hash)
-    expect(response_hash).to have_key(collection)
-    fetch_value(result_hash).zip(response_hash[collection]) do |expected, actual|
+    expect(response.parsed_body).to have_key(collection)
+    fetch_value(result_hash).zip(response.parsed_body[collection]) do |expected, actual|
       expect_result_to_match_hash(actual, expected)
     end
   end
@@ -242,39 +238,39 @@ module ApiSpecHelper
   end
 
   def expect_result_resource_keys_to_be_like_klass(collection, key, klass)
-    expect(response_hash).to have_key(collection)
-    expect(response_hash[collection].all? { |result| result[key].kind_of?(klass) }).to be_truthy
+    expect(response.parsed_body).to have_key(collection)
+    expect(response.parsed_body[collection].all? { |result| result[key].kind_of?(klass) }).to be_truthy
   end
 
   def expect_result_resources_to_include_keys(collection, keys)
-    expect(response_hash).to have_key(collection)
-    results = response_hash[collection]
+    expect(response.parsed_body).to have_key(collection)
+    results = response.parsed_body[collection]
     fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy, "resource missing: #{key}" }
   end
 
   def expect_result_resources_to_have_only_keys(collection, keys)
     key_list = fetch_value(keys).sort
-    expect(response_hash).to have_key(collection)
-    expect(response_hash[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
+    expect(response.parsed_body).to have_key(collection)
+    expect(response.parsed_body[collection].all? { |result| result.keys.sort == key_list }).to be_truthy
   end
 
   # Primary result construct methods
 
   def expect_empty_query_result(collection)
     expect(response).to have_http_status(:ok)
-    expect(response_hash).to include("name" => collection.to_s, "resources" => [])
+    expect(response.parsed_body).to include("name" => collection.to_s, "resources" => [])
   end
 
   def expect_query_result(collection, subcount, count = nil)
     expect(response).to have_http_status(:ok)
-    expect(response_hash).to include("name" => collection.to_s, "subcount" => fetch_value(subcount))
-    expect(response_hash["resources"].size).to eq(fetch_value(subcount))
-    expect(response_hash["count"]).to eq(fetch_value(count)) if count.present?
+    expect(response.parsed_body).to include("name" => collection.to_s, "subcount" => fetch_value(subcount))
+    expect(response.parsed_body["resources"].size).to eq(fetch_value(subcount))
+    expect(response.parsed_body["count"]).to eq(fetch_value(count)) if count.present?
   end
 
   def expect_single_resource_query(attr_hash)
     expect(response).to have_http_status(:ok)
-    expect_result_to_match_hash(response_hash, fetch_value(attr_hash))
+    expect_result_to_match_hash(response.parsed_body, fetch_value(attr_hash))
   end
 
   def expect_single_action_result(options = {})
@@ -284,7 +280,7 @@ module ApiSpecHelper
     expected["message"] = a_string_matching(options[:message]) if options[:message]
     expected["href"] = a_string_matching(fetch_value(options[:href])) if options[:href]
     expected.merge!(expected_task_response) if options[:task]
-    expect(response_hash).to include(expected)
+    expect(response.parsed_body).to include(expected)
   end
 
   def expect_multiple_action_result(count, options = {})
@@ -292,7 +288,7 @@ module ApiSpecHelper
     expected_result = {"success" => true}
     expected_result.merge!(expected_task_response) if options[:task]
     expected = {"results" => Array.new(count) { a_hash_including(expected_result) }}
-    expect(response_hash).to include(expected)
+    expect(response.parsed_body).to include(expected)
   end
 
   def expected_task_response
@@ -302,8 +298,8 @@ module ApiSpecHelper
   def expect_tagging_result(tagging_results)
     expect(response).to have_http_status(:ok)
     tag_results = fetch_value(tagging_results)
-    expect(response_hash).to have_key("results")
-    results = response_hash["results"]
+    expect(response.parsed_body).to have_key("results")
+    results = response.parsed_body["results"]
     expect(results.size).to eq(tag_results.size)
     tag_results.zip(results) do |tag_result, result|
       expect(result).to include(


### PR DESCRIPTION
Purpose or Intent
-----------------
Updates `response_hash` to use `response.parsed_body`, and then does away with this helper completely. It's one fewer thing to remember, and I was never happy with the naming of this method anyway (I disliked having the type in the name, but seemed like the best from a bunch). Thanks to @chrisarcand for bringing the new(ish) method on `response` to my attention.

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 