### PR TITLE
l10n in format_timezone()

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -730,8 +730,13 @@ module ApplicationController::Performance
       rpt.tz = @perf_options[:tz]
       rpt.extras = Hash.new
       rpt.extras[:realtime] = true
-      @perf_options[:range] = to_dt.nil? ? nil :
-                              "#{format_timezone(from_dt, @perf_options[:tz], "datetime")} to #{format_timezone(to_dt, @perf_options[:tz], "gtl")}"
+      @perf_options[:range] = if to_dt.nil?
+                                nil
+                              else
+                                _("%{date_from} to %{date_to}") %
+                                  {:date_from => format_timezone(from_dt, @perf_options[:tz], "datetime"),
+                                   :date_to   => format_timezone(to_dt, @perf_options[:tz], "gtl")}
+                              end
       rpt.where_clause =  ["resource_type = ? and resource_id = ? and timestamp >= ? and timestamp <= ? and capture_interval_name = ?",
                            @perf_options[:model],
                            @perf_record.id,

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -734,7 +734,7 @@ module ApplicationController::Performance
                                 nil
                               else
                                 _("%{date_from} to %{date_to}") %
-                                  {:date_from => format_timezone(from_dt, @perf_options[:tz], "datetime"),
+                                  {:date_from => format_timezone(from_dt, @perf_options[:tz], "gtl"),
                                    :date_to   => format_timezone(to_dt, @perf_options[:tz], "gtl")}
                               end
       rpt.where_clause =  ["resource_type = ? and resource_id = ? and timestamp >= ? and timestamp <= ? and capture_interval_name = ?",

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -40,14 +40,14 @@
             %label.control-label.col-md-2= _('Created')
             .col-md-8
               %p.form-control-static
-                = h(_("By Username %{username} %{created_on}") % {:username => @policy.created_by || _("N/A"), :created_on => format_timezone(@policy.created_on, session[:user_tz], "on_at")})
+                = h(_("By Username %{username} %{created_on}") % {:username => @policy.created_by || _("N/A"), :created_on => format_timezone(@policy.created_on, session[:user_tz], "gtl")})
 
           - if @policy.created_on != @policy.updated_on
             .form-group
               %label.control-label.col-md-2= _("Last Updated")
               .col-md-8
                 %p.form-control-static
-                  = h(_("By Username %{username} %{updated_on}") % {:username => @policy.updated_by || _("N/A"), :updated_on => format_timezone(@policy.updated_on, session[:user_tz], "on_at")})
+                  = h(_("By Username %{username} %{updated_on}") % {:username => @policy.updated_by || _("N/A"), :updated_on => format_timezone(@policy.updated_on, session[:user_tz], "gtl")})
         %hr
 
       -# Scope

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -53,7 +53,7 @@ module Vmdb
         when "compare_hdr"                          # for drift/compare headers
           new_time = new_time.strftime("%m/%d/%y %H:%M %Z")
         when "widget_footer"                        # for widget footers
-          new_time = new_time.strftime("%m/%d/%y %H:%M")
+          new_time = I18n.l(new_time, :format => :long)
         else                                        # for summary screens
           new_time = new_time.strftime("%a %b %d %H:%M:%S %Z %Y")
         end

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -39,7 +39,7 @@ module Vmdb
         new_time = time.in_time_zone(timezone)
         case ftype
         when "gtl"                                  # for gtl views
-          new_time = new_time.strftime("%m/%d/%y %H:%M:%S %Z")
+          new_time = I18n.l(new_time.to_date) + new_time.strftime(" %H:%M:%S %Z")
         when "on_at"                                  # for gtl views
           new_time = new_time.strftime("on %m/%d/%y at %H:%M:%S %Z")
         when "fname"                                # for download filename

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -51,7 +51,7 @@ module Vmdb
           new_time = new_time.gsub(/\) [a-zA-Z0-9\s\S]*/, ")")
         when "raw"                                  # return without formatting
         when "compare_hdr"                          # for drift/compare headers
-          new_time = new_time.strftime("%m/%d/%y %H:%M %Z")
+          new_time = I18n.l(new_time, :format => :long) + new_time.strftime(" %Z")
         when "widget_footer"                        # for widget footers
           new_time = I18n.l(new_time, :format => :long)
         else                                        # for summary screens

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -44,7 +44,7 @@ module Vmdb
           new_time = new_time.strftime("%Y_%m_%d")
         when "date"                                 # for just mm/dd/yy
           new_time = I18n.l(new_time.to_date)
-        when "export_filename", "support_log_fname"    # for export/log filename
+        when "export_filename"                      # for export/log filename
           new_time = new_time.strftime("%Y%m%d_%H%M%S")
         when "tl"
           new_time = new_time.strftime("%a %b %d %Y %H:%M:%S") + " " + Time.zone.to_s

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -40,8 +40,6 @@ module Vmdb
         case ftype
         when "gtl"                                  # for gtl views
           new_time = I18n.l(new_time.to_date) + new_time.strftime(" %H:%M:%S %Z")
-        when "on_at"                                  # for gtl views
-          new_time = new_time.strftime("on %m/%d/%y at %H:%M:%S %Z")
         when "fname"                                # for download filename
           new_time = new_time.strftime("%Y_%m_%d")
         when "date"                                 # for just mm/dd/yy

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -55,7 +55,7 @@ module Vmdb
         when "widget_footer"                        # for widget footers
           new_time = I18n.l(new_time, :format => :long)
         else                                        # for summary screens
-          new_time = new_time.strftime("%a %b %d %H:%M:%S %Z %Y")
+          new_time = I18n.l new_time
         end
       else    # if time is nil
         new_time = ""

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -43,7 +43,7 @@ module Vmdb
         when "fname"                                # for download filename
           new_time = new_time.strftime("%Y_%m_%d")
         when "date"                                 # for just mm/dd/yy
-          new_time = new_time.strftime("%m/%d/%y")
+          new_time = I18n.l(new_time.to_date)
         when "datetime"                             # mm/dd/yy hh:mm:ss
           new_time = new_time.strftime("%m/%d/%y %H:%M:%S")
         when "export_filename", "support_log_fname"    # for export/log filename

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -44,8 +44,6 @@ module Vmdb
           new_time = new_time.strftime("%Y_%m_%d")
         when "date"                                 # for just mm/dd/yy
           new_time = I18n.l(new_time.to_date)
-        when "datetime"                             # mm/dd/yy hh:mm:ss
-          new_time = new_time.strftime("%m/%d/%y %H:%M:%S")
         when "export_filename", "support_log_fname"    # for export/log filename
           new_time = new_time.strftime("%Y%m%d_%H%M%S")
         when "tl"

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -47,8 +47,7 @@ module Vmdb
         when "export_filename"                      # for export/log filename
           new_time = new_time.strftime("%Y%m%d_%H%M%S")
         when "tl"
-          new_time = new_time.strftime("%a %b %d %Y %H:%M:%S") + " " + Time.zone.to_s
-          new_time = new_time.gsub(/\) [a-zA-Z0-9\s\S]*/, ")")
+          new_time = I18n.l new_time
         when "raw"                                  # return without formatting
         when "compare_hdr"                          # for drift/compare headers
           new_time = I18n.l(new_time, :format => :long) + new_time.strftime(" %Z")


### PR DESCRIPTION
This PR adds support for localized date & times into `format_timezone()` routine.

Formats now localized: `gtl`, `date`, `tl`, `compare_hdr`, `widget_footer` & default format.

Ths PR also removes some of the formats, which are not needed: `on_at`, `datetime` &
`support_log_fname`.