### PR TITLE
Toolbar buttons for VMs moved to separate classes (part 2)

### DIFF
--- a/app/helpers/application_helper/button/instance_reset.rb
+++ b/app/helpers/application_helper/button/instance_reset.rb
@@ -1,0 +1,8 @@
+class ApplicationHelper::Button::InstanceReset < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    return false if @record.kind_of?(OrchestrationStack) && @display == "instances"
+    !@record.is_available?(:reset)
+  end
+end

--- a/app/helpers/application_helper/button/vm_migrate.rb
+++ b/app/helpers/application_helper/button/vm_migrate.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::VmMigrate < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.supports_migrate?
+  end
+end

--- a/app/helpers/application_helper/button/vm_reset.rb
+++ b/app/helpers/application_helper/button/vm_reset.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::VmReset < ApplicationHelper::Button::Basic
+  needs_record
+
+  def calculate_properties
+    self[:title] = @error_message if disabled?
+  end
+
+  def skip?
+    !@record.is_available?(:reset)
+  end
+
+  def disabled?
+    !!(@error_message = @record.is_available_now_error_message(:reset))
+  end
+end

--- a/app/helpers/application_helper/button/vm_retire.rb
+++ b/app/helpers/application_helper/button/vm_retire.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::VmRetire < ApplicationHelper::Button::Basic
+  needs_record
+
+  def calculate_properties
+    self[:title] = N_("VM is already retired") if disabled?
+  end
+
+  def skip?
+    !@record.supports_retire?
+  end
+
+  def disabled?
+    @record.retired
+  end
+end

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -70,7 +70,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Hard Reboot the Guest OS on this Instance'),
             N_('Hard Reboot'),
             :image   => "guest_restart",
-            :confirm => N_("Hard Reboot the Guest OS on this Instance?")),
+            :confirm => N_("Hard Reboot the Guest OS on this Instance?"),
+            :klass   => ApplicationHelper::Button::InstanceReset),
           included_class.button(
             :instance_terminate,
             nil,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -267,7 +267,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :url_parms => "main_div",
           :confirm   => N_("Hard Reboot the Guest OS on the selected items?"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::InstanceReset),
         button(
           :instance_terminate,
           nil,

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -173,7 +173,8 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Migrate selected items'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::BasicImage),
         button(
           :vm_retire,
           'fa fa-clock-o fa-lg',
@@ -181,7 +182,8 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           N_('Set Retirement Dates'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::BasicImage),
         button(
           :vm_retire_now,
           'fa fa-clock-o fa-lg',
@@ -190,7 +192,8 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :url_parms => "main_div",
           :confirm   => N_("Retire the selected items?"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::BasicImage),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -117,18 +117,21 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :vm_migrate,
           'product product-migrate fa-lg',
           N_('Migrate this VM to another Host/Datastore'),
-          N_('Migrate this VM')),
+          N_('Migrate this VM'),
+          :klass => ApplicationHelper::Button::VmMigrate),
         button(
           :vm_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for this VM'),
-          N_('Set Retirement Date')),
+          N_('Set Retirement Date'),
+          :klass => ApplicationHelper::Button::VmRetire),
         button(
           :vm_retire_now,
           'fa fa-clock-o fa-lg',
           t = N_('Retire this VM'),
           t,
-          :confirm => N_("Retire this VM?")),
+          :confirm => N_("Retire this VM?"),
+          :klass => ApplicationHelper::Button::VmRetire),
       ]
     ),
   ])
@@ -204,7 +207,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Reset this VM'),
           N_('Reset'),
           :image   => "power_reset",
-          :confirm => N_("Reset this VM?")),
+          :confirm => N_("Reset this VM?"),
+          :klass   => ApplicationHelper::Button::VmReset),
       ]
     ),
     button(

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -838,18 +838,10 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:shutdown_guest)
       when "vm_guest_restart", "instance_guest_restart"
         return true unless @record.is_available?(:reboot_guest)
-      when "vm_migrate"
-        return true unless @record.supports_migrate?
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
-      when "vm_retire"
-        return true unless @record.supports_retire?
-      when "vm_retire_now"
-        return true unless @record.supports_retire?
       when "instance_stop"
         return true unless @record.is_available?(:stop)
-      when "vm_reset", "instance_reset"
-        return true unless @record.is_available?(:reset)
       when "vm_suspend", "instance_suspend"
         return true unless @record.is_available?(:suspend)
       when "instance_shelve"
@@ -908,12 +900,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @report
       when "timeline_txt"
         return true unless @report
-      when "vm_migrate", "vm_retire", "vm_retire_now"
-        if @sb[:trees][:vandt_tree].present? &&
-           (@sb[:trees][:vandt_tree][:active_node] == "xx-arch" ||
-            @sb[:trees][:vandt_tree][:active_node] == "xx-orph")
-          return true
-        end
       else
         return !role_allows(:feature => id)
       end
@@ -1294,19 +1280,10 @@ class ApplicationHelper::ToolbarBuilder
         return @record.is_available_now_error_message(:shutdown_guest) if @record.is_available_now_error_message(:shutdown_guest)
       when "vm_guest_restart"
         return @record.is_available_now_error_message(:reboot_guest) if @record.is_available_now_error_message(:reboot_guest)
-      when "vm_reset"
-        return @record.is_available_now_error_message(:reset) if @record.is_available_now_error_message(:reset)
       when "vm_suspend"
         return @record.is_available_now_error_message(:suspend) if @record.is_available_now_error_message(:suspend)
-      when "instance_retire", "instance_retire_now",
-              "vm_retire", "vm_retire_now"
-        if @record.retired == true
-          if @record.kind_of?(ManageIQ::Providers::CloudManager::Vm)
-            return N_("Instance is already retired")
-          else
-            return N_("VM is already retired")
-          end
-        end
+      when "instance_retire", "instance_retire_now"
+        return N_("Instance is already retired") if @record.retired
       when "vm_timeline"
         unless @record.has_events? || @record.has_events?(:policy_events)
           return N_("No Timeline data has been collected for this VM")

--- a/spec/helpers/application_helper/buttons/instance_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_reset_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::InstanceReset do
+  describe '#skip?' do
+    context "when record is resetable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:reset).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not resetable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:reset).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
@@ -45,7 +45,7 @@ describe ApplicationHelper::Button::VmInstanceScan do
         allow(@record).to receive(:orphaned?).and_return(false)
       end
 
-      it "disables the button and return an error message" do
+      it "disables the button" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         expect(button.disabled?).to be_truthy
@@ -76,7 +76,7 @@ describe ApplicationHelper::Button::VmInstanceScan do
         allow(@record).to receive(:is_available_now_error_message).with(:smartstate_analysis).and_return(message)
       end
 
-      it "returns the smartstate_analysis error message" do
+      it "disables the button" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         expect(button.disabled?).to be_truthy

--- a/spec/helpers/application_helper/buttons/vm_migrate_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_migrate_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::VmMigrate do
+  describe '#skip?' do
+    context "when record is migrateable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:supports_migrate?).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not migrateable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:supports_migrate?).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/vm_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_reset_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::VmReset do
+  describe '#skip?' do
+    context "when record is resetable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available?).with(:reset).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not resetable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available?).with(:reset).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+
+  describe '#disabled?' do
+    context "when record has an error message" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        message = "xx reset message"
+        allow(@record).to receive(:is_available_now_error_message).with(:reset).and_return(message)
+      end
+
+      it "disables the button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/vm_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::VmRetire do
+  describe '#skip?' do
+    context "when record is retireable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:supports_retire?).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not retiretable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:supports_retire?).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+
+  describe '#disabled?' do
+    context "when record has an error message" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:retired).and_return(true)
+      end
+
+      it "disables the button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+  end
+
+  describe "#calculate_properties" do
+    context "when record is retired" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:retired).and_return(true)
+      end
+
+      it "sets the error message for disabled button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.calculate_properties
+        expect(button[:title]).to eq("VM is already retired")
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/vm_stop_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_stop_spec.rb
@@ -38,7 +38,7 @@ describe ApplicationHelper::Button::VmStop do
         allow(@record).to receive(:is_available_now_error_message).with(:stop).and_return(message)
       end
 
-      it "disables the button and returns the stop error message" do
+      it "disables the button" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         expect(button.disabled?).to be_truthy

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -373,7 +373,6 @@ describe ApplicationHelper do
      "vm_protect",
      "vm_start",
      "vm_suspend",
-     "vm_reset",
      "vm_retire",
      "vm_retire_now",
      "vm_snapshot_add",
@@ -1295,22 +1294,6 @@ describe ApplicationHelper do
         end
 
         it "and @record.is_available?(:reboot_guest)" do
-          expect(subject).to be_falsey
-        end
-      end
-
-      context "and id = vm_reset" do
-        before do
-          @id = "vm_reset"
-          allow(@record).to receive(:is_available?).with(:reset).and_return(true)
-        end
-
-        it "and !@record.is_available?(:reset)" do
-          allow(@record).to receive(:is_available?).with(:reset).and_return(false)
-          expect(subject).to be_truthy
-        end
-
-        it "and @record.is_available?(:reset)" do
           expect(subject).to be_falsey
         end
       end
@@ -2317,15 +2300,6 @@ describe ApplicationHelper do
           allow(@record).to receive(:is_available_now_error_message).and_return(false)
         end
         it_behaves_like 'record with error message', 'reboot_guest'
-        it_behaves_like 'default case'
-      end
-
-      context "and id = vm_reset" do
-        before do
-          @id = "vm_reset"
-          allow(@record).to receive(:is_available_now_error_message).and_return(false)
-        end
-        it_behaves_like 'record with error message', 'reset'
         it_behaves_like 'default case'
       end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -373,7 +373,6 @@ describe ApplicationHelper do
      "vm_protect",
      "vm_start",
      "vm_suspend",
-     "vm_retire_now",
      "vm_snapshot_add",
      "vm_snapshot_delete",
      "vm_snapshot_delete_all",
@@ -2311,17 +2310,6 @@ describe ApplicationHelper do
         it_behaves_like 'default case'
       end
 
-      ["vm_retire_now"].each do |button_id|
-        context "and id = #{button_id}" do
-          before { @id = button_id }
-          it "when VM is already retired" do
-            allow(@record).to receive_messages(:retired => true)
-            expect(subject).to eq("VM is already retired")
-          end
-          it_behaves_like 'default case'
-        end
-      end
-
       context "and id = storage_scan" do
         before do
           @id = "storage_scan"
@@ -2452,13 +2440,6 @@ describe ApplicationHelper do
     end
 
     context "Disable Retire button for already retired VMs and Instances" do
-      it "button vm_retire_now" do
-        @record = FactoryGirl.create(:vm_redhat, :retired => true)
-        res = build_toolbar_disable_button("vm_retire_now")
-        expect(res).to be_truthy
-        expect(res).to include("already retired")
-      end
-
       it "button instance_retire_now" do
         @record = FactoryGirl.create(:vm_amazon, :retired => true)
         res = build_toolbar_disable_button("instance_retire_now")

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1146,23 +1146,6 @@ describe ApplicationHelper do
         allow(user).to receive(:role_allows?).and_return(true)
       end
 
-      %w(vm_migrate).each do |id|
-        context "and id = #{id}" do
-          before { @id = id }
-
-          it "and vendor is redhat" do
-            @record = FactoryGirl.create(:vm_redhat)
-            expect(subject).to be_truthy
-          end
-
-          it "and vendor is not redhat" do
-            @record = FactoryGirl.create(:vm_vmware)
-            allow(@record).to receive(:archived?).and_return(false)
-            expect(subject).to be_falsey
-          end
-        end
-      end
-
       context "and id = vm_reconfigure" do
         before do
           @id = "vm_reconfigure"
@@ -1666,38 +1649,6 @@ describe ApplicationHelper do
       it "when with view_#{g}" do
         @gtl_type = g
         expect(build_toolbar_disable_button("view_#{g}")).to be_truthy
-      end
-    end
-
-    it "hides Lifecycle options in archived VMs list" do
-      allow(ApplicationHelper).to receive(:get_record_cls).and_return(nil)
-      @sb = {:trees => {:vandt_tree => {:active_node => "xx-arch"}}}
-      %w(vm_migrate).each do |tb_button|
-        expect(build_toolbar_hide_button(tb_button)).to be_truthy
-      end
-    end
-
-    it "hides Lifecycle options in orphaned VMs list" do
-      allow(ApplicationHelper).to receive(:get_record_cls).and_return(nil)
-      @sb = {:trees => {:vandt_tree => {:active_node => "xx-orph"}}}
-      %w(vm_migrate).each do |tb_button|
-        expect(build_toolbar_hide_button(tb_button)).to be_truthy
-      end
-    end
-
-    it "hides Lifecycle options for archived VMs" do
-      @record = FactoryGirl.create(:vm_microsoft)
-      allow(@record).to receive(:archived?).and_return(true)
-      %w(vm_migrate).each do |tb_button|
-        expect(build_toolbar_hide_button(tb_button)).to be_truthy
-      end
-    end
-
-    it "hides Lifecycle options for orphaned VMs" do
-      @record = FactoryGirl.create(:vm_microsoft)
-      allow(@record).to receive(:orphaned?).and_return(true)
-      %w(vm_migrate).each do |tb_button|
-        expect(build_toolbar_hide_button(tb_button)).to be_truthy
       end
     end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -373,7 +373,6 @@ describe ApplicationHelper do
      "vm_protect",
      "vm_start",
      "vm_suspend",
-     "vm_retire",
      "vm_retire_now",
      "vm_snapshot_add",
      "vm_snapshot_delete",
@@ -2312,7 +2311,7 @@ describe ApplicationHelper do
         it_behaves_like 'default case'
       end
 
-      ["vm_retire", "vm_retire_now"].each do |button_id|
+      ["vm_retire_now"].each do |button_id|
         context "and id = #{button_id}" do
           before { @id = button_id }
           it "when VM is already retired" do


### PR DESCRIPTION
## Continuation of PR #9540.
___

Purpose or Intent
-----------------

Purpose is to move toolbar buttons from helper (`app/helpers/application_helper/toolbar_builder.rb`) to separate classes.

*In this PR is converted just a second part of buttons for VMs. I'll continue with other buttons in another PR.*

**Classes for multiple buttons with same logic**:
- class `BasicImage` contains logic for buttons `vm_retire`, `vm_retire_now` and `vm_migrate` in list of VM and instances
- class `VmRetire` contains logic for `vm_retire` and `vm_retire_now` button in VM summary page

**Classes for one button**
- class `VmMigrate` contains logic for `vm_migrate` button in VM summary page
- class `VmReset` contains logic for `vm_reset` button in VM summary page
- class `InstanceReset` contains logic for `instance_reset` button in instance summary page


**Toolbar screenshots**

- cloud/instance_operations_button_group_mixin.rb
![screencapture-localhost-3000-vm_cloud-explorer-1469015689712](https://cloud.githubusercontent.com/assets/1187051/16985660/41f58846-4e82-11e6-9c56-c060e54d2016.png)

@martinpovolny @PanSpagetka can you review?

Links
-----
Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/126786879