### PR TITLE
Fix rendering of Middleware Deployment quadicons

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -557,7 +557,7 @@ module QuadiconHelper
                    "100/#{item.class.to_s.underscore}.png"
                  end
                elsif item.respond_to?(:decorator_class?) && item.decorator_class?
-                 item.decorate.try(:fonticon) || item.decorate.try(:listicon_image)
+                 item.decorate.try(:listicon_image)
                else
                  "100/#{item.class.base_class.to_s.underscore}.png"
                end

--- a/spec/factories/middleware_deployment.rb
+++ b/spec/factories/middleware_deployment.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :middleware_deployment do
+    ext_management_system
+    name "A Middleware Deployment"
+  end
+end

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -926,8 +926,18 @@ describe QuadiconHelper do
       end
 
       context "when item is decorated" do
-        it 'includes a vendor listicon img' do
-          expect(single_quad).to have_selector("img[src*='vendor-#{item.image_name}']")
+        context "when item is a config manager foreman" do
+          it 'includes a vendor listicon img' do
+            expect(single_quad).to have_selector("img[src*='vendor-#{item.image_name}']")
+          end
+        end
+
+        context "when item is a middleware deployment" do
+          let(:item) { FactoryGirl.create(:middleware_deployment) }
+
+          it 'includes a vendor listicon img' do
+            expect(single_quad).to have_selector("img[src*='middleware_deployment']")
+          end
         end
       end
 


### PR DESCRIPTION
Quadicons for some middleware objects are rendered with an incorrect image path.

**before**
![screen shot 2016-07-18 at 3 51 48 pm](https://cloud.githubusercontent.com/assets/39493/16933075/97f6d18e-4cff-11e6-8c63-5772543e4664.png)

**after**
![screen shot 2016-07-18 at 3 50 51 pm](https://cloud.githubusercontent.com/assets/39493/16933081/9e1fc5e8-4cff-11e6-98de-f334c8b3a28a.png)


/cc @martinpovolny 

Fixes #9892