### PR TITLE
Remove the need for expected_feature_count in product feature specs

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -17,6 +17,9 @@ class MiqProductFeature < ApplicationRecord
   ]
 
   FEATURE_TYPE_ORDER = ["view", "control", "admin", "node"]
+  REQUIRED_ATTRIBUTES = [:identifier].freeze
+  OPTIONAL_ATTRIBUTES = [:name, :feature_type, :description, :children, :hidden, :protected].freeze
+  ALLOWED_ATTRIBUTES = (REQUIRED_ATTRIBUTES + OPTIONAL_ATTRIBUTES).freeze
 
   def self.feature_yaml(path = FIXTURE_PATH)
     "#{path}.yml".freeze

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,8 +2,6 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1086 }
-
   # - container_dashboard
   # - miq_report_widget_editor
   #   - miq_report_widget_admin
@@ -36,14 +34,14 @@ describe MiqProductFeature do
 
   context ".seed" do
     it "creates feature identifiers once on first seed, changes nothing on second seed" do
-      status_seed1 = MiqProductFeature.seed
-      expect(MiqProductFeature.count).to eq(expected_feature_count)
+      status_seed1 = nil
+      expect { status_seed1 = MiqProductFeature.seed }.to change(MiqProductFeature, :count)
       expect(status_seed1[:created]).to match_array status_seed1[:created].uniq
       expect(status_seed1[:updated]).to match_array []
       expect(status_seed1[:unchanged]).to match_array []
 
-      status_seed2 = MiqProductFeature.seed
-      expect(MiqProductFeature.count).to eq(expected_feature_count)
+      status_seed2 = nil
+      expect { status_seed2 = MiqProductFeature.seed }.not_to change(MiqProductFeature, :count)
       expect(status_seed2[:created]).to match_array []
       expect(status_seed2[:updated]).to match_array []
       expect(status_seed2[:unchanged]).to match_array status_seed1[:created]

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -16,6 +16,24 @@ describe MiqProductFeature do
     )
   end
 
+  it "is properly configured" do
+    everything = YAML.load_file(described_class.feature_yaml)
+    required_keys = [:identifier]
+    possible_keys = required_keys + [:name, :feature_type, :description, :children, :hidden, :protected]
+    traverse_product_features(everything) do |pf|
+      expect(pf).to include(*required_keys)
+      expect(pf.keys - possible_keys).to be_empty
+      expect(pf[:children]).not_to be_empty if pf.key?(:children)
+    end
+  end
+
+  def traverse_product_features(product_feature, &block)
+    block.call(product_feature)
+    if product_feature.key?(:children)
+      product_feature[:children].each { |child| traverse_product_features(child, &block) }
+    end
+  end
+
   context ".seed" do
     it "creates feature identifiers once on first seed, changes nothing on second seed" do
       status_seed1 = MiqProductFeature.seed

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -16,11 +16,9 @@ describe MiqProductFeature do
 
   it "is properly configured" do
     everything = YAML.load_file(described_class.feature_yaml)
-    required_keys = [:identifier]
-    possible_keys = required_keys + [:name, :feature_type, :description, :children, :hidden, :protected]
     traverse_product_features(everything) do |pf|
-      expect(pf).to include(*required_keys)
-      expect(pf.keys - possible_keys).to be_empty
+      expect(pf).to include(*described_class::REQUIRED_ATTRIBUTES)
+      expect(pf.keys - described_class::ALLOWED_ATTRIBUTES).to be_empty
       expect(pf[:children]).not_to be_empty if pf.key?(:children)
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
This is a brittle test that can (and has) dodge(d) CI when two or more PRs are merged that change the product features, resulting in a broken build. This change adds a test which traverses the configuration, asserts that it can only have a few possible keys, asserts which are required and how it is structured so that we can be reasonably confident that the yaml is not misconfigured. Assuming that we can merely assert that the count changed on seeding.

@Fryguy I'm sure this could be improved but this is my first stab at this....LMK what you think!
@miq-bot add-label test, refactoring
@miq-bot assign @Fryguy 