### PR TITLE
Switch Policy button and Configuration button

### DIFF
--- a/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
@@ -1,19 +1,4 @@
 class ApplicationHelper::Toolbar::AuthKeyPairCloudCenter < ApplicationHelper::Toolbar::Basic
-  button_group('auth_key_pair_cloud_policy', [
-    select(
-      :auth_key_pair_cloud_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :auth_key_pair_cloud_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit tags for this Key Pair'),
-          N_('Edit Tags')),
-      ]
-    ),
-  ])
   button_group('auth_key_pair_cloud_vmdb', [
     select(
       :auth_key_pair_cloud_vmdb_choice,
@@ -28,6 +13,21 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudCenter < ApplicationHelper::To
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: The selected Key Pair and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Key Pair")),
+      ]
+    ),
+  ])
+  button_group('auth_key_pair_cloud_policy', [
+    select(
+      :auth_key_pair_cloud_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :auth_key_pair_cloud_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit tags for this Key Pair'),
+          N_('Edit Tags')),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/cloud_volume_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_center.rb
@@ -1,19 +1,4 @@
 class ApplicationHelper::Toolbar::CloudVolumeCenter < ApplicationHelper::Toolbar::Basic
-  button_group('cloud_volume_policy', [
-                 select(
-                   :cloud_volume_policy_choice,
-                   'fa fa-shield fa-lg',
-                   t = N_('Policy'),
-                   t,
-                   :items => [
-                     button(
-                       :cloud_volume_tag,
-                       'pficon pficon-edit fa-lg',
-                       N_('Edit tags for this Cloud Volume'),
-                       N_('Edit Tags')),
-                   ]
-                 ),
-               ])
   button_group('cloud_volume_vmdb', [
                  select(
                    :cloud_volume_vmdb_choice,
@@ -55,4 +40,19 @@ class ApplicationHelper::Toolbar::CloudVolumeCenter < ApplicationHelper::Toolbar
                    ]
                  )
                ])
+  button_group('cloud_volume_policy', [
+    select(
+      :cloud_volume_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :cloud_volume_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit tags for this Cloud Volume'),
+          N_('Edit Tags')),
+      ]
+    ),
+  ])
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Switch Policy button and Configuration button in Cloud Volume summary page and Cloud Key Pair summary page so it's consistent with other pages.

https://bugzilla.redhat.com/show_bug.cgi?id=1342294

Before:
![screen shot 2016-07-20 at 12 28 33 pm](https://cloud.githubusercontent.com/assets/9210860/16983537/801bf4e6-4e75-11e6-8f26-006bcbe8e9e1.png)
![screen shot 2016-07-20 at 12 27 00 pm](https://cloud.githubusercontent.com/assets/9210860/16983502/538ad974-4e75-11e6-9ec2-906cbf6c18cd.png)


After:
![screen shot 2016-07-20 at 12 15 07 pm](https://cloud.githubusercontent.com/assets/9210860/16983403/efecba22-4e74-11e6-9297-3dfdfb675db1.png)
![screen shot 2016-07-20 at 12 15 51 pm](https://cloud.githubusercontent.com/assets/9210860/16983405/f2c5f6f0-4e74-11e6-8560-3d2255df66c6.png)


Steps for Testing/QA
--------------------
Compute -> Clouds -> Volumes -> choose one
Compute -> Clouds -> Key Pairs -> choose one


@miq-bot add_label ui, bug