### PR TITLE
add arbitration_profiles to cloud_manager

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -13,6 +13,7 @@ module ManageIQ::Providers
       define_method(:singular_route_key) { "ems_cloud" }
     end
 
+    has_many :arbitration_profiles,          :foreign_key => :ems_id, :dependent => :destroy
     has_many :availability_zones,            :foreign_key => :ems_id, :dependent => :destroy
     has_many :flavors,                       :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_database_flavors,        :foreign_key => :ems_id, :dependent => :destroy


### PR DESCRIPTION
Purpose or Intent
-----------------
> Add arbitration_profiles relationship on cloud_manager as needed by @h-kataria for the creation of the arbitration profiles UX

@miq-bot add_label service broker, enhancement, darga/no 

Links
-----
> * This is part one of [this ticket](https://www.pivotaltracker.com/story/show/126412155)