### PR TITLE
Fixed Orchestration Stack instance delete button

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1669,7 +1669,7 @@ module ApplicationController::CiProcessing
     when "miq_template"
       return MiqTemplate
     when "orchestration_stack"
-      return OrchestrationStack
+      return params[:display] == 'instances' ? VmOrTemplate : OrchestrationStack
     when "service"
       return Service
     else


### PR DESCRIPTION
## Purpose or Intent

When you navigate through Compute -> Clouds -> Stacks -> Instances -> Power -> Delete

Before:
![screenshot from 2016-07-25 11-11-09](https://cloud.githubusercontent.com/assets/9535558/17929318/f6a2e6ec-69ff-11e6-9fc0-bd248897b8f8.png)

After:
![screenshot from 2016-08-24 13-36-45](https://cloud.githubusercontent.com/assets/9535558/17929323/fa9ed346-69ff-11e6-9313-154339d1ffbe.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1347002
