### PR TITLE
Fixed issue with scan button on instance pages

### DIFF
--- a/app/helpers/application_helper/button/vm_instance_scan.rb
+++ b/app/helpers/application_helper/button/vm_instance_scan.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::VmInstanceScan < ApplicationHelper::Button::Bas
   needs_record
 
   def skip?
-    return false if @record.kind_of?(OrchestrationStack) && @display == "instances"
+    return false if @display == "instances"
     !(@record.is_available?(:smartstate_analysis) ||
       @record.is_available_now_error_message(:smartstate_analysis)) ||
     !@record.has_proxy?


### PR DESCRIPTION
Purpose or Intent
-----------------
Since `instance_scan` button is used on all instance pages, the condition that check if 
`@record.kind_of?(OrchestrationStack)` can be removed

Links
-----
Fixes: #9969

@PanSpagetka can you review and make sure it works for other screens please?