### PR TITLE
MiqProductFeature.count spec that won't require contant updating

### DIFF
--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,8 +2,6 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1075 }
-
   # - container_dashboard
   # - miq_report_widget_editor
   #   - miq_report_widget_admin
@@ -19,13 +17,16 @@ describe MiqProductFeature do
   context ".seed" do
     it "creates feature identifiers once on first seed, changes nothing on second seed" do
       status_seed1 = MiqProductFeature.seed
-      expect(MiqProductFeature.count).to eq(expected_feature_count)
+      features_after_seed1 = MiqProductFeature.count
+      # If this fails because we went down to 998, update this test;
+      # the idea was just to test we're not suddenly getting 10 or 0...
+      expect(features_after_seed1).to be > 1000
       expect(status_seed1[:created]).to match_array status_seed1[:created].uniq
       expect(status_seed1[:updated]).to match_array []
       expect(status_seed1[:unchanged]).to match_array []
 
       status_seed2 = MiqProductFeature.seed
-      expect(MiqProductFeature.count).to eq(expected_feature_count)
+      expect(MiqProductFeature.count).to eq(features_after_seed1)
       expect(status_seed2[:created]).to match_array []
       expect(status_seed2[:updated]).to match_array []
       expect(status_seed2[:unchanged]).to match_array status_seed1[:created]


### PR DESCRIPTION
Purpose or Intent
-----------------
`expected_feature_count` is constant source of rebasing, merge conflicts and silent wrong merging (when 2 people increment by same #).

Last I heard on gitter, many [weasel words] dislike it, nobody knows [citation needed] what *exactly* it's testing, but it was suggested that it's useful to catch a hypotetical [non-neutral POV] seeding breakdown that would load 0 or very few features.  This PR still tests that.

Today I had to mergetool it twice again and figured maybe I someone with merge powers will tempted to press that green merge button before others notice :trollface: 

(Imagine it being green more often from this day forward.  Quicker, easier, more seductive...  ↴  :tada:)

@miq-bot label developer, enhancement, darga/yes

It must be darga/yes, otherwise all future feature-adding commits will fail tests once backported.
(Ironically, this PR doesn't merge cleanly into darga but only because 1034 != 1075.)