### PR TITLE
Pass error messages from Provider Validate action to UI

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -277,10 +277,8 @@ module AuthenticationMixin
           verify_credentials(*verify_args) ? [:valid, ""] : [:invalid, "Unknown reason"]
         rescue MiqException::MiqUnreachableError => err
           [:unreachable, err]
-        rescue MiqException::MiqInvalidCredentialsError => err
+        rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqEVMLoginError => err
           [:invalid, err]
-        rescue MiqException::MiqEVMLoginError
-          [:invalid, "Login failed due to a bad username or password."]
         rescue => err
           [:error, err]
         end

--- a/gems/pending/util/miq-exception.rb
+++ b/gems/pending/util/miq-exception.rb
@@ -26,7 +26,11 @@ module MiqException
   class PolicyPreventAction < MiqActionError; end
 
   # Login/Logout user related errors
-  class MiqEVMLoginError < Error; end
+  class MiqEVMLoginError < Error
+    def initialize(msg = "Login failed due to a bad username or password.")
+      super
+    end
+  end
   class MiqHostError < Error; end
   class MiqInvalidCredentialsError < Error; end
   class MiqUnreachableError < Error; end


### PR DESCRIPTION
Many error messages were swallowed by MIQ code. Updating MiqEVMLoginError
to pass more detailed error information to UI.

Useful e.g. for Openstack Regions connection testing with Validate button in add provider form.