### PR TITLE
Refactor: Extract method: CollectionConfig#option?

### DIFF
--- a/app/controllers/api_controller/collection_config.rb
+++ b/app/controllers/api_controller/collection_config.rb
@@ -8,25 +8,28 @@ class ApiController
       @cfg[collection_name.to_sym]
     end
 
+    def option?(collection_name, option_name)
+      self[collection_name][:options].include?(option_name) if self[collection_name]
+    end
+
     def collection?(collection_name)
-      self[collection_name][:options].include?(:collection)
+      option?(collection_name, :collection)
     end
 
     def custom_actions?(collection_name)
-      cspec = self[collection_name]
-      cspec && cspec[:options].include?(:custom_actions)
+      option?(collection_name, :custom_actions)
     end
 
     def primary?(collection_name)
-      self[collection_name][:options].include?(:primary)
+      option?(collection_name, :primary)
     end
 
     def show?(collection_name)
-      self[collection_name][:options].include?(:show)
+      option?(collection_name, :show)
     end
 
     def show_as_collection?(collection_name)
-      self[collection_name][:options].include?(:show_as_collection)
+      option?(collection_name, :show_as_collection)
     end
 
     def supports_http_method?(collection_name, method)

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -285,10 +285,7 @@ class ApiController
     end
 
     def collection_option?(option)
-      if @req.collection
-        cname = @req.collection.to_sym
-        collection_config[cname][:options].include?(option) if collection_config[cname]
-      end
+      collection_config.option?(@req.collection, option) if @req.collection
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
This is just small follow-up after #9718.  I have noticed, that we have got the `:options` accessor used in one more place.  Perhaps, it makes sense to extract this to a method.

@miq-bot add_label api, refactoring
@miq-bot assign @abellotti 
/cc @imtayadeway 