### PR TITLE
Keep JS function names and arguments even if they aren't referenced

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "simple-rss",                     "~>1.3.1",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sshkey",                         "~>1.8.0",       :require => false
 gem "thin",                           "~>1.7.0",       :require => false
-gem "uglifier",                       "~>2.7.1",       :require => false
+gem "uglifier",                       "~>2.7.1"
 gem "websocket-driver",               "~>0.6.3"
 
 # Modified gems (forked on Github)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,11 @@ Vmdb::Application.configure do
 
   config.action_controller.allow_forgery_protection = true
 
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(
+    :compress => {
+      :unused     => false,
+      :keep_fargs => true
+    }
+  )
   config.assets.css_compressor = :sass
 end


### PR DESCRIPTION
Uglifier removes unused functions that we call from controllers using RJS. This PR turns off this feature and also keeps unused arguments in functions.