### PR TITLE
Cloud Networks API

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -58,6 +58,7 @@ class ApiController < ApplicationController
   include_concern 'Authentication'
   include_concern 'AutomationRequests'
   include_concern 'Categories'
+  include_concern 'CloudNetworks'
   include_concern 'Conditions'
   include_concern 'ContainerDeployments'
   include_concern 'CustomAttributes'

--- a/app/controllers/api_controller/cloud_networks.rb
+++ b/app/controllers/api_controller/cloud_networks.rb
@@ -1,0 +1,7 @@
+class ApiController
+  module CloudNetworks
+    def cloud_networks_query_resource(object)
+      object.cloud_networks
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -627,6 +627,7 @@
     - :tags
     - :policies
     - :policy_profiles
+    - :cloud_networks
     :collection_actions:
       :get:
       - :name: read
@@ -672,6 +673,10 @@
         :identifier: ems_infra_protect
       - :name: unassign
         :identifier: ems_infra_protect
+    :cloud_networks_subcollection_actions:
+      :get:
+      - :name: show
+      - :identifier: miq_cloud_networks_view
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer
@@ -1694,3 +1699,14 @@
       :delete:
       - :name: delete
         :identifier: delete_arbitration_profile
+  :cloud_networks:
+    :description: Cloud Networks
+    :identifier: miq_cloud_networks
+    :options:
+    - :collection
+    :verbs: *70174834086080
+    :klass: CloudNetwork
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_cloud_networks_view

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5015,3 +5015,14 @@
           :description: Revert to selected snapshot on Templates
           :feature_type: control
           :identifier: miq_template_snapshot_revert
+
+# CloudNetworks
+- :name: Cloud Networks
+  :description: Get Cloud Networks
+  :feature_type: node
+  :identifier: miq_cloud_networks
+  :children:
+    - :name: View
+      :description: Show Cloud Networks
+      :feature_type: view
+      :identifier: miq_cloud_networks_view

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -152,6 +152,13 @@ FactoryGirl.define do
     end
   end
 
+  factory :ems_amazon_with_cloud_networks,
+          :parent => :ems_amazon do
+    after(:create) do |x|
+      2.times { x.cloud_networks << FactoryGirl.create(:cloud_network_amazon) }
+    end
+  end
+
   factory :ems_openstack,
           :aliases => ["manageiq/providers/openstack/cloud_manager"],
           :class   => "ManageIQ::Providers::Openstack::CloudManager",

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1068 }
+  let(:expected_feature_count) { 1070 }
 
   # - container_dashboard
   # - miq_report_widget_editor

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe 'Cloud Networks API' do
+  context 'cloud networks index' do
+    it 'rejects request without appropriate role' do
+      api_basic_authorize
+
+      run_get cloud_networks_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can list cloud networks' do
+      FactoryGirl.create_list(:cloud_network, 2)
+      api_basic_authorize collection_action_identifier(:cloud_networks, :read, :get)
+
+      run_get cloud_networks_url
+
+      expect_query_result(:cloud_networks, 2)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'Providers cloud_networks subcollection' do
+    let(:provider) { FactoryGirl.create(:ems_amazon_with_cloud_networks) }
+    let(:provider_url) { providers_url(provider.id) }
+    let(:providers_cloud_networks_url) { "#{provider_url}/cloud_networks" }
+
+    it 'queries Providers cloud_networks' do
+      cloud_network_ids = provider.cloud_networks.pluck(:id)
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      run_get providers_cloud_networks_url, :expand => 'resources'
+
+      expect_query_result(:cloud_networks, 2)
+      expect_result_resources_to_include_data('resources', 'id' => cloud_network_ids)
+    end
+
+    it 'queries individual provider cloud_network' do
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      network = provider.cloud_networks.first
+      cloud_network_url = "#{providers_cloud_networks_url}/#{network.id}"
+
+      run_get cloud_network_url
+
+      expect_single_resource_query('name' => network.name, 'id' => network.id, 'ems_ref' => network.ems_ref)
+    end
+  end
+end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -250,5 +250,10 @@ describe ApiController do
       FactoryGirl.create(:arbitration_profile, :ems_id => ems.id)
       test_collection_query(:arbitration_profiles, arbitration_profiles_url, ArbitrationProfile)
     end
+
+    it 'queries CloudNetworks' do
+      FactoryGirl.create(:cloud_network)
+      test_collection_query(:cloud_networks, cloud_networks_url, CloudNetwork)
+    end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
> API to retrieve cloud_networks 
> * Can query on its own `api/cloud_networks`, `api/cloud_networks/:id` etc 
> * Can query on provider 
    * `api/providers/:id/cloud_networks`, 
    * `api/providers/:id/cloud_networks/:id`
    * `api/providers/1/cloud_networks/4?attributes=security_groups` 
    * etc.

Links
-----
> * [pivotal tracker ticket](https://www.pivotaltracker.com/story/show/126533015)

@miq-bot add_label service broker, api, enhancement, darga/no