### PR TITLE
remove coupling of Host to authentication_mixin

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -268,13 +268,12 @@ module AuthenticationMixin
 
   def authentication_check_no_validation(type, options)
     header  = "type: [#{type.inspect}] for [#{id}] [#{name}]"
-    verify_args = self.kind_of?(Host) ? [type, options] : type
     status, details =
       if self.missing_credentials?(type)
         [:incomplete, "Missing credentials"]
       else
         begin
-          verify_credentials(*verify_args) ? [:valid, ""] : [:invalid, "Unknown reason"]
+          verify_credentials(type, options) ? [:valid, ""] : [:invalid, "Unknown reason"]
         rescue MiqException::MiqUnreachableError => err
           [:unreachable, err]
         rescue MiqException::MiqInvalidCredentialsError => err

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -340,7 +340,9 @@ describe AuthenticationMixin do
         conditions = {:class_name => @ems.class.base_class.name, :instance_id => @ems.id, :method_name => 'authentication_check_types', :role => @ems.authentication_check_role}
         queued_auth_checks = MiqQueue.where(conditions)
         expect(queued_auth_checks.length).to eq(1)
-        expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:verify_credentials).with(:default)
+        expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to(
+          receive(:verify_credentials).with(:default, :remember_host => true)
+        )
         queued_auth_checks.first.deliver
       end
 


### PR DESCRIPTION
authentication_check_no_validation was branching if it was called
as a Host. Then it would call verify_credentials with two arguments
type and options. As all methods of verify_credential accept two
parameters this branch is not needed and removed