### PR TITLE
Expose generic object and definition to automate

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -17,6 +17,10 @@ class GenericObjectDefinition < ApplicationRecord
 
   before_destroy :check_not_in_use
 
+  def create_object(options)
+    GenericObject.create!({:generic_object_definition => self}.merge(options))
+  end
+
   def defined_property_attributes
     properties[:attributes]
   end

--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -260,7 +260,7 @@ module MiqAeMethodService
     def object_send(name, *params)
       ar_method do
         begin
-          @object.send(name, *params)
+          @object.public_send(name, *params)
         rescue Exception => err
           $miq_ae_logger.error("The following error occurred during instance method <#{name}> for AR object <#{@object.inspect}>")
           raise

--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -1,0 +1,13 @@
+module MiqAeMethodService
+  class MiqAeServiceGenericObject < MiqAeServiceModelBase
+    private
+
+    def method_missing(method_name, *args)
+      object_send(method_name, *args)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      @object.respond_to?(method_name, include_private)
+    end
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object_definition.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object_definition.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceGenericObjectDefinition < MiqAeServiceModelBase
+    expose :defined_property_attributes
+    expose :create_object
+  end
+end

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -39,4 +39,13 @@ describe GenericObjectDefinition do
       expect { definition.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
     end
   end
+
+  describe '#create_object' do
+    it 'creates a generic object' do
+      obj = definition.create_object(:name => 'test', :max_number => 100)
+      expect(obj).to be_a_kind_of(GenericObject)
+      expect(obj.generic_object_definition).to eq(definition)
+      expect(obj.max_number).to eq(100)
+    end
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Add automate models for `GenericObjectDefinition` and `GenericObject`

Steps for Testing/QA
--------------------
User can create and access generic object. Generic object definition needs to pre-exist.