### PR TITLE
Scheduling AutomateTasks via the console

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -37,6 +37,13 @@ class AutomationRequest < MiqRequest
     create_request(options, user, auto_approve)
   end
 
+  def self.create_from_scheduled_task(user, uri_parts, parameters)
+    [:namespace, :class_name].each { |key| uri_parts.delete(key) if uri_parts.key?(key) }
+    approval = {'auto_approve' => true}
+    uri_parts.stringify_keys!
+    create_from_ws("1.1", user, uri_parts, parameters, approval)
+  end
+
   def self.zone(options)
     zone_name = options[:attrs][:miq_zone]
     return nil if zone_name.blank?


### PR DESCRIPTION
Purpose or Intent
-----------------
> This PR allows scheduling of an `AutomationTask` through the `rails console` using a correctly formed new `MiqSchedule` object. Once the new scheduled task is added it will run on a schedule as expected - though being an automation task it will follow the below rules.

> 1. An `AutomationRequest` will be created when the schedule runs.
2. This iteration will allow for auto approval of all Scheduled Automate Task.
3. Automate runs the task via the existing mechanism.

> Note: The Automation Request will be built on schedule, but the task itself will run within the timeframe allowed within the other queued jobs.

Links
-----
> * https://www.pivotaltracker.com/story/show/126161699


Steps for Testing/QA
--------------------
> 1. Create an instance of your task in /System/Process.
2. Open the appliance rails console `rails console`.
3. Paste the included hash (details obviously have to match your instance) into your console to build the `MiqSchedule` for your `AutomationTask`.

`schedule_automate = {:name=>"ShowStuff", :description=>"ShowStuff", :towhat=>"AutomationRequest", :userid=>1, :enabled=>true, :run_at=>{:tz=>"UTC", :start_time=>4.minutes.from_now.utc, :interval=>{:unit=>"daily", :value=>"1"}}, :sched_action=>{:method=>"automation_request"}, :filter=>{:uri_parts=>{ :instance=>"ShowStuff", :message=>"create"}, :parameters=>{}}}`

`MiqSchedule.create(schedule_automate)`