### PR TITLE
Fix an issue with provisioning where the single filter got auto-selected as the default.

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -306,21 +306,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     fields(:hardware) { |fn, f, _dn, _d| f[:read_only] = true if options[:read_only_fields].include?(fn) }
   end
 
-  def set_default_values
-    super
-    set_default_filters
-  end
-
-  def set_default_filters
-    [[:requester, :vm_filter, :Vm], [:environment, :host_filter, :Host], [:environment, :ds_filter, :Storage], [:environment, :cluster_filter, :EmsCluster]].each do |dialog, field, model|
-      filter = @dialogs.fetch_path(:dialogs, dialog, :fields, field)
-      unless filter.nil?
-        current_filter = get_value(@values[field])
-        filter[:default] = current_filter.nil? ? @requester.settings.fetch_path(:default_search, model) : current_filter
-      end
-    end
-  end
-
   #
   # Methods for populating lists of allowed values for a field
   # => Input  - A hash containing options specific to the called method

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -148,11 +148,6 @@ class MiqRequestWorkflow
 
         if !field_values[:default].nil?
           val = field_values[:default]
-
-        # if default is not set to anything and there is only one value in hash,
-        # use set element to be displayed default
-        elsif field_values[:values] && field_values[:values].length == 1
-          val = field_values[:values].first[0]
         end
 
         if field_values[:values]


### PR DESCRIPTION
Purpose or Intent
-----------------
Method get_field sets the default based on the value of auto_select_single and that result should not be overwritten by init_from_dialog.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1350115

Steps for Testing/QA
--------------------
1. Create a cluster filter, make sure this is the only one filter for cluster
2. Provision a VMware VM
3. Check on Environment tab, make sure no cluster filter is auto-selected.