### PR TITLE
Changing default values in Automate Simulation.

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -970,7 +970,7 @@ module ApplicationController::Buttons
     @resolve ||= {}
     @resolve[:new] ||= {}
     @resolve[:new][:starting_object] ||= "SYSTEM/PROCESS"
-    @resolve[:new][:readonly] = true
+    @resolve[:new][:readonly] = false
     @resolve[:throw_ready] = false
 
     # Following commented out since all resolutions start at SYSTEM/PROCESS
@@ -980,7 +980,7 @@ module ApplicationController::Buttons
     if matching_instances.any?
       @resolve[:instance_names] = matching_instances.collect(&:name)
       instance_name = @custom_button && @custom_button.uri_object_name
-      @resolve[:new][:instance_name] = instance_name ? instance_name : "Automation"
+      @resolve[:new][:instance_name] = instance_name ? instance_name : "Request"
       @resolve[:new][:object_message] = @custom_button && @custom_button.uri_message || "create"
       @resolve[:target_class] = nil
       @resolve[:target_classes] = {}


### PR DESCRIPTION
Purpose or Intent
-----------------
The default entry point should be to /System/Process/Request, with the 'Execute Methods' checkbox enabled by default. This probably covers 90% of the use-cases for Simulation.

https://bugzilla.redhat.com/show_bug.cgi?id=1316842
https://trello.com/c/QxcgpkJf