### PR TITLE
Remove variable interpolations from gettext strings

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1123,7 +1123,7 @@ module ApplicationController::Performance
       miq_task = MiqTask.find(params[:task_id])     # Not first time, read the task record
       begin
         unless miq_task.results_ready?
-          add_flash(_("Error while generating report: #{miq_task.message}"), :error)
+          add_flash(_("Error while generating report: %{error_message}") % {:error_message => miq_task.message}, :error)
           return
         end
         rpt = miq_task.miq_report_result.report_results # Grab the report object from the blob

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -419,7 +419,8 @@ module EmsCommon
         result, details = @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype),
                                                                    :save => true)
         if result
-          add_flash(_("Authentication status will be saved and workers will be restarted for this #{ui_lookup(:table => controller_name)}"))
+          add_flash(_("Authentication status will be saved and workers will be restarted for this %{controller_name}") %
+            {:controller_name => ui_lookup(:table => controller_name)})
         else
           add_flash(_("Re-checking Authentication status for this #{ui_lookup(:table => "ems_cloud")} was not successful: %{details}") % {:details => details}, :error)
         end

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -121,7 +121,7 @@ class MiddlewareServerController < ApplicationController
     items.split(/,/).each do |item|
       mw_server = identify_record item
       if mw_server.product == 'Hawkular' && operation_info.fetch(:skip)
-        add_flash(_("Not #{operation_info.fetch(:hawk)} the provider"))
+        add_flash(_("Not %{hawkular_info} the provider") % {:hawkular_info => operation_info.fetch(:hawk)})
       else
         if operation_info.key? :param
           # Fetch param from UI - > see #9462/#8079

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -167,7 +167,7 @@ class MiqCapacityController < ApplicationController
   def planning_wizard_get_vms(filter_type, filter_value)
     vms = planning_wizard_get_vms_records(filter_type, filter_value)
     vms.each_with_object({}) do |v, h|
-      description = v.ext_management_system ? _("#{v.ext_management_system.name}:#{v.name}") : v.name
+      description = v.ext_management_system ? "#{v.ext_management_system.name}:#{v.name}" : v.name
       h[v.id.to_s] = description
     end
   end

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -262,7 +262,8 @@ module ReportController::Reports
           end
         elsif @edit[:new][:cb_show_typ] == "entity"
           unless @edit[:new][:cb_entity_id]
-            add_flash(_("A specific #{ui_lookup(:model => @edit[:new][:cb_model])} or all must be selected"), :error)
+            add_flash(_("A specific %{chargeback} or all must be selected") %
+              {:chargeback => ui_lookup(:model => @edit[:new][:cb_model])}, :error)
             active_tab = "edit_3"
           end
         end

--- a/app/helpers/application_helper/toolbar/middleware_server_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_server_center.rb
@@ -95,7 +95,7 @@ class ApplicationHelper::Toolbar::MiddlewareServerCenter < ApplicationHelper::To
         button(
           :middleware_deployment_add,
           'pficon pficon-add-circle-o fa-lg',
-          N_('Add a new #{ui_lookup(:table=>"middleware_deployment")}'),
+          N_('Add a new Middleware Deployment'),
           N_('Add Deployment'),
           :data => {'toggle'        => 'modal',
                     'target'        => '#modal_d_div',

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -95,7 +95,7 @@ class Classification < ApplicationRecord
 
   def self.unclassify_by_tag(obj, tag, is_request = true)
     parts = tag.split("/")
-    raise _("Tag #{tag} is not a category entry") % {:tag => tag} unless parts[1] == "managed"
+    raise _("Tag %{tag} is not a category entry") % {:tag => tag} unless parts[1] == "managed"
 
     entry_name = parts.pop
     category_name = parts.pop

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -16,7 +16,7 @@ class DialogFieldSortedItem < DialogField
 
   def sort_order=(value)
     unless [:ascending, :descending].include?(value.to_sym)
-      raise _("Invalid sort_order type <#{value}> specified.") % {:value => value}
+      raise _("Invalid sort_order type <%{value}> specified.") % {:value => value}
     end
     options[:sort_order] = value.to_sym
   end

--- a/app/models/job/state_machine.rb
+++ b/app/models/job/state_machine.rb
@@ -32,7 +32,7 @@ class Job
         save
         send(signal, *args) if respond_to?(signal)
       else
-        raise _("%{signal} is not permitted at state #{state}") % {:signal => signal}
+        raise _("%{signal} is not permitted at state %{state}") % {:signal => signal, :state => state}
       end
     end
   end

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -46,7 +46,7 @@ class LogFile < ApplicationRecord
     # so that the nfs, ftp, smb, etc. mechanism have very little LogFile logic and only need to know how decipher the URI and build the directories as appropraite.
     raise _("LogFile local_file is nil") unless local_file
     unless File.exist?(local_file)
-      raise _("LogFile local_file: [#{file_name}] does not exist!") % {:file_name => local_file}
+      raise _("LogFile local_file: [%{file_name}] does not exist!") % {:file_name => local_file}
     end
     raise _("Log Depot settings not configured") unless file_depot
 


### PR DESCRIPTION
Variable interpolations inside a gettext string won't work -- the string will never be properly
translated into other locales.