### PR TITLE
Refactor: Widget and report editors should share pivotby (groupby) related code

### DIFF
--- a/app/controllers/report_controller/pivot_options.rb
+++ b/app/controllers/report_controller/pivot_options.rb
@@ -61,4 +61,18 @@ class ReportController
       end
     end
   end
+
+  def drop_from_selection(item)
+    # Compress the pivotby fields if being moved left
+    if item == by1
+      self.by1 = by2
+      self.by2 = by3
+      self.by3 = NOTHING_STRING
+    elsif item == by2
+      self.by2 = by3
+      self.by3 = NOTHING_STRING
+    elsif item == by3
+      self.by3 = NOTHING_STRING
+    end
+  end
 end

--- a/app/controllers/report_controller/pivot_options.rb
+++ b/app/controllers/report_controller/pivot_options.rb
@@ -1,6 +1,10 @@
 class ReportController
   # For groupby fields in repor
   PivotOptions = Struct.new(:by1, :by2, :by3, :by4) do
+    def initialize(by1 = NOTHING_STRING, by2 = NOTHING_STRING, by3 = NOTHING_STRING, by4 = NOTHING_STRING)
+      super
+    end
+
     def options=(options)
       @opts = {1 => options}
     end

--- a/app/controllers/report_controller/pivot_options.rb
+++ b/app/controllers/report_controller/pivot_options.rb
@@ -24,5 +24,41 @@ class ReportController
     def options4
       @opts[4] ||= options3.reject { |g| g[1] == by3 }
     end
+
+    def update(params)
+      if params[:chosen_pivot1] && params[:chosen_pivot1] != by1
+        self.by1 = params[:chosen_pivot1]
+        if params[:chosen_pivot1] == NOTHING_STRING
+          self.by2 = NOTHING_STRING
+          self.by3 = NOTHING_STRING
+          self.by4 = NOTHING_STRING
+        elsif params[:chosen_pivot1] == by2
+          self.by2 = by3
+          self.by3 = by4
+          self.by4 = NOTHING_STRING
+        elsif params[:chosen_pivot1] == by3
+          self.by3 = by4
+          self.by4 = NOTHING_STRING
+        end
+      elsif params[:chosen_pivot2] && params[:chosen_pivot2] != by2
+        self.by2 = params[:chosen_pivot2]
+        if params[:chosen_pivot2] == NOTHING_STRING
+          self.by3 = NOTHING_STRING
+          self.by4 = NOTHING_STRING
+        elsif params[:chosen_pivot2] == by3
+          self.by3 = by4
+          self.by4 = NOTHING_STRING
+        elsif params[:chosen_pivot2] == by4
+          self.by4 = NOTHING_STRING
+        end
+      elsif params[:chosen_pivot3] && params[:chosen_pivot3] != by3
+        self.by3 = params[:chosen_pivot3]
+        if params[:chosen_pivot3] == NOTHING_STRING || params[:chosen_pivot3] == by4
+          self.by4 = NOTHING_STRING
+        end
+      elsif params[:chosen_pivot4]
+        self.by4 = params[:chosen_pivot4]
+      end
+    end
   end
 end

--- a/app/controllers/report_controller/pivot_options.rb
+++ b/app/controllers/report_controller/pivot_options.rb
@@ -1,0 +1,4 @@
+class ReportController
+  # For groupby fields in repor
+  PivotOptions = Struct.new(:by1, :by2, :by3, :by4)
+end

--- a/app/controllers/report_controller/pivot_options.rb
+++ b/app/controllers/report_controller/pivot_options.rb
@@ -1,4 +1,24 @@
 class ReportController
   # For groupby fields in repor
-  PivotOptions = Struct.new(:by1, :by2, :by3, :by4)
+  PivotOptions = Struct.new(:by1, :by2, :by3, :by4) do
+    def options=(options)
+      @opts = {1 => options}
+    end
+
+    def options1
+      @opts[1]
+    end
+
+    def options2
+      @opts[2] ||= options1.reject { |g| g[1] == by1 }
+    end
+
+    def options3
+      @opts[3] ||= options2.reject { |g| g[1] == by2 }
+    end
+
+    def options4
+      @opts[4] ||= options3.reject { |g| g[1] == by3 }
+    end
+  end
 end

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -335,9 +335,6 @@ module ReportController::Reports::Editor
     @edit[:new][:fields]          = []                    # Clear fields array
     @edit[:new][:headers]         = {}                  # Clear headers hash
     @edit[:new][:pivot]           = ReportController::PivotOptions.new
-    @edit[:new][:pivot].by1       = NOTHING_STRING      # Clear consolidate group fields
-    @edit[:new][:pivot].by2       = NOTHING_STRING
-    @edit[:new][:pivot].by3       = NOTHING_STRING
     @edit[:new][:sortby1]         = NOTHING_STRING      # Clear sort fields
     @edit[:new][:sortby2]         = NOTHING_STRING
     @edit[:new][:filter_operator] = nil
@@ -1642,9 +1639,6 @@ module ReportController::Reports::Editor
     @edit[:new][:sortby1]  = NOTHING_STRING # Initialize sortby fields to nothing
     @edit[:new][:sortby2]  = NOTHING_STRING
     @edit[:new][:pivot] = ReportController::PivotOptions.new
-    @edit[:new][:pivot].by1 = NOTHING_STRING # Initialize groupby fields to nothing
-    @edit[:new][:pivot].by2 = NOTHING_STRING
-    @edit[:new][:pivot].by3 = NOTHING_STRING
     if params[:pressed] == "miq_report_new"
       @edit[:new][:fields]      = []
       @edit[:new][:categories]  = []

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -937,16 +937,7 @@ module ReportController::Reports::Editor
           @edit[:new][:col_formats].delete_if { |k, _v| k.starts_with?("#{nf.last}__") } # Delete pivot calc keys
 
           # Clear out pivot field options
-          if nf.last == @edit[:new][:pivot].by1              # Compress the pivotby fields if being moved left
-            @edit[:new][:pivot].by1 = @edit[:new][:pivot].by2
-            @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
-            @edit[:new][:pivot].by3 = NOTHING_STRING
-          elsif nf.last == @edit[:new][:pivot].by2
-            @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
-            @edit[:new][:pivot].by3 = NOTHING_STRING
-          elsif nf.last == @edit[:new][:pivot].by3
-            @edit[:new][:pivot].by3 = NOTHING_STRING
-          end
+          @edit[:new][:pivot].drop_from_selection(nf.last)
           @edit[:pivot_cols].delete(nf.last)          # Delete the column name from the pivot_cols hash
 
           # Clear out sort options

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -170,9 +170,7 @@ module ReportController::Reports::Editor
 
     when "8"  # Consolidate
       # Build group chooser arrays
-      @pivots1  = @edit[:new][:fields].dup
-      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by1 }
-      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by2 }
+      @edit[:new][:pivot].options = @edit[:new][:fields].dup
       @pivotby1 = @edit[:new][:pivot].by1
       @pivotby2 = @edit[:new][:pivot].by2
       @pivotby3 = @edit[:new][:pivot].by3

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -171,9 +171,7 @@ module ReportController::Reports::Editor
     when "8"  # Consolidate
       # Build group chooser arrays
       @edit[:new][:pivot].options = @edit[:new][:fields].dup
-      @pivotby1 = @edit[:new][:pivot].by1
-      @pivotby2 = @edit[:new][:pivot].by2
-      @pivotby3 = @edit[:new][:pivot].by3
+      @pivot = @edit[:new][:pivot]
     when "2"  # Formatting
     #     @edit[:calc_xml] = build_calc_combo_xml                                     # Get the combobox XML for any numeric fields
 

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -724,25 +724,7 @@ module ReportController::Reports::Editor
 
   def gfv_pivots
     @edit[:new][:pivot] ||= ReportController::PivotOptions.new
-    if params[:chosen_pivot1] && params[:chosen_pivot1] != @edit[:new][:pivot].by1
-      @edit[:new][:pivot].by1 = params[:chosen_pivot1]
-      if params[:chosen_pivot1] == NOTHING_STRING
-        @edit[:new][:pivot].by2 = NOTHING_STRING
-        @edit[:new][:pivot].by3 = NOTHING_STRING
-      elsif params[:chosen_pivot1] == @edit[:new][:pivot].by2
-        @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
-        @edit[:new][:pivot].by3 = NOTHING_STRING
-      elsif params[:chosen_pivot1] == @edit[:new][:pivot].by3
-        @edit[:new][:pivot].by3 = NOTHING_STRING
-      end
-    elsif params[:chosen_pivot2] && params[:chosen_pivot2] != @edit[:new][:pivot].by2
-      @edit[:new][:pivot].by2 = params[:chosen_pivot2]
-      if params[:chosen_pivot2] == NOTHING_STRING || params[:chosen_pivot2] == @edit[:new][:pivot].by3
-        @edit[:new][:pivot].by3 = NOTHING_STRING
-      end
-    elsif params[:chosen_pivot3] && params[:chosen_pivot3] != @edit[:new][:pivot].by3
-      @edit[:new][:pivot].by3 = params[:chosen_pivot3]
-    end
+    @edit[:new][:pivot].update(params)
     if params[:chosen_pivot1] || params[:chosen_pivot2] || params[:chosen_pivot3]
       if @edit[:new][:pivot].by1 == NOTHING_STRING
         @edit[:pivot_cols] = {}                       # Clear pivot_cols if no pivot grouping fields selected

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -171,11 +171,11 @@ module ReportController::Reports::Editor
     when "8"  # Consolidate
       # Build group chooser arrays
       @pivots1  = @edit[:new][:fields].dup
-      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivotby1] }
-      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivotby2] }
-      @pivotby1 = @edit[:new][:pivotby1]
-      @pivotby2 = @edit[:new][:pivotby2]
-      @pivotby3 = @edit[:new][:pivotby3]
+      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by1 }
+      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by2 }
+      @pivotby1 = @edit[:new][:pivot].by1
+      @pivotby2 = @edit[:new][:pivot].by2
+      @pivotby3 = @edit[:new][:pivot].by3
     when "2"  # Formatting
     #     @edit[:calc_xml] = build_calc_combo_xml                                     # Get the combobox XML for any numeric fields
 
@@ -338,9 +338,10 @@ module ReportController::Reports::Editor
   def reset_report_col_fields
     @edit[:new][:fields]          = []                    # Clear fields array
     @edit[:new][:headers]         = {}                  # Clear headers hash
-    @edit[:new][:pivotby1]        = NOTHING_STRING      # Clear consolidate group fields
-    @edit[:new][:pivotby2]        = NOTHING_STRING
-    @edit[:new][:pivotby3]        = NOTHING_STRING
+    @edit[:new][:pivot]           = ReportController::PivotOptions.new
+    @edit[:new][:pivot].by1       = NOTHING_STRING      # Clear consolidate group fields
+    @edit[:new][:pivot].by2       = NOTHING_STRING
+    @edit[:new][:pivot].by3       = NOTHING_STRING
     @edit[:new][:sortby1]         = NOTHING_STRING      # Clear sort fields
     @edit[:new][:sortby2]         = NOTHING_STRING
     @edit[:new][:filter_operator] = nil
@@ -729,32 +730,33 @@ module ReportController::Reports::Editor
   end
 
   def gfv_pivots
-    if params[:chosen_pivot1] && params[:chosen_pivot1] != @edit[:new][:pivotby1]
-      @edit[:new][:pivotby1] = params[:chosen_pivot1]
+    @edit[:new][:pivot] ||= ReportController::PivotOptions.new
+    if params[:chosen_pivot1] && params[:chosen_pivot1] != @edit[:new][:pivot].by1
+      @edit[:new][:pivot].by1 = params[:chosen_pivot1]
       if params[:chosen_pivot1] == NOTHING_STRING
-        @edit[:new][:pivotby2] = NOTHING_STRING
-        @edit[:new][:pivotby3] = NOTHING_STRING
-      elsif params[:chosen_pivot1] == @edit[:new][:pivotby2]
-        @edit[:new][:pivotby2] = @edit[:new][:pivotby3]
-        @edit[:new][:pivotby3] = NOTHING_STRING
-      elsif params[:chosen_pivot1] == @edit[:new][:pivotby3]
-        @edit[:new][:pivotby3] = NOTHING_STRING
+        @edit[:new][:pivot].by2 = NOTHING_STRING
+        @edit[:new][:pivot].by3 = NOTHING_STRING
+      elsif params[:chosen_pivot1] == @edit[:new][:pivot].by2
+        @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
+        @edit[:new][:pivot].by3 = NOTHING_STRING
+      elsif params[:chosen_pivot1] == @edit[:new][:pivot].by3
+        @edit[:new][:pivot].by3 = NOTHING_STRING
       end
-    elsif params[:chosen_pivot2] && params[:chosen_pivot2] != @edit[:new][:pivotby2]
-      @edit[:new][:pivotby2] = params[:chosen_pivot2]
-      if params[:chosen_pivot2] == NOTHING_STRING || params[:chosen_pivot2] == @edit[:new][:pivotby3]
-        @edit[:new][:pivotby3] = NOTHING_STRING
+    elsif params[:chosen_pivot2] && params[:chosen_pivot2] != @edit[:new][:pivot].by2
+      @edit[:new][:pivot].by2 = params[:chosen_pivot2]
+      if params[:chosen_pivot2] == NOTHING_STRING || params[:chosen_pivot2] == @edit[:new][:pivot].by3
+        @edit[:new][:pivot].by3 = NOTHING_STRING
       end
-    elsif params[:chosen_pivot3] && params[:chosen_pivot3] != @edit[:new][:pivotby3]
-      @edit[:new][:pivotby3] = params[:chosen_pivot3]
+    elsif params[:chosen_pivot3] && params[:chosen_pivot3] != @edit[:new][:pivot].by3
+      @edit[:new][:pivot].by3 = params[:chosen_pivot3]
     end
     if params[:chosen_pivot1] || params[:chosen_pivot2] || params[:chosen_pivot3]
-      if @edit[:new][:pivotby1] == NOTHING_STRING
+      if @edit[:new][:pivot].by1 == NOTHING_STRING
         @edit[:pivot_cols] = {}                       # Clear pivot_cols if no pivot grouping fields selected
       else
-        @edit[:pivot_cols].delete(@edit[:new][:pivotby1])   # Remove any pivot grouping fields from pivot cols
-        @edit[:pivot_cols].delete(@edit[:new][:pivotby2])
-        @edit[:pivot_cols].delete(@edit[:new][:pivotby3])
+        @edit[:pivot_cols].delete(@edit[:new][:pivot].by1)   # Remove any pivot grouping fields from pivot cols
+        @edit[:pivot_cols].delete(@edit[:new][:pivot].by2)
+        @edit[:pivot_cols].delete(@edit[:new][:pivot].by3)
       end
       build_field_order
       @refresh_div = "consolidate_div"
@@ -960,15 +962,15 @@ module ReportController::Reports::Editor
           @edit[:new][:col_formats].delete_if { |k, _v| k.starts_with?("#{nf.last}__") } # Delete pivot calc keys
 
           # Clear out pivot field options
-          if nf.last == @edit[:new][:pivotby1]              # Compress the pivotby fields if being moved left
-            @edit[:new][:pivotby1] = @edit[:new][:pivotby2]
-            @edit[:new][:pivotby2] = @edit[:new][:pivotby3]
-            @edit[:new][:pivotby3] = NOTHING_STRING
-          elsif nf.last == @edit[:new][:pivotby2]
-            @edit[:new][:pivotby2] = @edit[:new][:pivotby3]
-            @edit[:new][:pivotby3] = NOTHING_STRING
-          elsif nf.last == @edit[:new][:pivotby3]
-            @edit[:new][:pivotby3] = NOTHING_STRING
+          if nf.last == @edit[:new][:pivot].by1              # Compress the pivotby fields if being moved left
+            @edit[:new][:pivot].by1 = @edit[:new][:pivot].by2
+            @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
+            @edit[:new][:pivot].by3 = NOTHING_STRING
+          elsif nf.last == @edit[:new][:pivot].by2
+            @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
+            @edit[:new][:pivot].by3 = NOTHING_STRING
+          elsif nf.last == @edit[:new][:pivot].by3
+            @edit[:new][:pivot].by3 = NOTHING_STRING
           end
           @edit[:pivot_cols].delete(nf.last)          # Delete the column name from the pivot_cols hash
 
@@ -1302,7 +1304,7 @@ module ReportController::Reports::Editor
     @edit[:new][:fields].each do |field_entry|          # Go thru all of the fields
       field = field_entry[1]                            # Get the encoded fully qualified field name
 
-      if @edit[:new][:pivotby1] != NOTHING_STRING && # If we are doing pivoting and
+      if @edit[:new][:pivot].by1 != NOTHING_STRING && # If we are doing pivoting and
          @edit[:pivot_cols].key?(field)              # this is a pivot calc column
         @edit[:pivot_cols][field].each do |calc_typ|    # Add header/format/col_order for each calc type
           rpt.headers.push(@edit[:new][:headers][field + "__#{calc_typ}"])
@@ -1380,11 +1382,11 @@ module ReportController::Reports::Editor
             rpt.sortby.push(table_field)              # Add the field to the sortby array
           end
 
-          if field == @edit[:new][:pivotby1]          # Save the group fields
+          if field == @edit[:new][:pivot].by1          # Save the group fields
             @pg1 = table_field
-          elsif field == @edit[:new][:pivotby2]
+          elsif field == @edit[:new][:pivot].by2
             @pg2 = table_field
-          elsif field == @edit[:new][:pivotby3]
+          elsif field == @edit[:new][:pivot].by3
             @pg3 = table_field
           end
         else                                          # Set up for the next embedded include hash
@@ -1405,11 +1407,11 @@ module ReportController::Reports::Editor
       elsif field == sortby2                          # Is this the second sort field?
         rpt.sortby.push(@edit[:new][:sortby2].split("-")[1])  # Add the field to the sortby array
       end
-      if field == @edit[:new][:pivotby1]          # Save the group fields
+      if field == @edit[:new][:pivot].by1          # Save the group fields
         @pg1 = field.split("-")[1]
-      elsif field == @edit[:new][:pivotby2]
+      elsif field == @edit[:new][:pivot].by2
         @pg2 = field.split("-")[1]
-      elsif field == @edit[:new][:pivotby3]
+      elsif field == @edit[:new][:pivot].by3
         @pg3 = field.split("-")[1]
       end
     end
@@ -1643,9 +1645,10 @@ module ReportController::Reports::Editor
     # build selected fields array from the report record
     @edit[:new][:sortby1]  = NOTHING_STRING # Initialize sortby fields to nothing
     @edit[:new][:sortby2]  = NOTHING_STRING
-    @edit[:new][:pivotby1] = NOTHING_STRING # Initialize groupby fields to nothing
-    @edit[:new][:pivotby2] = NOTHING_STRING
-    @edit[:new][:pivotby3] = NOTHING_STRING
+    @edit[:new][:pivot] = ReportController::PivotOptions.new
+    @edit[:new][:pivot].by1 = NOTHING_STRING # Initialize groupby fields to nothing
+    @edit[:new][:pivot].by2 = NOTHING_STRING
+    @edit[:new][:pivot].by3 = NOTHING_STRING
     if params[:pressed] == "miq_report_new"
       @edit[:new][:fields]      = []
       @edit[:new][:categories]  = []
@@ -1720,13 +1723,13 @@ module ReportController::Reports::Editor
          rpt.rpt_options[:pivot][:group_cols] &&
          rpt.rpt_options[:pivot][:group_cols].kind_of?(Array)
         if rpt.rpt_options[:pivot][:group_cols].length > 0
-          @edit[:new][:pivotby1] = field_key if col == rpt.rpt_options[:pivot][:group_cols][0]
+          @edit[:new][:pivot].by1 = field_key if col == rpt.rpt_options[:pivot][:group_cols][0]
         end
         if rpt.rpt_options[:pivot][:group_cols].length > 1
-          @edit[:new][:pivotby2] = field_key if col == rpt.rpt_options[:pivot][:group_cols][1]
+          @edit[:new][:pivot].by2 = field_key if col == rpt.rpt_options[:pivot][:group_cols][1]
         end
         if rpt.rpt_options[:pivot][:group_cols].length > 2
-          @edit[:new][:pivotby3] = field_key if col == rpt.rpt_options[:pivot][:group_cols][2]
+          @edit[:new][:pivot].by3 = field_key if col == rpt.rpt_options[:pivot][:group_cols][2]
         end
       end
 
@@ -1780,7 +1783,7 @@ module ReportController::Reports::Editor
   def build_field_order
     @edit[:new][:field_order] = []
     @edit[:new][:fields].each do |f|
-      if @edit[:new][:pivotby1] != NOTHING_STRING && # If we are doing pivoting and
+      if @edit[:new][:pivot] && @edit[:new][:pivot].by1 != NOTHING_STRING && # If we are doing pivoting and
          @edit[:pivot_cols].key?(f.last)             # this is a pivot calc column
         MiqReport::PIVOTS.each do |c|
           calc_typ = c.first

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -404,20 +404,21 @@ module ReportController::Widgets
     end
 
     if @sb[:wtype] == "r"
-      @pivotby1 = @edit[:new][:pivotby1] = NOTHING_STRING # Initialize groupby fields to nothing
-      @pivotby2 = @edit[:new][:pivotby2] = NOTHING_STRING
-      @pivotby3 = @edit[:new][:pivotby3] = NOTHING_STRING
-      @pivotby4 = @edit[:new][:pivotby4] = NOTHING_STRING
+      @edit[:new][:pivot] = ReportController::PivotOptions.new
+      @pivotby1 = @edit[:new][:pivot].by1 = NOTHING_STRING # Initialize groupby fields to nothing
+      @pivotby2 = @edit[:new][:pivot].by2 = NOTHING_STRING
+      @pivotby3 = @edit[:new][:pivot].by3 = NOTHING_STRING
+      @pivotby4 = @edit[:new][:pivot].by4 = NOTHING_STRING
       rpt = @widget.resource_id && @widget.resource_type == "MiqReport" ? @widget.resource_id : nil
       widget_set_column_vars(rpt)
-      @pivotby1 = @edit[:new][:pivotby1] = @widget.options[:col_order][0] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][0]
-      @pivotby2 = @edit[:new][:pivotby2] = @widget.options[:col_order][1] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][1]
-      @pivotby3 = @edit[:new][:pivotby3] = @widget.options[:col_order][2] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][2]
-      @pivotby4 = @edit[:new][:pivotby4] = @widget.options[:col_order][3] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][3]
+      @pivotby1 = @edit[:new][:pivot].by1 = @widget.options[:col_order][0] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][0]
+      @pivotby2 = @edit[:new][:pivot].by2 = @widget.options[:col_order][1] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][1]
+      @pivotby3 = @edit[:new][:pivot].by3 = @widget.options[:col_order][2] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][2]
+      @pivotby4 = @edit[:new][:pivot].by4 = @widget.options[:col_order][3] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][3]
       @pivots1  = @edit[:new][:fields].dup
-      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivotby1] }
-      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivotby2] }
-      @pivots4  = @pivots3.dup.delete_if { |g| g[1] == @edit[:new][:pivotby3] }
+      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by1 }
+      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by2 }
+      @pivots4  = @pivots3.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by3 }
       @edit[:new][:row_count] = @widget.row_count
     elsif @sb[:wtype] == "rf"
       @edit[:rss_feeds] = {}
@@ -505,10 +506,10 @@ module ReportController::Widgets
     if @sb[:wtype] == "r"
       if params[:filter_typ] || params[:subfilter_typ] || params[:repfilter_typ]
         # reset columns if report has changed
-        @edit[:new][:pivotby1] = NOTHING_STRING
-        @edit[:new][:pivotby2] = NOTHING_STRING
-        @edit[:new][:pivotby3] = NOTHING_STRING
-        @edit[:new][:pivotby4] = NOTHING_STRING
+        @edit[:new][:pivot].by1 = NOTHING_STRING
+        @edit[:new][:pivot].by2 = NOTHING_STRING
+        @edit[:new][:pivot].by3 = NOTHING_STRING
+        @edit[:new][:pivot].by4 = NOTHING_STRING
       end
       @edit[:new][:subfilter] = params[:subfilter_typ] if params[:subfilter_typ]
       if params[:repfilter_typ] && params[:repfilter_typ] != "<Choose>"
@@ -552,38 +553,38 @@ module ReportController::Widgets
 
     if @sb[:wtype] == "r"
       # Look at the pivot group field selectors
-      if params[:chosen_pivot1] && params[:chosen_pivot1] != @edit[:new][:pivotby1]
-        @edit[:new][:pivotby1] = params[:chosen_pivot1]
+      if params[:chosen_pivot1] && params[:chosen_pivot1] != @edit[:new][:pivot].by1
+        @edit[:new][:pivot].by1 = params[:chosen_pivot1]
         if params[:chosen_pivot1] == NOTHING_STRING
-          @edit[:new][:pivotby2] = NOTHING_STRING
-          @edit[:new][:pivotby3] = NOTHING_STRING
-          @edit[:new][:pivotby4] = NOTHING_STRING
-        elsif params[:chosen_pivot1] == @edit[:new][:pivotby2]
-          @edit[:new][:pivotby2] = @edit[:new][:pivotby3]
-          @edit[:new][:pivotby3] = @edit[:new][:pivotby4]
-          @edit[:new][:pivotby4] = NOTHING_STRING
-        elsif params[:chosen_pivot1] == @edit[:new][:pivotby3]
-          @edit[:new][:pivotby3] = @edit[:new][:pivotby4]
-          @edit[:new][:pivotby4] = NOTHING_STRING
+          @edit[:new][:pivot].by2 = NOTHING_STRING
+          @edit[:new][:pivot].by3 = NOTHING_STRING
+          @edit[:new][:pivot].by4 = NOTHING_STRING
+        elsif params[:chosen_pivot1] == @edit[:new][:pivot].by2
+          @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
+          @edit[:new][:pivot].by3 = @edit[:new][:pivot].by4
+          @edit[:new][:pivot].by4 = NOTHING_STRING
+        elsif params[:chosen_pivot1] == @edit[:new][:pivot].by3
+          @edit[:new][:pivot].by3 = @edit[:new][:pivot].by4
+          @edit[:new][:pivot].by4 = NOTHING_STRING
         end
-      elsif params[:chosen_pivot2] && params[:chosen_pivot2] != @edit[:new][:pivotby2]
-        @edit[:new][:pivotby2] = params[:chosen_pivot2]
+      elsif params[:chosen_pivot2] && params[:chosen_pivot2] != @edit[:new][:pivot].by2
+        @edit[:new][:pivot].by2 = params[:chosen_pivot2]
         if params[:chosen_pivot2] == NOTHING_STRING
-          @edit[:new][:pivotby3] = NOTHING_STRING
-          @edit[:new][:pivotby4] = NOTHING_STRING
-        elsif params[:chosen_pivot2] == @edit[:new][:pivotby3]
-          @edit[:new][:pivotby3] = @edit[:new][:pivotby4]
-          @edit[:new][:pivotby4] = NOTHING_STRING
-        elsif params[:chosen_pivot2] == @edit[:new][:pivotby4]
-          @edit[:new][:pivotby4] = NOTHING_STRING
+          @edit[:new][:pivot].by3 = NOTHING_STRING
+          @edit[:new][:pivot].by4 = NOTHING_STRING
+        elsif params[:chosen_pivot2] == @edit[:new][:pivot].by3
+          @edit[:new][:pivot].by3 = @edit[:new][:pivot].by4
+          @edit[:new][:pivot].by4 = NOTHING_STRING
+        elsif params[:chosen_pivot2] == @edit[:new][:pivot].by4
+          @edit[:new][:pivot].by4 = NOTHING_STRING
         end
-      elsif params[:chosen_pivot3] && params[:chosen_pivot3] != @edit[:new][:pivotby3]
-        @edit[:new][:pivotby3] = params[:chosen_pivot3]
-        if params[:chosen_pivot3] == NOTHING_STRING || params[:chosen_pivot3] == @edit[:new][:pivotby4]
-          @edit[:new][:pivotby4] = NOTHING_STRING
+      elsif params[:chosen_pivot3] && params[:chosen_pivot3] != @edit[:new][:pivot].by3
+        @edit[:new][:pivot].by3 = params[:chosen_pivot3]
+        if params[:chosen_pivot3] == NOTHING_STRING || params[:chosen_pivot3] == @edit[:new][:pivot].by4
+          @edit[:new][:pivot].by4 = NOTHING_STRING
         end
-      elsif params[:chosen_pivot4] && params[:chosen_pivot4] != @edit[:new][:pivotby4]
-        @edit[:new][:pivotby4] = params[:chosen_pivot4]
+      elsif params[:chosen_pivot4] && params[:chosen_pivot4] != @edit[:new][:pivot].by4
+        @edit[:new][:pivot].by4 = params[:chosen_pivot4]
       end
       if @edit[:new][:filter]
         @folders ||= []
@@ -592,13 +593,13 @@ module ReportController::Widgets
         widget_set_column_vars(rpt)
       end
       @pivots1  = @edit[:new][:fields].dup
-      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivotby1] }
-      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivotby2] }
-      @pivots4  = @pivots3.dup.delete_if { |g| g[1] == @edit[:new][:pivotby3] }
-      @pivotby1 = @edit[:new][:pivotby1]
-      @pivotby2 = @edit[:new][:pivotby2]
-      @pivotby3 = @edit[:new][:pivotby3]
-      @pivotby4 = @edit[:new][:pivotby4]
+      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by1 }
+      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by2 }
+      @pivots4  = @pivots3.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by3 }
+      @pivotby1 = @edit[:new][:pivot].by1
+      @pivotby2 = @edit[:new][:pivot].by2
+      @pivotby3 = @edit[:new][:pivot].by3
+      @pivotby4 = @edit[:new][:pivot].by4
     elsif @sb[:wtype] == "c"
       widget_graph_menus      # to build report pulldown with only reports with grpahs
     elsif @sb[:wtype] == "rf"
@@ -632,11 +633,12 @@ module ReportController::Widgets
     else
       widget.resource = @edit[:rpt]
     end
-    widget.options[:col_order] = [] if @edit[:new][:pivotby1]
-    widget.options[:col_order].push(@edit[:new][:pivotby1]) if !@edit[:new][:pivotby1].blank? && @edit[:new][:pivotby1] != "<<< Nothing >>>"
-    widget.options[:col_order].push(@edit[:new][:pivotby2]) if !@edit[:new][:pivotby2].blank? && @edit[:new][:pivotby2] != "<<< Nothing >>>"
-    widget.options[:col_order].push(@edit[:new][:pivotby3]) if !@edit[:new][:pivotby3].blank? && @edit[:new][:pivotby3] != "<<< Nothing >>>"
-    widget.options[:col_order].push(@edit[:new][:pivotby4]) if !@edit[:new][:pivotby4].blank? && @edit[:new][:pivotby4] != "<<< Nothing >>>"
+    @edit[:new][:pivot] ||= ReportController::PivotOptions.new
+    widget.options[:col_order] = [] if @edit[:new][:pivot].by1
+    widget.options[:col_order].push(@edit[:new][:pivot].by1) if !@edit[:new][:pivot].by1.blank? && @edit[:new][:pivot].by1 != "<<< Nothing >>>"
+    widget.options[:col_order].push(@edit[:new][:pivot].by2) if !@edit[:new][:pivot].by2.blank? && @edit[:new][:pivot].by2 != "<<< Nothing >>>"
+    widget.options[:col_order].push(@edit[:new][:pivot].by3) if !@edit[:new][:pivot].by3.blank? && @edit[:new][:pivot].by3 != "<<< Nothing >>>"
+    widget.options[:col_order].push(@edit[:new][:pivot].by4) if !@edit[:new][:pivot].by4.blank? && @edit[:new][:pivot].by4 != "<<< Nothing >>>"
     widget.content_type = WIDGET_CONTENT_TYPE[@sb[:wtype]]
     widget.visibility ||= {}
     if @edit[:new][:visibility_typ] == "group"
@@ -681,7 +683,7 @@ module ReportController::Widgets
         add_flash(_("A %{type} must be selected") % {:type => typ.titleize}, :error)
       end
     end
-    if @sb[:wtype] == "r" && @edit[:new][:pivotby1] == "<<< Nothing >>>"
+    if @sb[:wtype] == "r" && @edit[:new][:pivot].by1 == "<<< Nothing >>>"
       add_flash(_("At least one Column must be selected"), :error)
     end
     if @sb[:wtype] == "m"

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -588,10 +588,10 @@ module ReportController::Widgets
     end
     widget.options[:col_order] = [] if @edit[:new][:pivot]
     @edit[:new][:pivot] ||= ReportController::PivotOptions.new
-    widget.options[:col_order].push(@edit[:new][:pivot].by1) if !@edit[:new][:pivot].by1.blank? && @edit[:new][:pivot].by1 != "<<< Nothing >>>"
-    widget.options[:col_order].push(@edit[:new][:pivot].by2) if !@edit[:new][:pivot].by2.blank? && @edit[:new][:pivot].by2 != "<<< Nothing >>>"
-    widget.options[:col_order].push(@edit[:new][:pivot].by3) if !@edit[:new][:pivot].by3.blank? && @edit[:new][:pivot].by3 != "<<< Nothing >>>"
-    widget.options[:col_order].push(@edit[:new][:pivot].by4) if !@edit[:new][:pivot].by4.blank? && @edit[:new][:pivot].by4 != "<<< Nothing >>>"
+    widget.options[:col_order].push(@edit[:new][:pivot].by1) if !@edit[:new][:pivot].by1.blank? && @edit[:new][:pivot].by1 != NOTHING_STRING
+    widget.options[:col_order].push(@edit[:new][:pivot].by2) if !@edit[:new][:pivot].by2.blank? && @edit[:new][:pivot].by2 != NOTHING_STRING
+    widget.options[:col_order].push(@edit[:new][:pivot].by3) if !@edit[:new][:pivot].by3.blank? && @edit[:new][:pivot].by3 != NOTHING_STRING
+    widget.options[:col_order].push(@edit[:new][:pivot].by4) if !@edit[:new][:pivot].by4.blank? && @edit[:new][:pivot].by4 != NOTHING_STRING
     widget.content_type = WIDGET_CONTENT_TYPE[@sb[:wtype]]
     widget.visibility ||= {}
     if @edit[:new][:visibility_typ] == "group"
@@ -636,7 +636,7 @@ module ReportController::Widgets
         add_flash(_("A %{type} must be selected") % {:type => typ.titleize}, :error)
       end
     end
-    if @sb[:wtype] == "r" && @edit[:new][:pivot].by1 == "<<< Nothing >>>"
+    if @sb[:wtype] == "r" && @edit[:new][:pivot].by1 == NOTHING_STRING
       add_flash(_("At least one Column must be selected"), :error)
     end
     if @sb[:wtype] == "m"

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -543,39 +543,8 @@ module ReportController::Widgets
 
     if @sb[:wtype] == "r"
       # Look at the pivot group field selectors
-      if params[:chosen_pivot1] && params[:chosen_pivot1] != @edit[:new][:pivot].by1
-        @edit[:new][:pivot].by1 = params[:chosen_pivot1]
-        if params[:chosen_pivot1] == NOTHING_STRING
-          @edit[:new][:pivot].by2 = NOTHING_STRING
-          @edit[:new][:pivot].by3 = NOTHING_STRING
-          @edit[:new][:pivot].by4 = NOTHING_STRING
-        elsif params[:chosen_pivot1] == @edit[:new][:pivot].by2
-          @edit[:new][:pivot].by2 = @edit[:new][:pivot].by3
-          @edit[:new][:pivot].by3 = @edit[:new][:pivot].by4
-          @edit[:new][:pivot].by4 = NOTHING_STRING
-        elsif params[:chosen_pivot1] == @edit[:new][:pivot].by3
-          @edit[:new][:pivot].by3 = @edit[:new][:pivot].by4
-          @edit[:new][:pivot].by4 = NOTHING_STRING
-        end
-      elsif params[:chosen_pivot2] && params[:chosen_pivot2] != @edit[:new][:pivot].by2
-        @edit[:new][:pivot].by2 = params[:chosen_pivot2]
-        if params[:chosen_pivot2] == NOTHING_STRING
-          @edit[:new][:pivot].by3 = NOTHING_STRING
-          @edit[:new][:pivot].by4 = NOTHING_STRING
-        elsif params[:chosen_pivot2] == @edit[:new][:pivot].by3
-          @edit[:new][:pivot].by3 = @edit[:new][:pivot].by4
-          @edit[:new][:pivot].by4 = NOTHING_STRING
-        elsif params[:chosen_pivot2] == @edit[:new][:pivot].by4
-          @edit[:new][:pivot].by4 = NOTHING_STRING
-        end
-      elsif params[:chosen_pivot3] && params[:chosen_pivot3] != @edit[:new][:pivot].by3
-        @edit[:new][:pivot].by3 = params[:chosen_pivot3]
-        if params[:chosen_pivot3] == NOTHING_STRING || params[:chosen_pivot3] == @edit[:new][:pivot].by4
-          @edit[:new][:pivot].by4 = NOTHING_STRING
-        end
-      elsif params[:chosen_pivot4] && params[:chosen_pivot4] != @edit[:new][:pivot].by4
-        @edit[:new][:pivot].by4 = params[:chosen_pivot4]
-      end
+      @edit[:new][:pivot].update(params)
+
       if @edit[:new][:filter]
         @folders ||= []
         report_selection_menus          # to build sub folders

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -404,17 +404,17 @@ module ReportController::Widgets
     end
 
     if @sb[:wtype] == "r"
-      @edit[:new][:pivot] = ReportController::PivotOptions.new
-      @pivotby1 = @edit[:new][:pivot].by1 = NOTHING_STRING # Initialize groupby fields to nothing
-      @pivotby2 = @edit[:new][:pivot].by2 = NOTHING_STRING
-      @pivotby3 = @edit[:new][:pivot].by3 = NOTHING_STRING
-      @pivotby4 = @edit[:new][:pivot].by4 = NOTHING_STRING
+      @pivot = @edit[:new][:pivot] = ReportController::PivotOptions.new
+      @edit[:new][:pivot].by1 = NOTHING_STRING # Initialize groupby fields to nothing
+      @edit[:new][:pivot].by2 = NOTHING_STRING
+      @edit[:new][:pivot].by3 = NOTHING_STRING
+      @edit[:new][:pivot].by4 = NOTHING_STRING
       rpt = @widget.resource_id && @widget.resource_type == "MiqReport" ? @widget.resource_id : nil
       widget_set_column_vars(rpt)
-      @pivotby1 = @edit[:new][:pivot].by1 = @widget.options[:col_order][0] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][0]
-      @pivotby2 = @edit[:new][:pivot].by2 = @widget.options[:col_order][1] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][1]
-      @pivotby3 = @edit[:new][:pivot].by3 = @widget.options[:col_order][2] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][2]
-      @pivotby4 = @edit[:new][:pivot].by4 = @widget.options[:col_order][3] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][3]
+      @edit[:new][:pivot].by1 = @widget.options[:col_order][0] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][0]
+      @edit[:new][:pivot].by2 = @widget.options[:col_order][1] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][1]
+      @edit[:new][:pivot].by3 = @widget.options[:col_order][2] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][2]
+      @edit[:new][:pivot].by4 = @widget.options[:col_order][3] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][3]
       @edit[:new][:pivot].options = @edit[:new][:fields].dup
       @edit[:new][:row_count] = @widget.row_count
     elsif @sb[:wtype] == "rf"
@@ -590,10 +590,7 @@ module ReportController::Widgets
         widget_set_column_vars(rpt)
       end
       @edit[:new][:pivot].options = @edit[:new][:fields].dup
-      @pivotby1 = @edit[:new][:pivot].by1
-      @pivotby2 = @edit[:new][:pivot].by2
-      @pivotby3 = @edit[:new][:pivot].by3
-      @pivotby4 = @edit[:new][:pivot].by4
+      @pivot = @edit[:new][:pivot]
     elsif @sb[:wtype] == "c"
       widget_graph_menus      # to build report pulldown with only reports with grpahs
     elsif @sb[:wtype] == "rf"

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -415,10 +415,7 @@ module ReportController::Widgets
       @pivotby2 = @edit[:new][:pivot].by2 = @widget.options[:col_order][1] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][1]
       @pivotby3 = @edit[:new][:pivot].by3 = @widget.options[:col_order][2] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][2]
       @pivotby4 = @edit[:new][:pivot].by4 = @widget.options[:col_order][3] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][3]
-      @pivots1  = @edit[:new][:fields].dup
-      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by1 }
-      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by2 }
-      @pivots4  = @pivots3.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by3 }
+      @edit[:new][:pivot].options = @edit[:new][:fields].dup
       @edit[:new][:row_count] = @widget.row_count
     elsif @sb[:wtype] == "rf"
       @edit[:rss_feeds] = {}
@@ -592,10 +589,7 @@ module ReportController::Widgets
         rpt = @edit[:new][:repfilter] ? @edit[:new][:repfilter] : (@widget.resource_id && @widget.resource_type == "MiqReport" ? @widget.resource_id : nil)
         widget_set_column_vars(rpt)
       end
-      @pivots1  = @edit[:new][:fields].dup
-      @pivots2  = @pivots1.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by1 }
-      @pivots3  = @pivots2.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by2 }
-      @pivots4  = @pivots3.dup.delete_if { |g| g[1] == @edit[:new][:pivot].by3 }
+      @edit[:new][:pivot].options = @edit[:new][:fields].dup
       @pivotby1 = @edit[:new][:pivot].by1
       @pivotby2 = @edit[:new][:pivot].by2
       @pivotby3 = @edit[:new][:pivot].by3

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -405,10 +405,6 @@ module ReportController::Widgets
 
     if @sb[:wtype] == "r"
       @pivot = @edit[:new][:pivot] = ReportController::PivotOptions.new
-      @edit[:new][:pivot].by1 = NOTHING_STRING # Initialize groupby fields to nothing
-      @edit[:new][:pivot].by2 = NOTHING_STRING
-      @edit[:new][:pivot].by3 = NOTHING_STRING
-      @edit[:new][:pivot].by4 = NOTHING_STRING
       rpt = @widget.resource_id && @widget.resource_type == "MiqReport" ? @widget.resource_id : nil
       widget_set_column_vars(rpt)
       @edit[:new][:pivot].by1 = @widget.options[:col_order][0] if @widget.options && @widget.options[:col_order] && @widget.options[:col_order][0]
@@ -503,10 +499,7 @@ module ReportController::Widgets
     if @sb[:wtype] == "r"
       if params[:filter_typ] || params[:subfilter_typ] || params[:repfilter_typ]
         # reset columns if report has changed
-        @edit[:new][:pivot].by1 = NOTHING_STRING
-        @edit[:new][:pivot].by2 = NOTHING_STRING
-        @edit[:new][:pivot].by3 = NOTHING_STRING
-        @edit[:new][:pivot].by4 = NOTHING_STRING
+        @pivot = @edit[:new][:pivot] = ReportController::PivotOptions.new
       end
       @edit[:new][:subfilter] = params[:subfilter_typ] if params[:subfilter_typ]
       if params[:repfilter_typ] && params[:repfilter_typ] != "<Choose>"
@@ -624,8 +617,8 @@ module ReportController::Widgets
     else
       widget.resource = @edit[:rpt]
     end
+    widget.options[:col_order] = [] if @edit[:new][:pivot]
     @edit[:new][:pivot] ||= ReportController::PivotOptions.new
-    widget.options[:col_order] = [] if @edit[:new][:pivot].by1
     widget.options[:col_order].push(@edit[:new][:pivot].by1) if !@edit[:new][:pivot].by1.blank? && @edit[:new][:pivot].by1 != "<<< Nothing >>>"
     widget.options[:col_order].push(@edit[:new][:pivot].by2) if !@edit[:new][:pivot].by2.blank? && @edit[:new][:pivot].by2 != "<<< Nothing >>>"
     widget.options[:col_order].push(@edit[:new][:pivot].by3) if !@edit[:new][:pivot].by3.blank? && @edit[:new][:pivot].by3 != "<<< Nothing >>>"

--- a/app/views/report/_form_consolidate.html.haml
+++ b/app/views/report/_form_consolidate.html.haml
@@ -8,7 +8,7 @@
         = _('Column 1')
       .col-md-8
         = select_tag('chosen_pivot1',
-          options_for_select([NOTHING_STRING] + @pivots1, @pivotby1),
+          options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options1, @pivotby1),
           :multiple             => false,
           :class                => "selectpicker")
         :javascript
@@ -20,7 +20,7 @@
           = _('Column 2')
         .col-md-8
           = select_tag('chosen_pivot2',
-            options_for_select([NOTHING_STRING] + @pivots2, @pivotby2),
+            options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options2, @pivotby2),
             :multiple             => false,
             :class                => "selectpicker")
           :javascript
@@ -32,7 +32,7 @@
             = _('Column 3')
           .col-md-8
             = select_tag('chosen_pivot3',
-              options_for_select([NOTHING_STRING] + @pivots3, @pivotby3),
+              options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options3, @pivotby3),
               :multiple             => false,
               :class                => "selectpicker")
             :javascript

--- a/app/views/report/_form_consolidate.html.haml
+++ b/app/views/report/_form_consolidate.html.haml
@@ -8,31 +8,31 @@
         = _('Column 1')
       .col-md-8
         = select_tag('chosen_pivot1',
-          options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options1, @pivotby1),
+          options_for_select([NOTHING_STRING] + @pivot.options1, @pivot.by1),
           :multiple             => false,
           :class                => "selectpicker")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('chosen_pivot1', '#{url}', {beforeSend: true, complete: true});
-    - if @pivotby1 != NOTHING_STRING
+    - if @pivot.by1 != NOTHING_STRING
       .form-group
         %label.control-label.col-md-2
           = _('Column 2')
         .col-md-8
           = select_tag('chosen_pivot2',
-            options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options2, @pivotby2),
+            options_for_select([NOTHING_STRING] + @pivot.options2, @pivot.by2),
             :multiple             => false,
             :class                => "selectpicker")
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent('chosen_pivot2', '#{url}', {beforeSend: true});
-      - if @pivotby2 != NOTHING_STRING
+      - if @pivot.by2 != NOTHING_STRING
         .form-group
           %label.control-label.col-md-2
             = _('Column 3')
           .col-md-8
             = select_tag('chosen_pivot3',
-              options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options3, @pivotby3),
+              options_for_select([NOTHING_STRING] + @pivot.options3, @pivot.by3),
               :multiple             => false,
               :class                => "selectpicker")
             :javascript
@@ -43,7 +43,7 @@
     = _('Note:')
   = _('Consolidating records will not show detail records in the report.')
   %hr
-  - if @pivotby1 != NOTHING_STRING
+  - if @pivot.by1 != NOTHING_STRING
     %h3
       = _('Specify Calculations of Numeric Values for Grouped Records')
     %table.table.table-striped.table-bordered
@@ -55,7 +55,7 @@
             = _('Calculations')
       %tbody
         - @edit[:new][:fields].each_with_index do |f, f_idx|
-          - next if [@pivotby1, @pivotby2, @pivotby3]. include?(f.last)
+          - next if [@pivot.by1, @pivot.by2, @pivot.by3]. include?(f.last)
           - next unless MiqReport.get_col_info(f.last)[:numeric]
           %tr
             %td

--- a/app/views/report/_widget_columns.html.haml
+++ b/app/views/report/_widget_columns.html.haml
@@ -5,49 +5,49 @@
       *
     = _('Column 1')
   .col-md-8
-    = select_tag("chosen_pivot1", options_for_select([NOTHING_STRING] + @pivots1, @pivotby1),
+    = select_tag("chosen_pivot1", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options1, @pivotby1),
       :multiple             => false,
       :class                => "selectpicker",
       :disabled             => @edit[:read_only])
     :javascript
       miqInitSelectPicker();
       miqSelectPickerEvent('chosen_pivot1', '#{url}', {beforeSend: true})
-- if @pivotby1 != NOTHING_STRING && @pivots2.length >= 1
+- if @pivotby1 != NOTHING_STRING && @edit[:new][:pivot].options2.present?
   .form-group
     %label.control-label.col-md-2
       - if @edit[:read_only]
         *
       = _('Column 2')
     .col-md-8
-      = select_tag("chosen_pivot2", options_for_select([NOTHING_STRING] + @pivots2, @pivotby2),
+      = select_tag("chosen_pivot2", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options2, @pivotby2),
         :multiple             => false,
         :class                => "selectpicker",
         :disabled             => @edit[:read_only])
       :javascript
         miqInitSelectPicker();
         miqSelectPickerEvent('chosen_pivot2', '#{url}', {beforeSend: true});
-  - if @pivotby2 != NOTHING_STRING && @pivots3.length >= 1
+  - if @pivotby2 != NOTHING_STRING && @edit[:new][:pivot].options3.present?
     .form-group
       %label.control-label.col-md-2
         - if @edit[:read_only]
           *
         = _('Column 3')
       .col-md-8
-        = select_tag("chosen_pivot3", options_for_select([NOTHING_STRING] + @pivots3, @pivotby3),
+        = select_tag("chosen_pivot3", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options3, @pivotby3),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only])
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('chosen_pivot3', '#{url}', {beforeSend: true});
-  - if @pivotby3 != NOTHING_STRING && @pivots4.length >= 1
+  - if @pivotby3 != NOTHING_STRING && @edit[:new][:pivot].options4.present?
     .form-group
       %label.control-label.col-md-2
         - if @edit[:read_only]
           *
         = _('Column 4')
       .col-md-8
-        = select_tag("chosen_pivot4", options_for_select([NOTHING_STRING] + @pivots4, @pivotby4),
+        = select_tag("chosen_pivot4", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options4, @pivotby4),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only],

--- a/app/views/report/_widget_columns.html.haml
+++ b/app/views/report/_widget_columns.html.haml
@@ -5,49 +5,49 @@
       *
     = _('Column 1')
   .col-md-8
-    = select_tag("chosen_pivot1", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options1, @pivotby1),
+    = select_tag("chosen_pivot1", options_for_select([NOTHING_STRING] + @pivot.options1, @pivot.by1),
       :multiple             => false,
       :class                => "selectpicker",
       :disabled             => @edit[:read_only])
     :javascript
       miqInitSelectPicker();
       miqSelectPickerEvent('chosen_pivot1', '#{url}', {beforeSend: true})
-- if @pivotby1 != NOTHING_STRING && @edit[:new][:pivot].options2.present?
+- if @pivot.by1 != NOTHING_STRING && @pivot.options2.present?
   .form-group
     %label.control-label.col-md-2
       - if @edit[:read_only]
         *
       = _('Column 2')
     .col-md-8
-      = select_tag("chosen_pivot2", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options2, @pivotby2),
+      = select_tag("chosen_pivot2", options_for_select([NOTHING_STRING] + @pivot.options2, @pivot.by2),
         :multiple             => false,
         :class                => "selectpicker",
         :disabled             => @edit[:read_only])
       :javascript
         miqInitSelectPicker();
         miqSelectPickerEvent('chosen_pivot2', '#{url}', {beforeSend: true});
-  - if @pivotby2 != NOTHING_STRING && @edit[:new][:pivot].options3.present?
+  - if @pivot.by2 != NOTHING_STRING && @pivot.options3.present?
     .form-group
       %label.control-label.col-md-2
         - if @edit[:read_only]
           *
         = _('Column 3')
       .col-md-8
-        = select_tag("chosen_pivot3", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options3, @pivotby3),
+        = select_tag("chosen_pivot3", options_for_select([NOTHING_STRING] + @pivot.options3, @pivot.by3),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only])
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('chosen_pivot3', '#{url}', {beforeSend: true});
-  - if @pivotby3 != NOTHING_STRING && @edit[:new][:pivot].options4.present?
+  - if @pivot.by3 != NOTHING_STRING && @edit[:new][:pivot].options4.present?
     .form-group
       %label.control-label.col-md-2
         - if @edit[:read_only]
           *
         = _('Column 4')
       .col-md-8
-        = select_tag("chosen_pivot4", options_for_select([NOTHING_STRING] + @edit[:new][:pivot].options4, @pivotby4),
+        = select_tag("chosen_pivot4", options_for_select([NOTHING_STRING] + @pivot.options4, @pivot.by4),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only],

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -481,10 +481,7 @@ describe ReportController do
 
         it "clearing pivot 1 also clears pivot 2 and 3" do
           edit = assigns(:edit)
-          edit[:new][:pivot] = ReportController::PivotOptions.new
-          edit[:new][:pivot].by1 = P1
-          edit[:new][:pivot].by2 = P2
-          edit[:new][:pivot].by3 = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot1 => NOTHING_STRING)
           controller.send(:gfv_pivots)
@@ -498,10 +495,7 @@ describe ReportController do
 
         it "clearing pivot 2 also clears pivot 3" do
           edit = assigns(:edit)
-          edit[:new][:pivot] = ReportController::PivotOptions.new
-          edit[:new][:pivot].by1 = P1
-          edit[:new][:pivot].by2 = P2
-          edit[:new][:pivot].by3 = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot2 => NOTHING_STRING)
           controller.send(:gfv_pivots)
@@ -515,10 +509,7 @@ describe ReportController do
 
         it "setting pivot 1 = pivot 2 bubbles up pivot 3 to 2" do
           edit = assigns(:edit)
-          edit[:new][:pivot] = ReportController::PivotOptions.new
-          edit[:new][:pivot].by1 = P1
-          edit[:new][:pivot].by2 = P2
-          edit[:new][:pivot].by3 = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot1 => P2)
           controller.send(:gfv_pivots)
@@ -532,10 +523,7 @@ describe ReportController do
 
         it "setting pivot 2 = pivot 3 clears pivot 3" do
           edit = assigns(:edit)
-          edit[:new][:pivot] = ReportController::PivotOptions.new
-          edit[:new][:pivot].by1 = P1
-          edit[:new][:pivot].by2 = P2
-          edit[:new][:pivot].by3 = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot2 => P3)
           controller.send(:gfv_pivots)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -458,7 +458,7 @@ describe ReportController do
         it "sets pivot 1" do
           controller.instance_variable_set(:@_params, :chosen_pivot1 => P1)
           controller.send(:gfv_pivots)
-          expect(assigns(:edit)[:new][:pivotby1]).to eq(P1)
+          expect(assigns(:edit)[:new][:pivot].by1).to eq(P1)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
@@ -466,7 +466,7 @@ describe ReportController do
         it "sets pivot 2" do
           controller.instance_variable_set(:@_params, :chosen_pivot2 => P2)
           controller.send(:gfv_pivots)
-          expect(assigns(:edit)[:new][:pivotby2]).to eq(P2)
+          expect(assigns(:edit)[:new][:pivot].by2).to eq(P2)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
@@ -474,71 +474,75 @@ describe ReportController do
         it "sets pivot 3" do
           controller.instance_variable_set(:@_params, :chosen_pivot3 => P3)
           controller.send(:gfv_pivots)
-          expect(assigns(:edit)[:new][:pivotby3]).to eq(P3)
+          expect(assigns(:edit)[:new][:pivot].by3).to eq(P3)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
 
         it "clearing pivot 1 also clears pivot 2 and 3" do
           edit = assigns(:edit)
-          edit[:new][:pivotby1] = P1
-          edit[:new][:pivotby2] = P2
-          edit[:new][:pivotby3] = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new
+          edit[:new][:pivot].by1 = P1
+          edit[:new][:pivot].by2 = P2
+          edit[:new][:pivot].by3 = P3
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot1 => NOTHING_STRING)
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
-          expect(edit_new[:pivotby1]).to eq(NOTHING_STRING)
-          expect(edit_new[:pivotby2]).to eq(NOTHING_STRING)
-          expect(edit_new[:pivotby3]).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by1).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by2).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
 
         it "clearing pivot 2 also clears pivot 3" do
           edit = assigns(:edit)
-          edit[:new][:pivotby1] = P1
-          edit[:new][:pivotby2] = P2
-          edit[:new][:pivotby3] = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new
+          edit[:new][:pivot].by1 = P1
+          edit[:new][:pivot].by2 = P2
+          edit[:new][:pivot].by3 = P3
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot2 => NOTHING_STRING)
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
-          expect(edit_new[:pivotby1]).to eq(P1)
-          expect(edit_new[:pivotby2]).to eq(NOTHING_STRING)
-          expect(edit_new[:pivotby3]).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by1).to eq(P1)
+          expect(edit_new[:pivot].by2).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
 
         it "setting pivot 1 = pivot 2 bubbles up pivot 3 to 2" do
           edit = assigns(:edit)
-          edit[:new][:pivotby1] = P1
-          edit[:new][:pivotby2] = P2
-          edit[:new][:pivotby3] = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new
+          edit[:new][:pivot].by1 = P1
+          edit[:new][:pivot].by2 = P2
+          edit[:new][:pivot].by3 = P3
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot1 => P2)
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
-          expect(edit_new[:pivotby1]).to eq(P2)
-          expect(edit_new[:pivotby2]).to eq(P3)
-          expect(edit_new[:pivotby3]).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by1).to eq(P2)
+          expect(edit_new[:pivot].by2).to eq(P3)
+          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end
 
         it "setting pivot 2 = pivot 3 clears pivot 3" do
           edit = assigns(:edit)
-          edit[:new][:pivotby1] = P1
-          edit[:new][:pivotby2] = P2
-          edit[:new][:pivotby3] = P3
+          edit[:new][:pivot] = ReportController::PivotOptions.new
+          edit[:new][:pivot].by1 = P1
+          edit[:new][:pivot].by2 = P2
+          edit[:new][:pivot].by3 = P3
           controller.instance_variable_set(:@edit, edit)
           controller.instance_variable_set(:@_params, :chosen_pivot2 => P3)
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
-          expect(edit_new[:pivotby1]).to eq(P1)
-          expect(edit_new[:pivotby2]).to eq(P3)
-          expect(edit_new[:pivotby3]).to eq(NOTHING_STRING)
+          expect(edit_new[:pivot].by1).to eq(P1)
+          expect(edit_new[:pivot].by2).to eq(P3)
+          expect(edit_new[:pivot].by3).to eq(NOTHING_STRING)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
           expect(assigns(:refresh_partial)).to eq("form_consolidate")
         end


### PR DESCRIPTION
There are some similarities among editor of widgets and editor of reports. One of them is the manipulation of pivots (groupby) statements.

This pr is best reviewed commit by commit. The next step would be to move `gfv_key_pivot_calculations` and `@pg1` to PivotOptions, this would really help to lighten :flashlight: the report editor. 

@miq-bot add_label ui, reporting, refactoring, darga/no
@miq-bot assign @martinpovolny 
/cc @lpichler 
:baby_chick: 