### PR TITLE
Use a mutex to prevent concurrent deliver calls

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -16,6 +16,7 @@ module MiqAeEngine
   AE_ROOT_DIR            = File.expand_path(File.join(Rails.root,    'product/automate'))
   AE_IMPORT_DIR          = File.expand_path(File.join(AE_ROOT_DIR,   'import'))
   AE_DEFAULT_IMPORT_FILE = File.expand_path(File.join(AE_IMPORT_DIR, 'automate.xml'))
+  @@deliver_mutex        = Mutex.new
 
   def self.instantiate(uri, user)
     $miq_ae_logger.info("MiqAeEngine: Instantiating Workspace for URI=#{uri}")
@@ -50,6 +51,10 @@ module MiqAeEngine
   end
 
   def self.deliver(*args)
+    @@deliver_mutex.synchronize { deliver_block(*args) }
+  end
+
+  def self.deliver_block(*args)
     options = {}
 
     case args.length

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -16,7 +16,7 @@ module MiqAeEngine
   AE_ROOT_DIR            = File.expand_path(File.join(Rails.root,    'product/automate'))
   AE_IMPORT_DIR          = File.expand_path(File.join(AE_ROOT_DIR,   'import'))
   AE_DEFAULT_IMPORT_FILE = File.expand_path(File.join(AE_IMPORT_DIR, 'automate.xml'))
-  @@deliver_mutex        = Mutex.new
+  @deliver_mutex         = Mutex.new
 
   def self.instantiate(uri, user)
     $miq_ae_logger.info("MiqAeEngine: Instantiating Workspace for URI=#{uri}")
@@ -51,7 +51,7 @@ module MiqAeEngine
   end
 
   def self.deliver(*args)
-    @@deliver_mutex.synchronize { deliver_block(*args) }
+    @deliver_mutex.synchronize { deliver_block(*args) }
   end
 
   def self.deliver_block(*args)
@@ -161,6 +161,8 @@ module MiqAeEngine
       vmdb_object.after_ae_delivery(ae_result.to_s.downcase) if vmdb_object.respond_to?(:after_ae_delivery)
     end
   end
+
+  private_class_method :deliver_block
 
   def self.format_benchmark_counts(bm)
     formatted = ''


### PR DESCRIPTION
Purpose or Intent
-----------------
> With PUMA and RAILS 5 we get concurrent requests into Automate and since DRb uses class methods to start/stop services we end up removing the service incorrectly causing DRb connection errors. We have one approach that delivers Automate Request via the Queue, that turned out to be slower because of the queue polling time intervals and it was talking 4 seconds to dequeue the entries. To improve the performance we have tried implementing a mutex  on the MiqAeEngine deliver code so that only one deliver runs at a time.


Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1354054
> * https://github.com/ManageIQ/manageiq/pull/9860 (different approach)


Steps for Testing/QA
--------------------
> [Optional] Run dialogs with multiple dynamic fields.