### PR TITLE
Added extend_retires_on method for automate

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -52,6 +52,14 @@ module RetirementMixin
     retires_on.nil? ? nil : retires_on.to_date
   end
 
+  def extend_retires_on(days, date = Time.zone.today)
+    _log.info "Extending Retirement Date on #{self.class.name} id:<#{self.id}>, name:<#{self.name}> "
+    new_retires_date = date + days.to_i
+    _log.info "Original Date: #{date} Extend days: #{days} New Retirement Date: #{new_retires_date}"
+    self.retires_on = new_retires_date
+    save
+  end
+
   def retire(options = {})
     return unless options.keys.any? { |key| [:date, :warn].include?(key) }
 

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
@@ -7,6 +7,7 @@ module MiqAeServiceRetirementMixin
     expose :retiring?
     expose :error_retiring?
     expose :retired?
+    expose :extend_retires_on
   end
 
   def retirement_state=(state)

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
@@ -149,17 +149,61 @@ module MiqAeServiceVmSpec
     end
 
     it "#retires_on - today" do
-      service_vm.retires_on = Date.today
-      vm.reload
+      vm.update_attributes(:retirement_last_warn => Date.today)
+      service_vm.retires_on = Time.zone.today
 
+      vm.reload
+      expect(vm.retirement_last_warn).to be_nil
       expect(vm.retirement_due?).to be_truthy
     end
 
     it "#retires_on - tomorrow" do
-      service_vm.retires_on = Date.today + 1
+      vm.update_attributes(
+        :retired              => true,
+        :retirement_last_warn => Time.zone.today,
+        :retirement_state     => "retiring"
+      )
+      service_vm.retires_on = Time.zone.today + 1
       vm.reload
 
-      expect(vm.retirement_due?).to be_falsey
+      expect(vm).to have_attributes(
+        :retirement_last_warn => nil,
+        :retired              => false,
+        :retirement_state     => nil,
+        :retirement_due?      => false
+      )
+    end
+
+    it "#extend_retires_on - no retirement date set" do
+      Timecop.freeze(Time.zone.today) do
+        extend_days = 7
+        service_vm.extend_retires_on(extend_days)
+        vm.reload
+
+        expect(vm.retires_on.day).to eq(Time.zone.today.day + extend_days)
+      end
+    end
+
+    it "#extend_retires_on - future retirement date set" do
+      Timecop.freeze(Time.zone.today) do
+        vm.update_attributes(
+          :retired              => true,
+          :retirement_last_warn => Time.zone.today,
+          :retirement_state     => "retiring"
+        )
+        future_retires_on = Time.zone.today + 30
+        service_vm.retires_on = future_retires_on
+        extend_days = 7
+        service_vm.extend_retires_on(extend_days, future_retires_on)
+        vm.reload
+
+        expect(vm).to have_attributes(
+          :retirement_last_warn => nil,
+          :retired              => false,
+          :retirement_state     => nil,
+          :retires_on           => future_retires_on + extend_days
+        )
+      end
     end
 
     it "#retirement_warn" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Automate methods can set the service and vm objects retires_on date. Added a new extend_retires_on method to make it easier to manipulate the retires_on date by adding a number of days to an existing retires_on date or set a new retires_on date some specified number of days from today. 


