### PR TITLE
 remove false positive path in is_available?

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -639,10 +639,10 @@ module EmsCommon
   end
 
   def retrieve_provider_regions
-    cloud_managers = model.supported_subclasses.select { |c| c.is_available?(:regions) }
-    cloud_managers.each_with_object({}) do |cloud_manager, provider_regions|
-      regions = cloud_manager.parent::Regions.all.sort_by { |r| r[:description] }
-      provider_regions[cloud_manager.ems_type] = regions.map do |region|
+    managers = model.supported_subclasses.select(&:supports_regions?)
+    managers.each_with_object({}) do |manager, provider_regions|
+      regions = manager.parent::Regions.all.sort_by { |r| r[:description] }
+      provider_regions[manager.ems_type] = regions.map do |region|
         [region[:description], region[:name]]
       end
     end

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -43,6 +43,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
   supports :discovery
   supports :provisioning
+  supports :regions
 
   def ensure_managers
     build_network_manager unless network_manager

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -4,6 +4,7 @@ module ManageIQ::Providers
 
     include SupportsFeatureMixin
     supports_not :provisioning # via automate
+    supports_not :regions      # as in ManageIQ::Providers::<Type>::Regions
 
     def self.metrics_collector_queue_name
       self::MetricsCollectorWorker.default_queue_name

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -56,14 +56,6 @@ module ManageIQ::Providers
       {:available => true, :message => nil}
     end
 
-    def self.validate_regions
-      if "#{parent}::Regions".safe_constantize
-        {:available => true, :message => nil}
-      else
-        {:available => false, :message => nil}
-      end
-    end
-
     def validate_authentication_status
       {:available => true, :message => nil}
     end

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -35,6 +35,7 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   before_validation :ensure_managers
 
   supports :provisioning
+  supports :regions
 
   def ensure_managers
     build_network_manager unless network_manager

--- a/app/models/mixins/availability_mixin.rb
+++ b/app/models/mixins/availability_mixin.rb
@@ -1,6 +1,8 @@
 module AvailabilityMixin
   extend ActiveSupport::Concern
 
+  # PLEASE PREFER supports_feature_mixin.rb OVER THIS
+  #
   # UI Button Validation Methods
   #
   # The UI calls this method to determine if a feature is supported for this model
@@ -17,21 +19,17 @@ module AvailabilityMixin
 
   class_methods do
     def is_available?(request_type, *args)
+      # please prefer supports_feature_mixin.rb over this
       validate_method = "validate_#{request_type}"
-      if respond_to?(validate_method)
-        send(validate_method, *args)[:available]
-      else
-        false
-      end
+      send(validate_method, *args)[:available]
     end
 
     # Returns an error message string if there is an error.
     # Otherwise nil to indicate no errors.
     def is_available_now_error_message(request_type, *args)
+      # please prefer supports_feature_mixin.rb over this
       send("validate_#{request_type}", *args)[:message]
     end
-
-    # FIXME: refactor validate_ call
   end
 
   included do


### PR DESCRIPTION
before `is_available?` would return false in case the `validate_`  method is not defined. 
This leads to a false positive in certain cases, such as https://github.com/ManageIQ/manageiq/pull/9841
This is a follow up PR on https://github.com/ManageIQ/manageiq/pull/9880 which refactors the requirement for this behavior

depends on https://github.com/ManageIQ/manageiq/pull/9880 to be merged

@miq-bot add_labels refactoring, pluggable providers, bug, darga/no
