### PR TITLE
dont munge logging for simulate queue

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -19,7 +19,6 @@ module Vmdb
     # Development helper method for Rails console for simulating queue workers.
     def simulate_queue_worker(break_on_complete = false)
       raise NotImplementedError, "not implemented in production mode" if Rails.env.production?
-      Rails.logger.level = 0
       loop do
         q = MiqQueue.where(MiqQueue.arel_table[:queue_name].not_eq("miq_server")).order(:id).first
         if q


### PR DESCRIPTION

Don't set rails to debug when simulating the queue.
The user often wants to be in debug mode
But that will have already been set for other means.

---

I (rarely) need to turn off sql logging in my environment when running the queue.
And I can do this as a one off.

But I wouldn't expect running the queue to modify my logging preferences.
And most developers have their desired logging configured before calling this
method

I can appreciate closing or merging.