### PR TITLE
Remove ruby code from the JS that is calling dynatree

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -597,71 +597,71 @@ function miqTreeEventSafeEval(func) {
 
 function miqInitDynatree(options, tree) {
 
-  if (options.check_url) { // check_url
+  if (options.check_url) {
     ManageIQ.dynatree.checkUrl = options.check_url;
   }
 
-  if (options.click_url) { // click_url
+  if (options.click_url) {
     ManageIQ.dynatree.clickUrl = options.click_url;
   }
 
-  if (options.group_changed) { // session[:group_changed]
+  if (options.group_changed) {
     miqDeleteDynatreeCookies();
   }
 
-  $('#' + options.tree_id).dynatree({ // tree_id
-    title: options.tree_name, // tree_name
+  $('#' + options.tree_id).dynatree({
+    title: options.tree_name,
     imagePath: '',
     generateIds: true,
-    idPrefix: options.id_prefix, // id_prefix
-    children: tree, // json_tree.to_s.html_safe
-    cookieId: options.cookie_id, // cookie_id_prefix + tree_name
+    idPrefix: options.id_prefix,
+    children: tree,
+    cookieId: options.cookie_id,
     cookie: {
       path: '/'
     },
     onDblClick: function (node, event) {
-      if (options.no_base_exp) { // no_base_exp
+      if (options.no_base_exp) {
         miqOnDblClickNoBaseExpand(node, event);
       }
-      if (options.open_close_all_on_dbl_click) { // open_close_all_on_dbl_click
+      if (options.open_close_all_on_dbl_click) {
         miqOnDblClickExpand(node, event);
       }
     },
-    minExpandLevel: options.min_expand_level, // min_expand_level ? min_expand_level : 1
-    checkbox: options.checkboxes, // checkboxes
-    selectMode: options.select_mode, // three_checks ? three_checks : 2
-    persist: options.tree_state, // tree_state
+    minExpandLevel: options.min_expand_level,
+    checkbox: options.checkboxes,
+    selectMode: options.select_mode,
+    persist: options.tree_state,
     onClick: function(node, event) {
       var event_type = node.getEventTargetType(event);
 
-      if (options.no_click && event_type != 'expander') { // cfme_no_click
+      if (options.no_click && event_type != 'expander') {
         return false;
       }
 
-      if (options.onclick || options.disable_checks || options.oncheck) { // onclick || disable_checks || oncheck
+      if (options.onclick || options.disable_checks || options.oncheck) {
         if (event_type != 'expander' && node.data.cfmeNoClick) return false;
-        if (options.onclick) { // onclick
+        if (options.onclick) {
           if (event_type == 'icon' || event_type == 'title' || event.target.localName == 'img') {
-            if(options.click_url) { // click_url
-              if (node.isActive()) miqTreeEventSafeEval(options.onclick)(node.data.key); // onclick
+            if(options.click_url) {
+              if (node.isActive()) miqTreeEventSafeEval(options.onclick)(node.data.key);
               return;
             } else {
               if (miqCheckForChanges() == false) {
                 this.activeNode.focus();
                 return false;
               } else {
-                if (node.isActive()) miqTreeEventSafeEval(options.onclick)(node.data.key); // onclick
+                if (node.isActive()) miqTreeEventSafeEval(options.onclick)(node.data.key);
                 return;
               }
             }
           }
         }
-        if (options.disable_checks || options.oncheck) { // disable_checks || oncheck
+        if (options.disable_checks || options.oncheck) {
           if (event_type == 'checkbox') {
-            if (options.disable_checks) { // disable_checks
+            if (options.disable_checks) {
               return false;
-            } else if (options.oncheck) { // oncheck
-              miqTreeEventSafeEval(options.oncheck)(node, options.tree_name); // tree_name
+            } else if (options.oncheck) {
+              miqTreeEventSafeEval(options.oncheck)(node, options.tree_name);
               return;
             }
           }
@@ -671,17 +671,17 @@ function miqInitDynatree(options, tree) {
       }
     },
     onSelect: function(flag, node) {
-      if (options.onselect) { // onselect
+      if (options.onselect) {
         var selectedNodes = node.tree.getSelectedNodes();
         var selectedKeys = $.map(selectedNodes, function(node) {
           return node.data.key;
         });
-        miqTreeEventSafeEval(options.onselect)(options.tree_name, node.data.key, flag, selectedKeys); // onselect
+        miqTreeEventSafeEval(options.onselect)(options.tree_name, node.data.key, flag, selectedKeys);
       }
     },
     onActivate: function(node) {
-      if (options.onclick) { // onclick
-        miqTreeEventSafeEval(options.onclick)(node.data.key); // onclick
+      if (options.onclick) {
+        miqTreeEventSafeEval(options.onclick)(node.data.key);
       }
     },
     onExpand: function(node) {
@@ -690,37 +690,37 @@ function miqInitDynatree(options, tree) {
       }
     },
     onLazyRead: function(node) {
-      if(options.autoload) { // autoload
-        miqOnLazyReadGetNodeChildren(node, options.tree_name, options.controller); // request.parameters[:controller]
+      if(options.autoload) {
+        miqOnLazyReadGetNodeChildren(node, options.tree_name, options.controller);
       }
     },
     onPostInit: function(isReloading, isError) {
-      if (options.silent_activate) { // @explorer && tree_name == x_active_tree.to_s
-        miqDynatreeActivateNodeSilently(options.tree_name, options.select_node); // tree_name, select_node
+      if (options.silent_activate) {
+        miqDynatreeActivateNodeSilently(options.tree_name, options.select_node);
       }
     },
     debugLevel: 0
   });
 
-  if (options.reselect_node) { // @reselect_node
-    miqDynatreeActivateNodeSilently(options.tree_name, options.reselect_node); // tree_name, @reselect_node
+  if (options.reselect_node) {
+    miqDynatreeActivateNodeSilently(options.tree_name, options.reselect_node);
   }
 
-  if (options.expand_parent_nodes) { // @expand_parent_nodes
-    miqExpandParentNodes(options.tree_name, options.expand_parent_nodes); // tree_name, @expand_parent_nodes
+  if (options.expand_parent_nodes) {
+    miqExpandParentNodes(options.tree_name, options.expand_parent_nodes);
   }
 
-  if (options.add_nodes) { // @add_nodes && @add_nodes[x_active_tree] && tree_name == x_active_tree.to_s
+  if (options.add_nodes) {
     miqAddNodeChildren(
-      options.active_tree, // x_active_tree (treename)
-      options.add_node_key, // Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:key, nil) (selected_nodes)
-      options.select_node, // select_node
-      options.children // Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:children, nil).to_json.html_safe (children)
+      options.active_tree,
+      options.add_node_key,
+      options.select_node,
+      options.children
     );
   }
 
-  if (options.onhover) { // onmousein || onmouseout
-    miqBindHoverEvent(options.tree_name); // tree_name
+  if (options.onhover) {
+    miqBindHoverEvent(options.tree_name);
   }
 
 }

--- a/app/views/layouts/_dynatree.html.haml
+++ b/app/views/layouts/_dynatree.html.haml
@@ -16,127 +16,44 @@
 - no_base_exp                 ||= false
 - open_close_all_on_dbl_click ||= false
 - autoload                    ||= false
+- json_tree                   ||= '{}'
 - min_expand_level            ||= 1
 - tree_id                     ||= "tree_div"
 - tree_name                   ||= "tree"
 
-%script{:type => "text/javascript"}
-  - if check_url
-    ManageIQ.dynatree.checkUrl = "#{j_str check_url}";
-  - if click_url
-    ManageIQ.dynatree.clickUrl = "#{j_str click_url}";
-  - if session[:group_changed]
-    miqDeleteDynatreeCookies();
-    - session[:group_changed] = false
 
-  $("##{tree_id}").dynatree({
-  title: "#{tree_name}",
-  imagePath: "",
-  generateIds: true,
-  idPrefix: "#{id_prefix}",
-  children: #{json_tree.to_s.html_safe},
-  cookieId: "#{cookie_id_prefix}#{tree_name}",
-  cookie: {path: "/"},
+- options = {:tree_id                     => tree_id,
+             :tree_name                   => tree_name,
+             :group_changed               => session[:group_changed],
+             :id_prefix                   => id_prefix,
+             :cookie_id                   => "#{cookie_id_prefix}#{tree_name}",
+             :no_base_exp                 => no_base_exp,
+             :open_close_all_on_dbl_click => open_close_all_on_dbl_click,
+             :min_expand_level            => min_expand_level ? min_expand_level : 1,
+             :checkboxes                  => checkboxes,
+             :select_mode                 => three_checks ? 3 : 2,
+             :tree_state                  => tree_state,
+             :no_click                    => cfme_no_click,
+             :onclick                     => onclick,
+             :disable_checks              => disable_checks,
+             :oncheck                     => oncheck,
+             :click_url                   => click_url,
+             :check_url                   => check_url,
+             :onselect                    => onselect,
+             :autoload                    => autoload,
+             :controller                  => j(request.parameters[:controller]),
+             :silent_activate             => @explorer && tree_name == x_active_tree.to_s,
+             :select_node                 => select_node,
+             :reselect_node               => @reselect_node,
+             :expand_parent_nodes         => @expand_parent_nodes,
+             :add_nodes                   => @add_nodes && @add_nodes[x_active_tree] && tree_name == x_active_tree.to_s,
+             :active_tree                 => x_active_tree,
+             :add_node_key                => Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:key, nil),
+             :children                    => Hash.new(@add_nodes).fetch(x_active_tree, {}).fetch(:children, nil),
+             :onhover                     => onmousein || onmouseout}
 
-  - if no_base_exp
-    onDblClick: miqOnDblClickNoBaseExpand,
-  - if min_expand_level
-    minExpandLevel: #{min_expand_level},
-  - if checkboxes
-    checkbox: #{checkboxes},
-  - if three_checks
-    selectMode: 3,
-  - if open_close_all_on_dbl_click
-    onDblClick: miqOnDblClickExpand,
-  - if tree_state
-    persist: true,
+:javascript
+  miqInitDynatree(#{options.to_json.html_safe}, #{json_tree.html_safe})
 
-  - if cfme_no_click
-    onClick: function(node, event) {
-    var event_type = node.getEventTargetType(event);
-    if (event_type != 'expander') {
-    return false;
-    }
-    },
-
-  - if onselect
-    onSelect: function(flag, node) {
-    var selectedNodes = node.tree.getSelectedNodes();
-    var selectedKeys = $.map(selectedNodes, function(node) {
-    return node.data.key;
-    });
-    #{onselect}('#{tree_name}', node.data.key, flag, selectedKeys);
-    },
-
-  - if onclick || disable_checks || oncheck
-
-    - if onclick
-      onActivate: function(node) {
-      #{onclick}(node.data.key);
-      },
-
-    onClick: function(node, event) {
-    var event_type = node.getEventTargetType(event);
-    if (event_type != 'expander' && node.data.cfmeNoClick) return false;
-    - if onclick
-      if (event_type == 'icon' || event_type == 'title' || event.target.localName == 'img') {
-      - if click_url
-        if (node.isActive()) #{onclick}(node.data.key);
-        return;
-      - else
-        if (miqCheckForChanges() == false) {
-        this.activeNode.focus();
-        return false;
-        } else {
-        if (node.isActive()) #{onclick}(node.data.key);
-        return;
-        }
-      }
-
-    - if disable_checks || oncheck
-      if (event_type == 'checkbox') {
-      - if disable_checks
-        return false;
-      - elsif oncheck
-        #{oncheck}(node, "#{tree_name}");
-        return;
-      }
-
-      if (event_type != 'expander') return false;
-    },
-
-    - if onmousein || onmouseout
-      onExpand: function(node){
-      miqBindHoverEvent("#{tree_name}");
-      },
-
-
-  - if autoload
-    onLazyRead: function(node) {
-    miqOnLazyReadGetNodeChildren(node, '#{tree_name}', '#{request.parameters[:controller]}');
-    },
-
-  - if @explorer && tree_name == x_active_tree.to_s
-    onPostInit: function(isReloading, isError) {
-    miqDynatreeActivateNodeSilently('#{tree_name}', '#{select_node}');
-    },
-
-  debugLevel: 0
-  });
-
-  - if @reselect_node
-    miqDynatreeActivateNodeSilently('#{tree_name}', '#{@reselect_node}');
-
-  - if @expand_parent_nodes
-    miqExpandParentNodes("#{tree_name}", "#{@expand_parent_nodes}");
-
-  - if @add_nodes && @add_nodes[x_active_tree] && tree_name == x_active_tree.to_s
-    miqAddNodeChildren(
-    '#{x_active_tree}',
-    '#{@add_nodes[x_active_tree][:key]}',
-    '#{select_node}',
-    #{@add_nodes[x_active_tree][:children].to_json.html_safe}
-    );
-
-  - if onmousein || onmouseout
-    miqBindHoverEvent("#{tree_name}");
+- if session[:group_changed]
+  - session[:group_changed] = false

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -36,8 +36,6 @@ describe VmInfraController do
     expect(response).to redirect_to(:action => 'explorer')
 
     post :explorer
-    node_id = "v-#{vm_vmware.compressed_id}"
-    expect(response.body).to match(/miqDynatreeActivateNodeSilently\('vandt_tree', '#{node_id}'\);/)
 
     expect(response).to render_template('shared/summary/_textual_tags')
     expect(response.body).to match(/VM and Instance &quot;#{vm_vmware.name}&quot;/)


### PR DESCRIPTION
The current `_dynatree.html.haml` is quite unreadable because mixes ruby IFs with JS code. This code moves all the IFs to JS by using interpolation. This will make the migration to `bootstrap-treeview` much easier.

cc @himdel @bmclaughlin @martinpovolny 