### PR TITLE
WinRMv2.1 Support

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -20,11 +20,11 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     @description ||= "Microsoft System Center VMM".freeze
   end
 
-  def self.raw_connect(auth_url, security_protocol, connect_params)
+  def self.raw_connect(connect_params)
     require 'winrm'
 
-    winrm = WinRM::WinRMWebService.new(auth_url, security_protocol.to_sym, connect_params)
-    winrm.set_timeout(1800)
+    connect_params[:operation_timeout] = 1800
+    winrm = WinRM::Connection.new(connect_params)
     winrm
   end
 
@@ -35,11 +35,11 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
   def connect(options = {})
     raise "no credentials defined" if self.missing_credentials?(options[:auth_type])
 
-    hostname       = options[:hostname] || self.hostname
-    auth_url       = self.class.auth_url(hostname, port)
-    connect_params = build_connect_params(options)
+    hostname           = options[:hostname] || self.hostname
+    options[:endpoint] = self.class.auth_url(hostname, port)
+    connect_params     = build_connect_params(options)
 
-    self.class.raw_connect(auth_url, security_protocol, connect_params)
+    self.class.raw_connect(connect_params)
   end
 
   def verify_credentials(_auth_type = nil, options = {})
@@ -138,7 +138,8 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
   def build_connect_params(options)
     connect_params  = {
       :user         => options[:user] || authentication_userid(options[:auth_type]),
-      :pass         => options[:pass] || authentication_password(options[:auth_type]),
+      :password     => options[:pass] || authentication_password(options[:auth_type]),
+      :endpoint     => options[:endpoint],
       :disable_sspi => true
     }
 

--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -137,8 +137,8 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
 
   def build_connect_params(options)
     connect_params  = {
-      :user         => options[:user] || authentication_userid(options[:auth_type]),
-      :password     => options[:pass] || authentication_password(options[:auth_type]),
+      :user         => options[:user]     || authentication_userid(options[:auth_type]),
+      :password     => options[:password] || authentication_password(options[:auth_type]),
       :endpoint     => options[:endpoint],
       :disable_sspi => true
     }

--- a/app/models/manageiq/providers/microsoft/infra_manager/host.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/host.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::Microsoft::InfraManager::Host < ::Host
   def verify_credentials(auth_type = nil, _options = {})
     raise MiqException::MiqHostError "No credentials defined" if missing_credentials?(auth_type)
-    options                        = {}
-    options[:user], options[:pass] = auth_user_pwd(auth_type)
-    options[:hostname]             = hostname
+    options                            = {}
+    options[:user], options[:password] = auth_user_pwd(auth_type)
+    options[:hostname]                 = hostname
     verify_credentials_windows(options)
   end
 
@@ -12,7 +12,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::Host < ::Host
     $scvmm_log.info "MIQ(#{self.class.name}.#{__method__}) Verifying credentials for hostname #{options[:hostname]}"
     begin
       winrm = MiqWinRM.new
-      winrm.connect(options).run_powershell_script("hostname")
+      winrm.connect(options).shell(:powershell).run("hostname")
     rescue WinRM::WinRMHTTPTransportError => e
       raise MiqException::MiqHostError, "Check credentials and WinRM configuration settings. " \
       "Remote error message: #{e.message}"

--- a/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
@@ -9,10 +9,7 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       def run_powershell_script(connection, script)
         log_header = "MIQ(#{self.class.name}.#{__method__})"
-        script_string = ""
-        File.open(script, "r") do |file|
-          script_string << file.read
-        end
+        script_string = IO.read(script)
         begin
           results = connection.shell(:powershell).run(script_string)
           log_dos_error_results(results)
@@ -95,10 +92,7 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       _result, timings = Benchmark.realtime_block(:execution) do
         with_provider_connection do |connection|
-          script_string = ""
-          File.open(script, "r") do |file|
-            script_string << file.read
-          end
+          script_string = IO.read(script)
           results = connection.shell(:powershell).run(script_string)
           self.class.log_dos_error_results(results)
         end

--- a/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
@@ -9,12 +9,12 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       def run_powershell_script(connection, script)
         log_header = "MIQ(#{self.class.name}.#{__method__})"
-        script = ""
+        script_string = ""
         File.open(script, "r") do |file|
-          script << file.read
+          script_string << file.read
         end
         begin
-          results = connection.shell(:powershell).run(script)
+          results = connection.shell(:powershell).run(script_string)
           log_dos_error_results(results)
           results
         rescue Errno::ECONNREFUSED => err
@@ -95,11 +95,11 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       _result, timings = Benchmark.realtime_block(:execution) do
         with_provider_connection do |connection|
-          script = ""
+          script_string = ""
           File.open(script, "r") do |file|
-            script << file.read
+            script_string << file.read
           end
-          results = connection.shell(:powershell).run(script)
+          results = connection.shell(:powershell).run(script_string)
           self.class.log_dos_error_results(results)
         end
       end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
@@ -84,13 +84,13 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
       rescue Timeout::Error => err
         msg = "#{log_text} timed out for VM:[#{vm_name}] with error [#{err}] after [#{Time.now.getlocal - st}] seconds"
         $log.error msg
-        ost.miq_scvmm.close
         raise err, msg, err.backtrace
       rescue Exception => err
         msg = "#{log_text} failed for VM:[#{vm_name}] with error [#{err}] after [#{Time.now.getlocal - st}] seconds"
         $log.error msg
-        ost.miq_scvmm.close
         raise err, msg, err.backtrace
+      ensure
+        ost.miq_scvmm.close
       end
     end
   end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
@@ -84,10 +84,12 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
       rescue Timeout::Error => err
         msg = "#{log_text} timed out for VM:[#{vm_name}] with error [#{err}] after [#{Time.now.getlocal - st}] seconds"
         $log.error msg
+        ost.miq_scvmm.close
         raise err, msg, err.backtrace
       rescue Exception => err
         msg = "#{log_text} failed for VM:[#{vm_name}] with error [#{err}] after [#{Time.now.getlocal - st}] seconds"
         $log.error msg
+        ost.miq_scvmm.close
         raise err, msg, err.backtrace
       end
     end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -56,9 +56,8 @@ group :appliance do
   gem "highline", "~> 1.6.21", :require => false  # Needed for the appliance_console
 end
 
-gem "winrm",                   "~>2.0",             :require => false
-gem "winrm-elevated",          "~>1.0",             :require => false
-gem "winrm-fs",                "~>1.0",             :require => false
+gem "winrm",                   "~>2.1",             :require => false
+gem "winrm-elevated",          "~>1.0.1",           :require => false
 
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -46,8 +46,6 @@ gem "sys-proctable",           "~>1.1.3",           :require => false
 gem "sys-uname",               "~>1.0.1",           :require => false
 gem "trollop",                 "~>2.0",             :require => false
 gem "uuidtools",               "~>2.1.3",           :require => false
-gem "winrm",                   "~>1.7.2",           :require => false
-gem "winrm-elevated",          "~>0.4.0",           :require => false
 gem "zip-zip",                 "~>0.3.0",           :require => false
 
 # Modified gems (forked on github)
@@ -57,6 +55,10 @@ gem "rubywbem",            :require => false, :git => "https://github.com/Manage
 group :appliance do
   gem "highline", "~> 1.6.21", :require => false  # Needed for the appliance_console
 end
+
+gem "winrm",                   "~>2.0",             :require => false
+gem "winrm-elevated",          "~>1.0",             :require => false
+gem "winrm-fs",                "~>1.0",             :require => false
 
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")

--- a/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
+++ b/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
@@ -68,10 +68,8 @@ class MiqScvmmParsePowershell
   def stdout_stderr(output)
     stdout = ""
     stderr = ""
-    output[:data].each do |d|
-      stdout << d[:stdout] unless d[:stdout].nil?
-      stderr << d[:stderr] unless d[:stderr].nil?
-    end
+    stdout << output.stdout unless output.stdout.nil?
+    stderr << output.stderr unless output.stderr.nil?
     return stdout, stderr
   end
 end

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -12,11 +12,15 @@ class MiqScvmmVmSSAInfo
     @vhd_type    = nil
     @winrm       = MiqWinRM.new
     winrmport    = port.nil? ? 5985 : port
-    options      = {:port => winrmport, :user => user, :pass => pass, :hostname => provider}
+    options      = {:port => winrmport, :user => user, :password => pass, :hostname => provider}
     @elevated    = nil
 
     @winrm.connect(options)
     @parser = MiqScvmmParsePowershell.new
+  end
+
+  def close
+    @winrm.close
   end
 
   # Note the following method returns *all* hard disks and some common attributes from the Hyper-V host

--- a/gems/pending/spec/util/miq_winrm_spec.rb
+++ b/gems/pending/spec/util/miq_winrm_spec.rb
@@ -16,17 +16,17 @@ describe MiqWinRM do
 
   context "New Connection" do
     it "creates a network connection" do
-      expect { @winrm.connect(:user => @user, :pass => @password, :hostname => @host) }.to_not raise_error
+      expect { @winrm.connect(:user => @user, :password => @password, :hostname => @host) }.to_not raise_error
     end
   end
 
   context "Existing Connection Attributes" do
     before(:each) do
-      @connection = @winrm.connect(:user => @user, :pass => @password, :hostname => @host)
+      @connection = @winrm.connect(:user => @user, :password => @password, :hostname => @host)
     end
 
     it "is the correct WinRM class" do
-      expect(@connection).to be_a(WinRM::WinRMWebService)
+      expect(@connection).to be_a(WinRM::Connection)
     end
 
     it "still has a nil executor" do

--- a/gems/pending/spec/util/miq_winrm_spec.rb
+++ b/gems/pending/spec/util/miq_winrm_spec.rb
@@ -8,12 +8,6 @@ describe MiqWinRM do
     @winrm    = MiqWinRM.new
   end
 
-  context "New Object" do
-    it "has a nil executor" do
-      expect(@winrm.executor).to be_nil
-    end
-  end
-
   context "New Connection" do
     it "creates a network connection" do
       expect { @winrm.connect(:user => @user, :password => @password, :hostname => @host) }.to_not raise_error
@@ -27,10 +21,6 @@ describe MiqWinRM do
 
     it "is the correct WinRM class" do
       expect(@connection).to be_a(WinRM::Connection)
-    end
-
-    it "still has a nil executor" do
-      expect(@winrm.executor).to be_nil
     end
 
     it "has the correct attributes" do

--- a/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
@@ -18,25 +18,25 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
     end
 
     it "defaults" do
-      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
-        expect(url).to match(/host/)
-        expect(protocol).to eq("ssl")
-        expect(creds[:user]).to eq("user")
-        expect(creds[:pass]).to eq("pass")
+      expect(described_class).to receive(:raw_connect) do |connection|
+        expect(connection[:endpoint]).to match("http://host:5985/wsman")
+        expect(connection[:disable_sspi]).to eq(true)
+        expect(connection[:user]).to eq("user")
+        expect(connection[:password]).to eq("pass")
       end
 
       @e.connect
     end
 
     it "accepts overrides" do
-      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
-        expect(url).to match(/host2/)
-        expect(protocol).to eq("ssl")
-        expect(creds[:user]).to eq("user2")
-        expect(creds[:pass]).to eq("pass2")
+      expect(described_class).to receive(:raw_connect) do |connection|
+        expect(connection[:endpoint]).to match("http://host2:5985/wsman")
+        expect(connection[:disable_sspi]).to eq(true)
+        expect(connection[:user]).to eq("user2")
+        expect(connection[:password]).to eq("pass2")
       end
 
-      @e.connect(:user => "user2", :pass => "pass2", :hostname => "host2")
+      @e.connect(:user => "user2", :password => "pass2", :hostname => "host2")
     end
   end
 
@@ -47,27 +47,29 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
     end
 
     it "defaults" do
-      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
-        expect(url).to match(/host/)
-        expect(protocol).to eq("kerberos")
-        expect(creds[:user]).to eq("user")
-        expect(creds[:pass]).to eq("pass")
-        expect(creds[:realm]).to eq("pretendrealm")
+      expect(described_class).to receive(:raw_connect) do |connection|
+        expect(connection[:endpoint]).to match("http://host:5985/wsman")
+        expect(connection[:disable_sspi]).to eq(false)
+        expect(connection[:basic_auth_only]).to eq(false)
+        expect(connection[:user]).to eq("user")
+        expect(connection[:password]).to eq("pass")
+        expect(connection[:realm]).to eq("pretendrealm")
       end
 
       @e.connect
     end
 
     it "accepts overrides" do
-      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
-        expect(url).to match(/host2/)
-        expect(protocol).to eq("kerberos")
-        expect(creds[:user]).to eq("user2")
-        expect(creds[:pass]).to eq("pass2")
-        expect(creds[:realm]).to eq("pretendrealm")
+      expect(described_class).to receive(:raw_connect) do |connection|
+        expect(connection[:endpoint]).to match("http://host2:5985/wsman")
+        expect(connection[:disable_sspi]).to eq(false)
+        expect(connection[:basic_auth_only]).to eq(false)
+        expect(connection[:user]).to eq("user2")
+        expect(connection[:password]).to eq("pass2")
+        expect(connection[:realm]).to eq("pretendrealm")
       end
 
-      @e.connect(:user => "user2", :pass => "pass2", :hostname => "host2")
+      @e.connect(:user => "user2", :password => "pass2", :hostname => "host2")
     end
   end
 end


### PR DESCRIPTION
Add support for the new V2.1 version of the WinRM Gem.
This Gem uses the PSRP protocol to communicate to PowerShell
processes running on the Windows server.

Except for elevated processes needed to access network shares (see below)
this support allows powershell to run across invocations of WinRM.  Variables
created in one invocation can continue to be accessed in further invocations
using the same shell.

The API has changed somewhat requiring changes in the Microsoft Provider code
as well as in the gems/pending code for SCVMM/HyperV SSA.


@roliveri @Fryguy @djberg96 please review and merge.