### PR TITLE
[WIP] API endpoint for queue (MiqQueue)

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -70,6 +70,7 @@ class ApiController < ApplicationController
   include_concern 'PolicyActions'
   include_concern 'Providers'
   include_concern 'ProvisionRequests'
+  include_concern "Queue"
   include_concern "Rates"
   include_concern "Reports"
   include_concern 'Requests'

--- a/app/controllers/api_controller/queue.rb
+++ b/app/controllers/api_controller/queue.rb
@@ -1,0 +1,21 @@
+class ApiController
+  INVALID_QUEUE_ATTRS = %w(id href state lock_version)
+
+  module Queue
+    def create_resource_queue(_type, _id, data)
+      validate_queue_data(data)
+
+      zone = fetch_zone(data)
+      data[:zone] = zone.name if zone
+
+      MiqQueue.put(data)
+    end
+
+    private
+
+    def validate_queue_data(data)
+      invalid_attrs = data.keys & INVALID_QUEUE_ATTRS
+      raise BadRequestError, "Invalid attributes(s) #{invalide_attrs}" unless invalid_attrs.empty?
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -717,6 +717,17 @@
         :identifier: miq_request_approval
       - :name: deny
         :identifier: miq_request_approval
+  :queue:
+    :description: Queue
+    :options:
+    - :collection
+    :verbs: *70174834085860
+    :klass: MiqQueue
+    :collection_actions:
+      :get:
+      - :name: read
+      :post:
+      - :name: create
   :rates:
     :description: Chargeback Rates
     :identifier: chargeback_rates

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -123,6 +123,11 @@ describe ApiController do
       test_collection_query(:provision_dialogs, provision_dialogs_url, MiqDialog)
     end
 
+    it "query Queue" do
+      FactoryGirl.create(:miq_queue)
+      test_collection_query(:queue, queue_url, MiqQueue)
+    end
+
     it "query Provision Requests" do
       FactoryGirl.create(:miq_provision_request, :source => template, :requester => @user)
       test_collection_query(:provision_requests, provision_requests_url, MiqProvisionRequest)

--- a/spec/requests/api/queue_spec.rb
+++ b/spec/requests/api/queue_spec.rb
@@ -1,0 +1,27 @@
+# Rest API Request Tests - Queue specs
+#
+# - Creating a queue entry (put)         /api/queue                           POST
+#
+RSpec.describe "queue API" do
+  let(:sample_queue_request) { {:method_name => "some_method", :args => ["arg_1", "arg_2"], } }
+
+  describe "queue create" do
+    it "supports single queue entry creation" do
+      expected = {
+        "id" => a_kind_of(Integer),
+        "args" => ["arg_1", "arg_2"],
+        "method_name" => "some_method"
+      }
+
+      api_basic_authorize collection_action_identifier(:queue, :create)
+
+      run_post(queue_url, sample_queue_request)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["results"].first).to a_hash_including(expected)
+
+      queue_id = response.parsed_body["results"].first["id"]
+      expect(MiqQueue.exists?(queue_id)).to be_truthy
+    end
+  end
+end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -114,7 +114,7 @@ module ApiSpecHelper
   end
 
   def update_user_role(role, *identifiers)
-    return if identifiers.blank?
+    return if identifiers.compact.blank?
     product_features = identifiers.collect do |identifier|
       MiqProductFeature.find_or_create_by(:identifier => identifier)
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
Support for Central Administration remote queuing. This enables putting a message on the queue of a remote region.

Sample request:

```ruby
{
  "method_name": "test_me_out",
  "args": [
    "string_a", "string_b"
  ],
  "zone": {"id": 1}
}
```

Note: Authentication, which will be in the form of a server to server trusted token will come in a later PR.

https://www.pivotaltracker.com/story/show/124176511