### PR TITLE
Translation should distinguish Template from ContainerImage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -696,7 +696,7 @@ en:
       Container:                Container
       ContainerGroup:           Pod
       ContainerImageRegistry:   Image Registry
-      ContainerImage:           Image
+      ContainerImage:           Container Image
       ContainerNode:            Node
       ContainerProject:         Project
       ContainerRoute:           Route


### PR DESCRIPTION
Both models (Vm Template and ContainerImage) were translated as "Image". This created problems when both models are shown to user on the same page. One of such pages is creation of new Report.

Addressing: https://bugzilla.redhat.com/show_bug.cgi?id=1357100

Note that we already regard the container_image/show_list page as
"Container Images" in the application menu. So this string is not new to the users.

Further, I have reviewed relationship pages that refer to ContainerImage, these pages also refer to ContainerBuild by "Container Build" string, so we are consistent in this regard.

@miq-bot add_label ui, bug, reporting 
@miq-bot assign @mzazrivec
