### PR TITLE
Fixed ordering of headers on VM watermark report.

### DIFF
--- a/product/reports/120_Configuration Management - Providers/050_Watermark Vms per Provider.yaml
+++ b/product/reports/120_Configuration Management - Providers/050_Watermark Vms per Provider.yaml
@@ -31,9 +31,9 @@ sortby:
 - resource_name
 headers:
 - Activity Sample - Month (YYYY/MM)
+- Region
 - Asset Name
 - VM Count Total (Max)
-- Region
 where_clause:
 db_options:
   :interval: daily


### PR DESCRIPTION
Purpose or Intent
-----------------
The headers for this report are out of order. See [here](https://github.com/imtayadeway/manageiq/blob/4cf140e56c7652fb567c3787595f371c66a644f4/product/reports/120_Configuration%20Management%20-%20Providers/050_Watermark%20Vms%20per%20Provider.yaml#L10-L14) for the column order as it appears in the report.

Steps for Testing/QA
--------------------
Requires some Cap&U metrics for running the report.

@miq-bot add-label core, bug, ui
@miq-bot assign @jrafanie 
