### PR TITLE
VMware retrieve vm/disk associations to storage profiles

### DIFF
--- a/gems/pending/VMwareWebService/MiqPbmInventory.rb
+++ b/gems/pending/VMwareWebService/MiqPbmInventory.rb
@@ -32,6 +32,24 @@ module MiqPbmInventory
     profiles
   end
 
+  def pbmQueryAssociatedEntity(profile_ids)
+    assoc_entities = {}
+    return assoc_entities if @pbm_svc.nil?
+
+    begin
+      profile_ids.each do |profile_id|
+        # If a string was passed in create a PbmProfileId object
+        profile_id = RbVmomi::PBM::PbmProfileId(:uniqueId => profile_id) if profile_id.kind_of?(String)
+
+        assoc_entities[profile_id.uniqueId] = @pbm_svc.queryAssociatedEntity(profile_id)
+      end
+    rescue => err
+      $vim_log.warn("MiqPbmInventory: pbmQueryAssociatedEntity: #{err}")
+    end
+
+    assoc_entities
+  end
+
   def pbmQueryMatchingHub(profile_id)
     hubs = []
     return hubs if @pbm_svc.nil?
@@ -47,4 +65,5 @@ module MiqPbmInventory
 
     hubs
   end
+
 end

--- a/spec/tools/vim_data/miq_vim_inventory/pbmQueryAssociatedEntity.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/pbmQueryAssociatedEntity.yml
@@ -1,0 +1,31 @@
+---
+f4e5bade-15a2-4805-bf8e-52318c4ce443: []
+aa6d5a82-1c88-45da-85d3-3d74b91a5bad:
+- !ruby/object:RbVmomi::PBM::PbmServerObjectRef
+  props:
+    :dynamicProperty: []
+    :objectType: virtualDiskId
+    :key: vm-901:2001
+    :serverUuid: af6dcd8d-0690-4b2c-9c63-d4b84f10823f
+6fe1c7b4-7f7e-4db1-a545-c756e392de62:
+- !ruby/object:RbVmomi::PBM::PbmServerObjectRef
+  props:
+    :dynamicProperty: []
+    :objectType: virtualDiskId
+    :key: vm-901:2000
+    :serverUuid: af6dcd8d-0690-4b2c-9c63-d4b84f10823f
+- !ruby/object:RbVmomi::PBM::PbmServerObjectRef
+  props:
+    :dynamicProperty: []
+    :objectType: virtualMachine
+    :key: vm-901
+    :serverUuid: af6dcd8d-0690-4b2c-9c63-d4b84f10823f
+Default-VM-Home521041ccef13f2d1-3d43b46f398ab14c: []
+Default-VirtualDisk521041ccef13f2d1-3d43b46f398ab14c: []
+521041ccef13f2d1-3d43b46f398ab14c:
+- !ruby/object:RbVmomi::PBM::PbmServerObjectRef
+  props:
+    :dynamicProperty: []
+    :objectType: datastore
+    :key: datastore-953
+    :serverUuid: af6dcd8d-0690-4b2c-9c63-d4b84f10823f


### PR DESCRIPTION
Retrieve associations between vms/disks and storage profiles from VMware using the `PbmProfileProfileManager#PbmQueryAssociatedEntity` method.