### PR TITLE
Associate storage profiles with storages

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -286,7 +286,19 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_storage_profiles_inventory(ems, hashes, _target = nil)
-    save_inventory_multi(ems.storage_profiles, hashes, :use_association, [:ems_ref])
+    save_inventory_multi(ems.storage_profiles, hashes, :use_association, [:ems_ref], [:storage_profile_storages])
+  end
+
+  def save_storage_profile_storages_inventory(storage_profile, storages)
+    hashes = storages.collect do |storage|
+      {
+        :storage_profile_id => storage_profile.id,
+        :storage_id         => storage[:id]
+      }
+    end
+
+    save_inventory_multi(storage_profile.storage_profile_storages, hashes,
+                         :use_association, [:storage_profile_id, :storage_id])
   end
 
   def save_customization_specs_inventory(ems, hashes, _target = nil)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -86,7 +86,8 @@ module ManageIQ::Providers
           }
 
           placement_inv[uid].to_miq_a.each do |placement_hub|
-            new_result[:storage_profile_storages] << storage_uids[placement_hub.hubId] if placement_hub.hubType == "Datastore"
+            datastore = storage_uids[placement_hub.hubId] if placement_hub.hubType == "Datastore"
+            new_result[:storage_profile_storages] << datastore unless datastore.nil?
           end
 
           result << new_result

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -113,6 +113,10 @@ module ManageIQ::Providers
             @vc_data[type] = inv_hash unless inv_hash.blank?
             _log.info("#{log_header} Retrieving #{type.to_s.titleize} inventory...Complete - Count: [#{inv_hash.blank? ? 0 : inv_hash.length}]")
           end
+
+          @vc_data[:storage_profile].each do |uid, profile|
+            @vc_data[:storage_profile_datastore][uid] = @vi.pbmQueryMatchingHub(profile.profileId)
+          end
         end
 
         # Merge Virtual Apps into Resource Pools

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -114,9 +114,8 @@ module ManageIQ::Providers
             _log.info("#{log_header} Retrieving #{type.to_s.titleize} inventory...Complete - Count: [#{inv_hash.blank? ? 0 : inv_hash.length}]")
           end
 
-          @vc_data[:storage_profile].each do |uid, profile|
-            @vc_data[:storage_profile_datastore][uid] = @vi.pbmQueryMatchingHub(profile.profileId)
-          end
+          storage_profile_ids = @vc_data[:storage_profile].collect { |uid, _profile| uid }
+          @vc_data[:storage_profile_datastore] = @vi.pbmQueryMatchingHub(storage_profile_ids)
         end
 
         # Merge Virtual Apps into Resource Pools

--- a/gems/pending/VMwareWebService/MiqPbmInventory.rb
+++ b/gems/pending/VMwareWebService/MiqPbmInventory.rb
@@ -50,20 +50,21 @@ module MiqPbmInventory
     assoc_entities
   end
 
-  def pbmQueryMatchingHub(profile_id)
-    hubs = []
+  def pbmQueryMatchingHub(profile_ids)
+    hubs = {}
     return hubs if @pbm_svc.nil?
 
     begin
-      # If a string was passed in create a PbmProfileId object
-      profile_id = RbVmomi::PBM::PbmProfileId(:uniqueId => profile_id) if profile_id.kind_of?(String)
+      profile_ids.each do |profile_id|
+        # If a string was passed in create a PbmProfileId object
+        profile_id = RbVmomi::PBM::PbmProfileId(:uniqueId => profile_id) if profile_id.kind_of?(String)
 
-      hubs = @pbm_svc.queryMatchingHub(profile_id)
+        hubs[profile_id.uniqueId] = @pbm_svc.queryMatchingHub(profile_id)
+      end
     rescue => err
       $vim_log.warn("MiqPbmInventory: pbmQueryMatchingHub: #{err}")
     end
 
     hubs
   end
-
 end

--- a/spec/tools/vim_data/miq_vim_inventory/pbmProfilesByUid.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/pbmProfilesByUid.yml
@@ -1,0 +1,638 @@
+---
+f4e5bade-15a2-4805-bf8e-52318c4ce443: !ruby/object:RbVmomi::PBM::PbmCapabilityProfile
+  props:
+    :dynamicProperty: []
+    :profileId: !ruby/object:RbVmomi::PBM::PbmProfileId
+      props:
+        :dynamicProperty: []
+        :uniqueId: f4e5bade-15a2-4805-bf8e-52318c4ce443
+    :name: VVol No Requirements Policy
+    :description: Allow the datastore to determine the best placement strategy for
+      storage objects
+    :creationTime: 2016-05-31 15:28:17.968000000 Z
+    :createdBy: Temporary user handle
+    :lastUpdatedTime: 2016-05-31 15:28:17.968000000 Z
+    :lastUpdatedBy: Temporary user handle
+    :profileCategory: REQUIREMENT
+    :resourceType: !ruby/object:RbVmomi::PBM::PbmProfileResourceType
+      props:
+        :dynamicProperty: []
+        :resourceType: STORAGE
+    :constraints: !ruby/object:RbVmomi::PBM::PbmCapabilityConstraints
+      props:
+        :dynamicProperty: []
+    :generationId: 0
+    :isDefault: false
+aa6d5a82-1c88-45da-85d3-3d74b91a5bad: !ruby/object:RbVmomi::PBM::PbmCapabilityProfile
+  props:
+    :dynamicProperty: []
+    :profileId: !ruby/object:RbVmomi::PBM::PbmProfileId
+      props:
+        :dynamicProperty: []
+        :uniqueId: aa6d5a82-1c88-45da-85d3-3d74b91a5bad
+    :name: Virtual SAN Default Storage Policy
+    :description: Storage policy used as default for Virtual SAN datastores
+    :creationTime: 2016-05-31 15:28:17.852000000 Z
+    :createdBy: Temporary user handle
+    :lastUpdatedTime: 2016-06-02 21:00:30.844000000 Z
+    :lastUpdatedBy: Temporary user handle
+    :profileCategory: REQUIREMENT
+    :resourceType: !ruby/object:RbVmomi::PBM::PbmProfileResourceType
+      props:
+        :dynamicProperty: []
+        :resourceType: STORAGE
+    :constraints: !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfileConstraints
+      props:
+        :dynamicProperty: []
+        :subProfiles:
+        - !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfile
+          props:
+            :dynamicProperty: []
+            :name: VSAN sub-profile
+            :capability:
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: hostFailuresToTolerate
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: hostFailuresToTolerate
+                        :value: 1
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: stripeWidth
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: stripeWidth
+                        :value: 1
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: forceProvisioning
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: forceProvisioning
+                        :value: false
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: proportionalCapacity
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: proportionalCapacity
+                        :value: 0
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: cacheReservation
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: cacheReservation
+                        :value: 0
+    :generationId: 1
+    :isDefault: false
+6fe1c7b4-7f7e-4db1-a545-c756e392de62: !ruby/object:RbVmomi::PBM::PbmCapabilityProfile
+  props:
+    :dynamicProperty: []
+    :profileId: !ruby/object:RbVmomi::PBM::PbmProfileId
+      props:
+        :dynamicProperty: []
+        :uniqueId: 6fe1c7b4-7f7e-4db1-a545-c756e392de62
+    :name: Tag-based VM Storage Policy
+    :description: ''
+    :creationTime: 2016-06-02 20:45:55.648000000 Z
+    :createdBy: Temporary user handle
+    :lastUpdatedTime: 2016-06-28 17:11:20.666000000 Z
+    :lastUpdatedBy: Temporary user handle
+    :profileCategory: REQUIREMENT
+    :resourceType: !ruby/object:RbVmomi::PBM::PbmProfileResourceType
+      props:
+        :dynamicProperty: []
+        :resourceType: STORAGE
+    :constraints: !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfileConstraints
+      props:
+        :dynamicProperty: []
+        :subProfiles:
+        - !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfile
+          props:
+            :dynamicProperty: []
+            :name: Rule-Set 1
+            :capability:
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: http://www.vmware.com/storage/tag
+                    :id: StorageTagCategory
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: com.vmware.storage.tag.StorageTagCategory.property
+                        :value: !ruby/object:RbVmomi::PBM::PbmCapabilityDiscreteSet
+                          props:
+                            :dynamicProperty: []
+                            :values:
+                            - storageTag1
+    :generationId: 5
+    :isDefault: false
+Default-VM-Home521041ccef13f2d1-3d43b46f398ab14c: !ruby/object:RbVmomi::PBM::PbmDefaultCapabilityProfile
+  props:
+    :dynamicProperty: []
+    :profileId: !ruby/object:RbVmomi::PBM::PbmProfileId
+      props:
+        :dynamicProperty: []
+        :uniqueId: Default-VM-Home521041ccef13f2d1-3d43b46f398ab14c
+    :name: Default-VM-Home
+    :description: ''
+    :creationTime: 2012-01-19 03:19:22.000000000 Z
+    :createdBy: VMware Inc
+    :lastUpdatedTime: 2012-01-19 03:19:22.000000000 Z
+    :lastUpdatedBy: ''
+    :profileCategory: RESOURCE
+    :resourceType: !ruby/object:RbVmomi::PBM::PbmProfileResourceType
+      props:
+        :dynamicProperty: []
+        :resourceType: CapabilityBased
+    :constraints: !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfileConstraints
+      props:
+        :dynamicProperty: []
+        :subProfiles:
+        - !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfile
+          props:
+            :dynamicProperty: []
+            :name: Object
+            :capability:
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: hostFailuresToTolerate
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: hostFailuresToTolerate
+                        :value: 0
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: stripeWidth
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: stripeWidth
+                        :value: 1
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: forceProvisioning
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: forceProvisioning
+                        :value: false
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: proportionalCapacity
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: proportionalCapacity
+                        :value: 0
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: cacheReservation
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: cacheReservation
+                        :value: 0
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: checksumDisabled
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: checksumDisabled
+                        :value: false
+    :generationId: -9223372036854775808
+    :isDefault: false
+    :vvolType:
+    - Config
+    :containerId: 521041ccef13f2d1-3d43b46f398ab14c
+Default-VirtualDisk521041ccef13f2d1-3d43b46f398ab14c: !ruby/object:RbVmomi::PBM::PbmDefaultCapabilityProfile
+  props:
+    :dynamicProperty: []
+    :profileId: !ruby/object:RbVmomi::PBM::PbmProfileId
+      props:
+        :dynamicProperty: []
+        :uniqueId: Default-VirtualDisk521041ccef13f2d1-3d43b46f398ab14c
+    :name: Default-VirtualDisk
+    :description: ''
+    :creationTime: 2012-01-19 03:19:22.000000000 Z
+    :createdBy: VMware Inc
+    :lastUpdatedTime: 2012-01-19 03:19:22.000000000 Z
+    :lastUpdatedBy: ''
+    :profileCategory: RESOURCE
+    :resourceType: !ruby/object:RbVmomi::PBM::PbmProfileResourceType
+      props:
+        :dynamicProperty: []
+        :resourceType: CapabilityBased
+    :constraints: !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfileConstraints
+      props:
+        :dynamicProperty: []
+        :subProfiles:
+        - !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfile
+          props:
+            :dynamicProperty: []
+            :name: Object
+            :capability:
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: hostFailuresToTolerate
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: hostFailuresToTolerate
+                        :value: 0
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: stripeWidth
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: stripeWidth
+                        :value: 1
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: forceProvisioning
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: forceProvisioning
+                        :value: false
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: proportionalCapacity
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: proportionalCapacity
+                        :value: 0
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: cacheReservation
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: cacheReservation
+                        :value: 0
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: checksumDisabled
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: checksumDisabled
+                        :value: false
+    :generationId: -9223372036854775808
+    :isDefault: false
+    :vvolType:
+    - Data
+    :containerId: 521041ccef13f2d1-3d43b46f398ab14c
+521041ccef13f2d1-3d43b46f398ab14c: !ruby/object:RbVmomi::PBM::PbmCapabilityProfile
+  props:
+    :dynamicProperty: []
+    :profileId: !ruby/object:RbVmomi::PBM::PbmProfileId
+      props:
+        :dynamicProperty: []
+        :uniqueId: 521041ccef13f2d1-3d43b46f398ab14c
+    :name: VSANStorageCapabilityProfile
+    :description: ''
+    :creationTime: 2012-01-19 03:19:22.000000000 Z
+    :createdBy: VMware Inc
+    :lastUpdatedTime: 2012-01-19 03:19:22.000000000 Z
+    :lastUpdatedBy: ''
+    :profileCategory: RESOURCE
+    :resourceType: !ruby/object:RbVmomi::PBM::PbmProfileResourceType
+      props:
+        :dynamicProperty: []
+        :resourceType: CapabilityBased
+    :constraints: !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfileConstraints
+      props:
+        :dynamicProperty: []
+        :subProfiles:
+        - !ruby/object:RbVmomi::PBM::PbmCapabilitySubProfile
+          props:
+            :dynamicProperty: []
+            :name: Object
+            :capability:
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: hostFailuresToTolerate
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: hostFailuresToTolerate
+                        :value: !ruby/object:RbVmomi::PBM::PbmCapabilityRange
+                          props:
+                            :dynamicProperty: []
+                            :min: 0
+                            :max: 3
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: stripeWidth
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: stripeWidth
+                        :value: !ruby/object:RbVmomi::PBM::PbmCapabilityRange
+                          props:
+                            :dynamicProperty: []
+                            :min: 1
+                            :max: 12
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: forceProvisioning
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: forceProvisioning
+                        :value: !ruby/object:RbVmomi::PBM::PbmCapabilityDiscreteSet
+                          props:
+                            :dynamicProperty: []
+                            :values:
+                            - true
+                            - false
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: proportionalCapacity
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: proportionalCapacity
+                        :value: !ruby/object:RbVmomi::PBM::PbmCapabilityRange
+                          props:
+                            :dynamicProperty: []
+                            :min: 0
+                            :max: 100
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: cacheReservation
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: cacheReservation
+                        :value: !ruby/object:RbVmomi::PBM::PbmCapabilityRange
+                          props:
+                            :dynamicProperty: []
+                            :min: 0
+                            :max: 1000000
+            - !ruby/object:RbVmomi::PBM::PbmCapabilityInstance
+              props:
+                :dynamicProperty: []
+                :id: !ruby/object:RbVmomi::PBM::PbmCapabilityMetadataUniqueId
+                  props:
+                    :dynamicProperty: []
+                    :namespace: VSAN
+                    :id: checksumDisabled
+                :constraint:
+                - !ruby/object:RbVmomi::PBM::PbmCapabilityConstraintInstance
+                  props:
+                    :dynamicProperty: []
+                    :propertyInstance:
+                    - !ruby/object:RbVmomi::PBM::PbmCapabilityPropertyInstance
+                      props:
+                        :dynamicProperty: []
+                        :id: checksumDisabled
+                        :value: !ruby/object:RbVmomi::PBM::PbmCapabilityDiscreteSet
+                          props:
+                            :dynamicProperty: []
+                            :values:
+                            - true
+                            - false
+    :generationId: -9223372036854775808
+    :isDefault: false

--- a/spec/tools/vim_data/miq_vim_inventory/pbmQueryMatchingHub.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/pbmQueryMatchingHub.yml
@@ -1,0 +1,58 @@
+---
+f4e5bade-15a2-4805-bf8e-52318c4ce443: []
+aa6d5a82-1c88-45da-85d3-3d74b91a5bad:
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-33
+6fe1c7b4-7f7e-4db1-a545-c756e392de62:
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-30
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-35
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-38
+63502904-c546-4d17-b70b-3aa82d8f2897:
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-30
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-33
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-35
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-38
+Default-VM-Home521041ccef13f2d1-3d43b46f398ab14c:
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-33
+Default-VirtualDisk521041ccef13f2d1-3d43b46f398ab14c:
+- !ruby/object:RbVmomi::PBM::PbmPlacementHub
+  props:
+    :dynamicProperty: []
+    :hubType: Datastore
+    :hubId: datastore-33
+521041ccef13f2d1-3d43b46f398ab14c: []

--- a/spec/tools/vim_data/miq_vim_inventory/pbmQueryMatchingHub.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/pbmQueryMatchingHub.yml
@@ -5,54 +5,18 @@ aa6d5a82-1c88-45da-85d3-3d74b91a5bad:
   props:
     :dynamicProperty: []
     :hubType: Datastore
-    :hubId: datastore-33
-6fe1c7b4-7f7e-4db1-a545-c756e392de62:
-- !ruby/object:RbVmomi::PBM::PbmPlacementHub
-  props:
-    :dynamicProperty: []
-    :hubType: Datastore
-    :hubId: datastore-30
-- !ruby/object:RbVmomi::PBM::PbmPlacementHub
-  props:
-    :dynamicProperty: []
-    :hubType: Datastore
-    :hubId: datastore-35
-- !ruby/object:RbVmomi::PBM::PbmPlacementHub
-  props:
-    :dynamicProperty: []
-    :hubType: Datastore
-    :hubId: datastore-38
-63502904-c546-4d17-b70b-3aa82d8f2897:
-- !ruby/object:RbVmomi::PBM::PbmPlacementHub
-  props:
-    :dynamicProperty: []
-    :hubType: Datastore
-    :hubId: datastore-30
-- !ruby/object:RbVmomi::PBM::PbmPlacementHub
-  props:
-    :dynamicProperty: []
-    :hubType: Datastore
-    :hubId: datastore-33
-- !ruby/object:RbVmomi::PBM::PbmPlacementHub
-  props:
-    :dynamicProperty: []
-    :hubType: Datastore
-    :hubId: datastore-35
-- !ruby/object:RbVmomi::PBM::PbmPlacementHub
-  props:
-    :dynamicProperty: []
-    :hubType: Datastore
-    :hubId: datastore-38
+    :hubId: datastore-953
+6fe1c7b4-7f7e-4db1-a545-c756e392de62: []
 Default-VM-Home521041ccef13f2d1-3d43b46f398ab14c:
 - !ruby/object:RbVmomi::PBM::PbmPlacementHub
   props:
     :dynamicProperty: []
     :hubType: Datastore
-    :hubId: datastore-33
+    :hubId: datastore-953
 Default-VirtualDisk521041ccef13f2d1-3d43b46f398ab14c:
 - !ruby/object:RbVmomi::PBM::PbmPlacementHub
   props:
     :dynamicProperty: []
     :hubType: Datastore
-    :hubId: datastore-33
+    :hubId: datastore-953
 521041ccef13f2d1-3d43b46f398ab14c: []


### PR DESCRIPTION
Purpose or Intent
-----------------
Link datastores with their associated storage profiles using the `StorageProfileStorages` model.
This uses the SPBM method `#PbmQueryMatchingHub` which takes a `ProfileId` and returns a list of datastores which can be used with that profile.  This can be used as a datastore filter for provisioning when a user selects a storage profile they want to use.


Links
-----
* http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.vspsdk.apiref.doc/pbm.placement.PlacementSolver.html#queryMatchingHub
