### PR TITLE
Fix 9055: @gtl_url wasn't set in the controller

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -73,8 +73,10 @@ class MiddlewareServerController < ApplicationController
     @record = identify_record(params[:id], ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer)
 
     if @display == 'middleware_datasources'
+      @gtl_url = '/show'
       show_container_display(@record, 'middleware_datasource', MiddlewareDatasource)
     elsif @display == 'middleware_deployments'
+      @gtl_url = '/show'
       show_container_display(@record, 'middleware_deployment', MiddlewareDeployment)
     else
       show_container(@record, controller_name, display_name)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/9055#issuecomment-225868132 was exactly the case, the `@gtl_url` was undefined, so that [this](https://git.io/vKaKL) was called as a fallback mechanism. Hence the 
POST -> `/middleware_server/button/1?pressed=view_tile` 

instead of the correct

 GET -> `/middleware_server/show/1?display=middleware_deployments&type=tile` 

@miq-bot add_label bug, ui, providers/hawkular