### PR TITLE
Fixed value assignment of id variable

### DIFF
--- a/app/views/miq_ae_customization/_dialog_field_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form.html.haml
@@ -61,9 +61,9 @@
       = _('Options')
     .form-horizontal
       - if @edit[:field_dynamic] == true
-        = render :partial => 'dialog_field_form_dynamic_options'
+        = render :partial => 'dialog_field_form_dynamic_options', :locals => {:url => url}
       - else
-        = render :partial => 'dialog_field_form_non_dynamic_options'
+        = render :partial => 'dialog_field_form_non_dynamic_options', :locals => {:url => url}
       .form-group
         %label.col-md-2.control-label
           = _('Auto Refresh other fields when modified')

--- a/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
@@ -1,5 +1,3 @@
-- url = url_for(:action => 'dialog_form_field_changed', :id => @record.id.to_s || 'new')
-
 .form-group
   %label.col-md-2.control-label
     = _('Entry Point (NS/Cls/Inst)')

--- a/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
@@ -1,4 +1,3 @@
-- url = url_for(:action => 'dialog_form_field_changed', :id => @record.id.to_s || 'new')
 .form-group
   %label.col-md-2.control-label
     = _('Visible')


### PR DESCRIPTION
Purpose or Intent
-----------------
This bug was introduced in https://github.com/ManageIQ/manageiq/pull/9423, changes at:
https://github.com/ManageIQ/manageiq/pull/9423/files#diff-e9876bc0951cc0bfad5b083d90d726efR1 & https://github.com/ManageIQ/manageiq/pull/9423/files#diff-c81c325b15df3f6deb16b0ebe7592ed2R1 were causing id to be set as "" in absence of ``@record.id``, changed code to set id to "new" when ``@record`` does not have id set(for new records).

Steps for Testing/QA
--------------------
Add a new Service Dialog, add a tab/box/element of TextBox type, then try to add a default value for textbox, this should throw an error.

Fixes #9862

@mkanoor please review/test.
@dclarizio please review.