### PR TITLE
simulate_queue_worker - pass number of runs

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -28,6 +28,7 @@ module Vmdb
         else
           break_on_complete ? break : sleep(1.second)
         end
+        break if break_on_complete.kind_of?(Integer) && (break_on_complete -= 1) <= 0
       end
     end
   end


### PR DESCRIPTION
When running `simulate_queue_worker` to exercise the
queue, sometimes it is advantageous
to only run for a fixed number of iterations.

This allows a developer to pass in `true`, `false`, or nothing, as it did before.
But if a developer passes in 5, it will run the queue up to 5 times.

/cc @Fryguy @jrafanie you may have an opinion here