### PR TITLE
[WIP] Added new role - database_failover_admin

### DIFF
--- a/db/fixtures/server_roles.csv
+++ b/db/fixtures/server_roles.csv
@@ -1,5 +1,6 @@
 name,description,max_concurrent,external_failover,role_scope
 automate,Automation Engine,0,false,region
+database_failover_admin,Database Failover Administration,1,false,region
 database_operations,Database Operations,0,false,region
 database_owner,Database Owner,1,false,database
 database_synchronization,Database Synchronization,1,false,region

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -4,6 +4,7 @@ describe "Server Role Management" do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         automate,Automation Engine,0,false,region
+        database_failover_admin,Database Failover Administration,1,false,region
         database_operations,Database Operations,0,false,region
         database_owner,Database Owner,1,false,database
         database_synchronization,Database Synchronization,1,false,region

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -4,6 +4,7 @@ describe "Server Monitor" do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         automate,Automation Engine,0,false,region
+        database_failover_admin,Database Failover Administration,1,false,region
         database_operations,Database Operations,0,false,region
         database_owner,Database Owner,1,false,database
         database_synchronization,Database Synchronization,1,false,region

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -31,6 +31,7 @@ describe ServerRole do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         automate,Automation Engine,0,false,region
+        database_failover_admin,Database Failover Administration,1,false,region
         database_operations,Database Operations,0,false,region
         database_owner,Database Owner,1,false,database
         database_synchronization,Database Synchronization,1,false,region


### PR DESCRIPTION
database_failover_admin role will be assigned to only one server in Region and will indicate that vmdb_high_availability (name subject to change) daemon running on a particular server

/cc @carbonin @Fryguy 