### PR TITLE
Rbac extract find_options and focus on scopes

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -240,8 +240,7 @@ module Rbac
     user_or_group = user || miq_group
     tenant_id_clause = klass.tenant_id_clause(user_or_group)
 
-    find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], tenant_id_clause) if tenant_id_clause
-    find_options
+    tenant_id_clause ? scope.where(tenant_id_clause) : scope
   end
 
   def self.accessible_tenant_ids_strategy(klass)
@@ -250,7 +249,7 @@ module Rbac
 
   def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options, user, miq_group)
     if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
-      find_options = find_options_for_tenant(scope, user, miq_group, find_options)
+      scope = find_options_for_tenant(scope, user, miq_group, find_options)
     end
 
     if apply_rbac_to_class?(klass)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -175,21 +175,19 @@ module Rbac
     filtered_ids
   end
 
-  def self.find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
+  def self.scope_by_indirect_rbac(scope, rbac_filters, user, miq_group)
     parent_class = rbac_class(scope)
     filtered_ids = calc_filtered_ids(parent_class, rbac_filters, user, miq_group)
 
-    find_targets_filtered_by_parent_ids(parent_class, scope, find_options, filtered_ids)
+    scope_by_parent_ids(parent_class, scope, filtered_ids)
   end
 
   # @param parent_class [Class] Class of parent (e.g. Host)
   # @param klass [Class] Class of child node (e.g. Vm)
   # @param scope [] scope for active records (e.g. Vm.archived)
-  # @param find_options [Hash<Symbol,String|Array>] options for active record conditions
-  # @option find_options :conditions [String|Hash|Array] active record where conditions for primary records (e.g. { "vms.archived" => true} )
   # @param filtered_ids [nil|Array<Integer>] ids for the parent class (e.g. [1,2,3] for host)
   # @return [Array<Array<Object>,Integer,Integer] targets, authorized count
-  def self.find_targets_filtered_by_parent_ids(parent_class, scope, find_options, filtered_ids)
+  def self.scope_by_parent_ids(parent_class, scope, filtered_ids)
     if filtered_ids
       reflection = scope.reflections[parent_class.name.underscore]
       if reflection
@@ -202,7 +200,7 @@ module Rbac
     end
   end
 
-  def self.find_targets_filtered_by_ids(scope, find_options, filtered_ids)
+  def self.scope_by_ids(scope, filtered_ids)
     filtered_ids ? scope.where("#{scope.table_name}.id IN (?)", filtered_ids) : scope
   end
 
@@ -217,12 +215,12 @@ module Rbac
     scope.find_tags_by_grouping(filter, :ns => '*').reorder(nil)
   end
 
-  def self.find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
+  def self.scope_by_direct_rbac(scope, rbac_filters, user, miq_group)
     filtered_ids = calc_filtered_ids(scope, rbac_filters, user, miq_group)
-    find_targets_filtered_by_ids(scope, find_options, filtered_ids)
+    scope_by_ids(scope, filtered_ids)
   end
 
-  def self.find_targets_with_user_group_rbac(scope, _rbac_filters, find_options, user, miq_group)
+  def self.scope_by_user_group_rbac(scope, user, miq_group)
     klass = scope.respond_to?(:klass) ? scope.klass : scope
     if klass == User && user
       scope.where(:id => user.id)
@@ -233,7 +231,7 @@ module Rbac
     end
   end
 
-  def self.find_options_for_tenant(scope, user, miq_group, find_options)
+  def self.scope_to_tenant(scope, user, miq_group)
     klass = scope.respond_to?(:klass) ? scope.klass : scope
     user_or_group = user || miq_group
     tenant_id_clause = klass.tenant_id_clause(user_or_group)
@@ -245,17 +243,17 @@ module Rbac
     TENANT_ACCESS_STRATEGY[klass.base_model.to_s]
   end
 
-  def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options, user, miq_group)
+  def self.scope_targets(klass, scope, rbac_filters, user, miq_group)
     if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
-      scope = find_options_for_tenant(scope, user, miq_group, find_options)
+      scope = scope_to_tenant(scope, user, miq_group)
     end
 
     if apply_rbac_to_class?(klass)
-      scope = find_targets_with_direct_rbac(scope, rbac_filters, find_options, user, miq_group)
+      scope = scope_by_direct_rbac(scope, rbac_filters, user, miq_group)
     elsif apply_rbac_to_associated_class?(klass)
-      scope = find_targets_with_indirect_rbac(scope, rbac_filters, find_options, user, miq_group)
+      scope = scope_by_indirect_rbac(scope, rbac_filters, user, miq_group)
     elsif apply_user_group_rbac_to_class?(klass, miq_group)
-      scope = find_targets_with_user_group_rbac(scope, rbac_filters, find_options, user, miq_group)
+      scope = scope_by_user_group_rbac(scope, user, miq_group)
     else
       scope
     end
@@ -409,7 +407,7 @@ module Rbac
 
     _log.debug("Find options: #{find_options.inspect}")
 
-    scope = find_targets_with_rbac(klass, scope, user_filters, find_options, user, miq_group)
+    scope = scope_targets(klass, scope, user_filters, user, miq_group)
     targets = method_with_scope(scope, find_options)
     auth_count = find_options[:limit] ? targets.except(:offset, :limit, :order).count(:all) : targets.length
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1039,10 +1039,6 @@ describe Rbac do
 
   # find_targets_with_direct_rbac(klass, scope, rbac_filters, find_options, user_or_group)
   describe "find_targets_with_direct_rbac" do
-    let(:host_filter_find_options) do
-      {:conditions => {"hosts.hostname" => "good"}, :include => "host"}
-    end
-
     let(:host_match) { FactoryGirl.create(:host, :hostname => 'good') }
     let(:host_other) { FactoryGirl.create(:host, :hostname => 'bad') }
     let(:vms_match) { FactoryGirl.create_list(:vm_vmware, 2, :host => host_match) }
@@ -1051,15 +1047,13 @@ describe Rbac do
 
     it "works with no filters" do
       all_vms
-      result = Rbac.find_targets_with_direct_rbac(Vm, {}, {}, nil, nil)
+      result = Rbac.filtered(Vm)
       expect(result).to match_array(all_vms)
     end
 
-    # most of the functionality of search is channeled through find_options. including filters
-    # including :conditions, :include, :order, :limit
     it "applies find_options[:conditions, :include]" do
       all_vms
-      result = Rbac.find_targets_with_direct_rbac(Vm, {}, host_filter_find_options, nil, nil)
+      result = Rbac.filtered(Vm, :conditions => {"hosts.hostname" => "good"}, :include_for_find => {:host => {}})
       expect(result).to match_array(vms_match)
     end
   end


### PR DESCRIPTION
Theme
----

More details can be found in #9740 

Rbac is currently used to query the database and apply user centric security filters.
It applies rbac logic but also applies other logic like `limit`, `order`, `group`. The goal is to reduce rbac down so it only focuses on security filtering.

The result is a smaller simpler rbac interface. It will essentially just be `find_targets_with_rbac()`.

Overview
-------

Extract the `find_options` out of the `find_targets_with_rbac` methods. These are applied with the corresponding scope.
