### PR TITLE
Upgrade vcr gem to 3.x.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -84,7 +84,7 @@ unless ENV['APPLIANCE']
     gem "rspec",         "~>3.5.0",     :require => false
     gem "test-unit",                    :require => false
     gem "timecop",       "~>0.7.3",     :require => false
-    gem "vcr",           "~>2.6",       :require => false
+    gem "vcr",           "~>3.0.0",     :require => false
     gem "webmock",       "~>1.12",      :require => false
     gem "xml-simple",    "~>1.1.0",     :require => false  # Used by test/xml/tc_xmlhash_methods.rb
   end


### PR DESCRIPTION
Let's see if we can upgrade to VCR 3.x which added better thread safety, among other things. When I ran the full suite locally, I only saw 1 failure and it appeared to be unrelated.

For the VCR changelog, please see https://github.com/vcr/vcr/blob/master/CHANGELOG.md.
