### PR TITLE
refactor is_available retire to supports_retire

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -847,9 +847,9 @@ class ApplicationHelper::ToolbarBuilder
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
       when "vm_retire"
-        return true unless @record.is_available?(:retire)
+        return true unless @record.supports_retire?
       when "vm_retire_now"
-        return true unless @record.is_available?(:retire_now)
+        return true unless @record.supports_retire?
       when "vm_stop", "instance_stop"
         return true unless @record.is_available?(:stop)
       when "vm_reset", "instance_reset"


### PR DESCRIPTION
changes two calls to `is_available?(:retire)` to `supports_retire?` which were missed in https://github.com/ManageIQ/manageiq/pull/9841

@miq-bot add_labels pluggable providers, refactoring, darga/yes

@chessbyte this fixes broken build of darga introduced by https://github.com/ManageIQ/manageiq/pull/9841