### PR TITLE
Add #empty? to ActsAsArQuery

### DIFF
--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -136,7 +136,7 @@ class ActsAsArQuery
     to_a.size
   end
 
-  def_delegators :to_a, :size, :take, :each
+  def_delegators :to_a, :size, :take, :each, :empty?
 
   # TODO: support arguments
   def first

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -228,6 +228,18 @@ describe ActsAsArQuery do
     end
   end
 
+  describe "#empty?" do
+    it "returns false when results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([1, 2])
+      expect(query.empty?).to be false
+    end
+
+    it "returns true when no results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([])
+      expect(query.empty?).to be true
+    end
+  end
+
   describe "klass" do
     it "is the model" do
       expect(query.klass).to eq(model)


### PR DESCRIPTION
This is needed for cases where `ActsAsArModel.all.empty?` is called

Specifically, [this](https://github.com/ManageIQ/manageiq/blob/c4ff3fb5c69deffc9c26801eff7f536da35e89aa/app/controllers/ops_controller/settings/common.rb#L184-L185) was failing.

@kbrock please review