### PR TITLE
Remove support for date/time with =/!= expressions

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1600,15 +1600,7 @@ class MiqExpression
     case operator.downcase
     when "equal", "="
       field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil).to_date
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil).utc
-              else
-                exp[operator]["value"]
-              end
-      field.eq(value)
+      field.eq(exp[operator]["value"])
     when ">", "after"
       field = Field.parse(exp[operator]["field"])
       value = case
@@ -1655,15 +1647,7 @@ class MiqExpression
       field.lteq(value)
     when "!="
       field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], "UTC", mode = nil).to_date
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, mode = nil).utc
-              else
-                exp[operator]["value"]
-              end
-      field.not_eq(value)
+      field.not_eq(exp[operator]["value"])
     when "like", "includes"
       field = Field.parse(exp[operator]["field"])
       field.matches("%#{exp[operator]["value"]}%")

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -187,16 +187,6 @@ describe MiqExpression do
     end
 
     context "date/time support" do
-      it "generates the SQL for an EQUAL expression with a datetime field" do
-        sql, * = MiqExpression.new("EQUAL" => {"field" => "Vm-boot_time", "value" => "2016-01-01"}).to_sql
-        expect(sql).to eq("\"vms\".\"boot_time\" = '2016-01-01 00:00:00'")
-      end
-
-      it "generates the SQL for a = expression with a datetime field" do
-        sql, * = MiqExpression.new("=" => {"field" => "Vm-boot_time", "value" => "2016-01-01"}).to_sql
-        expect(sql).to eq("\"vms\".\"boot_time\" = '2016-01-01 00:00:00'")
-      end
-
       it "generates the SQL for a = expression with a date field" do
         sql, * = described_class.new("=" => {"field" => "Vm-retires_on", "value" => "2016-01-01"}).to_sql
         expect(sql).to eq(%q("vms"."retires_on" = '2016-01-01'))
@@ -263,11 +253,6 @@ describe MiqExpression do
       it "generates the SQL for a != expression with a date field" do
         sql, * = described_class.new("!=" => {"field" => "Vm-retires_on", "value" => "2016-01-01"}).to_sql
         expect(sql).to eq(%q("vms"."retires_on" != '2016-01-01'))
-      end
-
-      it "generates the SQL for a != expression with a datetime field" do
-        sql, * = described_class.new("!=" => {"field" => "Vm-last_scan_on", "value" => "2016-01-01"}).to_sql
-        expect(sql).to eq(%q("vms"."last_scan_on" != '2016-01-01 00:00:00'))
       end
 
       it "generates the SQL for an IS expression" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Currently if an =/!= expression is passed a relative datetime ("Today",
"Yesterday", etc.) it will error out because it is passing a mode of
`nil` to RelativeDatetime, which is not supported.

When selecting a date or datetime field from the UI the only operators
that are supported are IS, BEFORE, AFTER, FROM, IS EMPTY and IS NOT
EMPTY. Since neither = nor != are supported in the UI, support in the
back end can be removed which not only helps in simplifying the code,
but will circumvent the need to fix this bug.

@miq-bot add-label core
@miq-bot assign @gtanzillo 
:fire: :scissors: :fire: 