### PR TITLE
Moved restful controller check into a mixin in helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -756,6 +756,7 @@ module ApplicationHelper
   def _toolbar_chooser
     ToolbarChooser.new(
       self,
+      binding,
       :alert_profiles => @alert_profiles,
       :button_group   => @button_group,
       :conditions     => @conditions,
@@ -770,6 +771,7 @@ module ApplicationHelper
       :record         => @record,
       :report         => @report,
       :sb             => @sb,
+      :showtype       => @showtype,
       :tabform        => @tabform,
       :view           => @view,
       :center_toolbar => @center_toolbar

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1,5 +1,7 @@
 class ApplicationHelper::ToolbarBuilder
   include MiqAeClassHelper
+  include RestfulControllerMixin
+
   def call(toolbar_name)
     build_toolbar(toolbar_name)
   end
@@ -1449,21 +1451,6 @@ class ApplicationHelper::ToolbarBuilder
     return true if id == "view_topology" && @showtype == "topology"
     return true if id == "view_summary" && @showtype == "main"
     false
-  end
-
-  def controller_restful?
-    # want to be able to cache false, so no ||=
-    return @_restful_cache unless @_restful_cache.nil?
-
-    @_restful_cache = (
-      obj = @view_binding.receiver
-
-      if obj.respond_to? :controller
-        obj.controller.try(:restful?)
-      else
-        obj.try(:restful?)
-      end
-    )
   end
 
   def url_for_button(name, url_tpl, controller_restful)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -1,4 +1,6 @@
 class ApplicationHelper::ToolbarChooser
+  include RestfulControllerMixin
+
   # Return a blank tb if a placeholder is needed for AJAX explorer screens, return nil if no center toolbar to be shown
   def center_toolbar_filename
     if @explorer
@@ -44,7 +46,7 @@ class ApplicationHelper::ToolbarChooser
     elsif !%w(all_tasks all_ui_tasks timeline diagnostics my_tasks my_ui_tasks miq_server usage).include?(@layout) &&
           (!@layout.starts_with?("miq_request")) && !@treesize_buttons &&
           @display == "main" && @showtype == "main" && !@in_a_form
-      @view_context.send(:restful?) ? "summary_view_restful_tb" : "summary_view_tb"
+      controller_restful? ? "summary_view_restful_tb" : "summary_view_tb"
     else
       'blank_view_tb'
     end
@@ -55,8 +57,9 @@ class ApplicationHelper::ToolbarChooser
   delegate :session, :from_cid, :x_node, :x_active_tree, :super_admin_user?, :render_gtl_view_tb?, :x_gtl_view_tb_render?,
            :to => :@view_context
 
-  def initialize(view_context, instance_data)
+  def initialize(view_context, view_binding, instance_data)
     @view_context = view_context
+    @view_binding = view_binding
 
     instance_data.each do |name, value|
       instance_variable_set(:"@#{name}", value)

--- a/app/helpers/restful_controller_mixin.rb
+++ b/app/helpers/restful_controller_mixin.rb
@@ -1,0 +1,9 @@
+module RestfulControllerMixin
+  def controller_restful?
+    # want to be able to cache false, so no ||=
+    return @_restful_cache unless @_restful_cache.nil?
+
+    obj = @view_binding.receiver
+    @_restful_cache = obj.respond_to?(:controller) ? obj.controller.try(:restful?) : obj.try(:restful?)
+  end
+end


### PR DESCRIPTION
@showtype should also be passed in to ToolbarChooser.new call. Due to @showtype not being passed in @view_context.send(:restful?) was not getting called at all, after @showtype was passed in @view_context.send(:restful?) call was throwing an error, to fix the error moved restful controller check from toolbar_builder into a mixin so it can be used from other places such as toolbar_chooser to determine which summary_view_tb should be rendered.

https://bugzilla.redhat.com/show_bug.cgi?id=1358449

@martinpovolny please review.