### PR TITLE
Automate IoLogger

### DIFF
--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -16,6 +16,7 @@ module MiqAeEngine
       svc.inputs     = inputs
       svc.preamble   = method_preamble(drb_uri, svc.object_id)
       svc.body       = body
+      svc.logger     = $miq_ae_logger
 
       yield [svc.preamble, svc.body, RUBY_METHOD_POSTSCRIPT]
     ensure
@@ -101,6 +102,11 @@ begin
   $evm = $evmdrb.find(MIQ_ID)
   raise AutomateMethodException,"Cannot find Service for id=\#{MIQ_ID} and uri=\#{MIQ_URI}" if $evm.nil?
   MIQ_ARGS = $evm.inputs
+
+  # Setup stdout and stderr to go through the logger on the MiqAeService instance ($evm)
+  silence_warnings { STDOUT = $stdout = $evm.stdout ; nil}
+  silence_warnings { STDERR = $stderr = $evm.stderr ; nil}
+
 rescue Exception => err
   STDERR.puts('The following error occurred during inline method preamble evaluation:')
   STDERR.puts("  \#{err.class}: \#{err.message}")

--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -11,12 +11,8 @@ module MiqAeEngine
     def with_server(inputs, body)
       setup if num_methods == 0
       self.num_methods += 1
-
-      svc = MiqAeMethodService::MiqAeService.new(@workspace)
-      svc.inputs     = inputs
-      svc.preamble   = method_preamble(drb_uri, svc.object_id)
-      svc.body       = body
-      svc.logger     = $miq_ae_logger
+      svc = MiqAeMethodService::MiqAeService.new(@workspace, inputs, body)
+      svc.preamble = method_preamble(drb_uri, svc.object_id)
 
       yield [svc.preamble, svc.body, RUBY_METHOD_POSTSCRIPT]
     ensure

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -21,6 +21,8 @@ module MiqAeMethodService
     include MiqAeMethodService::MiqAeServiceModelLegacy
     include MiqAeMethodService::MiqAeServiceVmdb
 
+    attr_accessor :logger
+
     @@id_hash = {}
     @@current = []
 
@@ -50,6 +52,14 @@ module MiqAeMethodService
       @body                  = []
       @persist_state_hash    = ws.persist_state_hash
       self.class.add(self)
+    end
+
+    def stdout
+      @stdout ||= Vmdb::Loggers::IoLogger.new(logger, :info, "Method STDOUT:")
+    end
+
+    def stderr
+      @stderr ||= Vmdb::Loggers::IoLogger.new(logger, :error, "Method STDERR:")
     end
 
     def destroy

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -44,13 +44,15 @@ module MiqAeMethodService
       @@current.delete(obj)
     end
 
-    def initialize(ws)
+    def initialize(ws, inputs = {}, body = nil, logger = $miq_ae_logger)
       @drb_server_references = []
-      @inputs                = {}
+      @inputs                = inputs
       @workspace             = ws
       @preamble_lines        = 0
       @body                  = []
+      self.body              = body if body
       @persist_state_hash    = ws.persist_state_hash
+      @logger                = logger
       self.class.add(self)
     end
 

--- a/lib/vmdb/loggers/io_logger.rb
+++ b/lib/vmdb/loggers/io_logger.rb
@@ -1,0 +1,31 @@
+module Vmdb::Loggers
+  class IoLogger < StringIO
+    def initialize(logger, level = :info, prefix = nil)
+      @logger = logger
+      @level  = level
+      @prefix = prefix
+      super()
+    end
+
+    def write(string)
+      @buffer ||= ""
+      @buffer << string
+      dump_buffer if string.include?("\n")
+    end
+
+    def <<(string)
+      write(string)
+    end
+
+    private
+
+    def dump_buffer
+      @buffer.each_line do |l|
+        next if l.empty?
+        line = [@prefix, l].join(" ").strip
+        @logger.send(@level, line)
+      end
+      @buffer = nil
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
@@ -1,0 +1,66 @@
+describe MiqAeEngine::MiqAeMethod do
+  context ".invoke_inline_ruby" do
+    it "writes to the logger immediately" do
+      script = <<-EOS
+        puts 'Hi from puts'
+        STDOUT.puts 'Hi from STDOUT.puts'
+        $stdout.puts 'Hi from $stdout.puts'
+        STDERR.puts 'Hi from STDERR.puts'
+        $stderr.puts 'Hi from $stderr.puts'
+        $evm.logger.sleep
+      EOS
+
+      workspace = Class.new do
+        attr_accessor :invoker
+
+        def persist_state_hash
+        end
+      end.new
+
+      logger_klass = Class.new do
+        attr_reader :expected_messages
+
+        def initialize
+          @expected_messages = [
+            "Method STDOUT: Hi from puts",
+            "Method STDOUT: Hi from STDOUT.puts",
+            "Method STDOUT: Hi from $stdout.puts",
+            "Method STDERR: Hi from STDERR.puts",
+            "Method STDERR: Hi from $stderr.puts",
+          ]
+        end
+
+        def sleep
+          # Raise if all messages have not already been written before a method like sleep runs.
+          raise unless expected_messages == []
+        end
+
+        def verify_next_message(message)
+          expected = @expected_messages.shift
+          return if message == expected
+          puts "Expected: #{expected.inspect}, Got: #{message.inspect}"
+          raise
+        end
+        alias_method :error, :verify_next_message
+        alias_method :info,  :verify_next_message
+      end
+
+      aem         = double("AEM", :data => script, :fqname => "fqname")
+      inputs      = []
+      logger_stub = logger_klass.new
+      obj         = double("OBJ", :workspace => workspace)
+      svc         = MiqAeMethodService::MiqAeService.new(workspace, inputs, aem.data, logger_stub)
+
+      expect(MiqAeMethodService::MiqAeService).to receive(:new).with(workspace, inputs, aem.data).and_return(svc)
+
+      expect($miq_ae_logger).to receive(:info).with("<AEMethod [fqname]> Starting ").ordered
+      expect(logger_stub).to    receive(:sleep).and_call_original.ordered
+      expect($miq_ae_logger).to receive(:info).with("<AEMethod [fqname]> Ending").ordered
+      expect($miq_ae_logger).to receive(:info).with("Method exited with rc=MIQ_OK").ordered
+
+      expect(described_class.invoke_inline_ruby(aem, obj, inputs)).to eq(0)
+
+      expect(logger_stub.expected_messages).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Replace stdout and stderr thread listeners with an IO object that will write to the logger of choice directly.  Redirect stdout and stderr to those loggers.