### PR TITLE
Fix wrong datetime in automate instances and methods after updating.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -104,21 +104,21 @@ class MiqAeClassController < ApplicationController
       @sb[:namespace_path] = rec.fqname
     when "aei"
       txt = ui_lookup(:model => "MiqAeInstance")
-      updated_by = rec.updated_by ? _(" by %{time}") % {:time => rec.updated_by} : ""
+      updated_by = rec.updated_by ? _(" by %{user}") % {:user => rec.updated_by} : ""
       @sb[:namespace_path] = rec.fqname
       @right_cell_text = _("%{model} [%{name} - Updated %{time}%{update}]") %
         {:model  => txt,
          :name   => get_rec_name(rec),
-         :time   => format_timezone(rec.created_on, Time.zone, "gtl"),
+         :time   => format_timezone(rec.updated_on, Time.zone, "gtl"),
          :update => updated_by}
     when "aem"
       txt = ui_lookup(:model => "MiqAeMethod")
-      updated_by = rec.updated_by ? _(" by %{time}") % {:time => rec.updated_by} : ""
+      updated_by = rec.updated_by ? _(" by %{user}") % {:user => rec.updated_by} : ""
       @sb[:namespace_path] = rec.fqname
       @right_cell_text = _("%{model} [%{name} - Updated %{time}%{update}]") %
         {:model  => txt,
          :name   => get_rec_name(rec),
-         :time   => format_timezone(rec.created_on, Time.zone, "gtl"),
+         :time   => format_timezone(rec.updated_on, Time.zone, "gtl"),
          :update => updated_by}
     when "aen"
       txt = ui_lookup(:model => rec.domain? ? "MiqAeDomain" : "MiqAeNamespace")

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -2,8 +2,8 @@ class MiqAeField < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
 
-  belongs_to :ae_class,   :class_name => "MiqAeClass",  :foreign_key => :class_id
-  belongs_to :ae_method,  :class_name => "MiqAeMethod", :foreign_key => :method_id
+  belongs_to :ae_class,   :class_name => "MiqAeClass",  :foreign_key => :class_id, :touch => true
+  belongs_to :ae_method,  :class_name => "MiqAeMethod", :foreign_key => :method_id, :touch => true
   has_many   :ae_values,  :class_name => "MiqAeValue",  :foreign_key => :field_id, :dependent => :destroy
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]

--- a/lib/miq_automation_engine/models/miq_ae_value.rb
+++ b/lib/miq_automation_engine/models/miq_ae_value.rb
@@ -2,7 +2,7 @@ class MiqAeValue < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
   belongs_to :ae_field,    :class_name => "MiqAeField",    :foreign_key => :field_id
-  belongs_to :ae_instance, :class_name => "MiqAeInstance", :foreign_key => :instance_id
+  belongs_to :ae_instance, :class_name => "MiqAeInstance", :foreign_key => :instance_id, :touch => true
 
   def to_export_xml(options = {})
     require 'builder'

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -242,6 +242,7 @@ describe MiqAeClassController do
                                     :name         => "some_name",
                                     :fqname       => "fqname",
                                     :created_on   => Time.now,
+                                    :updated_on   => Time.current,
                                     :updated_by   => "some_user",
                                     :domain       => miq_ae_domain
                                    )
@@ -255,6 +256,7 @@ describe MiqAeClassController do
                                     :name         => "some_name",
                                     :fqname       => "fqname",
                                     :created_on   => Time.now,
+                                    :updated_on   => Time.current,
                                     :updated_by   => "some_user",
                                     :domain       => miq_ae_domain
                                    )


### PR DESCRIPTION
Purpose or Intent
-----------------
Wrong updated datetime in automate instances and methods. Automate explorer showed created_on time instead of updated_on and further there were missing options ":touch = true" in miq_ae_values and miq_ae_fields associations for changing updated_on time after updating.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1351973