### PR TITLE
[Darga] Update version in zanata.xml for the darga branch

### DIFF
--- a/config/locales/zanata.xml
+++ b/config/locales/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://translate.zanata.org/zanata/</url>
   <project>manageiq</project>
-  <project-version>master</project-version>
+  <project-version>d-release</project-version>
   <project-type>gettext</project-type>
   <locales>
     <locale>ja</locale>


### PR DESCRIPTION
The version was incorrectly changed to 'master' with one of the previous merges.

The correct version for the darga branch in zanata is 'd-release'.