### PR TITLE
Check for product permissions in RBAC tree.

### DIFF
--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -31,6 +31,7 @@ class OpsController
 
       section.items.each do |item|
         if item.kind_of?(Menu::Section) # recurse for sections
+          next unless Vmdb::PermissionStores.instance.can?(item.id)
           feature = build_section(item, parent_checked)
           kids.push(feature)
         else # kind_of?(Menu::Item) # add item features
@@ -76,6 +77,7 @@ class OpsController
         # skip storage node unless it's enabled in product setting
         next if section.id == :sto && !VMDB::Config.new("vmdb").config[:product][:storage]
         next if section.id == :cons && !Settings.product.consumption
+        next unless Vmdb::PermissionStores.instance.can?(section.id)
 
         top_nodes.push(build_section(section, root_node[:select]))
       end


### PR DESCRIPTION
## Check for product permissions in RBAC tree.
    
    In role editor's RBAC tree we need to check the PermissionStores to
    ensure that the give section is enabled.
    
    https://bugzilla.redhat.com/show_bug.cgi?id=1342000
    https://bugzilla.redhat.com/show_bug.cgi?id=1343723


Steps for Testing/QA
--------------------

 1. Open the RBAC role editor tree.
 1. See the stuff there
 1. copy `config/permissions.tmpl.yml` to `config/permissions.yml`
 1. edit the file to hide stuff (e.g. containers and middleware to test both 1st and 2nd level items). Example below or do it by hand:

```
devil - [~/Projects/manageiq] (bz_1342000_rbac_feature_check)$ diff -u config/permissions.*
--- config/permissions.tmpl.yml 2016-07-15 22:28:58.968304733 +0200
+++ config/permissions.yml      2016-07-18 14:28:41.898199272 +0200
@@ -1,12 +1,9 @@
 ---
 - :aut
 - :clo
-- :cnt
 - :compute
-- :con
 - :conf
 - :inf
-- :mdl
 - :net
 - :opt
```

 5. restart the appliance or the web UI worker
 6. see the RBAC tree again