### PR TITLE
indicate a partial refresh error by raising an exception

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
@@ -26,6 +26,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   def refresh_ems(ems, error)
     allow(ManageIQ::Providers::Openstack::CloudManager::RefreshParser)
       .to receive(:ems_inv_to_hashes).and_raise(Excon::Errors::BadRequest.new(error))
-    EmsRefresh.refresh(ems)
+    expect do
+      EmsRefresh.refresh(ems)
+    end.to raise_error(EmsRefresh::Refreshers::EmsRefresherMixin::PartialRefreshError)
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_errors_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_errors_spec.rb
@@ -27,6 +27,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Refresher)
       .to receive(:refresh_targets_for_ems)
       .and_raise(StandardError.new(error))
-    EmsRefresh.refresh(ems)
+    expect do
+      EmsRefresh.refresh(ems)
+    end.to raise_error(EmsRefresh::Refreshers::EmsRefresherMixin::PartialRefreshError)
   end
 end


### PR DESCRIPTION
In EmsRefresh a failure will only be logged in the refresh context of the log.

See [error handling in ems_refresher_mixin.rb](https://github.com/ManageIQ/manageiq/blob/95dca49ce029cd4cb11d5bf041093810ca85926e/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb#L23-L36)

A queue message will still be delivered with the state ok.
See [error handling in miq_queue.rb](https://github.com/ManageIQ/manageiq/blob/95dca49ce029cd4cb11d5bf041093810ca85926e/app/models/miq_queue.rb#L340-L372)

This is the relevant log line.

`[----] I, [2016-03-16T10:18:06.067938 #3002:90798c]  INFO -- : MIQ(MiqQueue#delivered) Message id: [2000001124178], State: [ok], Delivered in [157.827267344] seconds`

While for me this indicates, that the delivery of the message was successful but not necessarily the result of the invoked method, it seems that users think different. 

I dont like that I have to use an Exception for this, because right now the refresh is designed to not raise execptions, but log the errors in `ems.last_refresh_error`

So, should we close this as NOTABUG ?
Should we use [m_callback](https://github.com/ManageIQ/manageiq/blob/95dca49ce029cd4cb11d5bf041093810ca85926e/app/models/miq_queue.rb#L385) to log something ? - Sounds like a dirty workaround and misuse of this

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1319324

@jrafanie @gtanzillo @Fryguy thoughts?

@miq-bot add_labels core