### PR TITLE
EmsEvent: set container_node_id by ems & name when event has no UID

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -88,7 +88,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       # Workaround for missing/useless node UID (#9600, https://github.com/kubernetes/kubernetes/issues/29289)
       if event_data[:uid].nil? || event_data[:uid] == event_data[:name]
         node = ContainerNode.find_by(:ems_id => @ems.id, :name => event_data[:name])
-        event_data[:uid] = node ? node.ems_ref : nil
+        event_data[:uid] = node.try!(:ems_ref)
       end
     when 'Pod'
       /^spec.containers{(?<container_name>.*)}$/ =~ event_data[:fieldpath]

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -1,0 +1,230 @@
+describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
+  let(:dummy_class) do
+    Class.new do
+      def initialize(ems = nil)
+        @ems = ems if ems
+      end
+    end.include(described_class)
+  end
+  let(:ems) { FactoryGirl.create(:ems_kubernetes) }
+
+  describe '#extract_event_data' do
+    it 'processes node event' do
+    end
+
+    context 'given container event (Pod event with fieldPath)' do
+      let(:kubernetes_event) do
+        {
+          'kind'           => 'Event',
+          'apiVersion'     => 'v1',
+          'metadata'       => {
+            'name'              => 'heapster-aas69.14636726235d5e81',
+            'namespace'         => 'openshift-infra',
+            'selfLink'          => '/api/v1/namespaces/openshift-infra/events/heapster-aas69.14636726235d5e81',
+            'uid'               => 'fa735ca9-4f7d-11e6-b177-525400c7c086',
+            'resourceVersion'   => '1329090',
+            'creationTimestamp' => '2016-07-21T20:01:57Z',
+            'deletionTimestamp' => '2016-07-21T22:01:57Z'
+          },
+          'involvedObject' => {
+            'kind'            => 'Pod',
+            'namespace'       => 'openshift-infra',
+            'name'            => 'heapster-aas69',
+            'uid'             => '72d3098a-4f6a-11e6-b177-525400c7c086',
+            'apiVersion'      => 'v1',
+            'resourceVersion' => '1323182',
+            'fieldPath'       => 'spec.containers{heapster}'
+          },
+          'reason'         => 'Killing',
+          'message'        => 'Killing container with docker id 18a563fdb87c: failed to call event handler: '\
+                              'Error executing in Docker Container: -1',
+          'source'         => {
+            'component' => 'kubelet',
+            'host'      => 'vm-test-03.example.com'
+          },
+          'firstTimestamp' => '2016-07-21T20:01:56Z',
+          'lastTimestamp'  => '2016-07-21T20:01:56Z',
+          'count'          => 1,
+          'type'           => 'Normal'
+        }
+      end
+
+      it 'extracts CONTAINER_KILLING data' do
+        expected_data = {
+          :timestamp            => '2016-07-21T20:01:56Z',
+          :kind                 => 'Pod',
+          :name                 => 'heapster-aas69',
+          :namespace            => 'openshift-infra',
+          :reason               => 'Killing',
+          :message              => 'Killing container with docker id 18a563fdb87c: failed to call event handler: '\
+                                   'Error executing in Docker Container: -1',
+          :uid                  => '72d3098a-4f6a-11e6-b177-525400c7c086',
+          :fieldpath            => 'spec.containers{heapster}',
+          :container_name       => 'heapster',
+          :container_group_name => 'heapster-aas69',
+          :container_namespace  => 'openshift-infra',
+          :event_type           => 'CONTAINER_KILLING'
+        }
+        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+      end
+    end
+
+    context 'given pod event (no fieldPath)' do
+      let(:kubernetes_event) do
+        {
+          'metadata'       => {
+            'name'              => 'ruby-ex-4-6o0b5.146481d987d53341',
+            'namespace'         => 'proj',
+            'selfLink'          => '/api/v1/namespaces/proj/events/ruby-ex-4-6o0b5.146481d987d53341',
+            'uid'               => 'b10955d1-5251-11e6-8564-525400c7c086',
+            'resourceVersion'   => '1358590',
+            'creationTimestamp' => '2016-07-25T10:22:29Z',
+            'deletionTimestamp' => '2016-07-25T13:04:06Z'
+          },
+          'involvedObject' => {
+            'kind'            => 'Pod',
+            'namespace'       => 'proj',
+            'name'            => 'ruby-ex-4-6o0b5',
+            'uid'             => 'e12e8bf2-4d8f-11e6-bcf3-525400c7c086',
+            'apiVersion'      => 'v1',
+            'resourceVersion' => '1342618'
+          },
+          'reason'         => 'FailedSync',
+          'message'        => 'Error syncing pod, skipping: API error (500): Unknown device '\
+                              'bd312cc17e3e1554ca5cb15468232c0d0cc51b0c25bf6fb487481237dab5d453\n',
+          'source'         => {
+            'component' => 'kubelet',
+            'host'      => 'vm-test-02.example.com'
+          },
+          'firstTimestamp' => '2016-07-25T10:22:29Z',
+          'lastTimestamp'  => '2016-07-25T11:04:06Z',
+          'count'          => 227,
+          'type'           => 'Warning'
+        }
+      end
+
+      it 'extracts POD_FAILEDSYNC data' do
+        expected_data = {
+          :timestamp            => '2016-07-25T11:04:06Z',
+          :kind                 => 'Pod',
+          :name                 => 'ruby-ex-4-6o0b5',
+          :namespace            => 'proj',
+          :reason               => 'FailedSync',
+          :message              => 'Error syncing pod, skipping: API error (500): Unknown device '\
+                                   'bd312cc17e3e1554ca5cb15468232c0d0cc51b0c25bf6fb487481237dab5d453\n',
+          :uid                  => 'e12e8bf2-4d8f-11e6-bcf3-525400c7c086',
+          :container_group_name => 'ruby-ex-4-6o0b5',
+          :container_namespace  => 'proj',
+          :event_type           => 'POD_FAILEDSYNC'
+        }
+        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+      end
+    end
+
+    context 'given replicator event' do
+      let(:kubernetes_event) do
+        {
+          'metadata'       => {
+            'name'              => 'mysql-1.146486622e01d244',
+            'namespace'         => 'proj',
+            'selfLink'          => '/api/v1/namespaces/proj/events/mysql-1.146486622e01d244',
+            'uid'               => '4c513e6d-525d-11e6-8564-525400c7c086',
+            'resourceVersion'   => '1360577',
+            'creationTimestamp' => '2016-07-25T11:45:34Z',
+            'deletionTimestamp' => '2016-07-25T13:45:34Z'
+          },
+          'involvedObject' => {
+            'kind'            => 'ReplicationController',
+            'namespace'       => 'proj',
+            'name'            => 'mysql-1',
+            'uid'             => '7599d451-4c1c-11e6-89dd-525400c7c086',
+            'apiVersion'      => 'v1',
+            'resourceVersion' => '1360571'
+          },
+          'reason'         => 'SuccessfulCreate',
+          'message'        => 'Created pod: mysql-1-i4b54',
+          'source'         => {
+            'component' => 'replication-controller'
+          },
+          'firstTimestamp' => '2016-07-25T11:45:34Z',
+          'lastTimestamp'  => '2016-07-25T11:45:34Z',
+          'count'          => 1,
+          'type'           => 'Normal'
+        }
+      end
+
+      it 'extracts REPLICATOR_SUCCESSFULCREATE event data' do
+        expected_data = {
+          :timestamp                 => '2016-07-25T11:45:34Z',
+          :kind                      => 'ReplicationController',
+          :name                      => 'mysql-1',
+          :namespace                 => 'proj',
+          :reason                    => 'SuccessfulCreate',
+          :message                   => 'Created pod: mysql-1-i4b54',
+          :uid                       => '7599d451-4c1c-11e6-89dd-525400c7c086',
+          :container_replicator_name => 'mysql-1',
+          :container_namespace       => 'proj',
+          :event_type                => 'REPLICATOR_SUCCESSFULCREATE'
+        }
+        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+      end
+    end
+
+    context 'given node event' do
+      let(:kubernetes_event) do
+        {
+          'metadata'       => {
+            'name'              => 'vm-test-03.example.com.146481d4a19edff4',
+            'namespace'         => 'default',
+            'selfLink'          => '/api/v1/namespaces/default/events/vm-test-03.example.com.146481d4a19edff4',
+            'uid'               => 'a4b92ae1-5251-11e6-8564-525400c7c086',
+            'resourceVersion'   => '1356588',
+            'creationTimestamp' => '2016-07-25T10:22:09Z',
+            'deletionTimestamp' => '2016-07-25T12:22:09Z'
+          },
+          'involvedObject' => {
+            'kind' => 'Node',
+            'name' => 'vm-test-03.example.com',
+            # Actually saw 'uid' => 'vm-test-03.example.com' but this is what we will get once
+            # https://github.com/kubernetes/kubernetes/issues/29289 gets fixed.
+            'uid'  => 'd30a880d-dfa7-11e5-af89-525400c7c086'
+          },
+          'reason'         => 'Rebooted',
+          'message'        => 'Node vm-test-03.example.com has been rebooted, boot id: '\
+                              'c75d2b66-6d5b-49e0-b906-1d8abaf3e73b',
+          'source'         => {
+            'component' => 'kubelet',
+            'host'      => 'vm-test-03.example.com'
+          },
+          'firstTimestamp' => '2016-07-25T10:22:08Z',
+          'lastTimestamp'  => '2016-07-25T10:22:08Z',
+          'count'          => 1,
+          'type'           => 'Warning'
+        }
+      end
+
+      let(:expected_data) do
+        {
+          :timestamp           => '2016-07-25T10:22:08Z',
+          :kind                => 'Node',
+          :name                => 'vm-test-03.example.com',
+          :namespace           => nil,
+          :reason              => 'Rebooted',
+          :message             => 'Node vm-test-03.example.com has been rebooted, boot id: '\
+                                  'c75d2b66-6d5b-49e0-b906-1d8abaf3e73b',
+          :uid                 => 'd30a880d-dfa7-11e5-af89-525400c7c086',
+          :container_node_name => 'vm-test-03.example.com',
+          :event_type          => 'NODE_REBOOTED'
+        }
+      end
+
+      it 'given good uid extracts NODE_REBOOTED event data' do
+        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -1,5 +1,5 @@
 describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
-  let(:dummy_class) do
+  let(:test_class) do
     Class.new do
       def initialize(ems = nil)
         @ems = ems if ems
@@ -9,9 +9,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
   let(:ems) { FactoryGirl.create(:ems_kubernetes) }
 
   describe '#extract_event_data' do
-    it 'processes node event' do
-    end
-
     context 'given container event (Pod event with fieldPath)' do
       let(:kubernetes_event) do
         {
@@ -66,7 +63,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :event_type           => 'CONTAINER_KILLING'
         }
         event = RecursiveOpenStruct.new(:object => kubernetes_event)
-        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+        expect(test_class.new.extract_event_data(event)).to eq(expected_data)
       end
     end
 
@@ -119,7 +116,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :event_type           => 'POD_FAILEDSYNC'
         }
         event = RecursiveOpenStruct.new(:object => kubernetes_event)
-        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+        expect(test_class.new.extract_event_data(event)).to eq(expected_data)
       end
     end
 
@@ -169,7 +166,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :event_type                => 'REPLICATOR_SUCCESSFULCREATE'
         }
         event = RecursiveOpenStruct.new(:object => kubernetes_event)
-        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+        expect(test_class.new.extract_event_data(event)).to eq(expected_data)
       end
     end
 
@@ -223,7 +220,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
 
       it 'given good uid extracts NODE_REBOOTED event data' do
         event = RecursiveOpenStruct.new(:object => kubernetes_event)
-        expect(dummy_class.new.extract_event_data(event)).to eq(expected_data)
+        expect(test_class.new.extract_event_data(event)).to eq(expected_data)
       end
 
       # Remove when we no longer support kubernetes with bug
@@ -250,8 +247,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
         end
 
         it 'without matching node returns nil uid' do
-          expect(dummy_class.new(ems).extract_event_data(bad_uid_event)[:uid]).to eq(nil)
-          expect(dummy_class.new(ems).extract_event_data(missing_uid_event)[:uid]).to eq(nil)
+          expect(test_class.new(ems).extract_event_data(bad_uid_event)[:uid]).to eq(nil)
+          expect(test_class.new(ems).extract_event_data(missing_uid_event)[:uid]).to eq(nil)
         end
 
         it 'with matching node takes its uid' do
@@ -260,8 +257,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           node.ems_ref = 'd30a880d-dfa7-11e5-af89-525400c7c086'
           node.save
 
-          expect(dummy_class.new(ems).extract_event_data(bad_uid_event)).to eq(expected_data)
-          expect(dummy_class.new(ems).extract_event_data(missing_uid_event)).to eq(expected_data)
+          expect(test_class.new(ems).extract_event_data(bad_uid_event)).to eq(expected_data)
+          expect(test_class.new(ems).extract_event_data(missing_uid_event)).to eq(expected_data)
         end
       end
     end


### PR DESCRIPTION
Workaround for #9600, acknowledged as upsteam bug kubernetes/kubernetes#29289.
Ensures later the EmsEvent's container_node_id is set (#9600), if we have the node in inventory at event arrival.
Covers both missing involvedObject.uid and node name given as uid which I'm seeing in some events.

It's being fixed in Kubernetes but we need this anyway to support existing versions with this bug (at least v1.2.0 .. v1.4.0-alpha.1).

#9600 doesn't currently have it's own BZ (not even sure it's user-visible, maybe in node Timeline?)
but this fix is important for node event -> policy support (#9601, #9813) whose BZs are:
https://bugzilla.redhat.com/show_bug.cgi?id=1341253 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1346057 (darga)

@miq-bot add-label bug, providers/containers, darga/yes