### PR TITLE
s/response_hash/response.parsed_body/

### DIFF
--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "API entrypoint" do
 
     run_get entrypoint_url
 
-    expect(response_hash['settings']).to a_hash_including(test_settings.deep_stringify_keys)
+    expect(response.parsed_body).to include("settings" => a_hash_including(test_settings.deep_stringify_keys))
   end
 
   it "collection query is sorted" do


### PR DESCRIPTION
Purpose or Intent
-----------------

In #9857 we removed `response_hash` in favor of
`response.parsed_body`. #9801 was subsequently merged, which depended on
`response_hash`. This PR fixes the broken build by updating to use
`response.parsed_body` instead.

It also makes a small change to favor the `include` matcher over the
composable matcher `a_hash_including` to aid readability.

@miq-bot add-label api, test
@miq-bot assign @gtanzillo 