### PR TITLE
Replacing validate_* by supports_* methods for smartstate_analysis

### DIFF
--- a/app/helpers/application_helper/button/vm_instance_scan.rb
+++ b/app/helpers/application_helper/button/vm_instance_scan.rb
@@ -4,8 +4,8 @@ class ApplicationHelper::Button::VmInstanceScan < ApplicationHelper::Button::Bas
   def calculate_properties
     super
     if disabled?
-      self[:title] = if !@record.is_available?(:smartstate_analysis)
-                       @record.is_available_now_error_message(:smartstate_analysis)
+      self[:title] = if !@record.supports_smartstate_analysis?
+                       @record.unsupported_reason(:smartstate_analysis)
                      else
                        @record.active_proxy_error_message
                      end
@@ -14,13 +14,12 @@ class ApplicationHelper::Button::VmInstanceScan < ApplicationHelper::Button::Bas
 
   def skip?
     return false if @display == "instances"
-    !(@record.is_available?(:smartstate_analysis) ||
-      @record.is_available_now_error_message(:smartstate_analysis)) ||
-    !@record.has_proxy?
+    !(@record.supports_smartstate_analysis? || @record.unsupported_reason(:smartstate_analysis)) ||
+      !@record.has_proxy?
   end
 
   def disabled?
     return false if @display == "instances"
-    !(@record.is_available?(:smartstate_analysis) && @record.has_active_proxy?)
+    !(@record.supports_smartstate_analysis? && @record.has_active_proxy?)
   end
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -796,7 +796,8 @@ class ApplicationHelper::ToolbarBuilder
       when "miq_template_refresh"
         return true if @record && !@record.ext_management_system && !(@record.host && @record.host.vmm_product.downcase == "workstation")
       when "miq_template_scan", "image_scan"
-        return true unless @record.is_available?(:smartstate_analysis) || @record.is_available_now_error_message(:smartstate_analysis)
+        return true unless (@record.supports_smartstate_analysis? ||
+            @record.unsupported_reason(:smartstate_analysis))
         return true unless @record.has_proxy?
       when "miq_template_refresh", "miq_template_reload"
         return true unless @perf_options[:typ] == "realtime"
@@ -1233,7 +1234,7 @@ class ApplicationHelper::ToolbarBuilder
             {:storage => ui_lookup(:table => "storage")}
         end
       when "storage_scan"
-        return @record.is_available_now_error_message(:smartstate_analysis) unless @record.is_available?(:smartstate_analysis)
+        return @record.unsupported_reason(:smartstate_analysis) unless @record.supports_smartstate_analysis?
       end
     when "Tenant"
       return N_("Default Tenant can not be deleted") if @record.parent.nil? && id == "rbac_tenant_delete"
@@ -1336,7 +1337,7 @@ class ApplicationHelper::ToolbarBuilder
       when "miq_template_perf"
         return N_("No Capacity & Utilization data has been collected for this Template") unless @record.has_perf_data?
       when "miq_template_scan", "image_scan"
-        return @record.is_available_now_error_message(:smartstate_analysis) unless @record.is_available?(:smartstate_analysis)
+        return @record.unsupported_reason(:smartstate_analysis) unless @record.supports_smartstate_analysis?
         return @record.active_proxy_error_message unless @record.has_active_proxy?
       when "miq_template_timeline"
         unless @record.has_events? || @record.has_events?(:policy_events)

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -1,4 +1,15 @@
 module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
+  extend ActiveSupport::Concern
+
+  included do
+    supports :smartstate_analysis do
+      feature_supported, reason = check_feature_support('smartstate_analysis')
+      unless feature_supported
+        unsupported_reason_add(:smartstate_analysis, reason)
+      end
+    end
+  end
+
   def perform_metadata_scan(ost)
     require 'MiqVm/miq_azure_vm'
 
@@ -44,9 +55,5 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
 
   def requires_storage_for_scan?
     false
-  end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
   end
 end

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers
     include SupportsFeatureMixin
     supports_not :provisioning # via automate
     supports_not :regions      # as in ManageIQ::Providers::<Type>::Regions
+    supports_not :smartstate_analysis
 
     def self.metrics_collector_queue_name
       self::MetricsCollectorWorker.default_queue_name

--- a/app/models/manageiq/providers/google/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/template.rb
@@ -3,8 +3,4 @@ class ManageIQ::Providers::Google::CloudManager::Template < ManageIQ::Providers:
     connection ||= ext_management_system.connect
     connection.images[ems_ref]
   end
-
-  def validate_smartstate_analysis
-    validate_unsupported("Smartstate Analysis")
-  end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm.rb
@@ -36,8 +36,4 @@ class ManageIQ::Providers::Google::CloudManager::Vm < ManageIQ::Providers::Cloud
       "unknown"
     end
   end
-
-  def validate_smartstate_analysis
-    validate_unsupported("Smartstate Analysis")
-  end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
@@ -1,4 +1,15 @@
 module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scanning
+  extend ActiveSupport::Concern
+
+  included do
+    supports :smartstate_analysis do
+      feature_supported, reason = check_feature_support('smartstate_analysis')
+      unless feature_supported
+        unsupported_reason_add(:smartstate_analysis, reason)
+      end
+    end
+  end
+
   def perform_metadata_scan(ost)
     require 'MiqVm/miq_scvmm_vm'
 
@@ -20,10 +31,6 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
 
   def perform_metadata_sync(ost)
     sync_stashed_metadata(ost)
-  end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
   end
 
   def requires_storage_for_scan?

--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -1,6 +1,13 @@
 class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
   belongs_to :cloud_tenant
 
+  supports :smartstate_analysis do
+    feature_supported, reason = check_feature_support('smartstate_analysis')
+    unless feature_supported
+      unsupported_reason_add(:smartstate_analysis, reason)
+    end
+  end
+
   has_and_belongs_to_many :cloud_tenants,
                           :foreign_key             => "vm_id",
                           :join_table              => "cloud_tenants_vms",
@@ -56,9 +63,5 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
 
   def requires_storage_for_scan?
     false
-  end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -3,6 +3,13 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   include_concern 'RemoteConsole'
   include_concern 'Resize'
 
+  supports :smartstate_analysis do
+    feature_supported, reason = check_feature_support('smartstate_analysis')
+    unless feature_supported
+      unsupported_reason_add(:smartstate_analysis, reason)
+    end
+  end
+
   POWER_STATES = {
     "ACTIVE"            => "on",
     "SHUTOFF"           => "off",
@@ -108,9 +115,5 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
 
   def memory_mb_available?
     true
-  end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/template.rb
@@ -1,6 +1,13 @@
 class ManageIQ::Providers::Openstack::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
   belongs_to :cloud_tenant
 
+  supports :smartstate_analysis do
+    feature_supported, reason = check_feature_support('smartstate_analysis')
+    unless feature_supported
+      unsupported_reason_add(:smartstate_analysis, reason)
+    end
+  end
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.images.get(ems_ref)
@@ -12,9 +19,5 @@ class ManageIQ::Providers::Openstack::InfraManager::Template < ManageIQ::Provide
 
   def has_proxy?
     true
-  end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb
@@ -1,4 +1,15 @@
 module ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared::Scanning
+  extend ActiveSupport::Concern
+
+  included do
+    supports :smartstate_analysis do
+      feature_supported, reason = check_feature_support('smartstate_analysis')
+      unless feature_supported
+        unsupported_reason_add(:smartstate_analysis, reason)
+      end
+    end
+  end
+
   def perform_metadata_scan(ost)
     require 'MiqVm/MiqRhevmVm'
 
@@ -54,10 +65,6 @@ module ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared::Scanning
     end
 
     {:proxies => proxies.flatten, :message => _(msg)}
-  end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
   end
 
   def miq_server_proxies

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -21,6 +21,7 @@ module ManageIQ::Providers
     before_destroy :stop_event_monitor
 
     supports :provisioning
+    supports :smartstate_analysis
 
     def self.ems_type
       @ems_type ||= "vmwarews".freeze

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
@@ -1,4 +1,15 @@
 module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
+  extend ActiveSupport::Concern
+
+  included do
+    supports :smartstate_analysis do
+      feature_supported, reason = check_feature_support('smartstate_analysis')
+      unless feature_supported
+        unsupported_reason_add(:smartstate_analysis, reason)
+      end
+    end
+  end
+
   def perform_metadata_scan(ost)
     require 'MiqVm/MiqVm'
 
@@ -27,10 +38,6 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
 
   def perform_metadata_sync(ost)
     sync_stashed_metadata(ost)
-  end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
   end
 
   private

--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -20,5 +20,4 @@ module Vm::Operations::Lifecycle
   def validate_publish
     {:available => !(self.blank? || self.orphaned? || self.archived?), :message   => nil}
   end
-
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1938,13 +1938,13 @@ class VmOrTemplate < ApplicationRecord
     {:available => true,   :message => nil}
   end
 
-  def validate_supported_check(message_prefix)
-    return {:available => false, :message => nil} if self.archived?
-    if self.orphaned?
-      return {:available => false,
-              :message   => "#{message_prefix} cannot be performed on orphaned #{self.class.model_suffix} VM."}
+  def check_feature_support(message_prefix)
+    if archived?
+      return [false, nil]
+    elsif orphaned?
+      return [false, _("#{message_prefix} cannot be performed on orphaned VM.")]
     end
-    {:available => true,   :message => nil}
+    [true, nil]
   end
 
   # this is verbose, helper for generating arel

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -8,6 +8,12 @@ require 'blackbox/VmBlackBox'
 module VmOrTemplate::Scanning
   extend ActiveSupport::Concern
 
+  # Smartstate Analysis is unsupported by default.
+  # Subclasses need to override this method if they support SSA.
+  included do
+    supports_not :smartstate_analysis, :reason => _("Smartstate Analysis is not available for VM or Template.")
+  end
+
   # Call the VmScan Job and raise a "request" event
   def scan(userid = "system", options = {})
     # Check if there are any current scan jobs already waiting to run
@@ -49,14 +55,6 @@ module VmOrTemplate::Scanning
       _log.log_backtrace(err)
       raise
     end
-  end
-
-  #
-  # Smartstate Analysis is unsupported by default.
-  # Subclasses need to override this method if they support SSA.
-  #
-  def validate_smartstate_analysis
-    validate_unsupported("Smartstate Analysis")
   end
 
   #

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -11,7 +11,8 @@ module VmOrTemplate::Scanning
   # Smartstate Analysis is unsupported by default.
   # Subclasses need to override this method if they support SSA.
   included do
-    supports_not :smartstate_analysis, :reason => _("Smartstate Analysis is not available for VM or Template.")
+    supports_not :smartstate_analysis,
+                 :reason => _("Smartstate Analysis is not available for this type of VM or Template.")
   end
 
   # Call the VmScan Job and raise a "request" event

--- a/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
@@ -71,9 +71,9 @@ describe ApplicationHelper::Button::VmInstanceScan do
       before do
         @record = FactoryGirl.create(:vm_amazon, :vendor => "amazon")
         allow(@record).to receive(:has_active_proxy?).and_return(true)
-        allow(@record).to receive(:is_available?).with(:smartstate_analysis).and_return(false)
+        allow(@record).to receive(:supports_smartstate_analysis?).and_return(false)
         message = "xx smartstate_analysis message"
-        allow(@record).to receive(:is_available_now_error_message).with(:smartstate_analysis).and_return(message)
+        allow(@record).to receive(:unsupported_reason).with(:smartstate_analysis).and_return(message)
       end
 
       it "returns the smartstate_analysis error message" do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1447,12 +1447,23 @@ describe ApplicationHelper do
       context "and id = miq_template_scan" do
         before { @id = "miq_template_scan" }
 
-        it "and !@record.has_proxy?" do
+        it "returns true for hiding the button when @record neither has proxy nor supports smartstate analysis" do
+          allow(@record).to receive_messages(:supports_smartstate_analysis? => false, :has_proxy? => false)
           expect(subject).to be_truthy
         end
 
-        it "and @record.has_proxy?" do
-          allow(@record).to receive_messages(:has_proxy? => true)
+        it "returns true for hiding the button when @record does not have proxy but it supports smartstate analysis" do
+          allow(@record).to receive_messages(:supports_smartstate_analysis? => true, :has_proxy? => false)
+          expect(subject).to be_truthy
+        end
+
+        it "returns true for hiding the button when @record has proxy but it does not support smartstate analysis" do
+          allow(@record).to receive_messages(:supports_smartstate_analysis? => false, :has_proxy? => true)
+          expect(subject).to be_truthy
+        end
+
+        it "returns false for hiding the button when @record has proxy and it supports smartstate analysis" do
+          allow(@record).to receive_messages(:supports_smartstate_analysis? => true, :has_proxy? => true)
           expect(subject).to be_falsey
         end
       end

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -415,15 +415,15 @@ describe Storage do
       @storage =  FactoryGirl.create(:storage)
     end
 
-    it "returns true for VMware Storage" do
+    it "returns true for VMware Storage when queried whether it supports smartstate analysis" do
       FactoryGirl.create(:host_vmware,
                          :ext_management_system => FactoryGirl.create(:ems_vmware),
                          :storages              => [@storage])
-      expect(@storage.is_available?(:smartstate_analysis)).to eq(true)
+      expect(@storage.supports_smartstate_analysis?).to eq(true)
     end
 
-    it "returns false for non-vmware Storage" do
-      expect(@storage.is_available?(:smartstate_analysis)).to_not eq(true)
+    it "returns false for non-vmware Storage when queried whether it supports smartstate analysis" do
+      expect(@storage.supports_smartstate_analysis?).to_not eq(true)
     end
   end
 
@@ -432,11 +432,11 @@ describe Storage do
       @storage =  FactoryGirl.create(:storage)
     end
 
-    it "when the storage supports smarstate analysis,  returns false" do
+    it "returns false when queried whether the storage supports smarstate analysis" do
       expect(Storage.batch_operation_supported?(:smartstate_analysis, [@storage.id])).to eq(false)
     end
 
-    it "when the storage perform smartstate analysis, returns true" do
+    it "returns true when queried whether the storage supports smarstate analysis" do
       FactoryGirl.create(:host_vmware,
                          :ext_management_system => FactoryGirl.create(:ems_vmware),
                          :storages              => [@storage])
@@ -481,15 +481,15 @@ describe Storage do
       @storage = FactoryGirl.create(:storage)
     end
 
-    it "returns true for VMware Storage" do
+    it "returns true for VMware Storage when queried whether it supports smartstate analysis" do
       FactoryGirl.create(:host_vmware,
                          :ext_management_system => FactoryGirl.create(:ems_vmware),
                          :storages              => [@storage])
-      expect(@storage.is_available?(:smartstate_analysis)).to eq(true)
+      expect(@storage.supports_smartstate_analysis?).to eq(true)
     end
 
-    it "returns false for non-vmware Storage" do
-      expect(@storage.is_available?(:smartstate_analysis)).to_not eq(true)
+    it "returns false for non-vmware Storage when queried whether it supports smartstate analysis" do
+      expect(@storage.supports_smartstate_analysis?).to_not eq(true)
     end
   end
   describe "#smartstate_analysis_count_for_host_id" do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -452,17 +452,17 @@ describe VmOrTemplate do
     end
   end
 
-  context "#is_available? for Smartstate Analysis" do
+  context "#supports_smartstate_analysis?" do
     it "returns true for VMware VM" do
       vm =  FactoryGirl.create(:vm_vmware)
       allow(vm).to receive_messages(:archived? => false)
       allow(vm).to receive_messages(:orphaned? => false)
-      expect(vm.is_available?(:smartstate_analysis)).to eq(true)
+      expect(vm.supports_smartstate_analysis?).to eq(true)
     end
 
     it "returns false for Amazon VM" do
       vm =  FactoryGirl.create(:vm_amazon)
-      expect(vm.is_available?(:smartstate_analysis)).to_not eq(true)
+      expect(vm.supports_smartstate_analysis?).to_not eq(true)
     end
   end
 

--- a/spec/support/examples_group/shared_examples_for_application_helper.rb
+++ b/spec/support/examples_group/shared_examples_for_application_helper.rb
@@ -23,7 +23,11 @@ end
 shared_examples_for 'record with error message' do |name|
   it "returns the #{name} error message" do
     message = "xx #{name} message"
-    allow(@record).to receive(:is_available_now_error_message).with(name.to_sym).and_return(message)
+    if @record.respond_to?("supports_#{name.to_sym}?")
+      allow(@record).to receive(:unsupported_reason).with(name.to_sym).and_return(message)
+    else
+      allow(@record).to receive(:is_available_now_error_message).with(name.to_sym).and_return(message)
+    end
     expect(subject).to eq(message)
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------

This PR targets to remove the occurrences of validate_* methods for migrate and smartstate_analysis and replace by them supports_* methods using SupportsFeatureMixin.

Testing
------------------------
Could not test this locally. Relying on travis build result.