### PR TITLE
Improve database configuration error handling in appliance_console_cli

### DIFF
--- a/gems/pending/appliance_console/cli.rb
+++ b/gems/pending/appliance_console/cli.rb
@@ -177,7 +177,10 @@ module ApplianceConsole
       # initdb, relabel log directory for selinux, update configs,
       # start pg, create user, create db update the rails configuration,
       # verify, set up the database with region. activate does it all!
-      config.activate
+      unless config.activate
+        say "Failed to configure internal database"
+        return
+      end
 
       # enable/start related services
       config.post_activation
@@ -195,7 +198,10 @@ module ApplianceConsole
       }.delete_if { |_n, v| v.nil? })
 
       # call create_or_join_region (depends on region value)
-      config.activate
+      unless config.activate
+        say "Failed to configure external database"
+        return
+      end
 
       # enable/start related services
       config.post_activation


### PR DESCRIPTION
Before this change, if we failed to "activate" the configuration for an internal or external database, we would still attempt to start the services using post_activation

This change will prevent us from starting the services when we know they will fail because the database hasn't been properly configured.

This is loosely related to https://bugzilla.redhat.com/show_bug.cgi?id=1347834
This PR will improve the error case that was hit in the BZ, but really the use case described is probably "not a bug". This addresses the feedback described in [comment 4](https://bugzilla.redhat.com/show_bug.cgi?id=1347834#c4)