### PR TITLE
Add subscription ID support to the Azure event runner.

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -37,8 +37,9 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
       client_key            = @ems.authentication_password
       tenant_id             = @ems.azure_tenant_id
       azure_region          = @ems.provider_region
+      subscription_id       = @ems.subscription
       @event_monitor_handle = ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream.new(
-        client_id, client_key, azure_region, tenant_id)
+        client_id, client_key, azure_region, tenant_id, subscription_id)
     end
     @event_monitor_handle
   end

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
@@ -2,11 +2,12 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
   #
   # Creates an event monitor
   #
-  def initialize(client_id, client_key, azure_region, tenant_id)
+  def initialize(client_id, client_key, azure_region, tenant_id, subscription_id)
     @client_id         = client_id
     @client_key        = client_key
     @tenant_id         = tenant_id
     @azure_region      = azure_region
+    @subscription_id   = subscription_id
     @collecting_events = false
   end
 
@@ -63,9 +64,10 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
 
   def create_event_service
     conf = Azure::Armrest::ArmrestService.configure(
-      :client_id  => @client_id,
-      :client_key => @client_key,
-      :tenant_id  => @tenant_id
+      :client_id       => @client_id,
+      :client_key      => @client_key,
+      :tenant_id       => @tenant_id,
+      :subscription_id => @subscription_id
     )
     Azure::Armrest::Insights::EventService.new(conf)
   end


### PR DESCRIPTION
This adds explicit subscription ID support for the Azure event catcher. This should be passed anyway IMO, but we'll definitely need it in order to work with the latest azure-armrest gem, where the subscription ID is mandatory.