### PR TITLE
Fixing bug introduced by settings hierarchy

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -610,6 +610,6 @@ class MiqServer < ApplicationRecord
   end
 
   def miq_region
-    MiqRegion.my_region
+    ::MiqRegion.my_region
   end
 end # class MiqServer


### PR DESCRIPTION
With new Settings hierarchy, auto-reloading application in RubyMine environment  (when modifying classes under ```/app```)  started throwing  error:

```
[----] F, [2016-07-19T20:44:12.503523 #3601:3fe56e9f1a08] FATAL -- : Error caught: [ArgumentError] A copy of MiqServer has been removed from the module tree but is still active!
/Users/yrudman/.gem/ruby/2.2.4/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:496:in `load_missing_constant'
/Users/yrudman/.gem/ruby/2.2.4/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:203:in `const_missing'
```

As found on http://stackoverflow.com/questions/29636334/a-copy-of-xxx-has-been-removed-from-the-module-tree-but-is-still-active
" ... Problem is that something reloadable (module)  included in something not reloadable (ActiveRecord::Base). At some point code is reloaded and now ActiveRecord still has this module included in it even though rails thinks it has unloaded it. "





/cc @Fryguy 

@miq-bot add-label bug