### PR TITLE
[DARGA] Fix for dialog field input being truncated upon submission

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1312,6 +1312,7 @@ function miqJqueryRequest(url, options) {
   // copy selected options over
   _.extend(ajax_options, _.pick(options, [
     'data',
+    'dataType',
     'contentType',
     'processData',
     'cache',

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1389,7 +1389,7 @@ function miqSelectPickerEvent(element, url, options) {
     miqObserveRequest(finalUrl, options);
 
     return true;
-  }, 700, { leading: false, trailing: true }));
+  }, 700, {leading: true, trailing: true}));
 }
 
 function miqAccordSelect(e) {

--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -58,7 +58,7 @@ $(document).ready(function () {
       if (parms.auto_refresh === true) {
         dialogFieldRefresh.triggerAutoRefresh(parms.field_id, parms.trigger);
       }
-    }
+    };
   };
 
   $(document).on('focus', '[data-miq_observe]', function () {
@@ -71,7 +71,7 @@ $(document).ready(function () {
 
     if (typeof interval == "undefined") {
       // No interval passed, use event observer
-      el.off('change')
+      el.off('change');
       el.on('change', _.debounce(function() {
         var id = el.attr('id');
         var value = el.prop('multiple') ? el.val() : encodeURIComponent(el.prop('value'));
@@ -83,7 +83,7 @@ $(document).ready(function () {
           complete: !! el.attr('data-miq_sparkle_off'),
           done: attemptAutoRefreshTrigger(parms),
         });
-      }, 700, { leading: false, trailing: true }));
+      }, 700, {leading: true, trailing: true}));
     } else {
       el.off(); // Use jQuery to turn off observe_field, prevents multi ajax transactions
       el.observe_field(interval, function () {

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -34,7 +34,6 @@ module ApplicationHelper::Dialogs
     }
 
     extra_options = {"data-miq_observe" => {
-      :interval => '.5',
       :url      => url,
     }.merge(auto_refresh_options(field)).to_json}
 
@@ -49,7 +48,6 @@ module ApplicationHelper::Dialogs
     }
 
     extra_options = {"data-miq_observe" => {
-      :interval => '.5',
       :url      => url,
     }.merge(auto_refresh_options(field)).to_json}
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -56,7 +56,7 @@ describe ApplicationHelper::Dialogs do
           expect(helper.textbox_tag_options(dialog_field, "url")).to eq(
             :maxlength         => 50,
             :class             => "dynamic-text-box-100 form-control",
-            "data-miq_observe" => '{"interval":".5","url":"url"}'
+            "data-miq_observe" => '{"url":"url"}'
           )
         end
       end
@@ -69,7 +69,6 @@ describe ApplicationHelper::Dialogs do
             :maxlength         => 50,
             :class             => "dynamic-text-box-100 form-control",
             "data-miq_observe" => {
-              :interval     => ".5",
               :url          => "url",
               :auto_refresh => true,
               :field_id     => "100",
@@ -108,7 +107,6 @@ describe ApplicationHelper::Dialogs do
             :maxlength         => 8192,
             :size              => "50x6",
             "data-miq_observe" => {
-              :interval     => ".5",
               :url          => "url",
               :auto_refresh => true,
               :field_id     => "100",
@@ -126,7 +124,7 @@ describe ApplicationHelper::Dialogs do
             :class             => "dynamic-text-area-100 form-control",
             :maxlength         => 8192,
             :size              => "50x6",
-            "data-miq_observe" => '{"interval":".5","url":"url"}'
+            "data-miq_observe" => '{"url":"url"}'
           )
         end
       end

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -73,39 +73,251 @@ describe('dialogFieldRefresh', function() {
     });
   });
 
-  describe('#refreshDropDownList', function() {
-    beforeEach(function() {
-      spyOn(dialogFieldRefresh, 'addOptionsToDropDownList');
+  describe('#refreshCheckbox', function() {
+    var loadedDoneFunction;
 
-      spyOn($.fn, 'selectpicker');
-      spyOn($, 'post').and.callFake(function() {
-        var d = $.Deferred();
-        d.resolve({values: {checked_value: 'selectedTest'}});
-        return d.promise();
+    beforeEach(function() {
+      spyOn(dialogFieldRefresh, 'setReadOnly');
+      spyOn($.fn, 'prop');
+
+      spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
+        loadedDoneFunction = doneFunction;
       });
     });
 
-    it('calls addOptionsToDropDownList', function() {
-      dialogFieldRefresh.refreshDropDownList('abc', 123, 'test');
-      expect(dialogFieldRefresh.addOptionsToDropDownList).toHaveBeenCalledWith(
-        {values: {checked_value: 'selectedTest'}},
-        123
+    it('calls sendRefreshRequest', function() {
+      dialogFieldRefresh.refreshCheckbox('abc', 123);
+      expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
+        'dynamic_checkbox_refresh',
+        {name: 'abc'},
+        loadedDoneFunction
       );
     });
 
-    it('ensures the select picker is refreshed', function() {
-      dialogFieldRefresh.refreshDropDownList('abc', 123, 'test');
-      expect($.fn.selectpicker).toHaveBeenCalledWith('refresh');
+    describe('#refreshCheckbox doneFunction', function() {
+      beforeEach(function() {
+        var data = {responseText: JSON.stringify({values: {checked: true, read_only: true}})};
+        loadedDoneFunction(data);
+      });
+
+      it('sets the checked prop to the checked value', function() {
+        expect($.fn.prop).toHaveBeenCalledWith('checked', true);
+      });
+
+      it('uses the correct selector', function() {
+        expect($.fn.prop.calls.mostRecent().object.selector).toEqual('.dynamic-checkbox-123');
+      });
+
+      it('sets the read only property', function() {
+        expect(dialogFieldRefresh.setReadOnly).toHaveBeenCalledWith(
+          jasmine.objectContaining({selector: '.dynamic-checkbox-123'}),
+          true
+        );
+      });
+    });
+  });
+
+  describe('#refreshDateTime', function() {
+    var loadedDoneFunction;
+
+    beforeEach(function() {
+      spyOn(dialogFieldRefresh, 'setReadOnly');
+      spyOn($.fn, 'val');
+
+      spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
+        loadedDoneFunction = doneFunction;
+      });
     });
 
-    it('sets the value in the select picker', function() {
-      dialogFieldRefresh.refreshDropDownList('abc', 123, 'test');
-      expect($.fn.selectpicker).toHaveBeenCalledWith('val', 'selectedTest');
+    it('calls sendRefreshRequest', function() {
+      dialogFieldRefresh.refreshDateTime('abc', 123);
+      expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
+        'dynamic_date_refresh',
+        {name: 'abc'},
+        loadedDoneFunction
+      );
     });
 
-    it('uses the correct selector', function() {
+    describe('#refreshDateTime doneFunction', function() {
+      beforeEach(function() {
+        var data = {responseText: JSON.stringify({values: {date: 'today', hour: '12', min: '34', read_only: true}})};
+        loadedDoneFunction(data);
+      });
+
+      it('sets the date val to the response data date', function() {
+        expect($.fn.val).toHaveBeenCalledWith('today');
+      });
+
+      it('uses the correct selector', function() {
+        expect($.fn.val.calls.first().object.selector).toEqual('.dynamic-date-123');
+      });
+
+      it('sets the hours val to the response data hour', function() {
+        expect($.fn.val).toHaveBeenCalledWith('12');
+      });
+
+      it('uses the correct selector', function() {
+        expect($.fn.val.calls.all()[1].object.selector).toEqual('.dynamic-date-hour-123');
+      });
+
+      it('sets the mins val to the response data min', function() {
+        expect($.fn.val).toHaveBeenCalledWith('34');
+      });
+
+      it('uses the correct selector', function() {
+        expect($.fn.val.calls.mostRecent().object.selector).toEqual('.dynamic-date-min-123');
+      });
+
+      it('sets the read only property', function() {
+        expect(dialogFieldRefresh.setReadOnly).toHaveBeenCalledWith(
+          jasmine.objectContaining({selector: '.dynamic-date-123'}),
+          true
+        );
+      });
+    });
+  });
+
+  describe('#refreshTextBox', function() {
+    var loadedDoneFunction;
+
+    beforeEach(function() {
+      spyOn(dialogFieldRefresh, 'setReadOnly');
+      spyOn($.fn, 'val');
+
+      spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
+        loadedDoneFunction = doneFunction;
+      });
+    });
+
+    it('calls sendRefreshRequest', function() {
+      dialogFieldRefresh.refreshTextBox('abc', 123);
+      expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
+        'dynamic_text_box_refresh',
+        {name: 'abc'},
+        loadedDoneFunction
+      );
+    });
+
+    describe('#refreshTextBox doneFunction', function() {
+      beforeEach(function() {
+        var data = {responseText: JSON.stringify({values: {text: 'text', read_only: true}})};
+        loadedDoneFunction(data);
+      });
+
+      it('sets the value of the text box with the text data', function() {
+        expect($.fn.val).toHaveBeenCalledWith('text');
+      });
+
+      it('uses the correct selector', function() {
+        expect($.fn.val.calls.mostRecent().object.selector).toEqual('.dynamic-text-box-123');
+      });
+
+      it('sets the read only property', function() {
+        expect(dialogFieldRefresh.setReadOnly).toHaveBeenCalledWith(
+          jasmine.objectContaining({selector: '.dynamic-text-box-123'}),
+          true
+        );
+      });
+    });
+  });
+
+  describe('#refreshTextAreaBox', function() {
+    var loadedDoneFunction;
+
+    beforeEach(function() {
+      spyOn(dialogFieldRefresh, 'setReadOnly');
+      spyOn($.fn, 'val');
+
+      spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
+        loadedDoneFunction = doneFunction;
+      });
+    });
+
+    it('calls sendRefreshRequest', function() {
+      dialogFieldRefresh.refreshTextAreaBox('abc', 123);
+      expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
+        'dynamic_text_box_refresh',
+        {name: 'abc'},
+        loadedDoneFunction
+      );
+    });
+
+    describe('#refreshTextAreaBox doneFunction', function() {
+      beforeEach(function() {
+        var data = {responseText: JSON.stringify({values: {text: 'text', read_only: true}})};
+        loadedDoneFunction(data);
+      });
+
+      it('sets the value of the text box with the text data', function() {
+        expect($.fn.val).toHaveBeenCalledWith('text');
+      });
+
+      it('uses the correct selector', function() {
+        expect($.fn.val.calls.mostRecent().object.selector).toEqual('.dynamic-text-area-123');
+      });
+
+      it('sets the read only property', function() {
+        expect(dialogFieldRefresh.setReadOnly).toHaveBeenCalledWith(
+          jasmine.objectContaining({selector: '.dynamic-text-area-123'}),
+          true
+        );
+      });
+    });
+  });
+
+  describe('#refreshDropDownList', function() {
+    var loadedDoneFunction;
+
+    beforeEach(function() {
+      spyOn(dialogFieldRefresh, 'addOptionsToDropDownList');
+      spyOn(dialogFieldRefresh, 'setReadOnly');
+      spyOn($.fn, 'selectpicker');
+
+      spyOn(dialogFieldRefresh, 'sendRefreshRequest').and.callFake(function(_url, _data, doneFunction) {
+        loadedDoneFunction = doneFunction;
+      });
+    });
+
+    it('calls sendRefreshRequest', function() {
       dialogFieldRefresh.refreshDropDownList('abc', 123, 'test');
-      expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('#abc');
+      expect(dialogFieldRefresh.sendRefreshRequest).toHaveBeenCalledWith(
+        'dynamic_radio_button_refresh',
+        {name: 'abc', checked_value: 'test'},
+        loadedDoneFunction
+      );
+    });
+
+    describe('#refreshDropDownList doneFunction', function() {
+      beforeEach(function() {
+        var data = {responseText: JSON.stringify({values: {checked_value: 'selectedTest', read_only: true}})};
+        loadedDoneFunction(data);
+      });
+
+      it('adds the options to the dropdown list', function() {
+        expect(dialogFieldRefresh.addOptionsToDropDownList).toHaveBeenCalledWith(
+          {values: {checked_value: 'selectedTest', read_only: true}},
+          123
+        );
+      });
+
+      it('sets the read only property', function() {
+        expect(dialogFieldRefresh.setReadOnly).toHaveBeenCalledWith(
+          jasmine.objectContaining({selector: '#abc'}),
+          true
+        );
+      });
+
+      it('ensures the select picker is refreshed', function() {
+        expect($.fn.selectpicker).toHaveBeenCalledWith('refresh');
+      });
+
+      it('sets the value in the select picker', function() {
+        expect($.fn.selectpicker).toHaveBeenCalledWith('val', 'selectedTest');
+      });
+
+      it('uses the correct selector', function() {
+        expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('#abc');
+      });
     });
   });
 


### PR DESCRIPTION
This ensures that the dialog fields when being refreshed are waiting for the requests that are in the MiqObserve queue so as not to lose any data. It also adjusts the observe requests so that they fire immediately upon moving from a text/textarea box. Before, they would have a delay that allowed someone to potentially get a different request to the server and cause the truncation issues.

This is the darga backport of #9840 that was originally for BZ1355841.

https://bugzilla.redhat.com/show_bug.cgi?id=1356973

/cc @gmcculloug 