### PR TITLE
Code refactor: Replacing validate_* by supports_* for migrate operation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1782,7 +1782,13 @@ class ApplicationController < ActionController::Base
     end
 
     vms = VmOrTemplate.where(:id => vm_ids)
-    vms.each { |vm| render_flash_not_applicable_to_model(typ) unless vm.is_available?(typ) }
+    vms.each do |vm|
+      if vm.respond_to?("supports_#{typ}?")
+        render_flash_not_applicable_to_model(typ) unless vm.send("supports_#{typ}?")
+      else
+        render_flash_not_applicable_to_model(typ) unless vm.is_available?(typ)
+      end
+    end
   end
 
   def prov_redirect(typ = nil)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -839,7 +839,7 @@ class ApplicationHelper::ToolbarBuilder
       when "vm_guest_restart", "instance_guest_restart"
         return true unless @record.is_available?(:reboot_guest)
       when "vm_migrate"
-        return true unless @record.is_available?(:migrate)
+        return true unless @record.supports_migrate?
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
       when "vm_retire"

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
   include_concern 'ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared'
 
+  supports_not :migrate, :reason => _("Migrate operation is not supported.")
+
   POWER_STATES = {
     "Running"  => "on",
     "Paused"   => "suspended",
@@ -10,10 +12,6 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
 
   def self.calculate_power_state(raw_power_state)
     POWER_STATES[raw_power_state] || super
-  end
-
-  def validate_migrate
-    validate_unsupported("Migrate")
   end
 
   def proxies4job(_job = nil)

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
@@ -5,6 +5,8 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
     supports :live_migrate do
       unsupported_reason_add(:live_migrate, unsupported_reason(:control)) unless supports_control?
     end
+
+    supports_not :migrate, :reason => _("Migrate operation is not supported.")
   end
 
   def raw_live_migrate(options = {})
@@ -35,9 +37,5 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
     msg = validate_vm_control
     return {:available => msg[0], :message => msg[1]} unless msg.nil?
     {:available => true, :message => nil}
-  end
-
-  def validate_migrate
-    validate_unsupported("Migrate")
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -4,6 +4,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   include_concern 'Reconfigure'
   include_concern 'ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared'
 
+  supports_not :migrate, :reason => _("Migrate operation is not supported.")
+
   POWER_STATES = {
     'up'        => 'on',
     'down'      => 'off',
@@ -40,10 +42,6 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
 
   def self.calculate_power_state(raw_power_state)
     POWER_STATES[raw_power_state] || super
-  end
-
-  def validate_migrate
-    validate_unsupported("Migrate")
   end
 
   def validate_publish

--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -5,6 +5,12 @@ module Vm::Operations::Lifecycle
     supports :retire do
       unsupported_reason_add(:retire, "VM orphaned or archived already") if orphaned? || archived?
     end
+
+    supports :migrate do
+      if blank? || orphaned? || archived?
+        unsupported_reason_add(:migrate, "Migrate operation in not supported.")
+      end
+    end
   end
 
   def validate_clone
@@ -12,10 +18,6 @@ module Vm::Operations::Lifecycle
   end
 
   def validate_publish
-    {:available => !(self.blank? || self.orphaned? || self.archived?), :message   => nil}
-  end
-
-  def validate_migrate
     {:available => !(self.blank? || self.orphaned? || self.archived?), :message   => nil}
   end
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1883,7 +1883,13 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def self.batch_operation_supported?(operation, ids)
-    VmOrTemplate.where(:id => ids).all? { |v| v.public_send("validate_#{operation}")[:available] }
+    VmOrTemplate.where(:id => ids).all? do |vm_or_template|
+      if vm_or_template.respond_to?("supports_#{operation}?")
+        vm_or_template.public_send("supports_#{operation}?")
+      else
+        vm_or_template.public_send("validate_#{operation}")[:available]
+      end
+    end
   end
 
   # Stop showing Reconfigure VM task unless the subclass allows

--- a/app/models/vm_xen.rb
+++ b/app/models/vm_xen.rb
@@ -1,5 +1,3 @@
 class VmXen < ManageIQ::Providers::InfraManager::Vm
-  def validate_migrate
-    validate_supported
-  end
+  supports :migrate
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -409,22 +409,22 @@ describe VmOrTemplate do
     end
   end
 
-  context "#is_available? for migrate" do
-    it "returns true for vmware VM" do
+  context "#supports_migrate?" do
+    it "returns true for vmware VM neither orphaned nor archived when queried if it supports migrate operation" do
       vm = FactoryGirl.create(:vm_vmware)
       allow(vm).to receive_messages(:archived? => false)
       allow(vm).to receive_messages(:orphaned? => false)
-      expect(vm.is_available?(:migrate)).to eq(true)
+      expect(vm.supports_migrate?).to eq(true)
     end
 
-    it "returns true for SCVMM VM" do
+    it "returns false for SCVMM VM when queried if it supports migrate operation" do
       vm = FactoryGirl.create(:vm_microsoft)
-      expect(vm.is_available?(:migrate)).to_not eq(true)
+      expect(vm.supports_migrate?).to eq(false)
     end
 
-    it "returns false for openstack VM" do
+    it "returns false for openstack VM  when queried if it supports migrate operation" do
       vm = FactoryGirl.create(:vm_openstack)
-      expect(vm.is_available?(:migrate)).to eq(false)
+      expect(vm.supports_migrate?).to eq(false)
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
This PR removes the validate_migrate calls and replaces it with supports_migrate? method provided by SupportsFeatureMixin.


Related Links
-----
This is continuation of refactor work addressed through earlier PRs:
> https://github.com/ManageIQ/manageiq/pull/9833
> https://github.com/ManageIQ/manageiq/pull/9865

Testing/QA
--------------------
Tested locally. All tests passed.

