### PR TITLE
only add middleware if have google

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,8 +1,10 @@
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"],
-           :scope => 'https://www.googleapis.com/auth/compute,' \
-             'https://www.googleapis.com/auth/devstorage.read_only,' \
-             'https://www.googleapis.com/auth/logging.write,' \
-             'https://www.googleapis.com/auth/cloud-platform,' \
-             'email,profile'
+if ENV["GOOGLE_CLIENT_SECRET"]
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"],
+             :scope => 'https://www.googleapis.com/auth/compute,' \
+               'https://www.googleapis.com/auth/devstorage.read_only,' \
+               'https://www.googleapis.com/auth/logging.write,' \
+               'https://www.googleapis.com/auth/cloud-platform,' \
+               'email,profile'
+  end
 end


### PR DESCRIPTION
This code is throwing errors when I do not have the google environment variables set.
While I think the error may be due to something else, it seems this middleware is not necessary without a valid google id/secret

Original change: #4521

/cc @lwander does this change make sense to you?
