### PR TITLE
Show Compliance status/history of replicators, pods, nodes

### DIFF
--- a/app/helpers/compliance_summary_helper.rb
+++ b/app/helpers/compliance_summary_helper.rb
@@ -1,4 +1,8 @@
 module ComplianceSummaryHelper
+  def textual_group_compliance
+    %i(compliance_status compliance_history)
+  end
+
   def textual_compliance_status
     h = {:label => _("Status")}
     if @record.number_of(:compliances) == 0
@@ -22,6 +26,24 @@ module ComplianceSummaryHelper
         :id         => @record,
         :display    => 'compliance_history', :count => 1
       )
+    end
+    h
+  end
+
+  def textual_compliance_history(options_if_available = {})
+    h = {:label => _("History")}
+    if @record.number_of(:compliances) == 0
+      h[:value] = _("Not Available")
+    else
+      h[:image] = "compliance"
+      h[:value] = _("Available")
+      h[:title] = _("Show Compliance History of this %{model} (Last 10 Checks)") % ui_lookup(:model => controller.model)
+      h[:link] = url_for(
+        :controller => controller.controller_name,
+        :action     => 'show',
+        :id         => @record,
+        :display    => 'compliance_history')
+      h.merge!(options_if_available)
     end
     h
   end

--- a/app/helpers/compliance_summary_helper.rb
+++ b/app/helpers/compliance_summary_helper.rb
@@ -37,7 +37,8 @@ module ComplianceSummaryHelper
     else
       h[:image] = "compliance"
       h[:value] = _("Available")
-      h[:title] = _("Show Compliance History of this %{model} (Last 10 Checks)") % ui_lookup(:model => controller.model)
+      h[:title] = _("Show Compliance History of this %{model} (Last 10 Checks)") %
+                  {:model => ui_lookup(:model => controller.class.model.name)}
       h[:link] = url_for(
         :controller => controller.controller_name,
         :action     => 'show',

--- a/app/helpers/container_group_helper.rb
+++ b/app/helpers/container_group_helper.rb
@@ -1,4 +1,5 @@
 module ContainerGroupHelper
+  include_concern 'ComplianceSummaryHelper'
   include_concern 'ContainerSummaryHelper'
   include_concern 'TextualSummary'
 end

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -130,4 +130,8 @@ module ContainerGroupHelper::TextualSummary
   def textual_terminated
     container_statuses_summary[:terminated] || 0
   end
+
+  def textual_compliance_history
+    super(:title => _("Show Compliance History of this Replicator (Last 10 Checks)"))
+  end
 end

--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -8,10 +8,6 @@ module ContainerImageHelper
       %i(name tag id full_name os_distribution product_type product_name)
     end
 
-    def textual_group_compliance
-      %i(compliance_status compliance_history)
-    end
-
     def textual_group_relationships
       %i(ems container_image_registry container_projects container_groups containers container_nodes)
     end
@@ -61,21 +57,8 @@ module ContainerImageHelper
     end
 
     def textual_compliance_history
-      h = {:label => _("History")}
-      if @record.number_of(:compliances) == 0
-        h[:value] = _("Not Available")
-      else
-        h[:image] = "compliance"
-        h[:value] = _("Available")
-        h[:title] = _("Show Compliance History of this Container Image (Last 10 Checks)")
-        h[:explorer] = true
-        h[:link] = url_for(
-          :controller => controller.controller_name,
-          :action     => 'show',
-          :id         => @record,
-          :display    => 'compliance_history')
-      end
-      h
+      super(:title    => _("Show Compliance History of this Container Image (Last 10 Checks)"),
+            :explorer => true)
     end
 
     def failed_rules_summary

--- a/app/helpers/container_node_helper.rb
+++ b/app/helpers/container_node_helper.rb
@@ -1,4 +1,5 @@
 module ContainerNodeHelper
+  include_concern 'ComplianceSummaryHelper'
   include_concern 'ContainerSummaryHelper'
   include_concern 'TextualSummary'
 end

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -112,4 +112,8 @@ module ContainerNodeHelper::TextualSummary
   def textual_kernel_version
     @record.computer_system.try(:operating_system).try(:kernel_version) || _("N/A")
   end
+
+  def textual_compliance_history
+    super(:title => _("Show Compliance History of this Node (Last 10 Checks)"))
+  end
 end

--- a/app/helpers/container_replicator_helper.rb
+++ b/app/helpers/container_replicator_helper.rb
@@ -1,4 +1,5 @@
 module ContainerReplicatorHelper
+  include_concern 'ComplianceSummaryHelper'
   include_concern 'ContainerSummaryHelper'
   include_concern 'TextualSummary'
 end

--- a/app/helpers/container_replicator_helper/textual_summary.rb
+++ b/app/helpers/container_replicator_helper/textual_summary.rb
@@ -28,4 +28,8 @@ module ContainerReplicatorHelper::TextualSummary
   def textual_current_replicas
     {:label => _("Current pods"), :value => @record.current_replicas}
   end
+
+  def textual_compliance_history
+    super(:title => _("Show Compliance History of this Replicator (Last 10 Checks)"))
+  end
 end

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -19,10 +19,6 @@ module HostHelper::TextualSummary
     %i(storage_systems storage_volumes logical_disks file_shares)
   end
 
-  def textual_group_compliance
-    %i(compliance_status compliance_history)
-  end
-
   def textual_group_security
     return nil if @record.is_vmware_esxi?
     %i(users groups patches firewall_rules ssh_root)
@@ -376,16 +372,7 @@ module HostHelper::TextualSummary
   end
 
   def textual_compliance_history
-    h = {:label => _("History")}
-    if @record.number_of(:compliances) == 0
-      h[:value] = _("Not Available")
-    else
-      h[:image] = "compliance"
-      h[:value] = _("Available")
-      h[:title] = _("Show Compliance History of this %{title} (Last 10 Checks)") % {:title => host_title}
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => 'compliance_history')
-    end
-    h
+    super(:title => _("Show Compliance History of this %{title} (Last 10 Checks)") % {:title => host_title})
   end
 
   def textual_users

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -45,10 +45,6 @@ module VmCloudHelper::TextualSummary
     textual_ems_custom_attributes
   end
 
-  def textual_group_compliance
-    %i(compliance_status compliance_history)
-  end
-
   def textual_group_power_management
     %i(power_state boot_time state_changed_on)
   end
@@ -270,17 +266,8 @@ module VmCloudHelper::TextualSummary
   end
 
   def textual_compliance_history
-    h = {:label => _("History")}
-    if @record.number_of(:compliances) == 0
-      h[:value] = _("Not Available")
-    else
-      h[:image] = "compliance"
-      h[:value] = _("Available")
-      h[:title] = _("Show Compliance History of this VM (Last 10 Checks)")
-      h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => 'compliance_history')
-    end
-    h
+    super(:title    => _("Show Compliance History of this VM (Last 10 Checks)"),
+          :explorer => true)
   end
 
   def textual_boot_time

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -75,10 +75,6 @@ module VmHelper::TextualSummary
     textual_ems_custom_attributes
   end
 
-  def textual_group_compliance
-    %i(compliance_status compliance_history)
-  end
-
   def textual_group_power_management
     %i(power_state boot_time state_changed_on)
   end
@@ -746,17 +742,8 @@ module VmHelper::TextualSummary
   end
 
   def textual_compliance_history
-    h = {:label => _("History")}
-    if @record.number_of(:compliances) == 0
-      h[:value] = _("Not Available")
-    else
-      h[:image] = "compliance"
-      h[:value] = _("Available")
-      h[:title] = _("Show Compliance History of this VM (Last 10 Checks)")
-      h[:explorer] = true
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => 'compliance_history')
-    end
-    h
+    super(:title    => _("Show Compliance History of this VM (Last 10 Checks)"),
+          :explorer => true)
   end
 
   def textual_boot_time

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -1,4 +1,5 @@
 class ContainerGroup < ApplicationRecord
+  include ComplianceMixin
   include CustomAttributeMixin
   include MiqPolicyMixin
   include NewWithTypeStiMixin

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -1,4 +1,5 @@
 class ContainerNode < ApplicationRecord
+  include ComplianceMixin
   include MiqPolicyMixin
   include NewWithTypeStiMixin
 

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -1,4 +1,5 @@
 class ContainerReplicator < ApplicationRecord
+  include ComplianceMixin
   include CustomAttributeMixin
   include MiqPolicyMixin
 

--- a/app/views/container_group/_main.html.haml
+++ b/app/views/container_group/_main.html.haml
@@ -8,6 +8,8 @@
                                                                :items => textual_container_node_selectors}
     = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Volumes"),
                                                                           :items => textual_group_volumes}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Compliance"),
+                                                               :items => textual_group_compliance}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                                :items => textual_group_relationships}

--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -10,5 +10,7 @@
         = render(:partial => "layouts/performance")
         :javascript
             var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    - when "compliance_history"
+        = render :partial => "shared/views/#{@showtype}"
     - else
         = render :partial => @showtype

--- a/app/views/container_node/_main.html.haml
+++ b/app/views/container_node/_main.html.haml
@@ -4,6 +4,8 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Labels"),
                                                                :items => textual_group_container_labels}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Compliance"),
+                                                               :items => textual_group_compliance}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
     = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Conditions"), :items => textual_group_conditions}

--- a/app/views/container_node/show.html.haml
+++ b/app/views/container_node/show.html.haml
@@ -9,5 +9,7 @@
   = render(:partial => "layouts/performance")
   :javascript
     var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+- elsif @showtype == "compliance_history"
+  = render :partial => "shared/views/#{@showtype}"
 - else
   = render :partial => @showtype

--- a/app/views/container_replicator/_main.html.haml
+++ b/app/views/container_replicator/_main.html.haml
@@ -4,7 +4,7 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Labels"), :items => textual_group_container_labels}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Selector"), :items => textual_group_container_selectors}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Compliance"), :items => textual_group_compliance}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}
-

--- a/app/views/container_replicator/show.html.haml
+++ b/app/views/container_replicator/show.html.haml
@@ -8,5 +8,7 @@
     = render(:partial => "layouts/performance")
     :javascript
         var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+- elsif @showtype == "compliance_history"
+    = render :partial => "shared/views/#{@showtype}"
 - else
     = render :partial => @showtype


### PR DESCRIPTION
Purpose or Intent
-----------------
#9813 adds ability to define replicator/pods/nodes compliance policies but the results are mostly invisible; this PR allows seeing compliance status & history on these entities' views.

Should be safe (though not very useful) to merge before of #9813.

First commit refactors nearly-duplicated methods.
If you prefer less refactoring in darga, let me know and I'll copy-paste here and follow with a darga/no refactor.

## Replicators
![screenshot-localhost 3000 2016-07-18 17-31-33 repl compliance](https://cloud.githubusercontent.com/assets/273688/16989301/5bc1ef52-4e9c-11e6-9a4d-7cb5b347e4e6.png)
![screenshot-localhost 3000 2016-07-20 16-50-48 repl complaince avail](https://cloud.githubusercontent.com/assets/273688/16989305/626081d4-4e9c-11e6-962b-41ffbe8b3e7c.png)
![screenshot-localhost 3000 2016-07-20 16-51-47 repl compliance history](https://cloud.githubusercontent.com/assets/273688/16989309/679a19a8-4e9c-11e6-951e-24bfa709ace5.png)

## Pods
![screenshot-localhost 3000 2016-07-20 16-43-02 pod compliance avail](https://cloud.githubusercontent.com/assets/273688/16989460/fe14ccca-4e9c-11e6-9462-a5ffde2892fd.png)
![screenshot-localhost 3000 2016-07-20 16-44-17 pod compliance history](https://cloud.githubusercontent.com/assets/273688/16989463/02937152-4e9d-11e6-918f-974f1fda2073.png)

## Nodes
![screenshot from 2016-07-20 16-47-16 node compliance avail](https://cloud.githubusercontent.com/assets/273688/16989482/0b2b1536-4e9d-11e6-9c9b-2ac1531ddad1.png)
![screenshot-localhost 3000 2016-07-20 16-48-25 node compliance history](https://cloud.githubusercontent.com/assets/273688/16989489/10da55f0-4e9d-11e6-88e3-87b875456aef.png)

Breadcrumbs are messed up in some screenshots as I directly navigated by editing the URL.

The "Status" lines have title like »Show Details of Compliance Check on Wed Jul 13 14:02:36 UTC 2016« and lead to a similar history screen showing only 1 check.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1341253 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1346057 (darga)

@miq-bot add-labels providers/containers, ui, darga/yes
