### PR TITLE
Delete a datasource definition in an EAP 7 standalone server

### DIFF
--- a/app/controllers/middleware_datasource_controller.rb
+++ b/app/controllers/middleware_datasource_controller.rb
@@ -8,6 +8,13 @@ class MiddlewareDatasourceController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  OPERATIONS = {
+    :middleware_datasource_remove => { :op   => :remove_middleware_datasource,
+                                       :hawk => N_('Not removed datasources'),
+                                       :msg  => N_('The selected datasources were removed')
+    }
+  }.freeze
+
   def show
     clear_topology_breadcrumb
     @display = params[:display] || "main" unless control_selected?
@@ -15,5 +22,44 @@ class MiddlewareDatasourceController < ApplicationController
     @showtype = "main"
     @record = identify_record(params[:id])
     show_container(@record, controller_name, display_name)
+  end
+
+  def button
+    selected_operation = params[:pressed].to_sym
+    if OPERATIONS.key?(selected_operation)
+      selected_ds = identify_selected_datasources
+      run_datasource_operation(OPERATIONS.fetch(selected_operation), selected_ds)
+      javascript_flash
+    else
+      super
+    end
+  end
+
+  private ############################
+
+  def identify_selected_datasources
+    items = params[:miq_grid_checks]
+    return items unless items.nil? || items.empty?
+    params[:id]
+  end
+
+  def run_datasource_operation(operation_info, items)
+    if items.nil?
+      add_flash(_("No datasources selected"))
+      return
+    end
+    operation_triggered = false
+    items.split(/,/).each do |item|
+      mw_server = identify_record item
+      trigger_mw_operation operation_info.fetch(:op), mw_server
+      operation_triggered = true
+    end
+    add_flash(operation_info.fetch(:msg)) if operation_triggered
+  end
+
+  def trigger_mw_operation(operation, mw_server)
+    mw_manager = mw_server.ext_management_system
+    op = mw_manager.public_method operation
+    op.call mw_server.ems_ref
   end
 end

--- a/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_datasource_center.rb
@@ -32,4 +32,21 @@ class ApplicationHelper::Toolbar::MiddlewareDatasourceCenter < ApplicationHelper
       ]
     ),
   ])
+  button_group(
+    'middleware_datasource_operations', [
+      select(
+        :middleware_datasource_operations_choice,
+        'fa fa-play-circle-o fa-lg',
+        t = N_('Operations'),
+        t,
+        :items => [
+          button(
+            :middleware_datasource_remove,
+            'pficon pficon-delete fa-lg',
+            N_('Remove Middleware Datasource'),
+            N_('Remove'),
+            :confirm => N_('Do you want to remove this datasource ?'))
+        ]
+      ),
+    ])
 end

--- a/app/helpers/application_helper/toolbar/middleware_datasources_center.rb
+++ b/app/helpers/application_helper/toolbar/middleware_datasources_center.rb
@@ -19,4 +19,26 @@ class ApplicationHelper::Toolbar::MiddlewareDatasourcesCenter < ApplicationHelpe
       ]
     ),
   ])
+  button_group(
+    'middleware_datasource_operations', [
+      select(
+        :middleware_datasource_operations_choice,
+        'fa fa-play-circle-o fa-lg',
+        t = N_('Operations'),
+        t,
+        :enabled => false,
+        :onwhen  => "1+",
+        :items   => [
+          button(
+            :middleware_datasource_remove,
+            'pficon pficon-delete fa-lg',
+            N_('Remove Middleware Datasources'),
+            N_('Remove'),
+            :url_parms => "main_div",
+            :enabled   => false,
+            :onwhen    => "1+",
+            :confirm   => N_('Do you want to remove these datasources ?'))
+        ]
+      ),
+    ])
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -244,43 +244,42 @@ module ManageIQ::Providers
     # selected target server. This server is identified
     # by ems_ref, which in Hawkular terms is the
     # fully qualified resource path from Hawkular inventory
-    def run_generic_operation(operation, ems_ref, parameters = {})
-      with_provider_connection do |connection|
-        the_operation = {
-          :operationName => operation,
-          :resourcePath  => ems_ref.to_s,
-          :parameters    => parameters
-        }
+    #
+    # this method execute an operation through ExecuteOperation request command.
+    #
+    def run_generic_operation(operation_name, ems_ref, parameters = {})
+      the_operation = {
+        :operationName => operation_name,
+        :resourcePath  => ems_ref.to_s,
+        :parameters    => parameters
+      }
+      run_operation(the_operation)
+    end
 
-        actual_data = {}
-        connection.operations(true).invoke_generic_operation(the_operation) do |on|
+    #
+    # this method send a specific command to the server
+    # with his own JSON. this doesn't use ExecuteOperation.
+    #
+    def run_specific_operation(operation_name, ems_ref, parameters = {})
+      parameters[:resourcePath] = ems_ref.to_s
+      run_operation(parameters, operation_name)
+    end
+
+    def run_operation(parameters, operation_name = nil)
+      with_provider_connection do |connection|
+        callback = proc do |on|
           on.success do |data|
             _log.debug "Success on websocket-operation #{data}"
-            actual_data[:data] = data
           end
           on.failure do |error|
-            actual_data[:data]  = {}
-            actual_data[:error] = error
             _log.error 'error callback was called, reason: ' + error.to_s
           end
         end
-      end
-    end
-
-    def run_specific_operation(operation_name, ems_ref, parameters = {})
-      with_provider_connection do |connection|
-        parameters[:resourcePath] = ems_ref.to_s
-        actual_data = {}
-        connection.operations(true).invoke_specific_operation(parameters, operation_name) do |on|
-          on.success do |data|
-            _log.debug "Success on websocket-operation #{data}"
-            actual_data[:data] = data
-          end
-          on.failure do |error|
-            actual_data[:data]  = {}
-            actual_data[:error] = error
-            _log.error 'error callback was called, reason: ' + error.to_s
-          end
+        operation_connection = connection.operations(true)
+        if operation_name.nil?
+          operation_connection.invoke_generic_operation(parameters, &callback)
+        else
+          operation_connection.invoke_specific_operation(parameters, operation_name, &callback)
         end
       end
     end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3499,7 +3499,7 @@
     - :name: Remove
       :description: Remove Middleware Datasource from the VMDB
       :feature_type: admin
-      :identifier: middleware_datasource_delete
+      :identifier: middleware_datasource_remove
     - :name: Edit
       :description: Edit a Middleware Datasource
       :feature_type: admin


### PR DESCRIPTION

![remove-1](https://cloud.githubusercontent.com/assets/3799716/17040601/3586d35a-4f66-11e6-8b80-edc033a67b58.png)

![remove-2](https://cloud.githubusercontent.com/assets/3799716/17040603/39b1cf98-4f66-11e6-86be-113475dc9afb.png)

Adds Remove operation to Datasources.



@miq-bot add_label providers/hawkular
@miq-bot add_label wip