### PR TITLE
Ensure report editor does not offer duplicate items

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -155,6 +155,7 @@ module ReportController::Reports::Editor
 
     case @sb[:miq_tab].split("_")[1]
     when "1"  # Select columns
+      @edit[:models] ||= reportable_models
       # Add the blank choice if no table chosen yet
       #     @edit[:models].insert(0,["<Choose>", "<Choose>"]) if @edit[:new][:model] == nil && @edit[:models][0][0] != "<Choose>"
       if @edit[:new][:model].nil?
@@ -275,6 +276,12 @@ module ReportController::Reports::Editor
     else
       # drop_breadcrumb( {:name=>"Edit Report", :url=>"/report/edit"} )
       @gtl_url = "/edit"
+    end
+  end
+
+  def reportable_models
+    MiqReport.reportable_models.collect do |m|
+      [Dictionary.gettext(m, :type => :model, :notfound => :titleize, :plural => true), m]
     end
   end
 
@@ -1661,10 +1668,6 @@ module ReportController::Reports::Editor
     end
 
     @edit[:current] = ["copy", "new"].include?(params[:action]) ? {} : copy_hash(@edit[:new])
-
-    @edit[:models] ||= MiqReport.reportable_models.collect do |m|
-      [Dictionary.gettext(m, :type => :model, :notfound => :titleize, :plural => true), m]
-    end
 
     # Only show chargeback users choice if an admin
     if admin_user?

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -20,7 +20,6 @@ class MiqExpression
     ContainerImageRegistry
     ContainerNode
     ContainerProject
-    ContainerService
     ContainerReplicator
     ContainerRoute
     ContainerService

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -701,7 +701,7 @@ en:
       ContainerProject:         Project
       ContainerRoute:           Route
       ContainerReplicator:      Replicator
-      ContainerService:         Service
+      ContainerService:         Container Service
       EmsCluster:               Cluster / Deployment Role
       EmsClusterPerformance:    Performance - Cluster
       EmsEvent:                 Management Event

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -68,6 +68,14 @@ describe ReportController do
 
         expect(rep.tz).to eq("Eastern Time (US & Canada)")
       end
+
+      describe '#reportable_models' do
+        subject { controller.send(:reportable_models) }
+        it 'does not contain duplicate items' do
+          duplicates = subject.group_by(&:first).select { |_, v| v.size > 1 }.map(&:first)
+          expect(duplicates).to be_empty
+        end
+      end
     end
 
     context "#miq_report_edit" do


### PR DESCRIPTION
Follow-up on #9886. Second part of https://bugzilla.redhat.com/show_bug.cgi?id=1357100

The report editor allows user to select a model, that report shall be based of. The editor contained three occurrences of `Services` string in the drop down. One was pure duplicate, the other two referred to `Service` and `ContainerService`.

@miq-bot add_label bug, ui, reporting, darga/no
@miq-bot assign @mzazrivec 
:cookie: 
