### PR TITLE
Remove %s from gettext strings and use nicer placeholders instead

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -679,13 +679,13 @@ class CatalogController < ApplicationController
       replace_right_cell(x_node)
       return
     end
-    ot_edit_set_form_vars(_("Editing %s"))
+    ot_edit_set_form_vars(_("Editing %{record_name}"))
     replace_right_cell("ot_edit")
   end
 
   def ot_copy
     assert_privileges("orchestration_template_copy")
-    ot_edit_set_form_vars(_("Copying %s"))
+    ot_edit_set_form_vars(_("Copying %{record_name}"))
     @edit[:new][:name] = @edit[:current][:name] = _("Copy of %{name}") % {:name => @edit[:new][:name]}
     replace_right_cell("ot_copy")
   end
@@ -980,7 +980,7 @@ class CatalogController < ApplicationController
     @edit[:current][:available_managers] = available_orchestration_managers_for_template_type(@record.type)
     @edit[:new] = @edit[:current].dup
     @edit[:key] = "ot_edit__#{@record.id}"
-    @right_cell_text = right_cell_text % @record.name
+    @right_cell_text = right_cell_text % {:record_name => @record.name}
     @in_a_form = true
   end
 
@@ -1027,7 +1027,7 @@ class CatalogController < ApplicationController
 
   def ot_edit_submit_reset
     add_flash(_("All changes have been reset"), :warning)
-    ot_edit_set_form_vars(_("Editing %s"))
+    ot_edit_set_form_vars(_("Editing %{record_name}"))
     @changed = session[:changed] = false
     replace_right_cell("ot_edit")
   end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -633,7 +633,8 @@ class OpsController < ApplicationController
       # when editing/adding schedule in settings tree
       presenter.update(:rbac_details, r[:partial => "tenant_form"])
       if !@tenant.id
-        @right_cell_text = _("Adding a new %s") % tenant_type_title_string(params[:tenant_type] == "tenant")
+        @right_cell_text = _("Adding a new %{tenant}") %
+          {:tenant => tenant_type_title_string(params[:tenant_type] == "tenant")}
       else
         model = tenant_type_title_string(@tenant.divisible)
         @right_cell_text = @edit ?

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -132,7 +132,9 @@ class ProviderForemanController < ApplicationController
                           :org_controller => "configured_system",
                           :escape         => false
     else
-      add_flash(_("No common configuration profiles available for the selected configured %s") % n_('system', 'systems', provisioning_ids.size), :error)
+      add_flash(n_("No common configuration profiles available for the selected configured system",
+                   "No common configuration profiles available for the selected configured systems",
+                   provisioning_ids.size), :error)
       replace_right_cell
     end
   end

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -345,7 +345,7 @@ module ReportController::Reports
           add_flash(_("Filter tab is not available until Trending Target Limit has been configured"), :error)
         end
         if @edit[:new][:perf_limit_val] && !is_numeric?(@edit[:new][:perf_limit_val])
-          add_flash(_("%s must be numeric") % "Trend Target Limit", :error)
+          add_flash(_("Trend Target Limit must be numeric"), :error)
         end
       else
         if @edit[:new][:fields].length == 0

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -268,7 +268,7 @@ module QuadiconHelper
     }
 
     if quadicon_render_for_policy_sim?
-      link_options[:options][:title] = _("Show policy details for %s") % row['name']
+      link_options[:options][:title] = _("Show policy details for %{name}") % {:name => row['name']}
     end
 
     if quadicon_in_explorer_view?
@@ -479,7 +479,7 @@ module QuadiconHelper
              end
 
       output << content_tag(:div, :class => 'flobj') do
-        title = _("Name: %s | Hostname: %s") % [h(item.name), h(item.hostname)]
+        title = _("Name: %{name} | Hostname: %{hostname}") % {:name => h(item.name), :hostname => h(item.hostname)}
 
         link_to(href, :title => title) do
           quadicon_reflection_img(:size => size)
@@ -512,8 +512,10 @@ module QuadiconHelper
       output << flobj_img_simple(size, "#{size}/reflection.png")
     else
       output << content_tag(:div, :class => 'flobj') do
-        values = [h(item.name), h(item.hostname), h(item.last_refresh_status.titleize)]
-        title = _("Name: %s | Hostname: %s | Refresh Status: %s") % values
+        title = _("Name: %{name} | Hostname: %{hostname} | Refresh Status: %{status}") %
+          {:name     => h(item.name),
+           :hostname => h(item.hostname),
+           :status   => h(item.last_refresh_status.titleize)}
 
         link_to(url_for_record(item), :title => title) do
           quadicon_reflection_img(:size => size)

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -39,8 +39,7 @@ class UserValidationService
     feature = missing_user_features(db_user)
     return ValidateResult.new(
       :fail,
-      _("Login not allowed, User's %s is missing. Please contact the administrator") %
-      feature
+      _("Login not allowed, User's %{feature} is missing. Please contact the administrator") % {:feature => feature}
     ) if feature
 
     session_init(db_user)

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -61,7 +61,7 @@
              [_("Retirement"),   :retire_fqname])
         - entry_points.each do |entry_points_op|
           .form-group
-            %label.col-md-2.control-label{:title => _("%s Entry Point (NameSpace/Class/Instance)") % entry_points_op[0]}
+            %label.col-md-2.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
               #{entry_points_op[0]} #{_('Entry Point')}
               %br
               = _('State Machine (NS/Cls/Inst)')

--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -65,7 +65,7 @@
                           :disabled                   => rollup_disabled,
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
           - unless @timeprofile.miq_reports.empty?
-            .note= _("In use by %s reports, cannot be disabled") % @timeprofile.miq_reports.count
+            .note= _("In use by %{count} reports, cannot be disabled") % {:counts => @timeprofile.miq_reports.count}
 
 
   - if %w(timeprofile_new timeprofile_copy timeprofile_create).include?(controller.action_name)

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -23,7 +23,7 @@
             - if icons_checkbox[0]
               .form-group
                 %label.col-md-3.control-label
-                  = _("Show %s Quadrants") % icons_checkbox[1]
+                  = _("Show %{title} Quadrants") % {:title => icons_checkbox[1]}
                 .col-md-8
                   = check_box_tag("quadicons_#{icons_checkbox[2]}",
                                   true,

--- a/app/views/ems_cloud/discover.html.haml
+++ b/app/views/ems_cloud/discover.html.haml
@@ -33,7 +33,7 @@
           = button_tag(_("Start"),
                        :name  => "start",
                        :class => "btn btn-primary",
-                       :alt   => t = _("Start the %s Discovery") % title_for_host,
+                       :alt   => t = _("Start the %{host} Discovery") % {:host => title_for_host},
                        :title => t,
                        :type  => "submit")
           = button_tag(_("Cancel"),

--- a/app/views/ems_cluster/_main.html.haml
+++ b/app/views/ems_cluster/_main.html.haml
@@ -5,7 +5,7 @@
     - if get_vmdb_config[:product][:storage]
       = render :partial => "shared/summary/textual", :locals => {:title => _("Storage Relationships"), :items => textual_group_storage_relationships}
   .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for %s") % title_for_hosts, :items => textual_group_host_totals}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for %{hosts}") % {:hosts => title_for_hosts}, :items => textual_group_host_totals}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for VMs"), :items => textual_group_vm_totals}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Configuration"), :items => textual_group_configuration}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -30,7 +30,7 @@
           .form-group
             %label.control-label.col-md-2
               %font{:color => "black"}
-                = _("Choose a saved %s filter:") % ui_lookup(:model => @edit[@expkey][:exp_model])
+                = _("Choose a saved %{model} filter:") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
             .col-md-8
               = select_tag("chosen_search",
                            options_for_select([[_("<Choose>"), "0"]] + @edit[@expkey][:exp_search_expressions],
@@ -48,7 +48,7 @@
           .form-group
             %label.control-label.col-md-2
               %font{:color => "black"}
-                = _("Choose a %s report filter") % ui_lookup(:model => @edit[@expkey][:exp_model])
+                = _("Choose a %{model} report filter") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
   - elsif mode == "save"
     .modal-body
       = render(:partial => "layouts/flash_msg",
@@ -67,7 +67,7 @@
       .form-horizontal
         .form-group
           %label.control-label.col-md-5
-            = _("Save this %s search as:") % ui_lookup(:model => @edit[@expkey][:exp_model])
+            = _("Save this %{model} search as:") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
           .col-md-6
             %span#search_name_span
               = text_field_tag("search_name",

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -44,7 +44,7 @@
                    :button => "delete"},
                   'data-confirm' => confirm_msg,
                   :class         => "btn btn-danger",
-                  :alt           => t = _("Delete the filter named %s") % @edit[@expkey][:selected][:description],
+                  :alt           => t = _("Delete the filter named %{filter_name}") % {:filter_name => @edit[@expkey][:selected][:description]},
                   :remote        => true,
                   "data-method"  => :post,
                   :title         => t)

--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -17,7 +17,7 @@
             Close
         %h4.modal-title#ep_modal_label
           = hidden_field_tag(:ignore_form_changes)
-          = _("Select Entry Point %s") % entry_point
+          = _("Select Entry Point %{entry_point}") % {:entry_point => entry_point}
 
       .modal-body
         #automate_treebox

--- a/app/views/layouts/_auth_credentials.html.haml
+++ b/app/views/layouts/_auth_credentials.html.haml
@@ -39,7 +39,7 @@
       %a{:id => "#{pfx}_cancel_password_change", "style" => "display:none;cursor: pointer; cursor: hand;", "onclick" => "cancelPasswordChange('#{pfx}', '#{url}')"}
         = cancel_password_change
 .form-group{:id => "#{pfx}_verify_group", :style => @edit[:new]["#{pfx}_userid".to_sym].blank? ? "display:block" : "display:none"}
-  %label.col-md-2.control-label= _("Confirm %s") % pwd_label
+  %label.col-md-2.control-label= _("Confirm %{password}") % {:password => pwd_label}
   .col-md-4
     = password_field_tag("#{pfx}_verify",
                          '',

--- a/app/views/layouts/_classify_table.html.haml
+++ b/app/views/layouts/_classify_table.html.haml
@@ -11,9 +11,9 @@
           %td.narrow
           %td
             - if @tagitems.length == 1
-              = _("No %s Tags are assigned") % current_tenant.name
+              = _("No %{tenant_name} Tags are assigned") % {:tenant_name => current_tenant.name}
             - else
-              = _("No %s Tags are common to all of the items below") % current_tenant.name
+              = _("No %{tenant_name} Tags are common to all of the items below") % {:tenant_name => current_tenant.name}
           %td
       - else
         - session[:assignments].sort_by { |a| [a.parent.description, a.description] }.each do |a|

--- a/app/views/layouts/_discover.html.haml
+++ b/app/views/layouts/_discover.html.haml
@@ -64,7 +64,7 @@
     = button_tag(_("Start"),
                  :class => "btn btn-primary",
                  :name  => "start",
-                 :alt   => t = _("Start the %s Discovery") % title_for_host,
+                 :alt   => t = _("Start the %{host} Discovery") % {:host => title_for_host},
                  :title => t,
                  :type  => "submit")
     = button_tag(_("Cancel"),

--- a/app/views/layouts/_edit_email.html.haml
+++ b/app/views/layouts/_edit_email.html.haml
@@ -26,7 +26,7 @@
                            :maxlength         => MAX_DESC_LEN,
                            :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          = _("(Default: %s)") % get_vmdb_config[:smtp][:from]
+          = _("(Default: %{email_from})") % {:email_from => get_vmdb_config[:smtp][:from]}
   - if @edit[:new][:send_email]
     = render(:partial => "layouts/edit_to_email", :locals => {:action_url => action_url, :record => record})
   %hr

--- a/app/views/layouts/_edit_to_email.html.haml
+++ b/app/views/layouts/_edit_to_email.html.haml
@@ -27,7 +27,7 @@
                         "data-miq_sparkle_off" => true,
                         :remote                => true,
                         "data-method"          => :post,
-                        :title                 => _("Remove %s") % e)
+                        :title                 => _("Remove %{email}") % {:email => e})
       .form-group
         %label.control-label.col-md-2
           = _("Add a User")

--- a/app/views/layouts/_form_buttons_verify.html.haml
+++ b/app/views/layouts/_form_buttons_verify.html.haml
@@ -9,7 +9,7 @@
   - id = record_id ? record_id : nil
 
 - if session[:host_items].present?
-  - verify_title_on  = _("Validate the credentials by logging into the selected %s") % title_for_host
+  - verify_title_on  = _("Validate the credentials by logging into the selected %{host}") % {:host => title_for_host}
 - else
   - verify_title_on ||= _("Validate the credentials by logging into the Server")
 

--- a/app/views/layouts/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/_multi_auth_credentials.html.haml
@@ -74,7 +74,7 @@
           .form-group
             .col-md-12
               %span{:style => "color:black"}
-                = _("Used for SSH connection to all %s in this provider.") % title_for_hosts
+                = _("Used for SSH connection to all %{hosts} in this provider.") % {:hosts => title_for_hosts}
       - else
         = miq_tab_content('remote') do
           = render(:partial => "/layouts/auth_credentials",
@@ -114,7 +114,7 @@
     %table.admintable
       %tbody
         %tr
-          %td.key= _("Select %s to validate against") % title_for_host
+          %td.key= _("Select %{host} to validate against") % {:host => title_for_host}
           %td
             = select_tag('validate_id',
                          options_for_select(@edit[:selected_hosts].invert.sort,

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -2,7 +2,7 @@
                 :id     => @record.id)
 #perf_options_div{:onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   - if @charts || @perf_options[:chart_type] != :performance
-    %h3= _("Options %s") % (@record != @perf_record ? "(#{ui_lookup(:model => @perf_record.class.to_s)}: #{@perf_record.name})" : "")
+    %h3= _("Options %{model}") % {:model => (@record != @perf_record ? "(#{ui_lookup(:model => @perf_record.class.to_s)}: #{@perf_record.name})" : "")}
     %dl.dl-horizontal
       %dt
         = _("Interval")

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -38,7 +38,7 @@
               %td
                 = h(desc)
   %hr
-  %h3= _("Policy Simulation for %s") % pluralize(@tagitems.length, 'Item')
+  %h3= _("Policy Simulation for %{items}") % {:items => pluralize(@tagitems.length, 'Item')}
   %table.admintable{:height => "75"}
     %tbody
       %tr

--- a/app/views/layouts/_protect.html.haml
+++ b/app/views/layouts/_protect.html.haml
@@ -12,10 +12,10 @@
     = render :partial => '/layouts/edit_form_buttons',
              :locals  => {:action_url => "protect"}
   %h3
-    = _("Policy changes will affect %s") % pluralize(@politems.length,
+    = _("Policy changes will affect %{items}") % {:items => pluralize(@politems.length,
                                                      Dictionary.gettext(session[:pol_db].to_s,
                                                                          :type     => :model,
-                                                                         :notfound => :titleize))
+                                                                         :notfound => :titleize))}
   %table.admintable{:height => "75"}
     %tbody
       %tr

--- a/app/views/layouts/_spinner.html.haml
+++ b/app/views/layouts/_spinner.html.haml
@@ -6,5 +6,5 @@
       #spinner_div
       - if login && MiqServer.my_server(true).logon_status == :starting
         %span{:style => "color: white;"}
-          = _("The server is initializing; access is being retried every 10 seconds %s") % ". . ."
+          = _("The server is initializing; access is being retried every 10 seconds . . .")
           = render :partial => "login_message"

--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -1,7 +1,10 @@
 - url = url_for(:action => 'tag_edit_form_field_changed', :id => @sb[:rec_id] || @edit[:object_ids][0])
 #tab_div
   %h3
-    = _("Tag Assignment%s") % (@tagitems.length > 1 ? " (#{_('Tags common to all selected items')})" : "")
+    - if @tagitems.length > 1
+      = _("Tag Assignment (Tags common to all selected items)")
+    - else
+      = _("Tag Assignment")
   %table.table.table-bordered{:style => "margin-bottom: 0;"}
     %thead
       %tr

--- a/app/views/layouts/_tag_edit_assignments.html.haml
+++ b/app/views/layouts/_tag_edit_assignments.html.haml
@@ -14,9 +14,9 @@
           %td
           %td
             - if @edit[:object_ids].length == 1
-              = _("No %s Tags are assigned") % current_tenant.name
+              = _("No %{tenant_name} Tags are assigned") % {:tenant_name => current_tenant.name}
             - else
-              = _("No %s Tags are common to all of the items below") % current_tenant.name
+              = _("No %{tenant_name} Tags are common to all of the items below") % {:tenant_name => current_tenant.name}
           %td
       - else
         - @assignments.sort_by { |a| [a.parent.description, a.description] }.each do |a|

--- a/app/views/layouts/_tag_edit_items.html.haml
+++ b/app/views/layouts/_tag_edit_items.html.haml
@@ -1,7 +1,7 @@
 %hr
 %div
   %h3
-    = _("%s Being Tagged") % pluralize(@tagitems.length, ui_lookup(:model => @edit[:tagging]))
+    = _("%{objects} Being Tagged") % {:objects => pluralize(@tagitems.length, ui_lookup(:model => @edit[:tagging]))}
   %table.admintable{:height => "75"}
     %tbody
       %tr

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -3,7 +3,7 @@
   - if @timeline
     %h3
       - if @record != @tl_record
-        = _("Options %s: %s") % [ui_lookup(:model => @tl_record.class.to_s), @tl_record.name]
+        = _("Options %{model}: %{name}") % {:model => ui_lookup(:model => @tl_record.class.to_s), :name => @tl_record.name}
       - else
         = _("Options")
     .form-horizontal
@@ -140,4 +140,4 @@
         %input#filter1{:type => "hidden", :name => "filter1", :value => @tl_options.mngt.fltr1}
         %input#filter2{:type => "hidden", :name => "filter2", :value => @tl_options.mngt.fltr2}
         %input#filter3{:type => "hidden", :name => "filter3", :value => @tl_options.mngt.fltr3}
-    = _("* Dates/Times on this page are based on time zone: %s.") % session[:user_tz]
+    = _("* Dates/Times on this page are based on time zone: %{time_zone}.") % {:time_zone => session[:user_tz]}

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -8,7 +8,7 @@
     %ul.dropdown-menu
       %li.disabled
         %a{:href => "#"}
-          = _('Server: %s') % appliance_name
+          = _('Server: %{appliance_name}') % {:appliance_name => appliance_name}
 
       - if current_user.miq_groups.length > 1
         %li.dropdown-submenu.pull-left

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -1,6 +1,6 @@
 - if !session[:host_items].nil?
   - verify_title_on ||= _("Validate the credentials by logging into the selected %{title_for_host}") % {:title_for_host => title_for_host}
-  - verify_title_off ||= _("%s to validate against, Username and matching password fields are needed to perform verification of credentials") % title_for_host
+  - verify_title_off ||= _("%{host} to validate against, Username and matching password fields are needed to perform verification of credentials") % {:host => title_for_host}
 - else
   - verify_title_on = "Validate the credentials by logging into the Server"
   - verify_title_off ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -214,7 +214,7 @@
         .form-group
           .col-md-12
             %span{:style => "color:black"}
-              = _("Used for SSH connection to all %s in this provider.") % title_for_hosts
+              = _("Used for SSH connection to all %{hosts} in this provider.") % {:hosts => title_for_hosts}
     - elsif controller_name == "ems_container"
       = miq_tab_content('hawkular', 'default') do
         .form-group

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -178,11 +178,11 @@
                   - if !row['agent_class'].nil? && row['agent_class'] != ""
                     - a_rec = @targets_hash[row['agent_id']] if @targets_hash
                     - if a_rec.nil?
-                      - title = _("%s record no longer exists") % row['agent_class']
+                      - title = _("%{agent} record no longer exists") % {:agent => row['agent_class']}
                     - else
                       - if row['agent_class'] != "MiqServer"
                         - click = "DoNav('/#{row['agent_class'].underscore}/show/#{to_cid(row['agent_id'])}');"
-                        - title = _("Click to view %s") % h("#{row['agent_class']}<#{a_rec.name}>")
+                        - title = _("Click to view %{record}") % {:record => h("#{row['agent_class']}<#{a_rec.name}>")}
                 - else
                   - if row['target_id'].blank?
                     - title = _("No task target captured")
@@ -190,9 +190,9 @@
                     - target_class = row['target_class']
                     - action = target_class.to_s == "VmOrTemplate" ? "vm_show" : "show"
                     - click = "DoNav('/#{target_class.constantize.base_class.name.underscore.downcase}/#{action}/#{to_cid(row['target_id'])}');"
-                    - title = _("Click to view target %s") % h(ui_lookup(:model => target_class.constantize.base_class.name))
+                    - title = _("Click to view target %{model}") % {:model => h(ui_lookup(:model => target_class.constantize.base_class.name))}
               - elsif %w(total_space free_space).include?(col)
-                - title = _("%s bytes") % number_with_delimiter(h(row[col]), :delimiter => ",", :separator => ".")
+                - title = _("%{number} bytes") % {:number => number_with_delimiter(h(row[col]), :delimiter => ",", :separator => ".")}
               - else
                 - if (row[col].kind_of?(Time) || %w(updated_on created_on started_on finished_on).include?(col)) && !row[col].nil? && row[col] != ""
                   - row[col] = row[col].to_time if row[col].kind_of?(String)
@@ -285,7 +285,7 @@
               - elsif col == "agent_class" && row[col].nil? && view.db == "Job"
                 - unless row['agent_class'].blank?
                   - if a_rec.nil?
-                    = _("%s record no longer exists") % row['agent_class']
+                    = _("%{agent} record no longer exists") % {:agent => row['agent_class']}
                   - else
                     %center
                       = h(a_rec.name)

--- a/app/views/layouts/listnav/_auth_key_pair_cloud.html.haml
+++ b/app/views/layouts/listnav/_auth_key_pair_cloud.html.haml
@@ -13,9 +13,9 @@
         - if role_allows(:feature => "vm_show_list")
           - if @record.number_of(:vms) == 0
             %li.disabled
-              = link_to(_('Instances (%s)') % @record.number_of(:vms), '#')
+              = link_to(_('Instances (%{count})') % {:count => @record.number_of(:vms)}, '#')
           - else
             %li
-              = link_to(_("Instances (%s)") % @record.number_of(:vms),
+              = link_to(_("Instances (%{count})") % {:count => @record.number_of(:vms)},
                 {:action => 'show', :id => @record, :display => 'instances'},
                 :title => _("Show all Instances"))

--- a/app/views/layouts/listnav/_availability_zone.html.haml
+++ b/app/views/layouts/listnav/_availability_zone.html.haml
@@ -14,7 +14,7 @@
           %li
             = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
               ems_cloud_path(@record.ext_management_system.id),
-              :title => _("Show this Availability Zone's parent %s") % ui_lookup(:table => "ems_cloud"))
+              :title => _("Show this Availability Zone's parent Cloud Provider"))
         - if role_allows(:feature => "vm_show_list")
           = li_link(:count => @record.number_of(:vms),
             :text          => _("Instances"),

--- a/app/views/layouts/listnav/_cloud_tenant.html.haml
+++ b/app/views/layouts/listnav/_cloud_tenant.html.haml
@@ -14,7 +14,7 @@
           %li
             = link_to_with_icon("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
               ems_cloud_path(@record.ext_management_system.id),
-              :title => _("Show this Cloud Tenant's parent %s") % ui_lookup(:table => "ems_cloud"))
+              :title => _("Show this Cloud Tenant's parent Cloud Provider"))
         - if role_allows(:feature => "security_group_show_list")
           = li_link(:count => @record.number_of(:security_groups),
             :text          => _("Security Groups"),

--- a/app/views/layouts/listnav/_cloud_volume.html.haml
+++ b/app/views/layouts/listnav/_cloud_volume.html.haml
@@ -29,7 +29,7 @@
           %li
             = link_to("#{ui_lookup(:table => "base_snapshot")}: #{@record.base_snapshot.name}",
               {:action => 'show', :id => @record.base_snapshot.id, :controller => 'cloud_volume_snapshot'},
-              :title => _("Show this Cloud Volume's parent %s") % ui_lookup(:table => "cloud_volume_snapshot"))
+              :title => _("Show this Cloud Volume's parent Cloud Volume Snapshot"))
         - if role_allows(:feature => "cloud_volume_snapshot_show")
           - if @record.number_of(:cloud_volume_snapshots) == 0
             %li.disabled

--- a/app/views/layouts/listnav/_flavor.html.haml
+++ b/app/views/layouts/listnav/_flavor.html.haml
@@ -16,7 +16,7 @@
           %li
             = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
               ems_cloud_path(@record.ext_management_system.id),
-              :title => _("Show this Flavor's parent %s") % ui_lookup(:table => "ems_cloud"))
+              :title => _("Show this Flavor's parent Cloud Provider"))
 
         - if role_allows(:feature => "vm_show_list")
           = li_link(:count => @record.number_of(:vms),

--- a/app/views/layouts/listnav/_host.html.haml
+++ b/app/views/layouts/listnav/_host.html.haml
@@ -32,22 +32,22 @@
           :text       => _('Devices'),
           :record_id  => @record.id,
           :display    => 'devices',
-          :title      => _("Show %s devices") % host_title)
+          :title      => _("Show %{host} devices") % {:host => host_title})
         = li_link(:count => @record.number_of(:switches),
           :text          => _('Network'),
           :record_id     => @record.id,
           :display       => 'network',
-          :title         => _("Show %s network") % host_title)
+          :title         => _("Show %{host} network") % {:host => host_title})
         = li_link(:if => !(@record.hardware.blank? || @record.hardware.number_of(:storage_adapters) == 0),
           :text       => _('Storage Adapters'),
           :record_id  => @record.id,
           :display    => 'storage_adapters',
-          :title      => _("Show %s storage adapters") % host_title)
+          :title      => _("Show %{host} storage adapters") % {:host => host_title})
         = li_link(:if => !(@osinfo.nil? || @osinfo.empty?),
           :text       => _('OS Information'),
           :record_id  => @record.id,
           :display    => 'os_info',
-          :title      => _("Show %s OS information") % host_title)
+          :title      => _("Show %{host} OS information") % {:host => host_title})
         = li_link(:if => !(@vmminfo.nil? || @vmminfo.empty?),
           :text       => _('VMM Information'),
           :record_id  => @record.id,
@@ -75,14 +75,14 @@
           %li
             = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
               ems_infra_path(@record.ext_management_system),
-              :title => _("Show this %s parent %s") % ["#{host_title}'s", ui_lookup(:table => "ems_infra")])
+              :title => _("Show this parent %{provider} for this %{host}") % {:host => host_title, :provider => ui_lookup(:table => "ems_infra")})
 
         - if role_allows(:feature => "ems_cluster_show") && !@record.ems_cluster.nil?
           - cluster_title = title_for_cluster
           %li
             = link_to("#{cluster_title}: #{@record.ems_cluster.name}",
               {:controller => "ems_cluster", :action => 'show', :id => @record.ems_cluster.id.to_s},
-              :title => _("Show %s parent %s") % ["#{host_title}'s", cluster_title])
+              :title => _("Show parent %{cluster} for this %{host}") % {:host => host_title, :cluster => cluster_title})
 
         - if role_allows(:feature => "storage_show_list")
           = li_link(:count => @record.number_of(:storages),

--- a/app/views/layouts/listnav/_miq_ae_class.html.haml
+++ b/app/views/layouts/listnav/_miq_ae_class.html.haml
@@ -9,7 +9,7 @@
             {:action => 'show', :id => @record, :display => 'main'},
             :title => _("Show Summary"))
         %li
-          = link_to(_("Instances (%s)") % record.instances.count,
+          = link_to(_("Instances (%{count})") % {:count => record.instances.count},
             {:action => 'show_instances', :id => @record.id},
             :title  => _("View Instances"),
             :align  => 'left',

--- a/app/views/layouts/listnav/_ontap_logical_disk.html.haml
+++ b/app/views/layouts/listnav/_ontap_logical_disk.html.haml
@@ -27,7 +27,7 @@
             :tables                   => 'ontap_file_share',
             :display                  => 'ontap_file_share',
             :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "ontap_file_share"))
+            :title                    => _("Show all File Shares"))
 
         - if role_allows(:feature => "snia_local_file_system_show")
           = li_link_if_condition(:cond => !@record.file_system.nil?,
@@ -43,7 +43,7 @@
             :tables                   => 'cim_base_storage_extent',
             :display                  => 'cim_base_storage_extents',
             :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "cim_base_storage_extent"))
+            :title                    => _("Show all Base Extents"))
 
     = miq_accordion_panel(_("Infrastructure Relationships"), false, "cim_ld_inf_rel") do
       %ul.nav.nav-pills.nav-stacked
@@ -53,7 +53,7 @@
             :tables                   => 'vm',
             :display                  => 'vms',
             :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "vm"))
+            :title                    => _("Show all VMs") % ui_lookup(:tables => "vm"))
 
         - if role_allows(:feature => "host_show_list")
           = li_link_if_nonzero(:count => @record.hosts_size,
@@ -61,7 +61,7 @@
             :tables                   => 'host',
             :display                  => 'hosts',
             :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "host"))
+            :title                    => _("Show all Hosts"))
 
         - if role_allows(:feature => "storage_show_list")
           = li_link_if_nonzero(:count => @record.storages.size,
@@ -69,4 +69,4 @@
             :tables                   => 'storage',
             :display                  => 'storages',
             :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "storage"))
+            :title                    => _("Show all Datastores"))

--- a/app/views/layouts/listnav/_ontap_storage_volume.html.haml
+++ b/app/views/layouts/listnav/_ontap_storage_volume.html.haml
@@ -17,14 +17,14 @@
             :text       => "#{ui_lookup(:table => 'ontap_storage_system')}: #{@record.storage_system.evm_display_name}",
             :controller => "ontap_storage_system",
             :record_id  => @record.storage_system.id,
-            :title      => _("Show %s") % ui_lookup(:table => "ontap_storage_system"))
+            :title      => _("Show Filer"))
 
         - if role_allows(:feature => "cim_base_storage_extent_show_list")
           = li_link(:count => @record.base_storage_extents_size,
             :record_id     => @record.id,
             :tables        => 'cim_base_storage_extent',
             :display       => 'cim_base_storage_extents',
-            :title         => _("Show all %s") % ui_lookup(:tables => "cim_base_storage_extent"))
+            :title         => _("Show all Base Extents"))
 
     = miq_accordion_panel(_("Infrastructure Relationships"), false, "cim_sv_inf_rel") do
       %ul.nav.nav-pills.nav-stacked
@@ -33,18 +33,18 @@
             :record_id     => @record.id,
             :tables        => 'vm',
             :display       => 'vms',
-            :title         => _("Show all %s") % ui_lookup(:tables => "vm"))
+            :title         => _("Show all VMs"))
 
         - if role_allows(:feature => "host_show_list")
           = li_link(:count => @record.hosts_size,
             :record_id     => @record.id,
             :tables        => 'host',
             :display       => 'hosts',
-            :title         => _("Show all %s") % ui_lookup(:tables => "host"))
+            :title         => _("Show all Hosts"))
 
         - if role_allows(:feature => "storage_show_list")
           = li_link(:count => @record.storages.size,
             :record_id     => @record.id,
             :tables        => 'storage',
             :display       => 'storages',
-            :title         => _("Show all %s") % ui_lookup(:tables => "storage"))
+            :title         => _("Show all Datastores"))

--- a/app/views/layouts/listnav/_orchestration_stack.html.haml
+++ b/app/views/layouts/listnav/_orchestration_stack.html.haml
@@ -14,10 +14,9 @@
       %ul.nav.nav-pills.nav-stacked
         - if role_allows(:feature => "ems_cloud_show") && @record.ext_management_system
           %li
-            - l = [ui_lookup(:table => "ems_cloud"), ui_lookup(:table => "orchestration_stack")]
             = link_to("#{ui_lookup(:table => "ext_management_system")}: #{@record.ext_management_system.name}",
               ems_cloud_path(@record.ext_management_system.id),
-              :title => _("Show parent %s for this %s") % l)
+              :title => _("Show parent Cloud Provider for this Stack"))
 
         - if @record.try(:orchestration_template)
           %li.disabled

--- a/app/views/layouts/listnav/_persistent_volume.html.haml
+++ b/app/views/layouts/listnav/_persistent_volume.html.haml
@@ -14,4 +14,4 @@
           %li
             = link_to("#{ui_lookup(:table => "ems_container")}: #{@record.parent.name}",
                 {:controller => "ems_container", :action => 'show', :id => @record.parent.id.to_s},
-                :title => _("Show this container volume's parent %s") % ui_lookup(:table => "ems_container"))
+                :title => _("Show this container volume's parent Containers Provider"))

--- a/app/views/layouts/listnav/_security_group.html.haml
+++ b/app/views/layouts/listnav/_security_group.html.haml
@@ -21,7 +21,6 @@
                     :title     => _("Show all Instances"))
         - if role_allows(:feature => "orchestration_stack_show") && @record.orchestration_stack
           %li
-            - t = [ui_lookup(:table => "orchestration_stack"), ui_lookup(:table => "security_group")]
             = link_to("#{ui_lookup(:table => "orchestration_stack")}: #{@record.orchestration_stack.name}",
               {:controller => "orchestration_stack", :action => 'show', :id => @record.orchestration_stack.id.to_s},
-              :title => _("Show parent %s for this %s") % t)
+              :title => _("Show parent Orchestration Stack for this Security Group"))

--- a/app/views/layouts/listnav/_service.html.haml
+++ b/app/views/layouts/listnav/_service.html.haml
@@ -14,9 +14,9 @@
       %ul.nav.nav-pills.nav-stacked
         - if @record.number_of(:get_vms) == 0
           %li.disabled
-            = link_to(_("Member VMs (%s)") % @record.number_of(:get_vms), "#")
+            = link_to(_("Member VMs (%{count})") % {:count => @record.number_of(:get_vms)}, "#")
         - else
           %li
-            = link_to(_("Member VMs (%s)") % @record.number_of(:get_vms),
+            = link_to(_("Member VMs (%{count})") % {:count => @record.number_of(:get_vms)},
               {:action => 'show', :id => @record, :display => 'vms'},
               :title => _("Show member VMs"))

--- a/app/views/layouts/listnav/_storage.html.haml
+++ b/app/views/layouts/listnav/_storage.html.haml
@@ -40,7 +40,7 @@
               :record_id     => @record.id,
               :tables        => 'ontap_storage_system',
               :display       => 'storage_systems',
-              :title         => _("Show all %s") % ui_lookup(:tables => "ontap_storage_system"))
+              :title         => _("Show all Filers"))
 
           - unless @record.file_share.nil?
             - if role_allows(:feature => "ontap_file_share_show")
@@ -48,14 +48,14 @@
               %li
                 = link_to("#{ui_lookup(:table => "ontap_file_share")}: #{fs.name}",
                   {:controller => "ontap_file_share", :action => 'show', :id => fs.id.to_s},
-                  :title => _("Show %s") % ui_lookup(:table => "ontap_file_share"))
+                  :title => _("Show File Shares"))
             - else
               - if role_allows(:feature => "ontap_storage_volume_show_list")
                 = li_link(:count => @record.storage_volumes_size,
                   :record_id     => @record.id,
                   :tables        => 'ontap_storage_volume',
                   :display       => 'ontap_storage_volumes',
-                  :title         => _("Show all %s") % ui_lookup(:tables => "ontap_storage_volume"))
+                  :title         => _("Show all LUNs"))
 
           - if role_allows(:feature => "cim_base_storage_volume_show_list")
             = li_link(:count => @record.base_storage_extents_size,
@@ -63,7 +63,7 @@
               :tables        => 'cim_base_storage_extent',
               :display       => 'storage_extents',
               :action        => 'show',
-              :title         => _("Show all %s") % ui_lookup(:tables => "cim_base_storage_extent"))
+              :title         => _("Show all Base Extents"))
 
       = miq_accordion_panel(_("Content"), false, "storage_content") do
         %ul.nav.nav-pills.nav-stacked
@@ -71,40 +71,40 @@
             :record_id     => @record.id,
             :table         => 'storages',
             :action        => 'files',
-            :title         => _("Show all files on this %s") % ui_lookup(:table => "storages"),
+            :title         => _("Show all files on this Datastore"),
             :link_text     => _('All Files'))
 
           = li_link(:count => @record.number_of(:disk_files),
             :record_id     => @record.id,
             :table         => 'storages',
             :action        => 'disk_files',
-            :title         => _("Show VM Provisioned Disk Files on this %s") % ui_lookup(:table => "storages"),
+            :title         => _("Show VM Provisioned Disk Files on this Datastore"),
             :link_text     => _('VM Provisioned Disk Files'))
 
           = li_link(:count => @record.number_of(:snapshot_files),
             :record_id     => @record.id,
             :table         => 'storages',
             :action        => 'snapshot_files',
-            :title         => _("Show VM snapshot files on this %s") % ui_lookup(:table => "storages"),
+            :title         => _("Show VM snapshot files on this Datastore"),
             :link_text     => _('VM Snapshot Files'))
 
           = li_link(:count => @record.number_of(:vm_ram_files),
             :record_id     => @record.id,
             :table         => 'storages',
             :action        => 'vm_ram_files',
-            :title         => _("Show VM memory files on this %s") % ui_lookup(:table => "storages"),
+            :title         => _("Show VM memory files on this Datastore"),
             :link_text     => _('VM Memory Files'))
 
           = li_link(:count => @record.number_of(:vm_misc_files),
             :record_id     => @record.id,
             :table         => 'storages',
             :action        => 'vm_misc_files',
-            :title         => _("Show Other VM files on this %s") % ui_lookup(:table => "storages"),
+            :title         => _("Show Other VM files on this Datastore"),
             :link_text     => _('Other VM Files'))
 
           = li_link(:count => @record.number_of(:debris_files),
             :record_id     => @record.id,
             :table         => 'storages',
             :action        => 'debris_files',
-            :title         => _("Show non-VM files on this %s") % ui_lookup(:table => "storages"),
+            :title         => _("Show non-VM files on this Datastore"),
             :link_text     => _('Non-VM Files'))

--- a/app/views/miq_ae_class/_domain_overrides.html.haml
+++ b/app/views/miq_ae_class/_domain_overrides.html.haml
@@ -7,7 +7,7 @@
           %tr{:onclick => remote_function(:loading => "miqSparkle(true);",
                                           :complete => "miqSparkle(false);",
                                           :url     => "/miq_ae_class/x_show?id=#{node_prefix}-#{to_cid(id)}"),
-              :title => _("Click to view this %s in the \"%s\" Domain") % [model, name]}
+              :title => _("Click to view this %{model} in the \"%{domain_name}\" Domain") % {:model => model, :domain_name => name}}
             %td
               = name
         - else

--- a/app/views/miq_ae_class/_instance_fields.html.haml
+++ b/app/views/miq_ae_class/_instance_fields.html.haml
@@ -20,10 +20,10 @@
           - ae_value = field.ae_values.find_or_initialize_by(:instance_id => @record.id, :field_id => field.id)
           %tr
             %td.text-nowrap
-              %i.product.fa-lg{:class => "product-ae_#{field.aetype}", :title => _("Type: %s") % field.aetype}
+              %i.product.fa-lg{:class => "product-ae_#{field.aetype}", :title => _("Type: %{automation_type}") % {:automation_type => field.aetype}}
               - unless field.datatype.blank? || field.datatype == 'string'
-                %i.product.fa-lg{:class => "product-#{field.datatype}", :title => _("Data type: %s") % field.datatype}
-              %i.pficon.fa-lg{:class => "pficon-ok#{field.substitute ? '' : '-closed'}", :title => _("Substitute: %s") % field.substitute}
+                %i.product.fa-lg{:class => "product-#{field.datatype}", :title => _("Data type: %{data_type}") % {:data_type => field.datatype}}
+              %i.pficon.fa-lg{:class => "pficon-ok#{field.substitute ? '' : '-closed'}", :title => _("Substitute: %{substitute}") % {:substitute => field.substitute}}
               &nbsp;
               = record_name(field)
             %td

--- a/app/views/miq_ae_customization/_dialog_res_remove.html.haml
+++ b/app/views/miq_ae_customization/_dialog_res_remove.html.haml
@@ -10,5 +10,5 @@
   :remote               => true,
   "data-method"         => :post,
   :id                   => "#{parent_id}_#{obj[:id]}_close",
-  :title                => _("Remove this %s") % typ.capitalize.singularize,
+  :title                => _("Remove this %{type}") % {:type => typ.capitalize.singularize},
   :class                => "fa fa-close pull-right")

--- a/app/views/miq_ae_customization/_dialog_resources.html.haml
+++ b/app/views/miq_ae_customization/_dialog_resources.html.haml
@@ -14,7 +14,7 @@
         - when 2
           - objects = !@edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i].blank? ? @edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i][:fields] : nil
       - if objects.blank?
-        = _("No %s found.") % typ.pluralize.capitalize
+        = _("No %{types} found.") % {:types => typ.pluralize.capitalize}
       - else
         - objects.each_with_index do |obj, i|
           - if obj[:label]

--- a/app/views/miq_ae_customization/_old_dialogs_folders.html.haml
+++ b/app/views/miq_ae_customization/_old_dialogs_folders.html.haml
@@ -3,7 +3,7 @@
   %table.table.table-striped.table-bordered.table-hover
     %tbody
       - @folders.each do |f|
-        %tr{:title => (_("View %s Folder") % f[0]),
+        %tr{:title => (_("View %{name} Folder") % {:name => f[0]}),
           :onclick => "miqDynatreeActivateNode('old_dialogs_tree', 'xx-MiqDialog_#{f[1]}');"}
           %td.narrow
             %img{:src => image_path('100/folder.png')}

--- a/app/views/miq_capacity/_planning_instructions.html.haml
+++ b/app/views/miq_capacity/_planning_instructions.html.haml
@@ -1,5 +1,5 @@
 %h3
-  = _('Plan for VM placement on %s or %s') % [title_for_hosts, title_for_clusters]
+  = _('Plan for VM placement on %{hosts} or %{clusters}') % {:hosts => title_for_hosts, :clusters => title_for_clusters}
 .alert.alert-info
   %span.pficon.pficon-blank
   %strong
@@ -11,7 +11,7 @@
 .alert.alert-info
   %span.pficon.pficon-blank
   %strong
-    = _('3 - Specify Target Options to qualify target %s or %s.') % [title_for_hosts, title_for_clusters]
+    = _('3 - Specify Target Options to qualify target %{hosts} or %{clusters}.') % {:hosts => title_for_hosts, :clusters => title_for_clusters}
 .alert.alert-info
   %span.pficon.pficon-blank
   %strong

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -7,8 +7,8 @@
   .form.horizontal
     .form-group
       - options = [["<#{_('Choose')}>"],
-        [_("By %s") % ui_lookup(:table => "ems_infras"), "ems"],
-        [_("By %s") % ui_lookup(:table => "ems_clusters"), "cluster"],
+        [_("By Infrastructure Providers"), "ems"],
+        [_("By Clusters / Deployment Roles"), "cluster"],
         [_("By Host"), "host"],
         [_("By Filter"), "filter"],
         [_("All VMs"), "all"],]
@@ -24,7 +24,7 @@
         miqSelectPickerEvent("filter_typ", "#{url}");
     .form-group
       - if @sb[:planning][:options][:filter_typ] == "host"
-        - options = [["<#{_('Choose a %s') % title_for_host}>", "<Choose>"]] + Array(@sb[:planning][:hosts].invert).sort_by { |a| a.first.downcase }
+        - options = [["<#{_('Choose a %{host}') % {:host => title_for_host}}>", "<Choose>"]] + Array(@sb[:planning][:hosts].invert).sort_by { |a| a.first.downcase }
         = select_tag("filter_value",
                       options_for_select(options, @sb[:planning][:options][:filter_value]),
                       :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
@@ -35,7 +35,7 @@
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
       - elsif @sb[:planning][:options][:filter_typ] == "cluster"
-        - options = [["<#{_('Choose a %s')}>" % title_for_cluster, "<Choose>"]] + Array(@sb[:planning][:clusters].invert).sort_by { |a| a.first.downcase }
+        - options = [["<#{_('Choose a %{cluster}')}>" % {:cluster => title_for_cluster}, "<Choose>"]] + Array(@sb[:planning][:clusters].invert).sort_by { |a| a.first.downcase }
         = select_tag("filter_value",
                       options_for_select(options, @sb[:planning][:options][:filter_value]),
                       :disabled              => @sb[:planning][:options][:vm_mode] == :manual,
@@ -45,7 +45,7 @@
                       "data-miq_sparkle_off" => true,
                       "data-miq_observe"     => {:url => url}.to_json)
       - elsif @sb[:planning][:options][:filter_typ] == "ems"
-        - options = [["<#{_('Choose a %s')}>" % ui_lookup(:table => "ext_management_systems"), "<Choose>"]] + Array(@sb[:planning][:emss].invert).sort_by { |a| a.first.downcase }
+        - options = [["<#{_('Choose a %{provider}')}>" % {:provider => ui_lookup(:table => "ext_management_systems")}, "<Choose>"]] + Array(@sb[:planning][:emss].invert).sort_by { |a| a.first.downcase }
         = select_tag("filter_value",
                       options_for_select(options, @sb[:planning][:options][:filter_value]),
                       :disabled              => @sb[:planning][:options][:vm_mode] == :manual,

--- a/app/views/miq_capacity/_planning_report.html.haml
+++ b/app/views/miq_capacity/_planning_report.html.haml
@@ -3,14 +3,14 @@
 
   - if @perf_record && @sb[:planning] && @sb[:planning][:rpt]
 
-    %h3= _("VM Counts per %s") % ui_lookup(:model => @sb[:planning][:options][:target_typ])
+    %h3= _("VM Counts per %{model}") % {:model => ui_lookup(:model => @sb[:planning][:options][:target_typ])}
     = @sb[:planning][:rpt].to_html.html_safe
     - tvms = 0
     - @sb[:planning][:rpt].table.data.each { |r| tvms += r["total_vm_count"].to_i }
-    = _('Total number of VMs that can fit on all of the above %s: %s') % [ui_lookup(:models => @sb[:planning][:options][:target_typ]), tvms]
+    = _('Total number of VMs that can fit on all of the above %{models}: %{count}') % {:models => ui_lookup(:models => @sb[:planning][:options][:target_typ]), :count => tvms}
     - if @sb[:planning][:rpt].extras[:vm_profile]
       = render :partial => "planning_vm_profile"
   - if @perf_record
-    %p= _("* Information shown is based on available trend data going back %s.") % _(WEEK_CHOICES[@sb[:planning][:options][:days]])
+    %p= _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(WEEK_CHOICES[@sb[:planning][:options][:days]])}
   - else
     = render :partial => "planning_instructions"

--- a/app/views/miq_capacity/_planning_summary.html.haml
+++ b/app/views/miq_capacity/_planning_summary.html.haml
@@ -23,7 +23,7 @@
     %br{:clear => "all"}
     %hr
     - if @sb[:planning][:chart_data] && @sb[:planning][:chart_data]["planning"]
-      %h3= _("Eligible %s ") % ui_lookup(:models => @sb[:planning][:options][:target_typ])
+      %h3= _("Eligible %{type} ") % {:type => ui_lookup(:models => @sb[:planning][:options][:target_typ])}
       %table.table.table-bordered.table-striped
         %thead
           %tr
@@ -43,6 +43,6 @@
         = render :partial => "planning_vm_profile"
 
   - if @perf_record
-    %p= _("* Information shown is based on available trend data going back %s.") % _(WEEK_CHOICES[@sb[:planning][:options][:days]])
+    %p= _("* Information shown is based on available trend data going back %{weeks}.") % {:weeks => _(WEEK_CHOICES[@sb[:planning][:options][:days]])}
   - else
     = render :partial => "planning_instructions"

--- a/app/views/miq_capacity/_utilization_details.html.haml
+++ b/app/views/miq_capacity/_utilization_details.html.haml
@@ -16,6 +16,6 @@
   - if @sb[:util] && @sb[:util][:trend_rpt]
     %br{:clear => "all"}
     %hr
-    = _('* Information shown is based on available trend data from %s to %s in the %s time zone.') % [format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]]
+    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), :end_time => format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), :timezone => @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]}
     %p
     %br

--- a/app/views/miq_capacity/_utilization_report.html.haml
+++ b/app/views/miq_capacity/_utilization_report.html.haml
@@ -34,4 +34,4 @@
                   = c.last
   - if @sb[:util] && @sb[:util][:trend_rpt]
     %hr
-    = _('* Information shown is based on available trend data from %s to %s in the %s time zone.') % [format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]]
+    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), :end_time => format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), :timezone => @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]}

--- a/app/views/miq_capacity/_utilization_summary.html.haml
+++ b/app/views/miq_capacity/_utilization_summary.html.haml
@@ -33,6 +33,6 @@
     = render :partial => 'layouts/info_msg', :locals => {:message => msg}
   - if @sb[:util] && @sb[:util][:trend_rpt]
     %hr
-    = _('* Information shown is based on available trend data from %s to %s in the %s time zone.') % [format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]]
+    = _('* Information shown is based on available trend data from %{start_time} to %{end_time} in the %{timezone} time zone.') % {:start_time => format_timezone(@sb[:util][:options][:trend_start], @sb[:util][:options][:tz], "date"), :end_time => format_timezone(@sb[:util][:options][:trend_end], @sb[:util][:options][:tz], "date"), :timezone => @sb[:util][:options][:time_profile_tz] || @sb[:util][:options][:tz]}
     %p
     %br

--- a/app/views/miq_policy/_action_list.html.haml
+++ b/app/views/miq_policy/_action_list.html.haml
@@ -1,7 +1,10 @@
 #action_list_div
   - if x_active_tree == :action_tree && @view
     - if @view.table.data.empty?
-      - msg = _('No Actions are defined %s.') % @search_text.blank? ? "" : _("that match the entered search string")
+      - if @search_text.blank?
+        - msg = _('No Actions are defined.')
+      - else
+        - msg = _('No Actions are defined that match the entered search string')
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       #main_div

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -19,7 +19,7 @@
             :maxlength         => MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
-          = _("(Default: %s)") % h(get_vmdb_config[:smtp][:from])
+          = _("(Default: %{email_from})") % {:email_from => h(get_vmdb_config[:smtp][:from])}
       .form-group
         %label.control-label.col-md-2
           = _('To E-mail Address')

--- a/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -182,7 +182,7 @@
     .col-md-8
       - if @edit
         - if @edit[:emss].length == 0
-          = _("No %s found") % ui_lookup(:tables => "ext_management_system")
+          = _("No %{types} found") % {:types => ui_lookup(:tables => "ext_management_system")}
         - elsif @edit[:emss].length == 1
           = h(@edit[:emss][@edit[:new][:expression][:options][:ems_id]])
         - else
@@ -196,7 +196,7 @@
       - else
         - if @ems.blank?
           %span{:style => "color: red;"}
-            = _("%s no longer exists, this alert must be reconfigured") % ui_lookup(:model => "ExtManagementSystem")
+            = _("Provider no longer exists, this alert must be reconfigured")
         - else
           = h(@ems.name)
   - when :ems_alarm_mor
@@ -208,7 +208,7 @@
         - if @edit
           - if @edit[:new][:expression][:options][:ems_id]
             - if @edit[:ems_alarms].length == 0
-              = _("No alarms found for the selected %s") % ui_lookup(:table => "ext_management_system")
+              = _("No alarms found for the selected Provider")
             - else
               - opts = [["<#{_('Choose')}>", nil]] + @edit[:ems_alarms].invert.sort_by { |a| a.first.downcase }
               = select_tag('select_ems_alarm_mor',
@@ -218,7 +218,7 @@
                 miqInitSelectPicker();
                 miqSelectPickerEvent('select_ems_alarm_mor', '#{url}', {beforeSend: true, complete: true})
           - else
-            = _("Choose a %s first") % ui_lookup(:table => "ext_management_system")
+            = _("Choose a %{provider} first") % {:provider => ui_lookup(:table => "ext_management_system")}
         - else
           = h(@alert.expression[:options][:ems_alarm_name])
   - when :mw_operator

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -176,7 +176,7 @@
                 = _("From")
               .col-md-8
                 - if @alert.options[:notifications][:email][:from].blank?
-                  = _("(Default: %s)") % h(get_vmdb_config[:smtp][:from])
+                  = _("(Default: %{email_from})") % {:email_from => h(get_vmdb_config[:smtp][:from])}
                 - else
                   = h(@alert.options[:notifications][:email][:from])
             .form-group

--- a/app/views/miq_policy/_alert_list.html.haml
+++ b/app/views/miq_policy/_alert_list.html.haml
@@ -1,7 +1,10 @@
 #alert_list_div
   - if x_active_tree == :alert_tree && @view
     - if @view.table.data.empty?
-      - msg = _("No Alerts are defined %s.") % @search_text.blank? ? "" : _("that match the entered search string")
+      - if @search_text.blank?
+        - msg = _("No Alerts are defined.")
+      - else
+        - msg = _("No Alerts are defined that match the entered search string.")
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       #main_div

--- a/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/app/views/miq_policy/_alert_profile_details.html.haml
@@ -43,7 +43,7 @@
         %h3= _('Alert Selection')
         %table#formtest.form
           %tr
-            %td{:align => "left"}= _("Available %s Alerts:") % ui_lookup(:model => @edit[:new][:mode])
+            %td{:align => "left"}= _("Available %{model} Alerts:") % {:model => ui_lookup(:model => @edit[:new][:mode])}
             %td
             %td.widthed{:align => "left"}= _("Profile Alerts:")
           %tr
@@ -155,7 +155,7 @@
           .form-horizontal
             .form-group
               %label.control-label.col-md-2
-                = _("%s with %s Tags") % [ui_lookup(:tables => aa[:tags].first.last), @alert_profile_tag.description]
+                = _("%{alert_profiles} with %{type} Tags") % {:alert_profiles => ui_lookup(:tables => aa[:tags].first.last), :type => @alert_profile_tag.description}
               .col-md-8
                 - aa[:tags].sort_by { |a| a.first.description.downcase }.each do |tag|
                   = h(tag.first.description)

--- a/app/views/miq_policy/_alert_profile_list.html.haml
+++ b/app/views/miq_policy/_alert_profile_list.html.haml
@@ -2,8 +2,10 @@
   - if @alert_profiles
     = render :partial => "layouts/flash_msg"
     - if @alert_profiles.empty?
-      - t = @search_text.blank? ? "" : _(" that match the entered search string")
-      - msg = _("No %s Alert Profiles are defined %s.") % [ui_lookup(:model => @sb[:folder]), t]
+      - if @search_text.blank?
+        - msg = _("No %{alert_profile_type} Alert Profiles are defined.") % {:alert_profile_type => ui_lookup(:model => @sb[:folder])}
+      - else
+        - msg = _("No %{alert_profile_type} Alert Profiles are defined that match the entered search string.") % {:alert_profile_type => ui_lookup(:model => @sb[:folder])}
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       %table.table.table-striped.table-bordered.table-hover

--- a/app/views/miq_policy/_condition_folders.html.haml
+++ b/app/views/miq_policy/_condition_folders.html.haml
@@ -9,4 +9,4 @@
             %td.narrow
               %img{:src => image_path("100/#{f.underscore}.png")}
             %td
-              = _("%s Conditions") % ui_lookup(:model => f)
+              = _("%{object} Conditions") % {:object => ui_lookup(:model => f)}

--- a/app/views/miq_policy/_condition_list.html.haml
+++ b/app/views/miq_policy/_condition_list.html.haml
@@ -3,8 +3,10 @@
     %div{:style => "padding-top: 10px;"}
     = render :partial => "layouts/flash_msg"
     - if @conditions.empty?
-      - t = @search_text.blank? ? "" : _(" that match the entered search string")
-      - msg = _("No %s Conditions are defined %s.") % [ui_lookup(:model => @sb[:folder]), t]
+      - if @search_text.blank?
+        - msg = _("No %{model} Conditions are defined.") % {:model => ui_lookup(:model => @sb[:folder])}
+      - else
+        - msg = _("No %{model} Conditions are defined that match the entered search string.") % {:model => ui_lookup(:model => @sb[:folder])}
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       %table.table.table-striped.table-bordered.table-hover

--- a/app/views/miq_policy/_event_list.html.haml
+++ b/app/views/miq_policy/_event_list.html.haml
@@ -3,7 +3,10 @@
     = render :partial => "layouts/flash_msg"
     - if @events.empty?
       .note
-        = _("* No Events are defined%s.") % @search_text.blank? ? "" : _(" that match the entered search string")
+        - if @search_text.blank?
+          = _("* No Events are defined")
+        - else
+          = _("* No Events are defined that match the entered search string")
     - else
       %table.table.table-striped.table-bordered.table-hover
         %tbody

--- a/app/views/miq_policy/_export.html.haml
+++ b/app/views/miq_policy/_export.html.haml
@@ -90,7 +90,7 @@
       %tr
         %td{:align => "right"}
           #buttons
-            - t = _("Export Selected %s") % title
+            - t = _("Export Selected %{title}") % {:title => title}
             = link_to(_('Export'),
               {:action => "export", :button => "export"},
               :class                 => "btn btn-primary",

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -40,14 +40,14 @@
             %label.control-label.col-md-2= _('Created')
             .col-md-8
               %p.form-control-static
-                = h(_("By Username %s %s") % [@policy.created_by || _("N/A"), format_timezone(@policy.created_on, session[:user_tz], "on_at")])
+                = h(_("By Username %{username} %{created_on}") % {:username => @policy.created_by || _("N/A"), :created_on => format_timezone(@policy.created_on, session[:user_tz], "on_at")})
 
           - if @policy.created_on != @policy.updated_on
             .form-group
               %label.control-label.col-md-2= _("Last Updated")
               .col-md-8
                 %p.form-control-static
-                  = h(_("By Username %s %s") % [@policy.updated_by || _("N/A"), format_timezone(@policy.updated_on, session[:user_tz], "on_at")])
+                  = h(_("By Username %{username} %{updated_on}") % {:username => @policy.updated_by || _("N/A"), :updated_on => format_timezone(@policy.updated_on, session[:user_tz], "on_at")})
       %hr
 
       -# Scope
@@ -80,7 +80,7 @@
                 %td
                   %table#formtest.form{:width => "100%"}
                     %tr
-                      %td{:align => "left"}= _("Available %s Conditions:") % ui_lookup(:model => @edit[:new][:towhat])
+                      %td{:align => "left"}= _("Available %{model} Conditions:") % {:model => ui_lookup(:model => @edit[:new][:towhat])}
                       %td
                       %td.widthed{:align => "left"}= _("Policy Conditions:")
                     %tr

--- a/app/views/miq_policy/_policy_list.html.haml
+++ b/app/views/miq_policy/_policy_list.html.haml
@@ -1,8 +1,10 @@
 #policy_list_div
   - if x_active_tree == :policy_tree && @view
     - if @view.table.data.empty?
-      - t = @search_text.blank? ? "" : _(" that match the entered search string")
-      - msg = _("No %s %s Policies are defined %s.") % [ui_lookup(:model => @sb[:folder]), @mode, t]
+      - if @search_text.blank?
+        - msg = _("No %{model} %{mode} Policies are defined.") % {:model => ui_lookup(:model => @sb[:folder]), :mode => @mode}
+      - else
+        - msg = _("No %{model} %{mode} Policies are defined that match the entered search string.") % {:model => ui_lookup(:model => @sb[:folder]), :mode => @mode}
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       #main_div

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -88,7 +88,7 @@
         %table.table.table-striped.table-bordered.table-hover
           %tbody
             - @profile_policies.each do |p|
-              %tr{:title => _("View this %s Policy") % ui_lookup(:model => p.towhat),
+              %tr{:title => _("View this %{model} Policy") % {:model => ui_lookup(:model => p.towhat)},
                 :onclick => "miqDynatreeActivateNode('#{x_active_tree}', '#{x_node}_p-#{to_cid(p.id)}');"}
                 %td.narrow
                   %img{:src => image_path("100/miq_policy_#{p.towhat.downcase + (p.active ? '' : '_inactive')}.png")}

--- a/app/views/miq_policy/_profile_list.html.haml
+++ b/app/views/miq_policy/_profile_list.html.haml
@@ -2,8 +2,10 @@
   - if @profiles
     = render :partial => "layouts/flash_msg"
     - if @profiles.empty?
-      - t = @search_text.blank? ? "" : _(" that match the entered search string")
-      - msg = _("No %s Policy Profiles are defined%s.") % [@mode, t]
+      - if @search_text.blank?
+        - msg = _("No %{mode} Policy Profiles are defined.") % {:mode => @mode}
+      - else
+        - msg = _("No %{mode} Policy Profiles are defined that match the entered search string.") % {:mode => @mode}
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       %table.table.table-striped.table-bordered.table-hover

--- a/app/views/miq_policy/_rsop_form.html.haml
+++ b/app/views/miq_policy/_rsop_form.html.haml
@@ -25,9 +25,9 @@
             %h3= _("VM Selection")
             = select_tag('filter_typ',
               options_for_select([["<#{_('Choose')}>"],
-                [_("By %s") % ui_lookup(:table => "ext_management_systems"), "ems"],
-                [_("By %s") % title_for_clusters, "cluster"],
-                [_("By %s") % title_for_host, "host"],
+                [_("By Cloud/Infrastructure Providers"), "ems"],
+                [_("By %{clusters}") % {:clusters => title_for_clusters}, "cluster"],
+                [_("By %{hosts}") % {:hosts => title_for_host}, "host"],
                 [_("Single VM"), "vm"]], @sb[:rsop][:filter]), "data-miq_observe" => observe)
             - if @sb[:rsop][:filter] == "host"
               %br

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -2,7 +2,7 @@
 #pre_prov_div
   - typ = request.parameters[:controller] == "vm_cloud" ? ui_lookup(:table => "template_cloud") : ui_lookup(:table => "template_infra")
   %h3
-    = _("Provision %s based on the selected %s") % [ui_lookup(:tables => request.parameters[:controller]), typ]
+    = _("Provision %{what} based on the selected %{type}") % {:what => ui_lookup(:tables => request.parameters[:controller]), :type => typ}
   %table.table.table-bordered.table-hover.table-striped.table-selectable
     %thead
       %tr

--- a/app/views/ops/_classification_entry.html.haml
+++ b/app/views/ops/_classification_entry.html.haml
@@ -52,6 +52,6 @@
       %td.action-cell
         %button.btn.btn-default.btn-block.btn-sm{:onclick => remote_function(:url => {:action => 'ce_delete',
                                                     :id     => entry.id},
-                                           :confirm => _("Deleting the '%s' entry will also unassign it from all items, are you sure?") % entry.name),
+                                           :confirm => _("Deleting the '%{entry_name}' entry will also unassign it from all items, are you sure?") % {:entry_name => entry.name}),
                                            :title => _("Click to delete this entry")}
           = _("Delete")

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -74,7 +74,7 @@
             - unless forest.blank?
               %tr
                 %td{:onclick => remote_function(:url => {:action => 'forest_delete',
-                :ldaphost_id => forest[:ldaphost].to_s}, :confirm => _("Are you sure you want to delete forest %s ?") % forest[:ldaphost]),
+                :ldaphost_id => forest[:ldaphost].to_s}, :confirm => _("Are you sure you want to delete forest %{ldaphost} ?") % {:ldaphost => forest[:ldaphost]}),
                 :title => _("Click to delete this forest")}
                   = image_tag(image_path('toolbars/delete.png'))
                 %td{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => forest[:ldaphost].to_s}), :title => _("Click to edit this forest")}

--- a/app/views/ops/_ldap_server_entry.html.haml
+++ b/app/views/ops/_ldap_server_entry.html.haml
@@ -64,7 +64,7 @@
       %td
   - else
     %tr{:id => "#{entry_idx}_tr", :class => cycle('row0', 'row1')}
-      %td{:onclick => remote_function(:url => {:action => 'ls_delete', :id => entry_idx, :domain_id => domain_id}, :confirm => _("Deleting the '%s' LDAP Server, are you sure?")) % entry[:hostname],
+      %td{:onclick => remote_function(:url => {:action => 'ls_delete', :id => entry_idx, :domain_id => domain_id}, :confirm => _("Deleting the '%{hostname}' LDAP Server, are you sure?")) % {:hostname => entry[:hostname]},
           :title   => _("Click to delete this LDAP Server")}
         = image_tag(image_path('toolbars/delete.png'), :class => "rollover small")
       %td{:onclick => remote_function(:url => {:action => 'ls_select', :id => entry_idx, :field => "hostname", :domain_id => domain_id}), :title => t = _("Click to update this LDAP Server")}
@@ -80,7 +80,7 @@
                    :id        => entry_idx,
                    :domain_id => domain_id},
                   :class                 => "btn btn-primary",
-                  :alt                   => t = _("Validate the LDAP Settings by binding with the %s") % title_for_host,
+                  :alt                   => t = _("Validate the LDAP Settings by binding with the %{host}") % {:host => title_for_host},
                   "data-miq_sparkle_on"  => true,
                   "data-miq_sparkle_off" => true,
                   :remote                => true,

--- a/app/views/ops/_ldap_verify_button.html.haml
+++ b/app/views/ops/_ldap_verify_button.html.haml
@@ -6,12 +6,12 @@
      :button => "verify",
      :id     => id},
     :class                 => "btn btn-primary btn-xs",
-    :alt                   => _("Validate the LDAP Settings by binding with the %s") % title_for_host,
+    :alt                   => _("Validate the LDAP Settings by binding with the %{host}") % {:host => title_for_host},
     "data-miq_sparkle_on"  => true,
     "data-miq_sparkle_off" => true,
     :remote                => true,
     "data-method"          => :post,
-    :title                 => _("Validate the LDAP Settings by binding with the %s") % title_for_host)
+    :title                 => _("Validate the LDAP Settings by binding with the %{host}") % {:host => title_for_host})
 
 = hidden_div_if(! validate_disabled, :id => "verify_button_off") do
   = button_tag(_("Validate"),

--- a/app/views/ops/_rbac_details_tab.html.haml
+++ b/app/views/ops/_rbac_details_tab.html.haml
@@ -28,7 +28,7 @@
                 %li
                   %span.pficon.pficon-user
             %td{:onclick => "miqDynatreeActivateNode('rbac_tree', 'xx-u');", :title => _("View Users")}
-              = _("Users (%s)") % @users_count.to_s
+              = _("Users (%{users_count})") % {:users_count => @users_count.to_s}
         - if role_allows(:feature => "rbac_group_view", :any => true)
           %tr
             %td.narrow{:onclick => "miqDynatreeActivateNode('rbac_tree', 'xx-g');", :title => _("View Groups")}
@@ -36,7 +36,7 @@
                 %li
                   %span.product.product-group
             %td{:onclick => "miqDynatreeActivateNode('rbac_tree', 'xx-g');", :title => _("View Groups")}
-              = _("Groups (%s)") % @groups_count.to_s
+              = _("Groups (%{groups_count})") % {:groups_count => @groups_count.to_s}
         - if role_allows(:feature => "rbac_role_view", :any => true)
           %tr
             %td.narrow{:onclick => "miqDynatreeActivateNode('rbac_tree', 'xx-ur');", :title => _("View Roles")}
@@ -44,7 +44,7 @@
                 %li
                   %span.product.product-role
             %td{:onclick => "miqDynatreeActivateNode('rbac_tree', 'xx-ur');", :title => _("View Roles")}
-              = _("Roles (%s)") % @roles_count.to_s
+              = _("Roles (%{roles_count})") % {:roles_count => @roles_count.to_s}
         - if role_allows(:feature => "rbac_tenant_view", :any => true)
           %tr
             %td.narrow{:onclick => "miqDynatreeActivateNode('rbac_tree', 'xx-tn');", :title => _("View Tenants")}
@@ -52,4 +52,4 @@
                 %li
                   %span.product.product-tenant
             %td{:onclick => "miqDynatreeActivateNode('rbac_tree', 'xx-tn');", :title => _("View Tenants")}
-              = _("Tenants (%s)") % @tenants_count.to_s
+              = _("Tenants (%{tenants_count})") % {:tenants_count => @tenants_count.to_s}

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -55,9 +55,11 @@
                 = h(g.description)
     .col-md-12.col-lg-6
       %hr
-      - temp = @edit ? _("Editing") : _("Read Only")
+      - if @edit
+        = _("Product Features (Editing)")
+      - else
+        = _("Product Features (Read Only)")
       %h3
-        = _("Product Features (%s)") % temp
       #features_treebox{:style => "width:100%;height:100%;color:#000"}
       = render(:partial => "layouts/dynatree",
                :locals  => {:tree_id        => "features_treebox",

--- a/app/views/ops/_rbac_tag_box.html.haml
+++ b/app/views/ops/_rbac_tag_box.html.haml
@@ -7,7 +7,7 @@
     .col-md-8
       - if session[:assigned_filters].empty?
         %i.fa.fa-tag
-        = _("No %s Tags have been assigned") % current_tenant.name
+        = _("No %{tenant_name} Tags have been assigned") % {:tenant_name => current_tenant.name}
       - else
         - session[:assigned_filters].keys.sort.each do |k|
           - v = session[:assigned_filters][k]

--- a/app/views/ops/_settings_co_categories_tab.html.haml
+++ b/app/views/ops/_settings_co_categories_tab.html.haml
@@ -40,13 +40,13 @@
             = h(default)
 
           - if cat[:default] == "t" || cat[:default].to_s == "1"
-            %td.action-cell{:title => _("Category '%s' cannot be deleted") % cat[:name]}
+            %td.action-cell{:title => _("Category '%{category_name}' cannot be deleted") % {:category_name => cat[:name]}}
               %button.btn.btn-default.btn-block.btn-sm
                 = _("Delete")
           - else
             %td.action-cell{:onclick => remote_function(:url => {:action => 'category_delete',
               :id      => cat[:id]},
-              :confirm => _("Are you sure you want to delete category '%s'?") % cat[:name]),
+              :confirm => _("Are you sure you want to delete category '%{category_name}'?") % {:category_name => cat[:name]}),
               :title   => _("Click to delete this category")}
               %button.btn.btn-default.btn-block.btn-sm
                 = _("Delete")

--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -13,21 +13,21 @@
             = clusters_title
           .form-group
             %label.col-md-4.control-label
-              = _("Collect for All %s") % clusters_title
+              = _("Collect for All %{clusters}") % {:clusters => clusters_title}
             .col-md-8
               = check_box_tag("all_clusters", true, @edit[:new][:all_clusters],
                               "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => 'Yes', :off_text => 'No'})
             :javascript
               miqInitBootstrapSwitch('all_clusters', "#{url}")
           .note
-            %b= _("Note: Collect for All %s must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2") % clusters_title
+            %b= _("Note: Collect for All %{clusters} must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2") % {:clusters => clusters_title}
           #clusters_div{:style => "display:#{@edit[:new][:all_clusters] ? "none" : ""}"}
             - cluster_title = title_for_cluster
             - if @edit[:new][:clusters].blank? && @edit[:new][:non_cl_hosts].blank?
-              = _("No %s found in the current region.") % clusters_title
+              = _("No %{clusters} found in the current region.") % {:clusters => clusters_title}
             - else
               %br/
-              %b= _("Enable Collection by %s") % cluster_title
+              %b= _("Enable Collection by %{clusters}") % {:clusters => cluster_title}
               %br/
               %input#cl_toggle{:name => "cl_toggle", :onclick => "miqCheckCUAll(this,'#{session[:tree_name]}');", :type => "checkbox"}/
               = _("Check All")
@@ -42,7 +42,7 @@
                   :exp_tree => true,
                   :checkboxes => true})
               %br/
-              .note= _("VM data will be collected for VMs under selected %s only. Data is collected for a %s and all of its %s when at least one %s is selected.") % [title_for_hosts, cluster_title, title_for_hosts, title_for_host]
+              .note= _("VM data will be collected for VMs under selected %{hosts} only. Data is collected for a %{cluster} and all of its %{hosts} when at least one %{host} is selected.") % {:hosts => title_for_hosts, :cluster => cluster_title, :host => title_for_host}
       .col-md-12.col-lg-6
         %fieldset
           %h3= ui_lookup(:tables => "storages")

--- a/app/views/pxe/_template_folders.html.haml
+++ b/app/views/pxe/_template_folders.html.haml
@@ -9,7 +9,7 @@
             %img{:src => image_path('100/folder.png')}
           %td Examples (read only)
         - @folders.each do |f|
-          %tr{:title => _("View '%s' Folder") % f.name,
+          %tr{:title => _("View '%{name}' Folder") % {:name => f.name},
             :onclick => "miqDynatreeActivateNode('customization_templates_tree', 'xx-xx-#{to_cid(f.id)}');"}
             %td.icon
               %img{:src => image_path('100/folder.png')}

--- a/app/views/report/_db_list.html.haml
+++ b/app/views/report/_db_list.html.haml
@@ -9,7 +9,7 @@
             = _('Type')
       %tbody
         - @db_nodes_order.each do |node|
-          %tr{:title => _("Click to view '%s'") % @db_nodes[node][:title],
+          %tr{:title => _("Click to view '%{title}'") % {:title => @db_nodes[node][:title]},
             :onclick => "miqDynatreeActivateNode('#{@sb[:active_tree]}', '#{@db_nodes[node][:id]}');"}
             %td.narrow{:nowrap => 1}
               %ul.icons.list-unstyled
@@ -29,7 +29,7 @@
       %tbody
         - @miq_groups.sort_by(&:description).each do |g|
           %tr{:onclick => remote_function(:loading => "miqSparkle(true);", :complete => "miqSparkle(false);",
-              :url => {:action => 'tree_select', :id => "xx-g_g-#{to_cid(g.id)}"}), :title => _("Click to view %s ") % g.description, :class => "icon"}
+              :url => {:action => 'tree_select', :id => "xx-g_g-#{to_cid(g.id)}"}), :title => _("Click to view %{group} ") % {:group => g.description}, :class => "icon"}
             %td.narrow
               %ul.icons.list-unstyled
                 %li
@@ -50,7 +50,7 @@
         %tbody
           - @widgetsets.sort_by { |widgetset| widgetset.name.downcase }.each do |ws|
             %tr{:onclick => remote_function(:loading => "miqSparkle(true);", :complete => "miqSparkle(false);", :url => {:action => 'tree_select',
-                :id => "xx-g_g-#{@sb[:nodes][2]}_-#{to_cid(ws.id)}"}), :title => _("Click to view '%s (%s)'") % [ws.description, ws.name], :class => "icon"}
+                :id => "xx-g_g-#{@sb[:nodes][2]}_-#{to_cid(ws.id)}"}), :title => _("Click to view '%{widgetset_description} (%{widgetset_name})'") % {:widgetset_description => ws.description, :widgetset_name => ws.name}, :class => "icon"}
               %td.narrow
                 %i.fa.fa-2x.fa-dashboard{:title => ws.description}
               %td

--- a/app/views/report/_db_widget.html.haml
+++ b/app/views/report/_db_widget.html.haml
@@ -2,7 +2,7 @@
   Parameters:
     widget      MiqWidget object
 - if @edit && @edit[:current]
-  - params = {:id => "w_#{widget.id}", :title => _("Drag/drop Widget \"%s\"") % widget.title}
+  - params = {:id => "w_#{widget.id}", :title => _("Drag/drop Widget \"%{widget_title}\"") % {:widget_title => widget.title}}
 - else
   - url = "/report/x_show/xx-#{WIDGET_CONTENT_TYPE.invert[widget.content_type]}_-#{to_cid(widget.id)}?accord=widgets"
   - params = {:onclick => remote_function(:url => url), :id => widget.id, :title => _("View this Widget")}

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -34,7 +34,7 @@
           %label.control-label.col-md-2
             = _('Cancel after')
           .col-md-8
-            - opts = [["<#{_('System Default')}>", nil]] + (1..6).map { |i| [n_('%s Hour', '%s Hours', i) % i, i.hours] }
+            - opts = [["<#{_('System Default')}>", nil]] + (1..6).map { |i| [n_('%{number} Hour', '%{number} Hours', i) % {:number => i}, i.hours] }
             = select_tag('chosen_queue_timeout',
               options_for_select(opts, @edit[:new][:queue_timeout]),
               :multiple              => false,

--- a/app/views/report/_form_filter.html.haml
+++ b/app/views/report/_form_filter.html.haml
@@ -8,7 +8,7 @@
   - else
     -# Show expression editors for all other reports
     %h3
-      = _("Primary (Record) Filter - Filters the %s table records") % @edit[:new][:model]
+      = _("Primary (Record) Filter - Filters the %{model} table records") % {:model => @edit[:new][:model]}
     - if @expkey == :record_filter
       = render :partial => 'layouts/exp_editor'
     - else

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -11,9 +11,9 @@
         - if @edit[:new][:model] == "ChargebackContainerProject"
           - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"]]
         - elsif @edit[:new][:model] == "ChargebackVm"
-          - opts += [[_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"], [_('Tenant'), "tenant"]]
+          - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_('Tenant'), "tenant"]]
         - else
-          - opts += [[_('Owner'), "owner"], ["%s Tag" % current_tenant.name, "tag"], [_(@edit[:new][:cb_model].to_s), "entity"]]
+          - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_(@edit[:new][:cb_model].to_s), "entity"]]
         = select_tag("cb_show_typ",
           options_for_select(opts, @edit[:new][:cb_show_typ]),
           :class                 => "selectpicker")
@@ -130,11 +130,11 @@
         miqSelectPickerEvent('cb_interval', '#{url}', {beforeSend: true, complete: true});
   .form-group
     %label.control-label.col-md-2
-      = _("%s  Ending with") % @edit[:new][:cb_interval].capitalize
+      = _("%{chargeback_interval} Ending with") % {:chargeback_interval => @edit[:new][:cb_interval].capitalize}
     .col-md-8
       - case @edit[:new][:cb_interval]
       - when "daily"
-        - opts = [[_("Today (partial)"), 0], [_("Yesterday"), 1]] + (2..6).map { |i| [_("%s Days Ago") % i, i] } + [[_("1 Week Ago"), 7]]
+        - opts = [[_("Today (partial)"), 0], [_("Yesterday"), 1]] + (2..6).map { |i| [_("%{number} Days Ago") % {:number => i}, i] } + [[_("1 Week Ago"), 7]]
       - when "weekly"
         - opts = [[_("This Week (partial)"), 0], [_("Last Week"), 1]] + (2..4).map { |i| [_("%d Weeks Ago") % i, i] }
       - when "monthly"
@@ -148,11 +148,11 @@
       = _("going back")
       - case @edit[:new][:cb_interval]
       - when "daily"
-        - opts = (1..6).map { |i| [n_('%s Day', '%s Days', i) % i, i] } + (1..4).map { |i| [n_('%s Week', '%s Weeks', i) % i, i * 7] }
+        - opts = (1..6).map { |i| [n_('%{number} Day', '%{number} Days', i) % {:number => i}, i] } + (1..4).map { |i| [n_('%{number} Week', '%{number} Weeks', i) % {:number => i}, i * 7] }
       - when "weekly"
-        - opts = [1, 2, 3, 4, 8, 12].map! { |i| [n_('%s Week', '%s Weeks', i) % i, i] }
+        - opts = [1, 2, 3, 4, 8, 12].map! { |i| [n_('%{number} Week', '%{number} Weeks', i) % {:number => i}, i] }
       - when "monthly"
-        - opts = [1, 2, 3, 6, 9, 12].map! { |i| [n_('%s Month', '%s Months', i) % i, i] }
+        - opts = [1, 2, 3, 6, 9, 12].map! { |i| [n_('%{number} Month', '%{number} Months', i) % {:number => i}, i] }
       = select_tag("cb_interval_size",
         options_for_select(opts, @edit[:new][:cb_interval_size]),
         :class                 => "selectpicker")

--- a/app/views/report/_form_sort.html.haml
+++ b/app/views/report/_form_sort.html.haml
@@ -119,7 +119,7 @@
           = _('Number of Rows to Show')
         .col-md-8
           - if @edit[:new][:group] == "No"
-            - opts = [[_("All"), ""]] + [5, 10, 20, 50, 100].map! { |x| [_("First %s") % x, x] }
+            - opts = [[_("All"), ""]] + [5, 10, 20, 50, 100].map! { |x| [_("First %{number}") % {:number => x}, x] }
             = select_tag('row_limit',
               options_for_select(opts, @edit[:new][:row_limit]),
               :multiple              => false,

--- a/app/views/report/_show_schedule.html.haml
+++ b/app/views/report/_show_schedule.html.haml
@@ -21,7 +21,7 @@
       .col-md-10
         %p.form-control-static
           - if @schedule.sched_action[:options][:email][:from].blank?
-            = _("(Default: %s)") % h(get_vmdb_config[:smtp][:from])
+            = _("(Default: %{email_from})") % {:email_from => h(get_vmdb_config[:smtp][:from])}
           - else
             = h(@schedule.sched_action[:options][:email][:from])
   .form-group

--- a/app/views/report/_widget_show.html.haml
+++ b/app/views/report/_widget_show.html.haml
@@ -140,7 +140,7 @@
     - if @sb[:wtype] == "r"
       - @sb[:col_order].each_with_index do |col, idx|
         .form-group
-          %label.control-label.col-md-2= _("Column %s") % (idx + 1)
+          %label.control-label.col-md-2= _("Column %{index}") % {:index => (idx + 1)}
           .col-md-10
             %p.form-control-static= h(col)
 

--- a/app/views/report/sample_chart.html.haml
+++ b/app/views/report/sample_chart.html.haml
@@ -41,7 +41,7 @@
         %null
         - @edit[:new][:graph_count].to_i.times do |i|
           %string
-            = _("OS %s") % (i + 1)
+            = _("OS %{number}") % {:number => (i + 1)}
         - if @edit[:new][:graph_other]
           %string
             = _("Other")
@@ -67,7 +67,7 @@
       - @edit[:new][:graph_count].to_i.times do |i|
         %row
           %string
-            = _("OS %s") % (i + 1)
+            = _("OS %{number}") % {:number => (i + 1)}
           %number
             = ((rand(5) + 1) * (@edit[:new][:graph_count].to_i - i)).to_s
           %number

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -290,7 +290,7 @@
               :keys                       => keys})
         - if (@edit && @edit[:new] && @edit[:new][:sysprep_upload_text]) || (@options && @options[:sysprep_upload_text])
           - file_name = (@edit && @edit[:new]) ? @edit[:new][:sysprep_upload_file] : @options[:sysprep_upload_file]
-          - label = _("Uploaded File '%s'") % file_name
+          - label = _("Uploaded File '%{filename}'") % {:filename => file_name}
           - keys = [:sysprep_upload_text]
           = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,

--- a/app/views/shared/views/ems_common/_form.html.haml
+++ b/app/views/shared/views/ems_common/_form.html.haml
@@ -101,7 +101,7 @@
         %td{:align => "right"}
           #buttons_on
             - name = ui_lookup(:model => @ems.class.base_manager.name)
-            - t = _("Add this %s") % name
+            - t = _("Add this %{provider}") % {:provider => name}
             = button_tag(_('Add'),
               :class   => "btn btn-primary",
               :alt     => t,
@@ -112,7 +112,7 @@
               :class   => "btn btn-default",
               :alt     => t,
               :title   => t,
-              :href    => url_for(:action => "show_list", :flash_msg => _("Add of new %s was cancelled by the user") % name),
+              :href    => url_for(:action => "show_list", :flash_msg => _("Add of new %{provider} was cancelled by the user") % {:provider => name}),
               :onclick => 'window.location = this.getAttribute("href");')
   - else
     = render :partial => '/layouts/edit_form_buttons', :locals  => {:record_id => @ems.id, :ajax_buttons => true, :restful => true}

--- a/app/views/storage/_storage_pod_folders.html.haml
+++ b/app/views/storage/_storage_pod_folders.html.haml
@@ -4,7 +4,7 @@
     %table.table.table-bordered.table-striped.table-hover
       %tbody
         - @folders.each do |f|
-          %tr{:title => _("View '%s' Cluster") % f.name,
+          %tr{:title => _("View '%{name}' Cluster") % {:name => f.name},
             :onclick => "miqDynatreeActivateNode('storage_pod_tree', 'dsc_xx-#{to_cid(f.id)}');"}
             %td.icon
               %img{:src => image_path('100/folder.png')}

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -36,12 +36,12 @@
                                     :width  => "20",
                                     :height => "20",
                                     :align  => "left",
-                                    :alt    => t = _("View the %s Guide") % title),
+                                    :alt    => t = _("View the %{title} Guide") % {:title => title}),
                           docfile_path,
                           :title   => t,
                           :onclick => "return miqClickAndPop(this);")
                 &nbsp;
-                = link_to((_("%s Guide") % title), docfile_path, :onclick => "return miqClickAndPop(this);")
+                = link_to((_("%{title} Guide") % {:title => title}), docfile_path, :onclick => "return miqClickAndPop(this);")
                 %br
             - if cond_url
               %br

--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -211,7 +211,7 @@
 
   .note
     - arr = [Vm.cpu_recommendation_minimum, MiqReport.new.format_mbytes_to_human_size(Vm.mem_recommendation_minimum)]
-    = _("* Recommendations are subject to minimum of CPU: %s and Memory: %s.") % arr
+    = _("* Recommendations are subject to minimum of CPU: %{cpu} and Memory: %{memory}.") % {:cpu => arr[0], :memory => arr[1]}
 
   - unless @explorer
     #buttons_on{:style => "float: right"}

--- a/app/views/vm_common/_snapshots_desc.html.haml
+++ b/app/views/vm_common/_snapshots_desc.html.haml
@@ -20,7 +20,7 @@
           - unless selected_id[:total_size].blank?
             %p.form-control-static
               = number_to_human_size(selected_id[:total_size], :precision => 2)
-              = _("(%s bytes)") % number_with_delimiter(selected_id[:total_size], :delimiter => ",", :separator => ".")
+              = _("(%{number} bytes)") % {:number => number_with_delimiter(selected_id[:total_size], :delimiter => ",", :separator => ".")}
       .form-group
         %label.control-label.col-sm-2
           = _('Created On')
@@ -30,4 +30,4 @@
               = format_timezone(selected_id[:create_time].to_time, Time.zone, "view")
     %hr
   - else
-    = render :partial => 'layouts/info_msg', :locals => {:message => _("%s has no snapshots") % @record.name}
+    = render :partial => 'layouts/info_msg', :locals => {:message => _("%{record_name} has no snapshots") % {:record_name => @record.name}}

--- a/app/views/vm_common/console_mks.html.haml
+++ b/app/views/vm_common/console_mks.html.haml
@@ -2,7 +2,7 @@
   %html{:lang => I18n.locale.to_s.sub('-', '_')}
     %head
       %title
-        = _("VM %s Remote Console") % @record.name
+        = _("VM %{name} Remote Console") % {:name => @record.name}
       = favicon_link_tag
       :javascript
         function connect() {
@@ -47,7 +47,7 @@
   %html{:lang => I18n.locale.to_s.sub('-', '_')}
     %head
       %title
-        = _("VM %s Remote Console") % @record.name
+        = _("VM %{name} Remote Console") % {:name => @record.name}
     :javascript
       const IMessageListener = Components.interfaces.xpcomIMessageListener;
       const IGrabStateListener = Components.interfaces.xpcomIGrabStateListener;

--- a/app/views/vm_common/console_spice.html.haml
+++ b/app/views/vm_common/console_spice.html.haml
@@ -12,7 +12,7 @@
     #spice-area
       .console-status
         #spice-status.label{'data-host' => @url}
-          = _("Connecting (unencrypted) to: %s") % @url
+          = _("Connecting (unencrypted) to: %{url}") % {:url => @url}
 
       #spice-screen.console-screen
 


### PR DESCRIPTION
This change is to give the translators more context when translating English strings
(a nice `%{placeholder}` being more informative than a plain `%s`).