### PR TITLE
Don't load keys when generating keys

### DIFF
--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -85,7 +85,7 @@ module FixAuth
     end
 
     def run
-      set_passwords
+      set_passwords unless options[:key]
 
       generate_password if options[:key]
       fix_database_yml if options[:databaseyml]


### PR DESCRIPTION
Purpose or Intent
-----------------
To generate a new appliance encryption key (aka `v2_key`) users use:

```
mv certs/v2_key certs/v2_key.old
bundle exec ruby tools/fix_auth.rb --key
```

This displays an ugly warning but actually works

```
On an appliance, it should be generated on boot by evmserverd.

If you're a developer, you can copy the certs/v2_key.dev to certs/v2_key.

Caution, using the developer key will allow anyone with the public developer key to decrypt the two-way
passwords in your database.
```

Now if the user had not deleted the old `certs/v2_key` then it would throw and error and not generate a new `v2_key`. But if you note, it is very hard for the user to know if this is a problem or not

```
Only generate one encryption_key (v2_key) per installation.
Chances are you did not want to overwrite this file.
If you do this all encrypted secrets in the database will not be readable.
Please backup your key and run again.

tools/fix_auth/fix_auth.rb:50:in `rescue in generate_password': File exists - File exists @ rb_sysopen - certs/v2_key (Errno::EEXIST)
  from tools/fix_auth/fix_auth.rb:42:in `generate_password'
  from tools/fix_auth/fix_auth.rb:90:in `run'
  from tools/fix_auth/cli.rb:37:in `run'
  from tools/fix_auth/cli.rb:41:in `run'
  from ./tools/fix_auth.rb:24:in `<main>'
```

Solution
-------

Don't display a warning that the `v2_key` does not exist if we are in the process of generating the key.

https://bugzilla.redhat.com/show_bug.cgi?id=1356697