### PR TITLE
Implement functionality from ActiveSupport::LoggerThreadSafeLevel and ActiveSupport::LoggerSilence into VMDBLogger

### DIFF
--- a/gems/pending/util/vmdb-logger.rb
+++ b/gems/pending/util/vmdb-logger.rb
@@ -19,6 +19,18 @@ class VMDBLogger < Logger
     @local_levels = {}
   end
 
+  # Silences the logger for the duration of the block.
+  #
+  # Taken from activesupport/logger_silence
+  def silence(temporary_level = Logger::ERROR)
+    old_local_level  = local_level
+    self.local_level = temporary_level
+
+    yield self
+  ensure
+    self.local_level = old_local_level
+  end
+
   attr_reader :logdev # Expose logdev
 
   def logdev=(logdev)


### PR DESCRIPTION
Purpose or Intent
-----------------
Allows the VMDBLogger to function more like the default `Rails::Logger` when using special features like `Logger#silence`, and do it in a thread safe manner since we are using `puma` as our application server.


Background/Motivation
---------------------
This is mostly scratching and itch for me based on a bit of fallout from the Rails 5 upgrade and the depreciation of the [`quiet_assets` gem](https://github.com/evrone/quiet_assets) when upgrading to Rails five.

Both that gem and `sprockets-rails` make use of a feature in the default rails logger which is the "silence" method.  This method basically sets the logging level of the Thread to `Error`, and the `quiet_assets` feature basically sets that on requests that are from the `assets` path.

The `silence` method makes use of another feature of the default `Rails.logger` called `local_level`, which uses a Mutex wrapped hash (basically) to set Thread ID specific log levels.  Simply put, it basically de-escalates the log level to `ERROR` temporarily so that nose is removed from the logs, useful for avoiding log output for a period of time (like during a request for an asset).

Since puma is multi threaded, this means that it could be accessing the to the Logger from multiple threads, so if you were to change the level variable directly you would then be messing with the other threads also making use of the logger.  This can cause a very easy race condition can occur where you set "temporarily" set the log level to `Error`, and another thread reads the temporary value as the current value, and when that second thread sets the "default" value back, it now has updated it the "temporary" value of the first thread.

A diagram might more easily depict this race condition:


```
* Starting log level is INFO
                                                                                
+-----------+           +-----------+           +---------------+       +---------+
| Thread A  |           | Thread B  |           | Rails Process |       | Browser |
+-----------+           +-----------+           +---------------+       +---------+
      |                       |                         |                    |    
      |                       |                         |<--- GET /asset/1 --|
      |<-------------- Process /asset/1 ----------------|                    |    
      |------------- READ Log.level INFO  --------------|                    |    
      |------------- SET  Log.level ERROR ------------->|                    |    
      |                       |                         |                    |    
      |                       |                         |<--- GET /asset/2 --|
      |                       |<--- Process /asset/2 ---|                    |    
      |                       |<- READ Log.level ERROR->|                    |    
      |                       |-- SET  Log.level ERROR->|                    |    
      |                       |                         |                    |    
      |                       |                         |                    |    
      |                       |--------------- Return /asset/1 ------------->|    
      |------------- SET  Log.level INFO  ------------->|                    |    
      |                       |                         |                    |    
      |                       |--------------- Return /asset/2 ------------->|    
      |                       |-- SET  Log.level ERROR->|                    |    
```

The above scenario can put you in a state where logs are no longer being outputted unless an error is raised.  By swapping in setting the `.level` with setting the `local_level`, the variable corruption is prevented and the proper log levels are preserved between requests.


VMDB Logger Updates
-------------------
Through a rat's nest of code to determine what sets our logger, the `VMDBLogger` is being configured as the `Rails.logger` when running the ManageIQ application in most, if not all, development/production scenarios, which is setting using the `Vmdb.rails_logger`.  For those less familiar, this is the code path that sets `VMDBLogger` as the logger for `Rails`:

- https://github.com/ManageIQ/manageiq/blob/3923a42/config/application.rb#L86-L95
- https://github.com/ManageIQ/manageiq/blob/3923a42/lib/vmdb/loggers.rb#L14-L16
- https://github.com/ManageIQ/manageiq/blob/3923a42/lib/vmdb/loggers.rb#L40-L48

This change then simply adds the necessary variables and methods to implement the `local_level` functionality, and the accompanying `silience` method, to the VMDBLogger.  This implementation doesn't require `ActiveSupport` (`activesupport` was recently removed from `VMDBLogger` as a dependency), and just uses the `Mutex` and a simple ruby `Hash` for the implementation.  This change should be additive, and only better interface with Rails logging better.


Implementation Considerations
-----------------------------

* Because This was done in a "vanilla ruby" fashion to avoid any extra dependencies to the `VMDBLogger`, this will most likely not run in a JRuby/Rubinius scenario.  As it seems we don't currently support those ruby interpreters, this was skipped, but if future support for those runtimes is needed, making use of the `Concurrent::Map` from the `concurrent-ruby` gem should be considered instead of using a vanilla `Hash`.
* This was dumped straight into the core `VMDBLogger` class, and it might make more sense to move this into a seperate `VMDBRailsLogger` that we then inherit from `VMDBLogger` for and set that to `Vmdb.rails_logger`.



Links
-----
* https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/quiet_assets.rb
* `concurrent-ruby` map links (most recent commit):
  - https://github.com/ruby-concurrency/concurrent-ruby/blob/9bd16bb/lib/concurrent/map.rb
  - https://github.com/ruby-concurrency/concurrent-ruby/blob/9bd16bb/lib/concurrent/collection/map/mri_map_backend.rb
  - https://github.com/ruby-concurrency/concurrent-ruby/blob/9bd16bb/lib/concurrent/collection/map/non_concurrent_map_backend.rb
* https://github.com/ManageIQ/manageiq/blob/3923a42/config/application.rb#L86-L95
* https://github.com/ManageIQ/manageiq/blob/3923a42/lib/vmdb/loggers.rb#L14-L16
* https://github.com/ManageIQ/manageiq/blob/3923a42/lib/vmdb/loggers.rb#L40-L48
* [Random `puts` from the ApplicationController](https://github.com/ManageIQ/manageiq/blob/3923a42/app/controllers/application_controller.rb#L2011-L2016)


Steps for Testing/QA
--------------------

Testing this is best done manually, and the changes can be observed by running the following three scenarios:

- Testing with only the `quiet_assets` initializer added
- Testing with "naive" `.silence` method implemented
- Testing with this branch

The following should also be added to test all three scenarios which implements `quiet_assets` via a initializer.  Add this to a file called `config/intializers/quiet_assets.local.rb`:

```ruby
Rails.application.config.middleware.insert_before ::Rails::Rack::Logger,
                                                  ::Sprockets::Rails::QuietAssets

# Add this if you don't want extra log output with `log_after_checkin` and 
# `log_after_checkout` from asset_pipeline requests and other requests 
# (thanks a lot LJ...)
#
# ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
#   def log_after_checkin; end
#   def log_after_checkout; end
# end
```

Step-by-Step instructions for each of the scenarios can be found below


### Without `.silence` implemented` (worse off than we started..)

1. Run a local instance of the application using `bin/rails s`
2. When going to the login page ( localhost:3000 ), observe the output from the logger:
  - You should see normal `ActiveRecord` logging for the request itself
  - You should see `NoMethodError` errors for `silence` and stack traces, since it is not implemented


### With a non-treadsafe implementation of `.silence`

1. Add the following as a public method for `gems/pending/util/vmdb-logger.rb`:
  
  ```
  def silence(temporary_level = Logger::ERROR)
    begin
      old_level  = self.level
      self.level = temporary_level

      yield self
    ensure
      self.level = old_level
    end
  end
  ```
  
2. Run a local instance of the application using `bin/rails s`
3. When going to the login page ( localhost:3000 ), observe the output from the logger:
  - You should see normal `ActiveRecord` logging for the **FIRST** request itself
  - You should see NO assets requests in the logs
4. When you run subsequent requests after that (either refreshing the page or continuing to log in), you will notice that the logs stop printing output, and the only thing that you should see is a "Random `puts` from the ApplicationController" (see link above)


### With a non-treadsafe implementation of `.silence`

1. Check out the changes from this branch
2. Run a local instance of the application using `bin/rails s`
3. When going to the login page ( localhost:3000 ), observe the output from the logger:
  - You should see normal `ActiveRecord` logging for the **FIRST** request itself
  - You should see NO assets requests in the logs
4. Subsequent requests should continue to show ActiveRecord logging, but not anything from the asset pipeline.