### PR TITLE
Update `MiqReport::filter_with_report_results_by` to use join instead of include

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -58,7 +58,7 @@ class MiqReport < ApplicationRecord
       miq_group_relation = where(miq_group_condition)
     end
 
-    miq_group_relation.includes(:miq_report_results).references(:miq_report_results)
+    miq_group_relation.joins(:miq_report_results).distinct
   end
 
   # Scope on reports that have report results.


### PR DESCRIPTION
Purpose or Intent
-----------------
By using a `.joins` plus a `.distinct` to help filter our data, we can reduce the number of records returned and instanciated by `ActiveRecord` significantly on the `/report/explorer` page.

The `include` that was used before was basically grabbing all of the `MiqReportResult` records (a table of about 30k records) to help filter the `MiqReports` (about 200 records, filtered down to about 80), and so 20k rows were being returned to be filtered down to about 80 in this scenario.

Some quick before and after metrics when run locally:

**Before**

```
Started GET "/report/explorer" for 127.0.0.1 at 2016-07-19 12:37:57 -0500
Completed 200 OK in 3154ms (Views: 174.9ms | ActiveRecord: 0.0ms)
```

|      ms |   objects | queries | query (ms) |   rows |
|    ---: |      ---: |    ---: |       ---: |   ---: |
| 2,722.8 | 2,905,999 |     240 |    1,899.2 | 20,854 |


**After**

```
Started GET "/report/explorer" for 127.0.0.1 at 2016-07-19 12:43:02 -0500
Completed 200 OK in 1171ms (Views: 174.8ms | ActiveRecord: 0.0ms)
```

|      ms |   objects | queries | query (ms) |   rows |
|    ---: |      ---: |    ---: |       ---: |   ---: |
|   997.6 | 1,455,795 |     240 |      230.7 |    424 |



**NOTE:**  This is before subtrees are expanded.  Once subtrees start to be expanded, there is a whole different set of queries that are run to do that, and are unrelated to the performance improvement made here.


Steps for Testing/QA
--------------------
If you wish to replicate this locally and try it out, the following script can get you some sample data to work with that is similar to the data used for the above metrics (it will take some time to generate):

```ruby
seed_array = [
  10000, 7000, 6000,
  Array.new(3){400},
  Array.new(3){250},
  Array.new(3){60},
  Array.new(5){20},
  Array.new(60){10}
].flatten

miq_task_states   = ::MiqTask.validators.detect {|v| v.attributes.include? :state  }.options[:in]
miq_task_statuses = ::MiqTask.validators.detect {|v| v.attributes.include? :status }.options[:in]
miq_group         = ::MiqGroup.where(:description => "EvmGroup-user_self_service").first

seed_array.size.times do |n|
  name = "Test %04d" % (n+1)
  report = ::MiqReport.create! :name => name,
                               :title => name,
                               :db => 'test',
                               :miq_group_id => miq_group.id,
                               :rpt_group => 'test',
                               :rpt_type => 'Custom'

  report_result_count.times do |i|
    task = ::MiqTask.create!
    task.update_attributes! :state  => miq_task_states.sample.first,
                            :status => miq_task_statuses.sample.first

    ::MiqReportResult.create! :name => name,
                              :report => report,
                              :last_run_on => (i+1).day.ago,
                              :miq_task_id => task.id,
                              :miq_report_id => report.id,
                              :miq_group_id => miq_group.id
end
```

Save this as a `.rb` file and run it using the `rails runner` and it should ( :fingers_crossed: ) seed the database for you.  You can dump it in (or load into) a rails console as well.

From there, just navagate to the `/report/explorer` page, and flop between the master code base and this branch.  The difference should be an almost immediate load time with this branch v.s. master, which will have about a 2 sec load time (basically stalling on this one query).