### PR TITLE
Externalize the feed-id into a helper so that it does not have to be …

### DIFF
--- a/spec/models/manageiq/providers/hawkular/middleware_manager/hawkular_helper.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/hawkular_helper.rb
@@ -1,0 +1,4 @@
+# Feed id to be used for all spec
+def the_feed_id
+  '70c798a0-6985-4f8a-a525-012d8d28e8a3'.freeze
+end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
@@ -1,5 +1,6 @@
+require_relative 'hawkular_helper'
+
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource do
-  THE_FEED_ID = '70c798a0-6985-4f8a-a525-012d8d28e8a3'.freeze
 
   let(:ems_hawkular) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
@@ -15,9 +16,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
     FactoryGirl.create(:hawkular_middleware_server,
                        :id                    => 1,
                        :name                  => 'Local',
-                       :feed                  => THE_FEED_ID,
+                       :feed                  => the_feed_id,
                        :ems_ref               => '/t;hawkular'\
-                                                 "/f;#{THE_FEED_ID}/r;Local~~",
+                                                 "/f;#{the_feed_id}/r;Local~~",
                        :nativeid              => 'Local~~',
                        :ext_management_system => ems_hawkular)
   end
@@ -26,7 +27,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
     FactoryGirl.create(:hawkular_middleware_datasource,
                        :name                  => 'KeycloakDS',
                        :ems_ref               => '/t;hawkular'\
-                                                 "/f;#{THE_FEED_ID}/r;Local~~"\
+                                                 "/f;#{the_feed_id}/r;Local~~"\
                                                  '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS',
                        :ext_management_system => ems_hawkular,
                        :middleware_server     => eap,

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -1,5 +1,6 @@
+require_relative 'hawkular_helper'
+
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
-  THE_FEED_ID = '70c798a0-6985-4f8a-a525-012d8d28e8a3'.freeze
 
   let(:ems_hawkular) do
     # allow(MiqServer).to receive(:my_zone).and_return("default")
@@ -15,9 +16,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   let(:eap) do
     FactoryGirl.create(:hawkular_middleware_server,
                        :name                  => 'Local',
-                       :feed                  => THE_FEED_ID,
+                       :feed                  => the_feed_id,
                        :ems_ref               => '/t;hawkular'\
-                                                 "/f;#{THE_FEED_ID}/r;Local~~",
+                                                 "/f;#{the_feed_id}/r;Local~~",
                        :nativeid              => 'Local~~',
                        :ext_management_system => ems_hawkular)
   end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'recursive-open-struct'
+require_relative 'hawkular_helper'
 
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
-  THE_FEED_ID = '70c798a0-6985-4f8a-a525-012d8d28e8a3'.freeze
 
   let(:ems_hawkular) do
     # allow(MiqServer).to receive(:my_zone).and_return("default")
@@ -18,9 +18,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
   let(:server) do
     FactoryGirl.create(:hawkular_middleware_server,
                        :name                  => 'Local',
-                       :feed                  => THE_FEED_ID,
+                       :feed                  => the_feed_id,
                        :ems_ref               => '/t;Hawkular'\
-                                                 "/f;#{THE_FEED_ID}/r;Local~~",
+                                                 "/f;#{the_feed_id}/r;Local~~",
                        :nativeid              => 'Local~~',
                        :ext_management_system => ems_hawkular)
   end
@@ -31,7 +31,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
       datasource = RecursiveOpenStruct.new(:name => 'ruby-sample-build',
                                            :id   => 'Local~/subsystem=datasources/data-source=ExampleDS',
                                            :path => '/t;Hawkular'\
-                                                    "/f;#{THE_FEED_ID}/r;Local~~"\
+                                                    "/f;#{the_feed_id}/r;Local~~"\
                                                     '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS'
                                           )
       config = {
@@ -47,7 +47,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
         :middleware_server => server,
         :nativeid          => 'Local~/subsystem=datasources/data-source=ExampleDS',
         :ems_ref           => '/t;Hawkular'\
-                                                 "/f;#{THE_FEED_ID}/r;Local~~"\
+                                                 "/f;#{the_feed_id}/r;Local~~"\
                                                  '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS',
         :properties        => {
           'Driver Name'    => 'h2',


### PR DESCRIPTION
Remove the duplicated declaration of THE_FEED_ID and move it into a Hawkular-specifc helper.
Personal travis is green https://travis-ci.org/pilhuhn/manageiq/jobs/146047589

See https://gitter.im/ManageIQ/manageiq?at=578e7bb13d74e5a01666f580
and
https://gitter.im/ManageIQ/manageiq?at=578e7c300720fd587a9f9c1f
for some background.

cc @Fryguy @durandom 

@miq-bot add_label providers/hawkular
@miq-bot assign @abonas 