### PR TITLE
Expose Key pairs to reporting.

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -105,6 +105,7 @@ class MiqExpression
     hosts
     host_services
     kernel_drivers
+    key_pairs
     lans
     last_compliances
     linux_initprocesses


### PR DESCRIPTION
Purpose or Intent
-----------------
Reporting should be able to display and filter on key_pairs. This changes makes all of the key_pair attributes available to reporting.

https://bugzilla.redhat.com/show_bug.cgi?id=1033681

before:
![screen shot 2016-07-18 at 2 21 05 pm](https://cloud.githubusercontent.com/assets/109132/16928205/6ba5d530-4cff-11e6-9263-97b24d6157a0.png)

after:
![screen shot 2016-07-18 at 3 20 49 pm](https://cloud.githubusercontent.com/assets/109132/16928208/75e7d610-4cff-11e6-9ffe-989f432328cf.png)

