### PR TITLE
[DARGA] Show hosts as archived when their ems is deleted

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1885,5 +1885,15 @@ class Host < ApplicationRecord
     storages.where(:host_storages => {:read_only => true})
   end
 
+  def archived?
+    ems_id.nil?
+  end
+
+  def normalized_state
+    return 'archived' if archived?
+    return power_state unless power_state.nil?
+    "unknown"
+  end
+
   include DeprecatedCpuMethodsMixin
 end

--- a/app/views/layouts/quadicon/_host.html.haml
+++ b/app/views/layouts/quadicon/_host.html.haml
@@ -7,7 +7,7 @@
 
   - unless item.state.blank?
     .flobj{:class => "b#{size}"}
-      %img{:src => image_path("72/currentstate-#{h(item.state.downcase)}.png")}
+      %img{:src => image_path("72/currentstate-#{h(item.normalized_state.downcase)}.png")}
 
   .flobj{:class => "c#{size}"}
     %img{:src => image_path(img_for_host_vendor(item))}


### PR DESCRIPTION
Purpose or Intent
-----------------
Hosts from a deleted EMS before the change:
![screenshot from 2016-07-06 12-21-49](https://cloud.githubusercontent.com/assets/12851112/16628160/778df6f0-437e-11e6-99f6-a92004965ab8.png)
Hosts from a deleted EMS after the change:
![screenshot from 2016-07-06 12-22-33](https://cloud.githubusercontent.com/assets/12851112/16628168/814e6684-437e-11e6-9d8c-6bb2455ae07e.png)

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1353308


Steps for Testing/QA
--------------------
1. Add an Infra provider and perform an inventory refresh
2. After the refresh completes, run `Configuration/Remove Infrastructure Provider from the VMDB`
3. Go to `Compute/Infrastructure/Hosts` and you should see an `A` instead of power state in the top right corner of the quadicon

https://bugzilla.redhat.com/show_bug.cgi?id=1353308