### PR TITLE
Fix error when retiring an orchestration stack

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -179,7 +179,7 @@ module ApplicationController::CiProcessing
   def retirevms
     assert_privileges(params[:pressed])
     vms = find_checked_items
-    if !%w(orchestration_template service).include?(request.parameters["controller"]) &&
+    if !%w(orchestration_stack service).include?(request.parameters["controller"]) &&
        VmOrTemplate.find(vms).any? { |vm| !vm.supports_retire? }
       add_flash(_("Set Retirement Date does not apply to selected %{model}") %
         {:model => ui_lookup(:table => "miq_template")}, :error)
@@ -1572,7 +1572,7 @@ module ApplicationController::CiProcessing
 
       vms = find_checked_items
       if method == 'retire_now' &&
-         !%w(orchestration_template service).include?(request.parameters["controller"]) &&
+         !%w(orchestration_stack service).include?(request.parameters["controller"]) &&
          VmOrTemplate.find(vms).any? { |vm| !vm.supports_retire? }
         add_flash(_("Retire does not apply to selected %{model}") %
           {:model => ui_lookup(:table => "miq_template")}, :error)

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -140,5 +140,23 @@ describe OrchestrationStackController do
         expect(response.body).to include("/catalog/ot_show/")
       end
     end
+
+    context "retire orchestration stack" do
+      it "set retirement date redirects to retirement screen" do
+        record = FactoryGirl.create(:orchestration_stack_cloud)
+        post :button, :params => {:miq_grid_checks => record.id, :pressed => "orchestration_stack_retire"}
+        expect(response.status).to eq(200)
+        expect(controller.send(:flash_errors?)).not_to be_truthy
+        expect(response.body).to include('window.location.href')
+      end
+
+      it "retires the orchestration stack now" do
+        record = FactoryGirl.create(:orchestration_stack_cloud)
+        session[:orchestration_stack_lastaction] = 'show_list'
+        post :button, :params => {:miq_grid_checks => record.id, :pressed => "orchestration_stack_retire_now"}
+        expect(response.status).to eq(200)
+        expect(controller.send(:flash_errors?)).not_to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixing the following error when retiring an orchestration stack:

```
Parameters: {"miq_grid_checks"=>"6", "pressed"=>"orchestration_stack_retire_now"}
Error caught: [ActiveRecord::RecordNotFound] Couldn't find VmOrTemplate with 'id'=6
app/controllers/application_controller/ci_processing.rb:1574:in `vm_button_operation'
app/controllers/application_controller/ci_processing.rb:1745:in `retirevms_now'
app/controllers/orchestration_stack_controller.rb:115:in `button'
```

'orchestration_template' is not a valid controller name. This I believe was a typo, correct controller
name here should have been 'orchestration_stack'.

We don't even have orchestration_template controller, nor can we retire orchestration template
as such.

The problem is also present in darga.

https://bugzilla.redhat.com/show_bug.cgi?id=1359150