### PR TITLE
[WIP] Send Dialog field requests to Automate via the Queue

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -61,6 +61,6 @@ class ResourceAction < ApplicationRecord
   def deliver_to_automate_from_dialog_field(dialog_hash_values, target, user)
     _log.info("Running <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
 
-    MiqAeEngine.deliver(automate_queue_hash(target, dialog_hash_values[:dialog], user))
+    MiqAeEngine.deliver_synchronous(automate_queue_hash(target, dialog_hash_values[:dialog], user))
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -835,5 +835,23 @@ module MiqAeEngineSpec
         expect(workspace.root.attributes.keys.exclude?('field3')).to be_truthy
       end
     end
+
+    context ".deliver_synchronous" do
+      it "check task results" do
+        EvmSpecHelper.local_guid_miq_server_zone
+        root = {'ae_result' => 'error', 'test' => 1}
+        allow(MiqAeEngine).to receive(:deliver).and_return(root)
+        original_method = MiqTask.method(:wait_for_taskid)
+        allow(MiqTask).to receive(:wait_for_taskid) do |task_id, options = {}|
+          q = MiqQueue.first
+          state, message, result = q.deliver
+          q.delivered(state, message, result)
+          original_method.call(task_id, options)
+        end
+
+        expect(MiqAeEngine.deliver_synchronous('a' => 1, 'b' => 2)).to eql(root)
+        expect(MiqTask.first.task_results).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
> With Rails 5 and PUMA we are getting concurrent requests into the Automate engine from Dialogs with dynamic fields. Automate engine uses DRb to launch methods, with concurrent requests we could get a race condition where one method is starting and the other one is ending. Since DRb uses class methods to start_service and stop_service, we might terminate incorrect methods causing "Connection Refused" ECONNREFUSED errors.
To resolve this issue instead of running concurrent requests into the same process we are routing the Automate calls via the Queue. This will cause the performance issues since it is not a direct call since each request would be run in a separate process. 


Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1354054
> * http://talk.manageiq.org/t/errno-econnrefused-connection-refused-with-multiple-refresh-listeners/1392/4


Steps for Testing/QA
--------------------
> Difficult to create the race condition

https://bugzilla.redhat.com/show_bug.cgi?id=1354054

Instead of directly calling Automate from Dialogs send the
request over the queue.