### PR TITLE
Fix an error page if show_list page parameter is zero

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1534,7 +1534,7 @@ class ApplicationController < ActionController::Base
     @items_per_page = controller_name.downcase == "miq_policy" ? ONE_MILLION : get_view_pages_perpage(dbname)
     @items_per_page = ONE_MILLION if 'vm' == db_sym.to_s && controller_name == 'service'
 
-    @current_page = options[:page] || (params[:page].blank? ? 1 : params[:page].to_i)
+    @current_page = options[:page] || ((params[:page].to_i < 1) ? 1 : params[:page].to_i)
 
     view.conditions = options[:conditions] # Get passed in conditions (i.e. tasks date filters)
 


### PR DESCRIPTION
**Description**
The `page` parameter can not be zero. When recovering from timeout it is set to zero, and cause an error in rendering the show_list page.

**Screenshot**
The error page if `page=0`
![page-zero-error](https://cloud.githubusercontent.com/assets/2181522/16982958/538b0ad8-4e7b-11e6-8fc2-21f23feac9ec.png)

The fix page if `page=0`
![page-zero-error-fix](https://cloud.githubusercontent.com/assets/2181522/16982962/58508124-4e7b-11e6-8f0a-888b52c6ec89.png)

**Issue**
https://github.com/ManageIQ/manageiq/issues/9937