### PR TITLE
[Darga] Backport #9801 from abellotti/api_user_settings

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -89,7 +89,7 @@ class ApiController
     def user_settings
       {
         :locale => I18n.locale.to_s.sub('-', '_'),
-      }
+      }.merge(@auth_user_obj.settings)
     end
 
     def userid_to_userobj(userid)

--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -69,7 +69,7 @@ class ApiController
     def edit_resource(type, id, data)
       klass = collection_class(type)
       resource = resource_search(id, type, klass)
-      resource.update_attributes(data.except(*ID_ATTRS))
+      resource.update_attributes!(data.except(*ID_ATTRS))
       resource
     end
 

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -16,4 +16,15 @@ RSpec.describe "API entrypoint" do
 
     expect(%w(en en_US)).to include(response_hash['settings']['locale'])
   end
+
+  it "returns users's settings" do
+    api_basic_authorize
+
+    test_settings = {:cartoons => {:saturday => {:tom_jerry => 'n', :bugs_bunny => 'y'}}}
+    @user.update_attributes!(:settings => test_settings)
+
+    run_get entrypoint_url
+
+    expect(response.parsed_body).to include("settings" => a_hash_including(test_settings.deep_stringify_keys))
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------

Enhancement to /api/users for settings
(cherry picked from commit 170bf4479b6139f244d5368d32efab3a21c77a72)

Conflicts:
	spec/requests/api/entrypoint_spec.rb

@miq-bot assign @chessbyte 

As per https://github.com/ManageIQ/manageiq/pull/9801#issuecomment-234074030