### PR TITLE
Fix error when rendering custom button set toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/custom_button_set_center.rb
+++ b/app/helpers/application_helper/toolbar/custom_button_set_center.rb
@@ -20,7 +20,7 @@ class ApplicationHelper::Toolbar::CustomButtonSetCenter < ApplicationHelper::Too
           :ab_group_reorder,
           'pficon pficon-edit fa-lg',
           proc do
-            if x_active_tree == :ab_tree
+            if @view_context.x_active_tree == :ab_tree
               _('Reorder Buttons Groups')
             else
               _('Reorder Buttons and Groups')


### PR DESCRIPTION
This is to fix the following error when rendering custom buttons toolbar under Automate -> Customization -> Buttons:

```
[NameError] undefined local variable or method `x_active_tree'
app/helpers/application_helper/toolbar/custom_button_set_center.rb:24
...
```

Fixes: #9971

https://bugzilla.redhat.com/show_bug.cgi?id=1359075