### PR TITLE
acts_as_ar_query collection methods

### DIFF
--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -136,7 +136,7 @@ class ActsAsArQuery
     to_a.size
   end
 
-  def_delegators :to_a, :size, :take, :each, :empty?
+  def_delegators :to_a, :size, :take, :each, :empty?, :presence
 
   # TODO: support arguments
   def first

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -228,6 +228,30 @@ describe ActsAsArQuery do
     end
   end
 
+  describe "#any?" do
+    it "returns true when results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([1, 2])
+      expect(query.any?).to be true
+    end
+
+    it "returns false when no results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([])
+      expect(query.any?).to be false
+    end
+  end
+
+  describe "#blank?" do
+    it "returns false when results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([1, 2])
+      expect(query.blank?).to be false
+    end
+
+    it "returns true when no results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([])
+      expect(query.blank?).to be true
+    end
+  end
+
   describe "#empty?" do
     it "returns false when results are returned" do
       expect(model).to receive(:find).with(:all, {}).and_return([1, 2])
@@ -237,6 +261,48 @@ describe ActsAsArQuery do
     it "returns true when no results are returned" do
       expect(model).to receive(:find).with(:all, {}).and_return([])
       expect(query.empty?).to be true
+    end
+  end
+
+  describe "#many?" do
+    it "returns true when many results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([1, 2])
+      expect(query.many?).to be true
+    end
+
+    it "returns false when 1 result is returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([1])
+      expect(query.many?).to be false
+    end
+
+    it "returns false when no results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([])
+      expect(query.many?).to be false
+    end
+  end
+
+  describe "#present?" do
+    it "returns false when results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([1, 2])
+      expect(query.present?).to be true
+    end
+
+    it "returns true when no results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([])
+      expect(query.present?).to be false
+    end
+  end
+
+  describe "#presence" do
+    it "returns array when results are returned" do
+      results = [1, 2]
+      expect(model).to receive(:find).with(:all, {}).and_return(results)
+      expect(query.presence).to be(results) # want same exact object
+    end
+
+    it "returns nil when no results are returned" do
+      expect(model).to receive(:find).with(:all, {}).and_return([])
+      expect(query.presence).to be_nil
     end
   end
 


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/9896

This adds tests around other collection methods that are called on the query.

The concern is these methods e.g.: `present?` will say that the query is present, and not ask the question of the collection returned by the query.


/cc @carbonin @Fryguy 