### PR TITLE
Add zone to the add/edit forms for configuration managers providers

### DIFF
--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -4,6 +4,7 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
         provtype: '',
         name: '',
         url: '',
+        zone: '',
         verify_ssl: '',
         log_userid: '',
         log_password: '',
@@ -21,6 +22,7 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
         $scope.newRecord                            = true;
         $scope.providerForemanModel.provtype        = '';
         $scope.providerForemanModel.name            = '';
+        $scope.providerForemanModel.zone            = '';
         $scope.providerForemanModel.url             = '';
         $scope.providerForemanModel.verify_ssl    = false;
 
@@ -37,6 +39,7 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
         $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId).success(function(data) {
           $scope.providerForemanModel.provtype        = data.provtype;
           $scope.providerForemanModel.name            = data.name;
+          $scope.providerForemanModel.zone            = data.zone;
           $scope.providerForemanModel.url             = data.url;
           $scope.providerForemanModel.verify_ssl      = data.verify_ssl == "1";
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -63,11 +63,21 @@ class ProviderForemanController < ApplicationController
     assert_privileges("provider_foreman_add_provider")
     @provider_cfgmgmt = ManageIQ::Providers::ConfigurationManager.new
     @provider_types = ["Ansible Tower", ui_lookup(:ui_title => 'foreman')]
+    @server_zones = []
+    zones = Zone.order('lower(description)')
+    zones.each do |zone|
+      @server_zones.push([zone.description, zone.name])
+    end
     render_form
   end
 
   def edit
     @provider_types = ["Ansible Tower", ui_lookup(:ui_title => 'foreman')]
+    @server_zones = []
+    zones = Zone.order('lower(description)')
+    zones.each do |zone|
+      @server_zones.push([zone.description, zone.name])
+    end
     case params[:button]
     when "cancel"
       cancel_provider_foreman
@@ -221,6 +231,7 @@ class ProviderForemanController < ApplicationController
 
     render :json => {:provtype   => model_to_name(config_mgr.type),
                      :name       => provider.name,
+                     :zone       => provider.zone.name,
                      :url        => provider.url,
                      :verify_ssl => provider.verify_ssl,
                      :log_userid => provider.authentications.first.userid}
@@ -521,7 +532,7 @@ class ProviderForemanController < ApplicationController
     @provider_cfgmgmt.name       = params[:name]
     @provider_cfgmgmt.url        = params[:url]
     @provider_cfgmgmt.verify_ssl = params[:verify_ssl].eql?("on")
-    @provider_cfgmgmt.zone       = Zone.find_by_name(MiqServer.my_zone)
+    @provider_cfgmgmt.zone       = Zone.find_by_name(params[:zone].to_s)
   end
 
   def features

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -63,21 +63,13 @@ class ProviderForemanController < ApplicationController
     assert_privileges("provider_foreman_add_provider")
     @provider_cfgmgmt = ManageIQ::Providers::ConfigurationManager.new
     @provider_types = ["Ansible Tower", ui_lookup(:ui_title => 'foreman')]
-    @server_zones = []
-    zones = Zone.order('lower(description)')
-    zones.each do |zone|
-      @server_zones.push([zone.description, zone.name])
-    end
+    @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
     render_form
   end
 
   def edit
     @provider_types = ["Ansible Tower", ui_lookup(:ui_title => 'foreman')]
-    @server_zones = []
-    zones = Zone.order('lower(description)')
-    zones.each do |zone|
-      @server_zones.push([zone.description, zone.name])
-    end
+    @server_zones = Zone.in_my_region.order('lower(description)').pluck(:description, :name)
     case params[:button]
     when "cancel"
       cancel_provider_foreman

--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -44,6 +44,28 @@
                               "readonly" => true,
                               "style"    => "color: black; font-weight: normal;"}
 
+    .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
+      %label.col-md-2.control-label{"for" => "prov_zone"}
+        = _("Zone")
+      .col-md-8
+        - if @server_zones.length <= 1
+          %input.form-control{"type"        => "text",
+                              "id"          => "prov_zone",
+                              "name"        => "zone",
+                              "ng-model"    => "providerForemanModel.zone",
+                              "maxlength"   => 15,
+                              "required"    => "",
+                              "checkchange" => "",
+                              "readonly"    => true,
+                              "style"       => "color: black;"}
+        - else
+          = select_tag('zone',
+                       options_for_select(@server_zones.sort_by { |name, _name| name }),
+                       "ng-model"                    => "providerForemanModel.zone",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+
     .form-group{"ng-class" => "{'has-error': angularForm.url.$invalid}"}
       %label.col-md-2.control-label{"for" => "provider_url"}
         = _("Url")

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -182,6 +182,22 @@ describe ProviderForemanController do
       expect(right_cell_text).to eq(_("Edit Configuration Manager Provider"))
     end
 
+    it "should display the zone field" do
+      newZone = FactoryGirl.create(:zone, :name => "TestZone")
+      post :edit, :params => { :id => @config_mgr.id }
+      expect(response.status).to eq(200)
+      expect(response.body).to include("Zone")
+    end
+
+    it "should save the zone field" do
+      newZone = FactoryGirl.create(:zone, :name => "TestZone")
+      controller.instance_variable_set(:@provider_cfgmgmt, @provider)
+      allow(controller).to receive(:leaf_record).and_return(false)
+      post :edit, :params => { :button => 'save', :id => @config_mgr.id, :zone => newZone.name, :url => @provider.url, :verify_ssl => @provider.verify_ssl }
+      expect(response.status).to eq(200)
+      expect(@provider.zone).to eq(newZone)
+    end
+
     it "renders the edit page when the configuration manager id is selected from a list view" do
       post :edit, :params => { :miq_grid_checks => @config_mgr.id }
       expect(response.status).to eq(200)

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -183,19 +183,24 @@ describe ProviderForemanController do
     end
 
     it "should display the zone field" do
-      newZone = FactoryGirl.create(:zone, :name => "TestZone")
+      new_zone = FactoryGirl.create(:zone, :name => "TestZone")
+      controller.instance_variable_set(:@provider_cfgmgmt, @provider)
       post :edit, :params => { :id => @config_mgr.id }
       expect(response.status).to eq(200)
-      expect(response.body).to include("Zone")
+      expect(response.body).to include("option value=\\\"#{new_zone.name}\\\"")
     end
 
     it "should save the zone field" do
-      newZone = FactoryGirl.create(:zone, :name => "TestZone")
+      new_zone = FactoryGirl.create(:zone, :name => "TestZone")
       controller.instance_variable_set(:@provider_cfgmgmt, @provider)
       allow(controller).to receive(:leaf_record).and_return(false)
-      post :edit, :params => { :button => 'save', :id => @config_mgr.id, :zone => newZone.name, :url => @provider.url, :verify_ssl => @provider.verify_ssl }
+      post :edit, :params => { :button     => 'save',
+                               :id         => @config_mgr.id,
+                               :zone       => new_zone.name,
+                               :url        => @provider.url,
+                               :verify_ssl => @provider.verify_ssl }
       expect(response.status).to eq(200)
-      expect(@provider.zone).to eq(newZone)
+      expect(@provider.zone).to eq(new_zone)
     end
 
     it "renders the edit page when the configuration manager id is selected from a list view" do

--- a/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
+++ b/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
@@ -31,6 +31,7 @@ describe('providerForemanFormController', function() {
     var providerForemanFormResponse = {
       name: '',
       url: '',
+      zone: '',
       verify_ssl: false,
       log_userid: ''
     };
@@ -46,6 +47,9 @@ describe('providerForemanFormController', function() {
     }));
     it('sets the name to blank', function () {
       expect($scope.providerForemanModel.name).toEqual('');
+    });
+    it('sets the zone to blank', function () {
+      expect($scope.providerForemanModel.zone).toEqual('');
     });
     it('sets the url to blank', function () {
       expect($scope.providerForemanModel.url).toEqual('');
@@ -68,6 +72,7 @@ describe('providerForemanFormController', function() {
       var providerForemanFormResponse = {
         name: 'Foreman',
         url: '10.10.10.10',
+        zone: 'My Test Zone',
         verify_ssl: true,
         log_userid: 'admin'
       };
@@ -85,6 +90,9 @@ describe('providerForemanFormController', function() {
 
       it('sets the name to the value returned from http request', function () {
         expect($scope.providerForemanModel.name).toEqual('Foreman');
+      });
+      it('sets the zone to the value returned from the http request', function () {
+        expect($scope.providerForemanModel.zone).toEqual('My Test Zone');
       });
       it('sets the url to the value returned from http request', function () {
         expect($scope.providerForemanModel.url).toEqual('10.10.10.10');


### PR DESCRIPTION
Purpose or Intent
-----------------
Add zone to the forms for adding and editing configuration management providers.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1353015
https://bugzilla.redhat.com/show_bug.cgi?id=1353651

Screenshoots with Zone for New and Edit forms:

![screenshot from 2016-07-25 17-48-11](https://cloud.githubusercontent.com/assets/12769982/17118766/30cb2c3a-5290-11e6-935c-dde340bcddd4.png)
![screenshot from 2016-07-25 17-49-03](https://cloud.githubusercontent.com/assets/12769982/17118767/30cb81d0-5290-11e6-8172-7934d07d1b6f.png)



