### PR TITLE
Remove extra authentication created when editing ems_container

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -431,6 +431,7 @@ module Mixins
          ems.supports_authentication?(:bearer) && !params[:default_password].blank?
         creds[:hawkular] = {:auth_key => params[:default_password], :userid => "_"}
         creds[:bearer] = {:auth_key => params[:default_password]}
+        creds.delete(:default)
         ems.update_authentication(creds, :save => (mode != :validate))
       end
       creds

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -192,6 +192,7 @@ describe EmsContainerController do
         after :each do
           set_user_privileges
           controller.instance_variable_set(:@_params, :name              => 'EMS 2',
+                                                      :default_userid    => '_',
                                                       :default_hostname  => '10.10.10.11',
                                                       :default_api_port  => '5000',
                                                       :default_password  => 'valid-token',
@@ -205,6 +206,7 @@ describe EmsContainerController do
           expect(@ems.connection_configurations.hawkular.endpoint.hostname).to eq('10.10.10.10')
           expect(@ems.connection_configurations.hawkular.endpoint.port).to eq(8443)
           expect(@ems.authentication_token("bearer")).to eq('valid-token')
+          expect(@ems.authentication_type("default")).to be_nil
           expect(@ems.hostname).to eq('10.10.10.11')
         end
 


### PR DESCRIPTION
**Description**
Remove the extra "default" authentication created when editing a container provider.

**Screenshots**
An extra endpoint named "default" is created
![authenticaion-list-bad](https://cloud.githubusercontent.com/assets/2181522/16988868/959f9cb2-4e9a-11e6-8bb6-35ae715be29c.png)

With this fix only "bearer" and "hawkular" are created
![authenticaion-list-good](https://cloud.githubusercontent.com/assets/2181522/16988875/9b279fc2-4e9a-11e6-967b-d4f45479edb0.png)


**Bugzilla**
https://bugzilla.redhat.com/show_bug.cgi?id=1361012

**Issue**
https://github.com/ManageIQ/manageiq/issues/9946