### PR TITLE
Broken links in ems-providers show-list view

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -241,7 +241,7 @@ module QuadiconHelper
     if quadicon_in_explorer_view?
       quadicon_build_explorer_url(item, row)
     else
-      url_for_db(quadicon_model_name(item))
+      url_for_db(quadicon_model_name(item), "show", item)
     end
   end
 

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -336,6 +336,21 @@ describe QuadiconHelper do
       end
     end
 
+    context "when item is a EmsContainer" do
+      let(:ems) do
+        FactoryGirl.create(:ems_container, :name => "Ems Container")
+      end
+
+      subject { helper.render_quadicon_text(ems, row) }
+
+      it "renders a link to ems_container" do
+        @id = ems.id
+
+        expect(subject).to have_selector('a')
+        expect(subject).to include("/ems_container/#{@id}")
+      end
+    end
+
     context "when item is a StorageManager" do
       let(:stor) do
         FactoryGirl.create(:storage_manager, :name => "Store Man")


### PR DESCRIPTION
**Description**

The show-list view of restful ems-providers has broken links, in the text below icon.

**Screenshot** 
The bug showing bad links:
![link-bug](https://cloud.githubusercontent.com/assets/2181522/16908274/d4b4a006-4cd2-11e6-8297-6833949884bb.png)

The fix showing good links:
![link-bug-fix](https://cloud.githubusercontent.com/assets/2181522/16908304/189841d8-4cd3-11e6-89b0-8b2106415946.png)

**Issue**
https://github.com/ManageIQ/manageiq/issues/9874